### PR TITLE
refactor: simplify with slices.Clone

### DIFF
--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -27,8 +28,8 @@ var (
 func snapshotFromModel(m model) historyEntry {
 	return historyEntry{
 		Path:          m.path,
-		Entries:       cloneDirEntries(m.entries),
-		LargeFiles:    cloneFileEntries(m.largeFiles),
+		Entries:       slices.Clone(m.entries),
+		LargeFiles:    slices.Clone(m.largeFiles),
 		TotalSize:     m.totalSize,
 		TotalFiles:    m.totalFiles,
 		Selected:      m.selected,
@@ -43,24 +44,6 @@ func cacheSnapshot(m model) historyEntry {
 	entry := snapshotFromModel(m)
 	entry.Dirty = false
 	return entry
-}
-
-func cloneDirEntries(entries []dirEntry) []dirEntry {
-	if len(entries) == 0 {
-		return nil
-	}
-	copied := make([]dirEntry, len(entries))
-	copy(copied, entries) //nolint:all
-	return copied
-}
-
-func cloneFileEntries(files []fileEntry) []fileEntry {
-	if len(files) == 0 {
-		return nil
-	}
-	copied := make([]fileEntry, len(files))
-	copy(copied, files) //nolint:all
-	return copied
 }
 
 func ensureOverviewSnapshotCacheLocked() error {

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -982,8 +983,8 @@ func (m model) enterSelectedDir() (tea.Model, tea.Cmd) {
 		}
 
 		if cached, ok := m.cache[m.path]; ok && !cached.Dirty {
-			m.entries = cloneDirEntries(cached.Entries)
-			m.largeFiles = cloneFileEntries(cached.LargeFiles)
+			m.entries = slices.Clone(cached.Entries)
+			m.largeFiles = slices.Clone(cached.LargeFiles)
 			m.totalSize = cached.TotalSize
 			m.totalFiles = cached.TotalFiles
 			m.selected = cached.Selected


### PR DESCRIPTION
This PR replaces `cloneDirEntries` and `cloneFileEntries` functions with [`slices.Clone`](https://pkg.go.dev/slices#Clone).