### PR TITLE
fix: cap entryChan buffer to prevent memory spikes

### DIFF
--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -53,7 +53,15 @@ func scanPathConcurrent(root string, filesScanned, dirsScanned, bytesScanned *in
 	var wg sync.WaitGroup
 
 	// Collect results via channels.
-	entryChan := make(chan dirEntry, len(children))
+	// Cap buffer size to prevent memory spikes with huge directories.
+	entryBufSize := len(children)
+	if entryBufSize > 4096 {
+		entryBufSize = 4096
+	}
+	if entryBufSize < 1 {
+		entryBufSize = 1
+	}
+	entryChan := make(chan dirEntry, entryBufSize)
 	largeFileChan := make(chan fileEntry, maxLargeFiles*2)
 
 	var collectorWg sync.WaitGroup


### PR DESCRIPTION
The scanner was allocating a channel buffer sized to len(children), which scales linearly with directory size. For directories with millions of entries (maildirs, caches, node_modules), this could allocate hundreds of MB to GBs just for the buffer, risking OOM.

Fix: cap buffer at 4096. All entries still process normally, but producers briefly block if the buffer fills, which is negligible since the collector drains it quickly.