### PR TITLE
chore: Always escape filepaths with --

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -238,7 +238,7 @@ get_cleanup_path_size_kb() {
     if [[ -f "$path" && ! -L "$path" ]]; then
         if command -v stat > /dev/null 2>&1; then
             local bytes
-            bytes=$(stat -f%z "$path" 2> /dev/null || echo "0")
+            bytes=$(stat -f%z -- "$path" 2> /dev/null || echo "0")
             if [[ "$bytes" =~ ^[0-9]+$ && "$bytes" -gt 0 ]]; then
                 echo $(((bytes + 1023) / 1024))
                 return 0
@@ -249,7 +249,7 @@ get_cleanup_path_size_kb() {
     if [[ -L "$path" ]]; then
         if command -v stat > /dev/null 2>&1; then
             local bytes
-            bytes=$(stat -f%z "$path" 2> /dev/null || echo "0")
+            bytes=$(stat -f%z -- "$path" 2> /dev/null || echo "0")
             if [[ "$bytes" =~ ^[0-9]+$ && "$bytes" -gt 0 ]]; then
                 echo $(((bytes + 1023) / 1024))
             else
@@ -470,7 +470,7 @@ safe_clean() {
                         else
                             echo "0 0" > "$tmp_file"
                         fi
-                        mv "$tmp_file" "$temp_dir/result_${idx}" 2> /dev/null || true
+                        mv -- "$tmp_file" "$temp_dir/result_${idx}" 2> /dev/null || true
                     ) &
                     pids+=($!)
                     ((idx++))
@@ -509,7 +509,7 @@ safe_clean() {
                     local removed=0
                     if [[ "$DRY_RUN" != "true" ]]; then
                         if [[ -L "$path" ]]; then
-                            rm "$path" 2> /dev/null && removed=1
+                            rm -- "$path" 2> /dev/null && removed=1
                         else
                             if safe_remove "$path" true; then
                                 removed=1
@@ -546,7 +546,7 @@ safe_clean() {
                 local removed=0
                 if [[ "$DRY_RUN" != "true" ]]; then
                     if [[ -L "$path" ]]; then
-                        rm "$path" 2> /dev/null && removed=1
+                        rm -- "$path" 2> /dev/null && removed=1
                     else
                         if safe_remove "$path" true; then
                             removed=1
@@ -651,7 +651,7 @@ safe_clean() {
                     fi
                 done
 
-                rm -f "$paths_temp"
+                rm -f -- "$paths_temp"
             fi
         else
             echo -e "  ${GREEN}${ICON_SUCCESS}${NC} $label ${GREEN}($size_human)${NC}"

--- a/bin/completion.sh
+++ b/bin/completion.sh
@@ -74,12 +74,12 @@ if [[ $# -eq 0 ]]; then
     if [[ -z "$completion_name" ]]; then
         if [[ -f "$config_file" ]] && grep -Eq "(^# Mole shell completion$|(mole|mo)[[:space:]]+completion)" "$config_file" 2> /dev/null; then
             original_mode=""
-            original_mode="$(stat -f '%Mp%Lp' "$config_file" 2> /dev/null || true)"
+            original_mode="$(stat -f '%Mp%Lp' -- "$config_file" 2> /dev/null || true)"
             temp_file="$(mktemp)"
             grep -Ev "(^# Mole shell completion$|(mole|mo)[[:space:]]+completion)" "$config_file" > "$temp_file" || true
-            mv "$temp_file" "$config_file"
+            mv -- "$temp_file" "$config_file"
             if [[ -n "$original_mode" ]]; then
-                chmod "$original_mode" "$config_file" 2> /dev/null || true
+                chmod -- "$original_mode" "$config_file" 2> /dev/null || true
             fi
             echo -e "${GREEN}${ICON_SUCCESS}${NC} Removed stale completion entries from $config_file"
             echo ""
@@ -91,12 +91,12 @@ if [[ $# -eq 0 ]]; then
     # Check if already installed and normalize to latest line
     if [[ -f "$config_file" ]] && grep -Eq "(mole|mo)[[:space:]]+completion" "$config_file" 2> /dev/null; then
         original_mode=""
-        original_mode="$(stat -f '%Mp%Lp' "$config_file" 2> /dev/null || true)"
+        original_mode="$(stat -f '%Mp%Lp' -- "$config_file" 2> /dev/null || true)"
         temp_file="$(mktemp)"
         grep -Ev "(^# Mole shell completion$|(mole|mo)[[:space:]]+completion)" "$config_file" > "$temp_file" || true
-        mv "$temp_file" "$config_file"
+        mv -- "$temp_file" "$config_file"
         if [[ -n "$original_mode" ]]; then
-            chmod "$original_mode" "$config_file" 2> /dev/null || true
+            chmod -- "$original_mode" "$config_file" 2> /dev/null || true
         fi
         {
             echo ""
@@ -134,18 +134,18 @@ if [[ $# -eq 0 ]]; then
     # Create config file if it doesn't exist
     if [[ ! -f "$config_file" ]]; then
         mkdir -p "$(dirname "$config_file")"
-        touch "$config_file"
+        touch -- "$config_file"
     fi
 
     # Remove previous Mole completion lines to avoid duplicates
     if [[ -f "$config_file" ]]; then
         original_mode=""
-        original_mode="$(stat -f '%Mp%Lp' "$config_file" 2> /dev/null || true)"
+        original_mode="$(stat -f '%Mp%Lp' -- "$config_file" 2> /dev/null || true)"
         temp_file="$(mktemp)"
         grep -Ev "(^# Mole shell completion$|(mole|mo)[[:space:]]+completion)" "$config_file" > "$temp_file" || true
-        mv "$temp_file" "$config_file"
+        mv -- "$temp_file" "$config_file"
         if [[ -n "$original_mode" ]]; then
-            chmod "$original_mode" "$config_file" 2> /dev/null || true
+            chmod -- "$original_mode" "$config_file" 2> /dev/null || true
         fi
     fi
 

--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -84,13 +84,13 @@ perform_purge() {
 
     if [[ -f "$stats_dir/purge_stats" ]]; then
         total_size_cleaned=$(cat "$stats_dir/purge_stats" 2> /dev/null || echo "0")
-        rm -f "$stats_dir/purge_stats"
+        rm -f -- "$stats_dir/purge_stats"
     fi
 
     # Read count
     if [[ -f "$stats_dir/purge_count" ]]; then
         total_items_cleaned=$(cat "$stats_dir/purge_count" 2> /dev/null || echo "0")
-        rm -f "$stats_dir/purge_count"
+        rm -f -- "$stats_dir/purge_count"
     fi
 
     if [[ $total_size_cleaned -gt 0 ]]; then

--- a/bin/touchid.sh
+++ b/bin/touchid.sh
@@ -61,7 +61,7 @@ show_status() {
 enable_touchid() {
     # Cleanup trap
     local temp_file=""
-    trap '[[ -n "${temp_file:-}" ]] && rm -f "${temp_file:-}"' EXIT
+    trap '[[ -n "${temp_file:-}" ]] && rm -f -- "${temp_file:-}"' EXIT
 
     # First check if system supports Touch ID
     if ! supports_touchid; then
@@ -82,7 +82,7 @@ enable_touchid() {
 
     # Create backup only if it doesn't exist to preserve original state
     if [[ ! -f "${PAM_SUDO_FILE}.mole-backup" ]]; then
-        if ! sudo cp "$PAM_SUDO_FILE" "${PAM_SUDO_FILE}.mole-backup" 2> /dev/null; then
+        if ! sudo cp -- "$PAM_SUDO_FILE" "${PAM_SUDO_FILE}.mole-backup" 2> /dev/null; then
             log_error "Failed to create backup"
             return 1
         fi
@@ -109,7 +109,7 @@ enable_touchid() {
     fi
 
     # Apply the changes
-    if sudo mv "$temp_file" "$PAM_SUDO_FILE" 2> /dev/null; then
+    if sudo mv -- "$temp_file" "$PAM_SUDO_FILE" 2> /dev/null; then
         log_success "Touch ID enabled - try: sudo ls"
         return 0
     else
@@ -122,7 +122,7 @@ enable_touchid() {
 disable_touchid() {
     # Cleanup trap
     local temp_file=""
-    trap '[[ -n "${temp_file:-}" ]] && rm -f "${temp_file:-}"' EXIT
+    trap '[[ -n "${temp_file:-}" ]] && rm -f -- "${temp_file:-}"' EXIT
 
     if ! is_touchid_configured; then
         echo -e "${YELLOW}Touch ID is not currently enabled${NC}"
@@ -131,7 +131,7 @@ disable_touchid() {
 
     # Create backup only if it doesn't exist
     if [[ ! -f "${PAM_SUDO_FILE}.mole-backup" ]]; then
-        if ! sudo cp "$PAM_SUDO_FILE" "${PAM_SUDO_FILE}.mole-backup" 2> /dev/null; then
+        if ! sudo cp -- "$PAM_SUDO_FILE" "${PAM_SUDO_FILE}.mole-backup" 2> /dev/null; then
             log_error "Failed to create backup"
             return 1
         fi
@@ -141,7 +141,7 @@ disable_touchid() {
     temp_file=$(mktemp)
     grep -v "pam_tid.so" "$PAM_SUDO_FILE" > "$temp_file"
 
-    if sudo mv "$temp_file" "$PAM_SUDO_FILE" 2> /dev/null; then
+    if sudo mv -- "$temp_file" "$PAM_SUDO_FILE" 2> /dev/null; then
         echo -e "${GREEN}${ICON_SUCCESS} Touch ID disabled${NC}"
         echo ""
         return 0

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -274,11 +274,11 @@ scan_applications() {
     else
         echo -ne "\r\033[K" >&2
     fi
-    rm -f "$progress_file"
+    rm -f -- "$progress_file"
 
     if [[ ! -s "$temp_file" ]]; then
         echo "No applications found to uninstall" >&2
-        rm -f "$temp_file"
+        rm -f -- "$temp_file"
         return 1
     fi
 
@@ -291,10 +291,10 @@ scan_applications() {
     fi
 
     sort -t'|' -k1,1n "$temp_file" > "${temp_file}.sorted" || {
-        rm -f "$temp_file"
+        rm -f -- "$temp_file"
         return 1
     }
-    rm -f "$temp_file"
+    rm -f -- "$temp_file"
 
     if [[ $total_apps -gt 50 ]]; then
         if [[ $inline_loading == true ]]; then
@@ -305,7 +305,7 @@ scan_applications() {
     fi
 
     ensure_user_file "$cache_file"
-    cp "${temp_file}.sorted" "$cache_file" 2> /dev/null || true
+    cp -- "${temp_file}.sorted" "$cache_file" 2> /dev/null || true
 
     if [[ -f "${temp_file}.sorted" ]]; then
         echo "${temp_file}.sorted"
@@ -430,7 +430,7 @@ main() {
                 unset MOLE_ALT_SCREEN_ACTIVE
                 unset MOLE_INLINE_LOADING MOLE_MANAGED_ALT_SCREEN
             fi
-            rm -f "$apps_file"
+            rm -f -- "$apps_file"
             return 1
         fi
 
@@ -448,7 +448,7 @@ main() {
             show_cursor
             clear_screen
             printf '\033[2J\033[H' >&2
-            rm -f "$apps_file"
+            rm -f -- "$apps_file"
 
             if [[ $exit_code -eq 10 ]]; then
                 force_rescan=true
@@ -470,7 +470,7 @@ main() {
         local selection_count=${#selected_apps[@]}
         if [[ $selection_count -eq 0 ]]; then
             echo "No apps selected"
-            rm -f "$apps_file"
+            rm -f -- "$apps_file"
             continue
         fi
         echo -e "${BLUE}${ICON_CONFIRM}${NC} Selected ${selection_count} app(s):"
@@ -548,7 +548,7 @@ main() {
 
         batch_uninstall_applications
 
-        rm -f "$apps_file"
+        rm -f -- "$apps_file"
 
         echo -e "${GRAY}Press Enter to return to application list, any other key to exit...${NC}"
         local key

--- a/bin/uninstall_lib.sh
+++ b/bin/uninstall_lib.sh
@@ -332,12 +332,12 @@ scan_applications() {
     else
         echo -ne "\r\033[K" >&2
     fi
-    rm -f "$progress_file"
+    rm -f -- "$progress_file"
 
     # Check if we found any applications
     if [[ ! -s "$temp_file" ]]; then
         echo "No applications found to uninstall" >&2
-        rm -f "$temp_file"
+        rm -f -- "$temp_file"
         return 1
     fi
 
@@ -352,10 +352,10 @@ scan_applications() {
     fi
 
     sort -t'|' -k1,1n "$temp_file" > "${temp_file}.sorted" || {
-        rm -f "$temp_file"
+        rm -f -- "$temp_file"
         return 1
     }
-    rm -f "$temp_file"
+    rm -f -- "$temp_file"
 
     # Clear processing message
     if [[ $total_apps -gt 50 ]]; then
@@ -368,7 +368,7 @@ scan_applications() {
 
     # Save to cache (simplified - no metadata)
     ensure_user_file "$cache_file"
-    cp "${temp_file}.sorted" "$cache_file" 2> /dev/null || true
+    cp -- "${temp_file}.sorted" "$cache_file" 2> /dev/null || true
 
     # Return sorted file
     if [[ -f "${temp_file}.sorted" ]]; then
@@ -514,7 +514,7 @@ main() {
                 unset MOLE_ALT_SCREEN_ACTIVE
                 unset MOLE_INLINE_LOADING MOLE_MANAGED_ALT_SCREEN
             fi
-            rm -f "$apps_file"
+            rm -f -- "$apps_file"
             return 1
         fi
 
@@ -533,7 +533,7 @@ main() {
             show_cursor
             clear_screen
             printf '\033[2J\033[H' >&2 # Also clear stderr
-            rm -f "$apps_file"
+            rm -f -- "$apps_file"
 
             # Handle Refresh (code 10)
             if [[ $exit_code -eq 10 ]]; then
@@ -559,7 +559,7 @@ main() {
         local selection_count=${#selected_apps[@]}
         if [[ $selection_count -eq 0 ]]; then
             echo "No apps selected"
-            rm -f "$apps_file"
+            rm -f -- "$apps_file"
             # Loop back or exit? If select_apps_for_uninstall returns 0 but empty selection,
             # it technically shouldn't happen based on that function's logic.
             continue
@@ -640,7 +640,7 @@ main() {
         batch_uninstall_applications
 
         # Cleanup current apps file
-        rm -f "$apps_file"
+        rm -f -- "$apps_file"
 
         # Pause before looping back
         echo -e "${GRAY}Press Enter to return to application list, ESC to exit...${NC}"

--- a/install.sh
+++ b/install.sh
@@ -404,7 +404,7 @@ build_binary_from_source() {
 
     if (cd "$SOURCE_DIR" && go build -ldflags="-s -w" -o "$target_path" "./$cmd_dir" > /dev/null 2>&1); then
         if [[ -t 1 ]]; then stop_line_spinner; fi
-        chmod +x "$target_path"
+        chmod +x -- "$target_path"
         log_success "Built ${binary_name} from source"
         return 0
     fi
@@ -425,13 +425,13 @@ download_binary() {
     fi
 
     if [[ -f "$SOURCE_DIR/bin/${binary_name}-go" ]]; then
-        cp "$SOURCE_DIR/bin/${binary_name}-go" "$target_path"
-        chmod +x "$target_path"
+        cp -- "$SOURCE_DIR/bin/${binary_name}-go" "$target_path"
+        chmod +x -- "$target_path"
         log_success "Installed local ${binary_name} binary"
         return 0
     elif [[ -f "$SOURCE_DIR/bin/${binary_name}-darwin-${arch_suffix}" ]]; then
-        cp "$SOURCE_DIR/bin/${binary_name}-darwin-${arch_suffix}" "$target_path"
-        chmod +x "$target_path"
+        cp -- "$SOURCE_DIR/bin/${binary_name}-darwin-${arch_suffix}" "$target_path"
+        chmod +x -- "$target_path"
         log_success "Installed local ${binary_name} binary"
         return 0
     fi
@@ -463,7 +463,7 @@ download_binary() {
 
     if curl -fsSL --connect-timeout 10 --max-time 60 -o "$target_path" "$url"; then
         if [[ -t 1 ]]; then stop_line_spinner; fi
-        chmod +x "$target_path"
+        chmod +x -- "$target_path"
         log_success "Downloaded ${binary_name} binary"
     else
         if [[ -t 1 ]]; then stop_line_spinner; fi
@@ -495,9 +495,9 @@ install_files() {
             fi
 
             # Atomic update: copy to temporary name first, then move
-            maybe_sudo cp "$SOURCE_DIR/mole" "$INSTALL_DIR/mole.new"
-            maybe_sudo chmod +x "$INSTALL_DIR/mole.new"
-            maybe_sudo mv -f "$INSTALL_DIR/mole.new" "$INSTALL_DIR/mole"
+            maybe_sudo cp -- "$SOURCE_DIR/mole" "$INSTALL_DIR/mole.new"
+            maybe_sudo chmod +x -- "$INSTALL_DIR/mole.new"
+            maybe_sudo mv -f -- "$INSTALL_DIR/mole.new" "$INSTALL_DIR/mole"
 
             log_success "Installed mole to $INSTALL_DIR"
         fi
@@ -510,9 +510,9 @@ install_files() {
         if [[ "$source_dir_abs" == "$install_dir_abs" ]]; then
             log_success "mo alias already present"
         else
-            maybe_sudo cp "$SOURCE_DIR/mo" "$INSTALL_DIR/mo.new"
-            maybe_sudo chmod +x "$INSTALL_DIR/mo.new"
-            maybe_sudo mv -f "$INSTALL_DIR/mo.new" "$INSTALL_DIR/mo"
+            maybe_sudo cp -- "$SOURCE_DIR/mo" "$INSTALL_DIR/mo.new"
+            maybe_sudo chmod +x -- "$INSTALL_DIR/mo.new"
+            maybe_sudo mv -f -- "$INSTALL_DIR/mo.new" "$INSTALL_DIR/mo"
             log_success "Installed mo alias"
         fi
     fi
@@ -525,9 +525,9 @@ install_files() {
         else
             local -a bin_files=("$SOURCE_DIR/bin"/*)
             if [[ ${#bin_files[@]} -gt 0 ]]; then
-                cp -r "${bin_files[@]}" "$CONFIG_DIR/bin/"
+                cp -r -- "${bin_files[@]}" "$CONFIG_DIR/bin/"
                 for file in "$CONFIG_DIR/bin/"*; do
-                    [[ -e "$file" ]] && chmod +x "$file"
+                    [[ -e "$file" ]] && chmod +x -- "$file"
                 done
                 log_success "Installed modules"
             fi
@@ -542,7 +542,7 @@ install_files() {
         else
             local -a lib_files=("$SOURCE_DIR/lib"/*)
             if [[ ${#lib_files[@]} -gt 0 ]]; then
-                cp -r "${lib_files[@]}" "$CONFIG_DIR/lib/"
+                cp -r -- "${lib_files[@]}" "$CONFIG_DIR/lib/"
                 log_success "Installed libraries"
             fi
         fi
@@ -551,13 +551,13 @@ install_files() {
     if [[ "$config_dir_abs" != "$source_dir_abs" ]]; then
         for file in README.md LICENSE install.sh; do
             if [[ -f "$SOURCE_DIR/$file" ]]; then
-                cp -f "$SOURCE_DIR/$file" "$CONFIG_DIR/"
+                cp -f -- "$SOURCE_DIR/$file" "$CONFIG_DIR/"
             fi
         done
     fi
 
     if [[ -f "$CONFIG_DIR/install.sh" ]]; then
-        chmod +x "$CONFIG_DIR/install.sh"
+        chmod +x -- "$CONFIG_DIR/install.sh"
     fi
 
     if [[ "$source_dir_abs" != "$install_dir_abs" ]]; then

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -134,7 +134,7 @@ scan_installed_apps() {
     safe_remove "$scan_tmp_dir" true
     sort -u "$installed_bundles" -o "$installed_bundles"
     ensure_user_dir "$(dirname "$cache_file")"
-    cp "$installed_bundles" "$cache_file" 2> /dev/null || true
+    cp -- "$installed_bundles" "$cache_file" 2> /dev/null || true
     local app_count=$(wc -l < "$installed_bundles" 2> /dev/null | tr -d ' ')
     debug_log "Scanned $app_count unique applications"
 }
@@ -170,7 +170,7 @@ is_bundle_orphaned() {
 }
 # Orphaned app data sweep.
 clean_orphaned_app_data() {
-    if ! ls "$HOME/Library/Caches" > /dev/null 2>&1; then
+    if ! ls -- "$HOME/Library/Caches" > /dev/null 2>&1; then
         stop_section_spinner
         echo -e "  ${YELLOW}${ICON_WARNING}${NC} Skipped: No permission to access Library folders"
         return 0
@@ -199,7 +199,7 @@ clean_orphaned_app_data() {
         if [[ ! -d "$base_path" ]]; then
             continue
         fi
-        if ! ls "$base_path" > /dev/null 2>&1; then
+        if ! ls -- "$base_path" > /dev/null 2>&1; then
             continue
         fi
         local -a file_patterns=()

--- a/lib/clean/brew.sh
+++ b/lib/clean/brew.sh
@@ -29,7 +29,7 @@ clean_homebrew() {
     local skip_cleanup=false
     local brew_cache_size=0
     if [[ -d ~/Library/Caches/Homebrew ]]; then
-        brew_cache_size=$(run_with_timeout 3 du -sk ~/Library/Caches/Homebrew 2> /dev/null | awk '{print $1}')
+        brew_cache_size=$(run_with_timeout 3 du -sk -- ~/Library/Caches/Homebrew 2> /dev/null | awk '{print $1}')
         local du_exit=$?
         if [[ $du_exit -eq 0 && -n "$brew_cache_size" && "$brew_cache_size" -lt 51200 ]]; then
             skip_cleanup=true

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -15,7 +15,7 @@ check_tcc_permissions() {
     )
     # Quick permission probe (avoid deep scans).
     local needs_permission_check=false
-    if ! ls "$HOME/Library/Caches" > /dev/null 2>&1; then
+    if ! ls -- "$HOME/Library/Caches" > /dev/null 2>&1; then
         needs_permission_check=true
     fi
     if [[ "$needs_permission_check" == "true" ]]; then

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -442,7 +442,7 @@ is_recently_modified() {
 get_dir_size_kb() {
     local path="$1"
     if [[ -d "$path" ]]; then
-        du -sk "$path" 2> /dev/null | awk '{print $1}' || echo "0"
+        du -sk -- "$path" 2> /dev/null | awk '{print $1}' || echo "0"
     else
         echo "0"
     fi

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -26,7 +26,7 @@ clean_empty_library_items() {
     local -a empty_dirs=()
     while IFS= read -r -d '' dir; do
         [[ -d "$dir" ]] && empty_dirs+=("$dir")
-    done < <(find "$HOME/Library" -mindepth 1 -maxdepth 1 -type d -empty -print0 2> /dev/null)
+    done < <(find -- "$HOME/Library" -mindepth 1 -maxdepth 1 -type d -empty -print0 2> /dev/null)
 
     if [[ ${#empty_dirs[@]} -gt 0 ]]; then
         safe_clean "${empty_dirs[@]}" "Empty Library folders"
@@ -60,7 +60,7 @@ clean_empty_library_items() {
                     continue
                 fi
                 [[ -d "$dir" ]] && nested_empty_dirs+=("$dir")
-            done < <(find "$location" -mindepth 1 -type d -empty -print0 2> /dev/null)
+            done < <(find -- "$location" -mindepth 1 -type d -empty -print0 2> /dev/null)
 
             # If no empty dirs found, we're done with this location
             if [[ ${#nested_empty_dirs[@]} -eq 0 ]]; then
@@ -104,7 +104,7 @@ clean_chrome_old_versions() {
         [[ -L "$current_link" ]] || continue
 
         local current_version
-        current_version=$(readlink "$current_link" 2> /dev/null || true)
+        current_version=$(readlink -- "$current_link" 2> /dev/null || true)
         current_version="${current_version##*/}"
         [[ -n "$current_version" ]] || continue
 
@@ -184,7 +184,7 @@ clean_edge_old_versions() {
         [[ -L "$current_link" ]] || continue
 
         local current_version
-        current_version=$(readlink "$current_link" 2> /dev/null || true)
+        current_version=$(readlink -- "$current_link" 2> /dev/null || true)
         current_version="${current_version##*/}"
         [[ -n "$current_version" ]] || continue
 
@@ -340,7 +340,7 @@ scan_external_volumes() {
         if [[ -d "$volume_trash" && "$DRY_RUN" != "true" ]] && ! is_path_whitelisted "$volume_trash"; then
             while IFS= read -r -d '' item; do
                 safe_remove "$item" true || true
-            done < <(command find "$volume_trash" -mindepth 1 -maxdepth 1 -print0 2> /dev/null || true)
+            done < <(command find -- "$volume_trash" -mindepth 1 -maxdepth 1 -print0 2> /dev/null || true)
         fi
         if [[ "$PROTECT_FINDER_METADATA" != "true" ]]; then
             clean_ds_store_tree "$volume" "$(basename "$volume") volume (.DS_Store)"
@@ -433,7 +433,7 @@ clean_mail_downloads() {
                         ((cleaned_kb += file_size_kb))
                     fi
                 fi
-            done < <(command find "$target_path" -type f -mtime +"$mail_age_days" -print0 2> /dev/null || true)
+            done < <(command find -- "$target_path" -type f -mtime +"$mail_age_days" -print0 2> /dev/null || true)
         fi
     done
     if [[ $count -gt 0 ]]; then
@@ -491,7 +491,7 @@ process_container_cache() {
     local cache_dir="$container_dir/Data/Library/Caches"
     [[ -d "$cache_dir" ]] || return 0
     # Fast non-empty check.
-    if find "$cache_dir" -mindepth 1 -maxdepth 1 -print -quit 2> /dev/null | grep -q .; then
+    if find -- "$cache_dir" -mindepth 1 -maxdepth 1 -print -quit 2> /dev/null | grep -q .; then
         local size=$(get_path_size_kb "$cache_dir")
         ((total_size += size))
         found_any=true
@@ -579,7 +579,7 @@ clean_virtualization_tools() {
 # Application Support logs/caches.
 clean_application_support_logs() {
     stop_section_spinner
-    if [[ ! -d "$HOME/Library/Application Support" ]] || ! ls "$HOME/Library/Application Support" > /dev/null 2>&1; then
+    if [[ ! -d "$HOME/Library/Application Support" ]] || ! ls -- "$HOME/Library/Application Support" > /dev/null 2>&1; then
         note_activity
         echo -e "  ${YELLOW}${ICON_WARNING}${NC} Skipped: No permission to access Application Support"
         return 0
@@ -611,7 +611,7 @@ clean_application_support_logs() {
         local -a start_candidates=("$app_dir/log" "$app_dir/logs" "$app_dir/activitylog" "$app_dir/Cache/Cache_Data" "$app_dir/Crashpad/completed")
         for candidate in "${start_candidates[@]}"; do
             if [[ -d "$candidate" ]]; then
-                if find "$candidate" -mindepth 1 -maxdepth 1 -print -quit 2> /dev/null | grep -q .; then
+                if find -- "$candidate" -mindepth 1 -maxdepth 1 -print -quit 2> /dev/null | grep -q .; then
                     local size=$(get_path_size_kb "$candidate")
                     ((total_size += size))
                     ((cleaned_count++))
@@ -635,7 +635,7 @@ clean_application_support_logs() {
         local -a gc_candidates=("$container_path/Logs" "$container_path/Library/Logs")
         for candidate in "${gc_candidates[@]}"; do
             if [[ -d "$candidate" ]]; then
-                if find "$candidate" -mindepth 1 -maxdepth 1 -print -quit 2> /dev/null | grep -q .; then
+                if find -- "$candidate" -mindepth 1 -maxdepth 1 -print -quit 2> /dev/null | grep -q .; then
                     local size=$(get_path_size_kb "$candidate")
                     ((total_size += size))
                     ((cleaned_count++))
@@ -672,7 +672,7 @@ check_ios_device_backups() {
     if [[ -d "$backup_dir" ]]; then
         local backup_kb=$(get_path_size_kb "$backup_dir")
         if [[ -n "${backup_kb:-}" && "$backup_kb" -gt 102400 ]]; then
-            local backup_human=$(command du -sh "$backup_dir" 2> /dev/null | awk '{print $1}')
+            local backup_human=$(command du -sh -- "$backup_dir" 2> /dev/null | awk '{print $1}')
             if [[ -n "$backup_human" ]]; then
                 note_activity
                 echo -e "  Found ${GREEN}${backup_human}${NC} iOS backups"

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -719,13 +719,13 @@ find_app_files() {
         [[ -f ~/Library/Preferences/"$bundle_id".plist ]] && files_to_clean+=("$HOME/Library/Preferences/$bundle_id.plist")
         [[ -d ~/Library/Preferences/ByHost ]] && while IFS= read -r -d '' pref; do
             files_to_clean+=("$pref")
-        done < <(command find ~/Library/Preferences/ByHost -maxdepth 1 \( -name "$bundle_id*.plist" \) -print0 2> /dev/null)
+        done < <(command find -- ~/Library/Preferences/ByHost -maxdepth 1 \( -name "$bundle_id*.plist" \) -print0 2> /dev/null)
 
         # Group Containers (special handling)
         if [[ -d ~/Library/Group\ Containers ]]; then
             while IFS= read -r -d '' container; do
                 files_to_clean+=("$container")
-            done < <(command find ~/Library/Group\ Containers -maxdepth 1 \( -name "*$bundle_id*" \) -print0 2> /dev/null)
+            done < <(command find -- ~/Library/Group\ Containers -maxdepth 1 \( -name "*$bundle_id*" \) -print0 2> /dev/null)
         fi
     fi
 
@@ -733,7 +733,7 @@ find_app_files() {
     if [[ ${#app_name} -gt 3 ]] && [[ -d ~/Library/LaunchAgents ]]; then
         while IFS= read -r -d '' plist; do
             files_to_clean+=("$plist")
-        done < <(command find ~/Library/LaunchAgents -maxdepth 1 \( -name "*$app_name*.plist" \) -print0 2> /dev/null)
+        done < <(command find -- ~/Library/LaunchAgents -maxdepth 1 \( -name "*$app_name*.plist" \) -print0 2> /dev/null)
     fi
 
     # Handle specialized toolchains and development environments
@@ -749,7 +749,7 @@ find_app_files() {
         for d in ~/AndroidStudioProjects ~/Library/Android ~/.android ~/.gradle; do
             [[ -d "$d" ]] && files_to_clean+=("$d")
         done
-        [[ -d ~/Library/Application\ Support/Google ]] && while IFS= read -r -d '' d; do files_to_clean+=("$d"); done < <(command find ~/Library/Application\ Support/Google -maxdepth 1 -name "AndroidStudio*" -print0 2> /dev/null)
+        [[ -d ~/Library/Application\ Support/Google ]] && while IFS= read -r -d '' d; do files_to_clean+=("$d"); done < <(command find -- ~/Library/Application\ Support/Google -maxdepth 1 -name "AndroidStudio*" -print0 2> /dev/null)
     fi
 
     # 3. Xcode (Apple)
@@ -761,7 +761,7 @@ find_app_files() {
     # 4. JetBrains (IDE settings)
     if [[ "$bundle_id" =~ jetbrains ]] || [[ "$app_name" =~ IntelliJ|PyCharm|WebStorm|GoLand|RubyMine|PhpStorm|CLion|DataGrip|Rider ]]; then
         for base in ~/Library/Application\ Support/JetBrains ~/Library/Caches/JetBrains ~/Library/Logs/JetBrains; do
-            [[ -d "$base" ]] && while IFS= read -r -d '' d; do files_to_clean+=("$d"); done < <(command find "$base" -maxdepth 1 -name "${app_name}*" -print0 2> /dev/null)
+            [[ -d "$base" ]] && while IFS= read -r -d '' d; do files_to_clean+=("$d"); done < <(command find -- "$base" -maxdepth 1 -name "${app_name}*" -print0 2> /dev/null)
         done
     fi
 
@@ -843,7 +843,7 @@ find_app_system_files() {
         for base in /Library/LaunchAgents /Library/LaunchDaemons; do
             [[ -d "$base" ]] && while IFS= read -r -d '' plist; do
                 system_files+=("$plist")
-            done < <(command find "$base" -maxdepth 1 \( -name "*$app_name*.plist" \) -print0 2> /dev/null)
+            done < <(command find -- "$base" -maxdepth 1 \( -name "*$app_name*.plist" \) -print0 2> /dev/null)
         done
     fi
 
@@ -852,11 +852,11 @@ find_app_system_files() {
     if [[ -n "$bundle_id" && "$bundle_id" != "unknown" && ${#bundle_id} -gt 3 ]]; then
         [[ -d /Library/PrivilegedHelperTools ]] && while IFS= read -r -d '' helper; do
             system_files+=("$helper")
-        done < <(command find /Library/PrivilegedHelperTools -maxdepth 1 \( -name "$bundle_id*" \) -print0 2> /dev/null)
+        done < <(command find -- /Library/PrivilegedHelperTools -maxdepth 1 \( -name "$bundle_id*" \) -print0 2> /dev/null)
 
         [[ -d /private/var/db/receipts ]] && while IFS= read -r -d '' receipt; do
             system_files+=("$receipt")
-        done < <(command find /private/var/db/receipts -maxdepth 1 \( -name "*$bundle_id*" \) -print0 2> /dev/null)
+        done < <(command find -- /private/var/db/receipts -maxdepth 1 \( -name "*$bundle_id*" \) -print0 2> /dev/null)
     fi
 
     if [[ ${#system_files[@]} -gt 0 ]]; then

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -352,7 +352,7 @@ ensure_user_dir() {
             fi
         fi
 
-        chown "$owner_uid:$owner_gid" "$dir" 2> /dev/null || true
+        chown -- "$owner_uid:$owner_gid" "$dir" 2> /dev/null || true
 
         if [[ "$dir" == "$user_home" ]]; then
             break
@@ -376,7 +376,7 @@ ensure_user_file() {
     fi
 
     ensure_user_dir "$(dirname "$target_path")"
-    touch "$target_path" 2> /dev/null || true
+    touch -- "$target_path" 2> /dev/null || true
 
     if ! is_root_user; then
         return 0
@@ -406,7 +406,7 @@ ensure_user_file() {
     fi
 
     if [[ -n "$owner_uid" && -n "$owner_gid" ]]; then
-        chown "$owner_uid:$owner_gid" "$target_path" 2> /dev/null || true
+        chown -- "$owner_uid:$owner_gid" "$target_path" 2> /dev/null || true
     fi
 }
 
@@ -548,13 +548,13 @@ cleanup_temp_files() {
     local file
     if [[ ${#MOLE_TEMP_FILES[@]} -gt 0 ]]; then
         for file in "${MOLE_TEMP_FILES[@]}"; do
-            [[ -f "$file" ]] && rm -f "$file" 2> /dev/null || true
+            [[ -f "$file" ]] && rm -f -- "$file" 2> /dev/null || true
         done
     fi
 
     if [[ ${#MOLE_TEMP_DIRS[@]} -gt 0 ]]; then
         for file in "${MOLE_TEMP_DIRS[@]}"; do
-            [[ -d "$file" ]] && rm -rf "$file" 2> /dev/null || true # SAFE: cleanup_temp_files
+            [[ -d "$file" ]] && rm -rf -- "$file" 2> /dev/null || true # SAFE: cleanup_temp_files
         done
     fi
 

--- a/lib/core/common.sh
+++ b/lib/core/common.sh
@@ -34,7 +34,7 @@ update_via_homebrew() {
     temp_upgrade=$(mktemp_file "brew_upgrade")
 
     # Set up trap for interruption (Ctrl+C) with inline cleanup
-    trap 'stop_inline_spinner 2>/dev/null; rm -f "$temp_update" "$temp_upgrade" 2>/dev/null; echo ""; exit 130' INT TERM
+    trap 'stop_inline_spinner 2>/dev/null; rm -f -- "$temp_update" "$temp_upgrade" 2>/dev/null; echo ""; exit 130' INT TERM
 
     # Update Homebrew
     if [[ -t 1 ]]; then

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -135,7 +135,7 @@ safe_remove() {
     # Use || to capture the exit code so set -e won't abort on rm failures
     local error_msg
     local rm_exit=0
-    error_msg=$(rm -rf "$path" 2>&1) || rm_exit=$? # safe_remove
+    error_msg=$(rm -rf -- "$path" 2>&1) || rm_exit=$? # safe_remove
 
     if [[ $rm_exit -eq 0 ]]; then
         return 0
@@ -211,7 +211,7 @@ safe_sudo_remove() {
     debug_log "Removing (sudo): $path"
 
     # Perform the deletion
-    if sudo rm -rf "$path" 2> /dev/null; then # SAFE: safe_sudo_remove implementation
+    if sudo rm -rf -- "$path" 2> /dev/null; then # SAFE: safe_sudo_remove implementation
         return 0
     else
         log_error "Failed to remove (sudo): $path"
@@ -262,7 +262,7 @@ safe_find_delete() {
             fi
         fi
         safe_remove "$match" true || true
-    done < <(command find "$base_dir" "${find_args[@]}" -print0 2> /dev/null || true)
+    done < <(command find -- "$base_dir" "${find_args[@]}" -print0 2> /dev/null || true)
 
     return 0
 }
@@ -275,12 +275,12 @@ safe_sudo_find_delete() {
     local type_filter="${4:-f}"
 
     # Validate base directory (use sudo for permission-restricted dirs)
-    if ! sudo test -d "$base_dir" 2> /dev/null; then
+    if ! sudo test -d -- "$base_dir" 2> /dev/null; then
         debug_log "Directory does not exist (skipping): $base_dir"
         return 0
     fi
 
-    if sudo test -L "$base_dir" 2> /dev/null; then
+    if sudo test -L -- "$base_dir" 2> /dev/null; then
         log_error "Refusing to search symlinked directory: $base_dir"
         return 1
     fi
@@ -306,7 +306,7 @@ safe_sudo_find_delete() {
             fi
         fi
         safe_sudo_remove "$match" || true
-    done < <(sudo find "$base_dir" "${find_args[@]}" -print0 2> /dev/null || true)
+    done < <(sudo find -- "$base_dir" "${find_args[@]}" -print0 2> /dev/null || true)
 
     return 0
 }
@@ -315,7 +315,6 @@ safe_sudo_find_delete() {
 # Size Calculation
 # ============================================================================
 
-# Get path size in KB (returns 0 if not found)
 get_path_size_kb() {
     local path="$1"
     [[ -z "$path" || ! -e "$path" ]] && {
@@ -326,7 +325,7 @@ get_path_size_kb() {
     # Use || echo 0 to ensure failure in du (e.g. permission error) doesn't exit script under set -e
     # Pipefail would normally cause the pipeline to fail if du fails, but || handle catches it.
     local size
-    size=$(command du -sk "$path" 2> /dev/null | awk 'NR==1 {print $1; exit}' || true)
+    size=$(command du -sk -- "$path" 2> /dev/null | awk 'NR==1 {print $1; exit}' || true)
 
     # Ensure size is a valid number (fix for non-numeric du output)
     if [[ "$size" =~ ^[0-9]+$ ]]; then

--- a/lib/core/log.sh
+++ b/lib/core/log.sh
@@ -40,7 +40,7 @@ rotate_log_once() {
 
     local max_size="$LOG_MAX_SIZE_DEFAULT"
     if [[ -f "$LOG_FILE" ]] && [[ $(get_file_size "$LOG_FILE") -gt "$max_size" ]]; then
-        mv "$LOG_FILE" "${LOG_FILE}.old" 2> /dev/null || true
+        mv -- "$LOG_FILE" "${LOG_FILE}.old" 2> /dev/null || true
         ensure_user_file "$LOG_FILE"
     fi
 }

--- a/lib/core/ui.sh
+++ b/lib/core/ui.sh
@@ -408,7 +408,7 @@ has_full_disk_access() {
         if [[ -e "$test_path" ]]; then
             tested_count=$((tested_count + 1))
             # Try to stat the ACTUAL protected path - this requires FDA
-            if stat "$test_path" > /dev/null 2>&1; then
+            if stat -- "$test_path" > /dev/null 2>&1; then
                 accessible_count=$((accessible_count + 1))
             fi
         fi

--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -35,7 +35,7 @@ run_launchctl_unload() {
 
 needs_permissions_repair() {
     local owner
-    owner=$(stat -f %Su "$HOME" 2> /dev/null || echo "")
+    owner=$(stat -f %Su -- "$HOME" 2> /dev/null || echo "")
     if [[ -n "$owner" && "$owner" != "$USER" ]]; then
         return 0
     fi
@@ -306,7 +306,7 @@ opt_sqlite_vacuum() {
 
             should_protect_path "$db_file" && continue
 
-            if ! file "$db_file" 2> /dev/null | grep -q "SQLite"; then
+            if ! file -- "$db_file" 2> /dev/null | grep -q "SQLite"; then
                 continue
             fi
 
@@ -738,7 +738,7 @@ opt_dock_refresh() {
 
     local dock_plist="$HOME/Library/Preferences/com.apple.dock.plist"
     if [[ -f "$dock_plist" ]]; then
-        touch "$dock_plist" 2> /dev/null || true
+        touch -- "$dock_plist" 2> /dev/null || true
     fi
 
     if [[ "${MOLE_DRY_RUN:-0}" != "1" ]]; then

--- a/lib/ui/menu_paginated.sh
+++ b/lib/ui/menu_paginated.sh
@@ -344,7 +344,7 @@ paginated_multi_select() {
                     view_indices+=("$_id")
                 done < <(LC_ALL=C sort -t $'\t' $sort_key -- "$tmpfile" 2> /dev/null)
 
-                rm -f "$tmpfile"
+                rm -f -- "$tmpfile"
             else
                 # Fallback: no sorting
                 view_indices=("${filtered[@]}")

--- a/scripts/setup-quick-launchers.sh
+++ b/scripts/setup-quick-launchers.sh
@@ -226,7 +226,7 @@ echo "Run this manually:"
 echo "    ${raw_cmd}"
 exit 1
 EOF
-    chmod +x "$target"
+    chmod +x -- "$target"
 }
 
 create_raycast_commands() {


### PR DESCRIPTION
Add -- separator to all file path arguments in shell commands to prevent paths starting with - from being interpreted as command-line options.

While unlikely, filepaths that start with a hyphen (e.g., -backup, --config) could be misinterpreted as command-line flags. This change adds the -- separator before all variable file path arguments across the codebase, which explicitly signals the end of option parsing and treats all subsequent arguments as positional parameters.

This is a defensive change, but may prevent bugs in the future as more user-defined paths are supported (ei. whitelist and purge paths config)

Example
```
# Before
cp "$SOURCE_DIR/mole" "$INSTALL_DIR/mole.new"
chmod +x "$INSTALL_DIR/mole.new"

# After
cp -- "$SOURCE_DIR/mole" "$INSTALL_DIR/mole.new"
chmod +x -- "$INSTALL_DIR/mole.new"
```