### PR TITLE
test: add formatUnusedTime tests and fix duplicate comment

### DIFF
--- a/cmd/status/metrics_health.go
+++ b/cmd/status/metrics_health.go
@@ -70,7 +70,6 @@ func calculateHealthScore(cpu CPUStatus, mem MemoryStatus, disks []DiskStatus, d
 	}
 
 	// Memory pressure penalty.
-	// Memory pressure penalty.
 	switch mem.Pressure {
 	case "warn":
 		score -= memPressureWarnPenalty


### PR DESCRIPTION
Add unit tests for `formatUnusedTime` in `cmd/analyze/format_test.go`

- Zero time (`time.Time{}`) returns empty string
- Recent files (< 90 days) return empty string
- Boundary tests at 89/90 days threshold
- Month formatting (3mo, 4mo, 6mo, 11mo, 12mo)
- Year formatting (1yr, 2yr, 3yr)
- Boundary tests at year transitions

Also remove duplicate "Memory pressure penalty" comment in `cmd/status/metrics_health.go` (line 72-73).