### PR TITLE
fix(purge): use regex OR pattern instead of multiple -g flags for fd

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -307,6 +307,10 @@ scan_purge_targets() {
         return
     fi
     if command -v fd > /dev/null 2>&1; then
+        local pattern="($(
+            IFS='|'
+            echo "${PURGE_TARGETS[*]}"
+        ))"
         local fd_args=(
             "--absolute-path"
             "--hidden"
@@ -320,10 +324,7 @@ scan_purge_targets() {
             "--exclude" ".Trash"
             "--exclude" "Applications"
         )
-        for target in "${PURGE_TARGETS[@]}"; do
-            fd_args+=("-g" "$target")
-        done
-        fd "${fd_args[@]}" . "$search_path" 2> /dev/null | while IFS= read -r item; do
+        fd "${fd_args[@]}" "$pattern" "$search_path" 2> /dev/null | while IFS= read -r item; do
             if is_safe_project_artifact "$item" "$search_path"; then
                 echo "$item"
             fi


### PR DESCRIPTION
# Bug Fix: Purge Command Not Finding Project Artifacts

## Issue Summary

The `mo purge` command is not finding any project artifacts (like `target` directories) even when they exist, causing it to always report "No old project artifacts to clean" despite directories being present.

## Root Cause

The issue is in `lib/clean/project.sh` in the `scan_purge_targets()` function (around line 315-335). When using `fd`, the script incorrectly constructs the command by adding multiple `-g` glob flags in a loop:

```bash
for target in "${PURGE_TARGETS[@]}"; do
    fd_args+=("-g" "$target")  # WRONG - adds "-g target -g build -g dist ..."
done
fd "${fd_args[@]}" . "$search_path"
```

This results in a command like:
```bash
fd --absolute-path --hidden --no-ignore --type d ... -g target -g build -g dist . /search/path
```

**The problem:** `fd` interprets the `-g` flag as a single global toggle for glob mode, not as individual pattern specifications. When multiple patterns are passed this way, `fd` misinterprets some of them as search paths rather than patterns, causing the search to fail silently.

### Verification

Manual testing confirms the issue:
```bash
# Works - finds the target
$ fd --absolute-path --hidden --no-ignore --type d --min-depth 2 --max-depth 8 -g "target" /Users/jackphallen/RustroverProjects
/Users/jackphallen/RustroverProjects/csvshard/target/

# Fails - multiple -g flags don't work as expected
$ fd --absolute-path --hidden --no-ignore --type d --min-depth 2 --max-depth 8 -g "target" -g "build" /Users/jackphallen/RustroverProjects
/Users/jackphallen/RustroverProjects/csvshard/target/
[fd error]: Search path 'build' is not a directory.
```

## Solution

Replace the loop that adds multiple `-g` flags with a single regex pattern using OR logic `(pattern1|pattern2|pattern3|...)`:

### Current Code (lines 315-335)
```bash
if command -v fd > /dev/null 2>&1; then
    local fd_args=(
        "--absolute-path"
        "--hidden"
        "--no-ignore"
        "--type" "d"
        "--min-depth" "$min_depth"
        "--max-depth" "$max_depth"
        "--threads" "4"
        "--exclude" ".git"
        "--exclude" "Library"
        "--exclude" ".Trash"
        "--exclude" "Applications"
    )
    for target in "${PURGE_TARGETS[@]}"; do
        fd_args+=("-g" "$target")
    done
    fd "${fd_args[@]}" . "$search_path" 2> /dev/null | while IFS= read -r item; do
```

### Fixed Code
```bash
if command -v fd > /dev/null 2>&1; then
    local pattern="($(
        IFS='|'
        echo "${PURGE_TARGETS[*]}"
    ))"
    local fd_args=(
        "--absolute-path"
        "--hidden"
        "--no-ignore"
        "--type" "d"
        "--min-depth" "$min_depth"
        "--max-depth" "$max_depth"
        "--threads" "4"
        "--exclude" ".git"
        "--exclude" "Library"
        "--exclude" ".Trash"
        "--exclude" "Applications"
    )
    fd "${fd_args[@]}" "$pattern" "$search_path" 2> /dev/null | while IFS= read -r item; do
```

This approach:
1. Builds a single regex pattern like `(target|build|dist|node_modules|...)`
2. Passes it directly to `fd` without the `-g` flag (fd uses regex by default)
3. Works correctly with all purge targets in one pass

## System Information

- **OS:** macOS 26.0.1 (25A362)
- **Architecture:** arm64
- **Shell:** zsh
- **fd version:** fd 10.2.0 installed via homebrew at `/opt/homebrew/bin/fd`
