### PR TITLE
Configurable Purge Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,23 @@ Select Categories to Clean - 18.5GB (8 selected)
 
 > **Use with caution:** This will permanently delete selected artifacts. Review carefully before confirming. Recent projects (< 7 days) are marked and unselected by default.
 
+#### Configuration
+
+You can configure which directories `mole` scans for projects by creating a config file:
+
+1. Create `~/.config/mole/purge_paths`
+2. Add one directory path per line (supports `~`)
+
+Example `~/.config/mole/purge_paths`:
+
+```
+~/Documents/MyProjects
+~/Work/ClientA
+~/Work/ClientB
+```
+
+If this file exists, `mole` will *only* scan the paths listed in it. If not, it uses the default paths (`~/Projects`, `~/GitHub`, `~/dev`, etc.).
+
 ## Quick Launchers
 
 Launch Mole commands instantly from Raycast or Alfred:

--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -111,6 +111,26 @@ perform_purge() {
     printf '\n'
 }
 
+# Show help message
+show_help() {
+    echo -e "${PURPLE_BOLD}Mole Purge${NC} - Clean old project build artifacts"
+    echo ""
+    echo -e "${YELLOW}Usage:${NC} mo purge [options]"
+    echo ""
+    echo -e "${YELLOW}Options:${NC}"
+    echo "  --help          Show this help message"
+    echo "  --debug         Enable debug logging"
+    echo ""
+    echo -e "${YELLOW}Configuration:${NC}"
+    echo "  To customize search paths, create: ${NC}$HOME/.config/mole/purge_paths${NC}"
+    echo "  Add one directory path per line (supports ~)."
+    echo ""
+    echo -e "${YELLOW}Default Paths:${NC}"
+    for path in "${DEFAULT_PURGE_SEARCH_PATHS[@]}"; do
+        echo "  - $path"
+    done
+}
+
 # Main entry point
 main() {
     # Set up signal handling
@@ -119,12 +139,16 @@ main() {
     # Parse arguments
     for arg in "$@"; do
         case "$arg" in
+            "--help")
+                show_help
+                exit 0
+                ;;
             "--debug")
                 export MO_DEBUG=1
                 ;;
             *)
                 echo "Unknown option: $arg"
-                echo "Use 'mo --help' for usage information"
+                echo "Use 'mo purge --help' for usage information"
                 exit 1
                 ;;
         esac

--- a/tests/purge_config.bats
+++ b/tests/purge_config.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+    
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-purge-config.XXXXXX")"
+    export HOME
+    
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+setup() {
+    rm -rf "$HOME/.config"
+    mkdir -p "$HOME/.config/mole"
+}
+
+@test "load_purge_config loads default paths when config file is missing" {
+    # Source the file in a subshell to avoid polluting test environment variables
+    # We need to export HOME so it's picked up by the script
+    run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${PURGE_SEARCH_PATHS[*]}\""
+    
+    [ "$status" -eq 0 ]
+    
+    # Check for a few expected default paths
+    [[ "$output" == *"$HOME/Projects"* ]]
+    [[ "$output" == *"$HOME/GitHub"* ]]
+    [[ "$output" == *"$HOME/dev"* ]]
+}
+
+@test "load_purge_config loads custom paths from config file" {
+    local config_file="$HOME/.config/mole/purge_paths"
+    
+    cat > "$config_file" << EOF
+$HOME/custom/projects
+$HOME/work
+EOF
+
+    run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${PURGE_SEARCH_PATHS[*]}\""
+    
+    [ "$status" -eq 0 ]
+    
+    [[ "$output" == *"$HOME/custom/projects"* ]]
+    [[ "$output" == *"$HOME/work"* ]]
+    # Should NOT have default paths
+    [[ "$output" != *"$HOME/GitHub"* ]]
+}
+
+@test "load_purge_config expands tilde in paths" {
+    local config_file="$HOME/.config/mole/purge_paths"
+    
+    cat > "$config_file" << EOF
+~/tilde/expanded
+~/another/one
+EOF
+
+    run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${PURGE_SEARCH_PATHS[*]}\""
+    
+    [ "$status" -eq 0 ]
+    
+    [[ "$output" == *"$HOME/tilde/expanded"* ]]
+    [[ "$output" == *"$HOME/another/one"* ]]
+    [[ "$output" != *"~"* ]]
+}
+
+@test "load_purge_config ignores comments and empty lines" {
+    local config_file="$HOME/.config/mole/purge_paths"
+    
+    cat > "$config_file" << EOF
+# This is a comment
+$HOME/valid/path
+
+   # Indented comment
+   
+$HOME/another/path
+EOF
+
+    run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${#PURGE_SEARCH_PATHS[@]}\"; echo \"\${PURGE_SEARCH_PATHS[*]}\""
+    
+    [ "$status" -eq 0 ]
+    
+    local lines
+    read -r -a lines <<< "$output"
+    # First line of output is count
+    local count="${lines[0]}"
+    
+    [ "$count" -eq 2 ]
+    [[ "$output" == *"$HOME/valid/path"* ]]
+    [[ "$output" == *"$HOME/another/path"* ]]
+}
+
+@test "load_purge_config falls back to defaults if config file is empty" {
+    local config_file="$HOME/.config/mole/purge_paths"
+    touch "$config_file"
+
+    run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${PURGE_SEARCH_PATHS[*]}\""
+    
+    [ "$status" -eq 0 ]
+    
+    # Should have default paths
+    [[ "$output" == *"$HOME/Projects"* ]]
+}
+
+@test "load_purge_config falls back to defaults if config file has only comments" {
+    local config_file="$HOME/.config/mole/purge_paths"
+    echo "# Just a comment" > "$config_file"
+
+    run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${PURGE_SEARCH_PATHS[*]}\""
+    
+    [ "$status" -eq 0 ]
+    
+    # Should have default paths
+    [[ "$output" == *"$HOME/Projects"* ]]
+}


### PR DESCRIPTION
## Description
This PR introduces the ability to configure custom search paths for the `mole purge` command. Previously, the search paths were hardcoded. Now, users can define their own project directories in `~/.config/mole/purge_paths`.

## Changes
- **lib/clean/project.sh**: Added [load_purge_config](file:///Users/andriimedvediev/Developer/Home/Mole/lib/clean/project.sh#49-72) function to read paths from the configuration file. Falls back to default paths if the config is missing or empty.
- **bin/purge.sh**: Added a [show_help](file:///Users/andriimedvediev/Developer/Home/Mole/bin/purge.sh#115-133) function and `--help` flag support to display usage and configuration instructions.
- **README.md**: Updated documentation to include the new configuration feature.
- **tests/purge_config.bats**: Added unit tests to verify the configuration loading logic (custom paths, tilde expansion, fallback behavior).

## How to Test
1.  Run `mo purge --help` to see the new configuration instructions.
2.  Create `~/.config/mole/purge_paths` with a test directory:
    ```bash
    mkdir -p ~/.config/mole
    echo "~/MyCustomProjects" > ~/.config/mole/purge_paths
    ```
3.  Run `mo purge` and verify it scans the configured directory.
4.  Remove the config file and verify it reverts to default paths.
5.  Run the tests: `bats tests/purge_config.bats`

## Checklist
- [x] Code works as expected
- [x] Documentation updated (README & CLI help)
- [x] Tests added and passed
- [x] Linting passed (shellcheck)
