### PR TITLE
Fix deno path

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -636,7 +636,7 @@ perform_cleanup() {
     safe_clean ~/.cache/swift-package-manager/* "Swift package manager cache"
     safe_clean ~/.cache/bazel/* "Bazel cache"
     safe_clean ~/.cache/zig/* "Zig cache"
-    safe_clean ~/.cache/deno/* "Deno cache"
+    safe_clean ~/Library/Caches/deno/* "Deno cache"
 
     # Database tools
     safe_clean ~/Library/Caches/com.sequel-ace.sequel-ace/* "Sequel Ace cache"


### PR DESCRIPTION
Deno uses ~/Library/Caches/deno as default cache dir