### PR TITLE
Fix inexistent command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ mo optimize                  # Refresh caches & services
 mo analyze                   # Visual disk explorer
 mo status                    # Live system health dashboard
 mo purge                     # Clean project build artifacts
-mo installer                 # Find and remove installer files
 
 mo touchid                   # Configure Touch ID for sudo
 mo completion                # Setup shell tab completion
@@ -225,23 +224,6 @@ Run `mo purge --paths` to configure which directories to scan, or edit `~/.confi
 When custom paths are configured, only those directories are scanned. Otherwise, defaults to `~/Projects`, `~/GitHub`, `~/dev`, etc.
 
 </details>
-
-### Installer Cleanup
-
-Find and remove large installer files scattered across Downloads, Desktop, Homebrew caches, iCloud, and Mail. Each file is labeled by source to help you know where the space is hiding.
-
-```bash
-mo installer
-
-Select Installers to Remove - 3.8GB (5 selected)
-
-➤ ● Photoshop_2024.dmg     1.2GB | Downloads
-  ● IntelliJ_IDEA.dmg       850.6MB | Downloads
-  ● Illustrator_Setup.pkg   920.4MB | Downloads
-  ● PyCharm_Pro.dmg         640.5MB | Homebrew
-  ● Acrobat_Reader.dmg      220.4MB | Downloads
-  ○ AppCode_Legacy.zip      410.6MB | Downloads
-```
 
 ## Quick Launchers
 


### PR DESCRIPTION
Hey,

If I am not mistaken mo installer doesn't exist. At least for me. Therefore I updated README.

What `mo --help` outputs for me is as follows:

```bash
❯ mo --help
 __  __       _
|  \/  | ___ | | ___
| |\/| |/ _ \| |/ _ \
| |  | | (_) | |  __/  https://github.com/tw93/mole
|_|  |_|\___/|_|\___|  Deep clean and optimize your Mac.


COMMANDS
  mo                           Main menu
  mo clean                     Free up disk space
  mo uninstall                 Remove apps completely
  mo optimize                  Check and maintain system
  mo analyze                   Explore disk usage
  mo status                    Monitor system health
  mo purge                     Remove old project artifacts
  mo touchid                   Configure Touch ID for sudo
  mo completion                Setup shell tab completion
  mo update                    Update to latest version
  mo remove                    Remove Mole from system
  mo --help                    Show help
  mo --version                 Show version

  mo clean --dry-run           Preview cleanup
  mo clean --whitelist         Manage protected caches
  mo optimize --dry-run        Preview optimization
  mo optimize --whitelist      Manage protected items
  mo purge --paths             Configure scan directories

OPTIONS
  --debug
```