### PR TITLE
feat: add cleanup support for Elixir, Haskell, OCaml, and Editors

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -255,6 +255,27 @@ clean_dev_network() {
 clean_sqlite_temp_files() {
     return 0
 }
+# Elixir/Erlang ecosystem.
+clean_dev_elixir() {
+    safe_clean ~/.mix/archives/* "Mix cache"
+    safe_clean ~/.hex/cache/* "Hex cache"
+}
+# Haskell ecosystem.
+clean_dev_haskell() {
+    safe_clean ~/.cabal/packages/* "Cabal install cache"
+    safe_clean ~/.stack/programs/* "Stack cache"
+}
+# OCaml ecosystem.
+clean_dev_ocaml() {
+    safe_clean ~/.opam/download-cache/* "Opam cache"
+}
+# Editor caches.
+clean_dev_editors() {
+    safe_clean ~/Library/Caches/com.microsoft.VSCode/Cache/* "VS Code cached data"
+    safe_clean ~/Library/Application\ Support/Code/CachedData/* "VS Code cached data"
+    safe_clean ~/Library/Application\ Support/Code/User/workspaceStorage/* "VS Code workspace storage"
+    safe_clean ~/Library/Caches/Zed/* "Zed cache"
+}
 # Main developer tools cleanup sequence.
 clean_developer_tools() {
     stop_section_spinner
@@ -277,6 +298,10 @@ clean_developer_tools() {
     clean_dev_api_tools
     clean_dev_network
     clean_dev_misc
+    clean_dev_elixir
+    clean_dev_haskell
+    clean_dev_ocaml
+    clean_dev_editors
     safe_clean ~/Library/Caches/Homebrew/* "Homebrew cache"
     # Clean Homebrew locks without repeated sudo prompts.
     local brew_lock_dirs=(

--- a/tests/dev_extended.bats
+++ b/tests/dev_extended.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-dev-extended.XXXXXX")"
+    export HOME
+
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+@test "clean_dev_elixir cleans mix and hex caches" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "$2"; }
+clean_dev_elixir
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Mix cache"* ]]
+    [[ "$output" == *"Hex cache"* ]]
+}
+
+@test "clean_dev_haskell cleans cabal install and stack caches" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "$2"; }
+clean_dev_haskell
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cabal install cache"* ]]
+    [[ "$output" == *"Stack cache"* ]]
+}
+
+@test "clean_dev_ocaml cleans opam cache" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "$2"; }
+clean_dev_ocaml
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Opam cache"* ]]
+}
+
+@test "clean_dev_editors cleans VS Code and Zed caches" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "$2"; }
+clean_dev_editors
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"VS Code cached data"* ]]
+    [[ "$output" == *"VS Code workspace storage"* ]]
+    [[ "$output" == *"Zed cache"* ]]
+}


### PR DESCRIPTION
This PR adds support for cleaning up caches and temporary files for additional developer tools:

- **Elixir**: Mix and Hex caches
- **Haskell**: Cabal and Stack caches
- **OCaml**: Opam cache
- **Editors**: VS Code and Zed caches

A new test file `tests/dev_extended.bats` has been added to verify these modules.