### PR TITLE
Fix macOS update detection in optimize

### DIFF
--- a/lib/check/all.sh
+++ b/lib/check/all.sh
@@ -246,7 +246,7 @@ check_macos_update() {
         fi
 
         if sw_output=$(run_with_timeout 10 softwareupdate -l --no-scan 2> /dev/null); then
-            sw_status=0
+            :
         else
             sw_status=$?
         fi
@@ -257,7 +257,7 @@ check_macos_update() {
 
         # Prefer avoiding false negatives: if the system indicates updates are pending,
         # only clear the flag when softwareupdate explicitly reports no updates.
-        if [[ $sw_status -eq 0 && -n "$sw_output" ]] && echo "$sw_output" | grep -q "No new software available"; then
+        if [[ $sw_status -eq 0 && -n "$sw_output" ]] && echo "$sw_output" | grep -qE '^[[:space:]]*No new software available'; then
             updates_available="false"
         fi
     fi


### PR DESCRIPTION
Fixes #181.

### What changed
- `check_macos_update` now validates pending updates with `softwareupdate -l --no-scan` (fast, avoids triggering a fresh scan).
- Increased timeout from 5s → 10s for the validation call.
- Avoids false negatives: when the system indicates updates are pending, we only clear the flag if `softwareupdate` explicitly reports `No new software available`.

### Why
On newer macOS versions, `softwareupdate -l` can exceed the previous 5s timeout due to scanning, causing the validation step to time out and Mole to incorrectly report “System up to date” even when an update is available.

### Tests
- Updated Bats tests in `tests/system_maintenance.bats` to cover:
  - update available
  - `No new software available`
  - timeout (124) with updates pending
  - success (0) with empty output (should keep update flag true)
  - defaults reports 0 (skip softwareupdate)
  - verifies the timeout arg is `10`
