### PR TITLE
fix: auth failed when pwd is `space`

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -474,7 +474,7 @@ request_sudo_access() {
         # Traditional password method
         echo -e "${PURPLE}${ICON_ARROW}${NC} ${prompt_msg}"
         echo -ne "${PURPLE}${ICON_ARROW}${NC} Password: "
-        read -s password
+        IFS= read -r -s password
         echo ""
         if [[ -n "$password" ]] && echo "$password" | sudo -S true 2> /dev/null; then
             return 0


### PR DESCRIPTION
My admin password is made up with `spaces`. The prompt always failed because Bash plain `read -s password` collapses leading whitespace unless `IFS` is cleared.

Update the prompt logic to use `IFS= read -r -s password`, which preserves whitespace exactly as typed. With this change the `sudo` call succeeds even when the password is composed entirely of spaces. :)