### PR TITLE
feat: Skip Time Machine cleaning if running

### DIFF
--- a/tests/clean_misc.bats
+++ b/tests/clean_misc.bats
@@ -100,6 +100,9 @@ run_with_timeout() { return 1; }
 clean_ds_store_tree() { :; }
 start_section_spinner() { :; }
 stop_section_spinner() { :; }
+is_path_whitelisted() { return 1; }
+WHITELIST_PATTERNS=()
+PROTECT_FINDER_METADATA="false"
 scan_external_volumes
 EOF
 

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -125,6 +125,8 @@ tmutil() {
 }
 start_section_spinner(){ :; }
 stop_section_spinner(){ :; }
+tm_is_running(){ return 1; }
+tm_snapshots_mounted(){ return 1; }
 
 DRY_RUN="false"
 clean_local_snapshots
@@ -154,6 +156,8 @@ tmutil() {
 start_section_spinner(){ :; }
 stop_section_spinner(){ :; }
 note_activity(){ :; }
+tm_is_running(){ return 1; }
+tm_snapshots_mounted(){ return 1; }
 
 DRY_RUN="true"
 clean_local_snapshots
@@ -188,6 +192,8 @@ tmutil() {
 start_section_spinner(){ :; }
 stop_section_spinner(){ :; }
 note_activity(){ :; }
+tm_is_running(){ return 1; }
+tm_snapshots_mounted(){ return 1; }
 
 unset -f read_key
 


### PR DESCRIPTION
Add Time Machine activity checks before snapshot cleanup

Adds two helper functions to safely detect Time Machine state:
- tm_is_running() - checks if a backup is actively running via tmutil status
- tm_snapshots_mounted() - checks if local snapshots are mounted (browsing Time Machine)

clean_local_snapshots() now skips cleanup when Time Machine is active or when status cannot be determined, preventing potential conflicts during backup operations.

Also updates clean_time_machine_failed_backups() to use the new tm_is_running helper for consistency.