### PR TITLE
fix: Respect whitelisted subdirectories

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -605,6 +605,13 @@ is_path_whitelisted() {
             [[ "$normalized_target" == $check_pattern ]]; then
             return 0
         fi
+
+        # Check if target is a parent directory of a whitelisted path
+        # e.g., if pattern is /path/to/dir/subdir and target is /path/to/dir,
+        # the target should be protected to preserve its whitelisted children
+        if [[ "$check_pattern" == "$normalized_target"/* ]]; then
+            return 0
+        fi
     done
 
     return 1

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -66,7 +66,7 @@ declare -a DEFAULT_WHITELIST_PATTERNS=(
     "$HOME/.ollama/models/*"
     "$HOME/Library/Caches/com.nssurge.surge-mac/*"
     "$HOME/Library/Application Support/com.nssurge.surge-mac/*"
-    "$HOME/Library/Caches/org.R-project.R/R/renv/*"
+    "$HOME/Library/Caches/org.R-project.R/R/renv"
     "$HOME/Library/Caches/pypoetry/virtualenvs*"
     "$HOME/Library/Caches/JetBrains*"
     "$HOME/Library/Caches/com.jetbrains.toolbox*"

--- a/tests/manage_whitelist.bats
+++ b/tests/manage_whitelist.bats
@@ -114,3 +114,18 @@ setup() {
     run grep -q "\\.m2/repository" "$whitelist_file"
     [ "$status" -eq 1 ]
 }
+
+@test "is_path_whitelisted protects parent directories of whitelisted nested paths" {
+    local status
+    if HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/base.sh'
+        source '$PROJECT_ROOT/lib/core/app_protection.sh'
+        WHITELIST_PATTERNS=(\"\$HOME/Library/Caches/org.R-project.R/R/renv\")
+        is_path_whitelisted \"\$HOME/Library/Caches/org.R-project.R\"
+    "; then
+        status=0
+    else
+        status=$?
+    fi
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
See issue and comments on https://github.com/tw93/Mole/issues/243

Changes:
+ Do not delete a directory if a subdirectory is whitelisted
+ Protect `org.R-project.R/R/renv` rather than just it's subdirectories