### PR TITLE
fix: golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # golangci-lint configuration for Mole
 # https://golangci-lint.run/usage/configuration/
 
-version: 2
+version: "2"
 
 run:
   timeout: 5m
@@ -17,26 +17,27 @@ linters:
     - ineffassign
     - unused
 
-linters-settings:
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment # struct field alignment optimization is noisy
-  errcheck:
-    exclude-functions:
-      - (io.Closer).Close
-      - (*os/exec.Cmd).Run
-      - (*os/exec.Cmd).Start
-  staticcheck:
-    checks: ["all", "-QF1003", "-SA9003"]
+  settings:
+    govet:
+      enable-all: true
+      disable:
+        - shadow
+        - fieldalignment # struct field alignment optimization is noisy
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os/exec.Cmd).Run
+        - (*os/exec.Cmd).Start
+    staticcheck:
+      checks: ["all", "-QF1003", "-SA9003"]
 
-issues:
-  exclude-rules:
-    # Ignore certain patterns in test files
-    - path: _test\.go
-      linters:
-        - errcheck
-    # Ignore errors from os.Remove in cleanup code
-    - text: "os.Remove"
-      linters:
-        - errcheck
+  exclusions:
+    rules:
+      # Ignore certain patterns in test files
+      - path: _test\.go
+        linters:
+          - errcheck
+      # Ignore errors from os.Remove in cleanup code
+      - text: "os.Remove"
+        linters:
+          - errcheck

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -112,6 +112,10 @@ fi
 
 echo -e "${YELLOW}3. Running Go linters...${NC}"
 if command -v golangci-lint > /dev/null 2>&1; then
+    if ! golangci-lint config verify; then
+        echo -e "${RED}${ICON_ERROR} golangci-lint config invalid${NC}\n"
+        exit 1
+    fi
     if golangci-lint run ./cmd/...; then
         echo -e "${GREEN}${ICON_SUCCESS} golangci-lint passed${NC}\n"
     else


### PR DESCRIPTION
This PR fixes wrong golangci-lint's configuration. Before the PR, it contains errors:

```console
$ golangci-lint version
golangci-lint has version 2.8.0 built with go1.25.5 from e2e4002 on 2026-01-07T21:23:22Z

$ golangci-lint config verify
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties": additional properties 'exclude-rules' not allowed
jsonschema: "version" does not validate with "/properties/version/type": got number, want string
jsonschema: "" does not validate with "/additionalProperties": additional properties 'linters-settings' not allowed
The command is terminated due to an error: the configuration contains invalid elements
```

Also, I added `golangci-lint config verify` to `check.sh` in order to prevent such mistakes in the future.

Follows 0cc205209cf9cb8b697c5b48b089a6aafb1f7d4c.

_I created a PR to the `main` branch instead of `dev` because `.golangci-lint.yml` doesn't exist in `dev`_.