### PR TITLE
feat: add .dart_tool to project purge targets and disk analyzer

### DIFF
--- a/cmd/analyze/cleanable.go
+++ b/cmd/analyze/cleanable.go
@@ -105,6 +105,7 @@ var projectDependencyDirs = map[string]bool{
 	"Pods":        true,
 	".build":      true,
 	"Carthage":    true,
+	".dart_tool":  true,
 
 	// Other tools
 	".terraform": true, // Terraform plugins

--- a/cmd/analyze/constants.go
+++ b/cmd/analyze/constants.go
@@ -138,6 +138,7 @@ var foldDirs = map[string]bool{
 	".build":      true,
 	"xcuserdata":  true,
 	"Carthage":    true,
+	".dart_tool":  true,
 
 	// Web frameworks
 	".angular":    true,

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -21,6 +21,7 @@ readonly PURGE_TARGETS=(
     "obj"           # C# / Unity
     ".turbo"        # Turborepo cache
     ".parcel-cache" # Parcel bundler
+    ".dart_tool"    # Flutter/Dart build cache
 )
 
 # Minimum age in days before considering for cleanup


### PR DESCRIPTION
This PR adds support for cleaning and analyzing the .dart_tool directory in Flutter and Dart projects. It updates the shell purge targets in lib/clean/project.sh for safe removal and integrates the directory into the Go-based disk analyzer constants and cleanable logic. These changes ensure that build caches are properly identified and can be safely cleared to free up disk space while adhering to the project's existing security architecture and safe removal wrappers.