### PR TITLE
fix: add input handling for mouse wheel events

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -259,8 +259,21 @@ read_key() {
                     else
                         echo "QUIT" # ESC [ timeout
                     fi
+                elif [[ "$rest" == "O" ]]; then
+                    # Application keypad mode sequences (mouse wheel often generates these)
+                    if IFS= read -r -s -n 1 -t 1 rest2 2> /dev/null; then
+                        case "$rest2" in
+                            "A") echo "UP" ;;     # ESC O A
+                            "B") echo "DOWN" ;;   # ESC O B
+                            "C") echo "RIGHT" ;;  # ESC O C  
+                            "D") echo "LEFT" ;;   # ESC O D
+                            *) echo "OTHER" ;;     # Ignore other ESC O sequences
+                        esac
+                    else
+                        echo "OTHER" # ESC O timeout
+                    fi
                 else
-                    echo "QUIT" # ESC + something else
+                    echo "OTHER" # ESC + something else (not [ or O)
                 fi
             else
                 # ESC pressed alone - treat as quit
@@ -280,12 +293,17 @@ read_key() {
 # Drain pending input (useful for scrolling prevention)
 drain_pending_input() {
     local drained=0
-    # Single pass with reasonable timeout
-    # Touchpad scrolling can generate bursts of arrow keys
+    # Multiple passes with very short timeout to catch mouse wheel bursts
+    # Mouse wheel scrolling can generate rapid sequences like B^[OB^[OB^[O...
+    while IFS= read -r -s -n 1 -t 0.01 _ 2> /dev/null; do
+        ((drained++))
+        # Higher safety limit for mouse wheel sequences
+        [[ $drained -gt 1000 ]] && break
+    done
+    # Second pass with even shorter timeout to catch any remaining input
     while IFS= read -r -s -n 1 -t 0.001 _ 2> /dev/null; do
         ((drained++))
-        # Safety limit to prevent infinite loop
-        [[ $drained -gt 500 ]] && break
+        [[ $drained -gt 1500 ]] && break
     done
 }
 

--- a/lib/menu_paginated.sh
+++ b/lib/menu_paginated.sh
@@ -27,12 +27,18 @@ _pm_parse_csv_to_array() {
     done
 }
 
-# Non-blocking input drain (bash 3.2)
+# Non-blocking input drain (bash 3.2) - improved for mouse wheel
 drain_pending_input() {
-    local _k
-    # -t 0 is non-blocking; -n 1 consumes one byte at a time
-    while IFS= read -r -s -n 1 -t 0 _k; do
-        IFS= read -r -s -n 1 _k || break
+    local _k drained=0
+    # Multiple passes to handle mouse wheel burst sequences
+    while IFS= read -r -s -n 1 -t 0.01 _k 2> /dev/null; do
+        ((drained++))
+        [[ $drained -gt 1000 ]] && break
+    done
+    # Second pass with shorter timeout
+    while IFS= read -r -s -n 1 -t 0.001 _k 2> /dev/null; do
+        ((drained++))
+        [[ $drained -gt 1500 ]] && break
     done
 }
 
@@ -488,6 +494,8 @@ paginated_multi_select() {
     # Main interaction loop
     while true; do
         draw_menu
+        # Drain any pending input to prevent mouse wheel scroll issues
+        drain_pending_input
         local key
         key=$(read_key)
 


### PR DESCRIPTION
## Bug
The mouse wheel events may interrupt the process, where the mouse input is identified as `B^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB^[OB%`.
<img width="1008" height="138" alt="image" src="https://github.com/user-attachments/assets/f986cefc-e7eb-4f06-a5cd-beb87c7abbca" />

## Solution
- Added the corresponding input handle
- Now you can use mouse wheel on the selecting page