### PR TITLE
feat: add Nix garbage collection to developer tools cleanup

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -665,6 +665,16 @@ perform_cleanup() {
         note_activity
     fi
 
+    # Nix package manager
+    if command -v nix-collect-garbage > /dev/null 2>&1; then
+        if [[ "$DRY_RUN" != "true" ]]; then
+            clean_tool_cache "Nix garbage collection" nix-collect-garbage -d
+        else
+            echo -e "  ${YELLOW}→${NC} Nix garbage collection (would clean)"
+        fi
+        note_activity
+    fi
+
     safe_clean ~/.gitconfig.lock "Git config lock"
     end_section
 


### PR DESCRIPTION
Adds support for cleaning Nix package manager cache using `nix-collect-garbage -d` https://nix.dev/manual/nix/2.32/command-ref/nix-collect-garbage

## Motivation
Nix accumulates disk space over time from old generations