### PR TITLE
Fix shell-format workflow for macOS bash compatibility

### DIFF
--- a/.github/workflows/shell-format.yml
+++ b/.github/workflows/shell-format.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Run shfmt in diff mode
         run: |
           set -euo pipefail
-          mapfile -d '' files < <(find . -type f \( -name '*.sh' -o -name 'mole' \) \
+          files=()
+          while IFS= read -r -d '' file; do
+            files+=("$file")
+          done < <(find . -type f \( -name '*.sh' -o -name 'mole' \) \
                                    ! -path './.git/*' ! -path './tests/tmp-*' -print0)
           if (( ${#files[@]} == 0 )); then
             echo "No shell files found; skipping shfmt"
@@ -36,7 +39,10 @@ jobs:
       - name: Run shellcheck
         run: |
           set -euo pipefail
-          mapfile -d '' files < <(find . -type f \( -name '*.sh' -o -name 'mole' \) \
+          files=()
+          while IFS= read -r -d '' file; do
+            files+=("$file")
+          done < <(find . -type f \( -name '*.sh' -o -name 'mole' \) \
                                    ! -path './.git/*' ! -path './tests/tmp-*' -print0)
           if (( ${#files[@]} == 0 )); then
             echo "No shell files found; skipping shellcheck"


### PR DESCRIPTION
## Summary
- replace unsupported bash mapfile usage with a portable loop when collecting shell files
- ensure shfmt and shellcheck steps run on the macOS runner without failing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb609e44ac8332a864e4087bbdd9ab