### PR TITLE
fix(history): prevent adding multiple history entries with same path when scanning

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -971,7 +971,9 @@ func (m model) enterSelectedDir() (tea.Model, tea.Cmd) {
 	}
 	selected := m.entries[m.selected]
 	if selected.IsDir {
-		m.history = append(m.history, snapshotFromModel(m))
+		if len(m.history) == 0 || m.history[len(m.history)-1].Path != m.path {
+			m.history = append(m.history, snapshotFromModel(m))
+		}
 		m.path = selected.Path
 		m.selected = 0
 		m.offset = 0


### PR DESCRIPTION
**Problem**

While scanning, if the user repeatedly presses the right key, the current path is added to m.history multiple times.

This causes an unintended UX issue:
- The history stack contains duplicate entries for the same path
- When navigating back, the user must press the back key multiple times to leave a single path
- Effectively, navigation feels “stuck” unless the user presses back as many times as they pressed right
---
**Solution**

Only append a snapshot to m.history when the path actually changes.

Before appending:
- Check if history is empty, or
- Check if the last stored snapshot has a different Path than the current one
This prevents redundant history entries while preserving correct navigation behavior.