### PR TITLE
docs: Add Windows alternative section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@
 - **Disk insights**: Visualizes usage, manages large files, **rebuilds caches**, and refreshes system services
 - **Live monitoring**: Real-time stats for CPU, GPU, memory, disk, and network to **diagnose performance issues**
 
+## Platform Support
+
+Mole is designed for **macOS** users. If you're on Windows, check out [**WinMole**](https://github.com/bhadraagada/winmole) - a Windows adaptation that brings similar deep cleaning and optimization capabilities to Windows systems.
+
+**WinMole features:**
+- Deep system cleanup (temp files, caches, logs)
+- Smart app uninstaller with leftover detection
+- System optimization and service refresh
+- Developer artifact cleanup (node_modules, target, etc.)
+- Disk analysis and real-time monitoring tools
+
+Built with PowerShell and Go for native Windows performance.
+
 ## Quick Start
 
 **Install via Homebrew — recommended:**


### PR DESCRIPTION
## Summary

Adds a "Platform Support" section to the README that acknowledges macOS as the primary platform and points Windows users to WinMole, a Windows port inspired by Mole.

## Motivation

Many Windows users discover Mole and attempt to use it, only to realize it's macOS-only. This addition:
- Saves users time by clarifying platform support upfront
- Provides Windows users with a clear alternative
- Increases visibility for the Windows ecosystem adaptation
- Shows the project's impact across platforms

## Changes

- Added "Platform Support" section after Features and before Quick Start
- Brief mention of WinMole with feature highlights
- Link to WinMole repository

## Preview

The new section appears naturally in the document flow and maintains consistency with Mole's documentation style.

---

**Note:** WinMole is a Windows adaptation built with PowerShell and Go, inspired by Mole's approach to system cleanup and optimization. It's an independent project that credits Mole as its inspiration.