### PR TITLE
feat: add Angular, SvelteKit, Astro, and coverage to purge targets

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -36,6 +36,10 @@ readonly PURGE_TARGETS=(
     ".dart_tool"    # Flutter/Dart build cache
     ".zig-cache"    # Zig
     "zig-out"       # Zig
+    ".angular"      # Angular
+    ".svelte-kit"   # SvelteKit
+    ".astro"        # Astro
+    "coverage"      # Code coverage reports
 )
 # Minimum age in days before considering for cleanup.
 readonly MIN_AGE_DAYS=7


### PR DESCRIPTION
feat: add Angular, SvelteKit, Astro, and coverage to purge targets

This PR expands `PURGE_TARGETS` in `lib/clean/project.sh` to include several common artifacts found in modern web development projects that often consume significant disk space:

*   `.angular` - Angular 13+ build cache.
*   `.svelte-kit` - SvelteKit build output.
*   `.astro` - Astro content layer cache.
*   `coverage` - Code coverage reports (often containing large HTML sets).

This improves the utility of `mo purge` for frontend developers using these frameworks.
