### PR TITLE
Add support for cleaning up Zig projects

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -28,6 +28,8 @@ readonly PURGE_TARGETS=(
     ".turbo"        # Turborepo cache
     ".parcel-cache" # Parcel bundler
     ".dart_tool"    # Flutter/Dart build cache
+    ".zig-cache"    # Zig
+    "zig-out"       # Zig
 )
 # Minimum age in days before considering for cleanup.
 readonly MIN_AGE_DAYS=7
@@ -65,6 +67,8 @@ readonly PROJECT_INDICATORS=(
     "composer.json"
     "pubspec.yaml"
     "Makefile"
+    "build.zig"
+    "build.zig.zon"
     ".git"
 )
 


### PR DESCRIPTION
Zig is still a pretty new language, but I thought it'll still be worth while for this tool to support it!

* Added `.zig-cache (build cache)` and `zig-out (build artifacts)` to `PURGE_TARGETS` .
* Added `build.zig (project build file)` and `build.zig.zon (project build info)` to `PROJECT_INDICATORS` .