### PR TITLE
fix(ui): improve arrow key responsiveness in menu

### DIFF
--- a/lib/ui/menu_paginated.sh
+++ b/lib/ui/menu_paginated.sh
@@ -628,9 +628,6 @@ paginated_multi_select() {
                     printf "\033[%d;1H" "$((items_per_page + 4))" >&2
 
                     prev_cursor_pos=$cursor_pos
-
-                    # Drain pending input for smoother fast scrolling
-                    drain_pending_input
                     continue # Skip full redraw
                 elif [[ $top_index -gt 0 ]]; then
                     ((top_index--))
@@ -669,9 +666,6 @@ paginated_multi_select() {
                             printf "\033[%d;1H" "$((items_per_page + 4))" >&2
 
                             prev_cursor_pos=$cursor_pos
-
-                            # Drain pending input for smoother fast scrolling
-                            drain_pending_input
                             continue # Skip full redraw
                         elif [[ $((top_index + visible_count)) -lt ${#view_indices[@]} ]]; then
                             ((top_index++))


### PR DESCRIPTION
## Summary
- Remove drain_pending_input from UP/DOWN handlers
- Buffered arrow keys now process naturally instead of being discarded
- Fixes slow scrolling and "runaway cursor" when holding arrow keys

## Test plan
- [x] Hold down arrow in app list - scrolling is now smooth
- [x] Release key - cursor stops immediately