### PR TITLE
fix: Use single quotes in trap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,7 +100,7 @@ resolve_source_dir() {
 
     local tmp
     tmp="$(mktemp -d)"
-    trap "stop_line_spinner 2>/dev/null; rm -rf '$tmp'" EXIT
+    trap 'stop_line_spinner 2>/dev/null; rm -rf "$tmp"' EXIT
 
     local branch="${MOLE_VERSION:-}"
     if [[ -z "$branch" ]]; then


### PR DESCRIPTION
Use single quotes, otherwise this expands now rather than when signalled.

This ultimately doesn't matter in the current implementation, but convention is to use single quotes to avoid unintended bugs.