### PR TITLE
fix: use BSD stat explicitly to avoid GNU coreutils conflict

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -210,9 +210,9 @@ is_recently_modified() {
         return 1
     fi
 
-    # Check modification time (macOS compatible)
+    # Get modification time using base.sh helper (handles GNU vs BSD stat)
     local mod_time
-    mod_time=$(stat -f "%m" "$path" 2> /dev/null || stat -c "%Y" "$path" 2> /dev/null || echo "0")
+    mod_time=$(get_file_mtime "$path")
     local current_time=$(date +%s)
     local age_seconds=$((current_time - mod_time))
     local age_in_days=$((age_seconds / 86400))

--- a/lib/clean/system.sh
+++ b/lib/clean/system.sh
@@ -40,7 +40,7 @@ clean_deep_system() {
 
                 # Skip system-protected files (restricted flag)
                 local item_flags
-                item_flags=$(command stat -f%Sf "$item" 2> /dev/null || echo "")
+                item_flags=$($STAT_BSD -f%Sf "$item" 2> /dev/null || echo "")
                 if [[ "$item_flags" == *"restricted"* ]]; then
                     continue
                 fi

--- a/scripts/build-analyze.sh
+++ b/scripts/build-analyze.sh
@@ -44,7 +44,7 @@ echo ""
 echo "✓ Build complete!"
 echo ""
 file bin/analyze-go
-size_bytes=$(stat -f%z bin/analyze-go 2> /dev/null || echo 0)
+size_bytes=$(/usr/bin/stat -f%z bin/analyze-go 2> /dev/null || echo 0)
 size_mb=$((size_bytes / 1024 / 1024))
 printf "Size: %d MB (%d bytes)\n" "$size_mb" "$size_bytes"
 echo ""

--- a/scripts/build-status.sh
+++ b/scripts/build-status.sh
@@ -37,7 +37,7 @@ echo ""
 echo "✓ Build complete!"
 echo ""
 file bin/status-go
-size_bytes=$(stat -f%z bin/status-go 2> /dev/null || echo 0)
+size_bytes=$(/usr/bin/stat -f%z bin/status-go 2> /dev/null || echo 0)
 size_mb=$((size_bytes / 1024 / 1024))
 printf "Size: %d MB (%d bytes)\n" "$size_mb" "$size_bytes"
 echo ""


### PR DESCRIPTION
## Summary
- Fix `mo purge` crash when GNU coreutils is installed via Homebrew and added to PATH
- Use `/usr/bin/stat` (BSD) explicitly instead of relying on PATH

## Problem
When GNU coreutils is installed (`brew install coreutils`), users can configure the GNU `stat` binary to shadow `/usr/bin/stat`. GNU stat uses `-c` for format strings while BSD stat uses `-f`, causing the purge command to fail with "unbound variable" errors.

```
> Purge Project Artifacts
[DEBUG] path=/Users/ndbroadbent/code/ai_assistant_boilerplate/node_modules/
[DEBUG] mod_time=  File: "/Users/ndbroadbent/code/ai_assistant_boilerplate/node_modules/"
    ID: 10000100000001a Namelen: ?       Type: apfs
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 242837545  Free: 4446893    Available: 4446893
Inodes: Total: 191888431  Free: 177875720
1741770358
/opt/homebrew/Cellar/mole/1.14.4/libexec/bin/../lib/clean/project.sh: line 219: File: unbound variable
```

## Solution
Use the existing `STAT_BSD` constant and `get_file_mtime()` helper from `base.sh` to always call BSD stat directly, bypassing any GNU coreutils in PATH.

## Files changed
- `lib/clean/project.sh` - use `get_file_mtime()` helper
- `lib/clean/system.sh` - use `$STAT_BSD` variable
- `scripts/build-analyze.sh` - use `/usr/bin/stat` explicitly
- `scripts/build-status.sh` - use `/usr/bin/stat` explicitly