### PR TITLE
fix: correct boot_time parsing error

### DIFF
--- a/lib/check/health_json.sh
+++ b/lib/check/health_json.sh
@@ -70,7 +70,7 @@ get_uptime_days() {
     local boot_output boot_time uptime_days
 
     boot_output=$(sysctl -n kern.boottime 2> /dev/null || echo "")
-    boot_time=$(echo "$boot_output" | sed -n 's/.*sec = \([0-9]*\).*/\1/p' 2> /dev/null || echo "")
+    boot_time=$(echo "$boot_output" | awk -F 'sec = |, usec' '{print $2}' 2> /dev/null || echo "")
 
     if [[ -n "$boot_time" && "$boot_time" =~ ^[0-9]+$ ]]; then
         local now=$(date +%s 2> /dev/null || echo "0")


### PR DESCRIPTION
```bash
echo $boot_output
{ sec = 1765766300, usec = 829969 } Mon Dec 15 10:38:20 2025

boot_time=$(echo "$boot_output" | sed -n 's/.*sec = \([0-9]*\).*/\1/p' 2> /dev/null || echo "")
$ echo $boot_time
829969
```

Using `s/.*sec = \([0-9]*\).*/\1/p` to parse `boot_output` resulted in an incorrect value (`usec`). I solved this problem by using awk to parse it.


Now:
```bash
echo $boot_output
{ sec = 1765766300, usec = 829969 } Mon Dec 15 10:38:20 2025

boot_time=$(echo "$boot_output" | awk -F 'sec = |, usec' '{print $2}' 2> /dev/null || echo "")
echo $boot_time
1765766300
```