### PR TITLE
improv: prompt user when Docker daemon not running

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -90,8 +90,24 @@ clean_dev_docker() {
             if run_with_timeout 3 docker info > /dev/null 2>&1; then
                 clean_tool_cache "Docker build cache" docker builder prune -af
             else
+                if [[ -t 0 ]]; then
+                    echo -ne "  ${YELLOW}${ICON_WARNING}${NC} Docker not running. ${GRAY}Enter${NC} retry / ${GRAY}any key${NC} skip: "
+                    local key
+                    IFS= read -r -s -n1 key || key=""
+                    printf "\r\033[2K"
+                    if [[ -z "$key" || "$key" == $'\n' || "$key" == $'\r' ]]; then
+                        if run_with_timeout 3 docker info > /dev/null 2>&1; then
+                            clean_tool_cache "Docker build cache" docker builder prune -af
+                        else
+                            echo -e "  ${GRAY}${ICON_SUCCESS}${NC} Docker build cache (still not running)"
+                        fi
+                    else
+                        echo -e "  ${GRAY}${ICON_SUCCESS}${NC} Docker build cache (skipped)"
+                    fi
+                else
+                    echo -e "  ${GRAY}${ICON_SUCCESS}${NC} Docker build cache (daemon not running)"
+                fi
                 note_activity
-                echo -e "  ${GRAY}${ICON_SUCCESS}${NC} Docker build cache (daemon not running)"
             fi
         else
             note_activity


### PR DESCRIPTION
When running mo clean, if Docker is installed but the daemon isn't running, users are now prompted instead of silently skipping.