### PR TITLE
fix: refresh not working in overview mode

### DIFF
--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -204,7 +204,7 @@ func TestMeasureOverviewSize(t *testing.T) {
 	if err := os.MkdirAll(target, 0o755); err != nil {
 		t.Fatalf("create target: %v", err)
 	}
-	content := []byte(strings.Repeat("x", 2048))
+	content := []byte(strings.Repeat("x", 4096))
 	if err := os.WriteFile(filepath.Join(target, "data.bin"), content, 0o644); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
@@ -224,6 +224,20 @@ func TestMeasureOverviewSize(t *testing.T) {
 	}
 	if cached != size {
 		t.Fatalf("snapshot mismatch: want %d, got %d", size, cached)
+	}
+
+	// Ensure measureOverviewSize does not use cache
+	// APFS block size is 4KB, 4097 bytes should use more blocks
+	content = []byte(strings.Repeat("x", 4097))
+	if err := os.WriteFile(filepath.Join(target, "data2.bin"), content, 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	size2, err := measureOverviewSize(target)
+	if err != nil {
+		t.Fatalf("measureOverviewSize: %v", err)
+	}
+	if size2 == size {
+		t.Fatalf("measureOverwiewSize used cache")
 	}
 }
 

--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -519,10 +519,6 @@ func measureOverviewSize(path string) (int64, error) {
 		excludePath = filepath.Join(home, "Library")
 	}
 
-	if cached, err := loadStoredOverviewSize(path); err == nil && cached > 0 {
-		return cached, nil
-	}
-
 	if duSize, err := getDirectorySizeFromDuWithExclude(path, excludePath); err == nil && duSize > 0 {
 		_ = storeOverviewSize(path, duSize)
 		return duSize, nil


### PR DESCRIPTION
Refresh functionality in overview mode does not work if cache exists

- Overview refresh (r) in main.go resets sizes and schedules scanOverviewPathCmd, but measureOverviewSize was short-circuiting on cached values.
- Because measureOverviewSize returned loadStoredOverviewSize, overview refresh never re-scanned directories once a cache entry existed, so sizes stayed stale.

This fix:
- removes the cached-size early return in measureOverviewSize so overview refresh always performs a fresh scan (du/logical/cache fallback) and then re-stores the new size.
- adds a regression test to confirm measureOverviewSize changes when underlying data changes (ensures it’s not returning cached values).

This should be the expected behaviour, given the implementation of prefetchOverviewCache function.