### PR TITLE
bug-fix: `mo uninstall` unbound variable on empty tuples

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -137,9 +137,15 @@ scan_applications() {
         done < <(command find "$app_dir" -name "*.app" -maxdepth 3 -print0 2> /dev/null)
     done
 
+    if [[ ${#app_data_tuples[@]:-0} -eq 0 ]]; then
+        rm -f "$temp_file"
+        printf "\r\033[K" >&2
+        echo "No applications found to uninstall." >&2
+        return 1
+    fi
     # Pass 2: metadata + size in parallel (mdls is slow).
     local app_count=0
-    local total_apps=${#app_data_tuples[@]}
+    local total_apps=${#app_data_tuples[@]:-0}
     local max_parallel
     max_parallel=$(get_optimal_parallel_jobs "io")
     if [[ $max_parallel -lt 8 ]]; then


### PR DESCRIPTION
This happens when no third party app is available to be uninstalled; this triggers an `unbound variable` on the app_data_tuple causing the utility to fail.

This is caused mostly because the bash version is 3.2 on MacOS; it seems that since Bash 4 this unbound_variable is set to 0 and would have not went to that error.

Added an alternative value in case of error of 0 for this topic. This should handle this corner case

Issue: #350 