### PR TITLE
feat(purge): Additional python purge targets

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -18,6 +18,11 @@ readonly PURGE_TARGETS=(
     "dist"          # JS builds
     "venv"          # Python
     ".venv"         # Python
+    ".pytest_cache" # Python (pytest)
+    ".mypy_cache"   # Python (mypy)
+    ".tox"          # Python (tox virtualenvs)
+    ".nox"          # Python (nox virtualenvs)
+    ".ruff_cache"   # Python (ruff)
     ".gradle"       # Gradle local
     "__pycache__"   # Python
     ".next"         # Next.js


### PR DESCRIPTION
Add additional python cache and venv targets



.pytest_cache - Created by pytest to store cache data between test runs. 

.mypy_cache - Created by mypy to cache type analysis results for faster subsequent runs.

.tox - Created by tox for isolated test environments. These are full virtual environments and can get quite large. 

.nox - Similar to tox
