### PR TITLE
refactor: replace deprecated `Start` with `Run`

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -148,7 +148,7 @@ func main() {
 	go prefetchOverviewCache(prefetchCtx)
 
 	p := tea.NewProgram(newModel(abs, isOverview), tea.WithAltScreen())
-	if err := p.Start(); err != nil {
+	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "analyzer error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -136,7 +136,7 @@ func animTickWithSpeed(cpuUsage float64) tea.Cmd {
 
 func main() {
 	p := tea.NewProgram(newModel(), tea.WithAltScreen())
-	if err := p.Start(); err != nil {
+	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "system status error: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR replaces deprecated [`Program.Start`](https://pkg.go.dev/github.com/charmbracelet/bubbletea#Program.Start) method with [`Program.Run`](https://pkg.go.dev/github.com/charmbracelet/bubbletea#Program.Run) in main functions.