### PR TITLE
chore: Skip tests that require timeout

### DIFF
--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -137,6 +137,10 @@ setup() {
 }
 
 @test "clean_project_caches handles timeout gracefully" {
+    if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+        skip "gtimeout/timeout not available"
+    fi
+
     mkdir -p "$HOME/test-project/.next"
 
     function find() {
@@ -145,7 +149,10 @@ setup() {
     }
     export -f find
 
-    run timeout 15 bash -c "
+    timeout_cmd="timeout"
+    command -v timeout >/dev/null 2>&1 || timeout_cmd="gtimeout"
+
+    run $timeout_cmd 15 bash -c "
         source '$PROJECT_ROOT/lib/core/common.sh'
         source '$PROJECT_ROOT/lib/clean/caches.sh'
         clean_project_caches

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -483,14 +483,21 @@ EOF
 }
 
 @test "clean_project_artifacts: scans and finds artifacts" {
+    if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+        skip "gtimeout/timeout not available"
+    fi
+
     mkdir -p "$HOME/www/test-project/node_modules/package1"
     echo "test data" > "$HOME/www/test-project/node_modules/package1/index.js"
 
     mkdir -p "$HOME/www/test-project"
 
+    timeout_cmd="timeout"
+    command -v timeout >/dev/null 2>&1 || timeout_cmd="gtimeout"
+
     run bash -c "
         export HOME='$HOME'
-        timeout 5 '$PROJECT_ROOT/bin/purge.sh' 2>&1 < /dev/null || true
+        $timeout_cmd 5 '$PROJECT_ROOT/bin/purge.sh' 2>&1 < /dev/null || true
     "
 
     [[ "$output" =~ "Scanning" ]] ||
@@ -511,17 +518,31 @@ EOF
 }
 
 @test "mo purge: accepts --debug flag" {
+    if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+        skip "gtimeout/timeout not available"
+    fi
+
+    timeout_cmd="timeout"
+    command -v timeout >/dev/null 2>&1 || timeout_cmd="gtimeout"
+
     run bash -c "
         export HOME='$HOME'
-        timeout 2 '$PROJECT_ROOT/mole' purge --debug < /dev/null 2>&1 || true
+        $timeout_cmd 2 '$PROJECT_ROOT/mole' purge --debug < /dev/null 2>&1 || true
     "
     true
 }
 
 @test "mo purge: creates cache directory for stats" {
+    if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+        skip "gtimeout/timeout not available"
+    fi
+
+    timeout_cmd="timeout"
+    command -v timeout >/dev/null 2>&1 || timeout_cmd="gtimeout"
+
     bash -c "
         export HOME='$HOME'
-        timeout 2 '$PROJECT_ROOT/mole' purge < /dev/null 2>&1 || true
+        $timeout_cmd 2 '$PROJECT_ROOT/mole' purge < /dev/null 2>&1 || true
     "
 
     [ -d "$HOME/.cache/mole" ] || [ -d "${XDG_CACHE_HOME:-$HOME/.cache}/mole" ]

--- a/tests/regression.bats
+++ b/tests/regression.bats
@@ -81,8 +81,15 @@ setup() {
 }
 
 @test "network timeout prevents hanging (simulated)" {
+    if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+        skip "gtimeout/timeout not available"
+    fi
+
+    timeout_cmd="timeout"
+    command -v timeout >/dev/null 2>&1 || timeout_cmd="gtimeout"
+
     # shellcheck disable=SC2016
-    result=$(timeout 5 bash -c '
+    result=$($timeout_cmd 5 bash -c '
         result=$(curl -fsSL --connect-timeout 1 --max-time 2 "http://192.0.2.1:12345/test" 2>/dev/null || echo "failed")
         if [[ "$result" == "failed" ]]; then
             echo "timeout_works"


### PR DESCRIPTION
Skip tests that require timeout/gtimeout if the machine does not have timeout/gtimeout.

I am reusing the pattern from core_timeouts.bats test `run_with_timeout`.