### PR TITLE
fix: handle empty arrays in clean_dev_jetbrains_toolbox

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -244,6 +244,13 @@ clean_dev_jetbrains_toolbox() {
         product_dirs+=("$product_dir")
     done < <(command find "$toolbox_root" -mindepth 1 -maxdepth 1 -type d -print0 2> /dev/null)
 
+    if [[ ${#product_dirs[@]} -eq 0 ]]; then
+        if [[ "$whitelist_overridden" == "true" ]]; then
+            WHITELIST_PATTERNS=("${original_whitelist[@]}")
+        fi
+        return 0
+    fi
+
     local product_dir
     for product_dir in "${product_dirs[@]}"; do
         while IFS= read -r -d '' channel_dir; do
@@ -275,6 +282,8 @@ clean_dev_jetbrains_toolbox() {
 
                 version_dirs+=("$version_dir")
             done < <(command find "$channel_dir" -mindepth 1 -maxdepth 1 -type d -print0 2> /dev/null)
+
+            [[ ${#version_dirs[@]} -eq 0 ]] && continue
 
             local -a sorted_dirs=()
             while IFS= read -r line; do


### PR DESCRIPTION
## Summary

- Add early return check when `product_dirs` array is empty to prevent unbound variable error
- Add continue check when `version_dirs` array is empty before iterating

Fixes the error:
```
lib/clean/dev.sh: line 248: product_dirs[@]: unbound variable
```

This occurs when running `mo clean` without JetBrains Toolbox installed, as the empty array triggers an error under `set -u`.

## Note on target branch

I'm targeting `main` instead of `dev` because `clean_dev_jetbrains_toolbox` only exists in `main` (and released versions like V1.23.2), not in `dev`. Happy to retarget if you prefer a different approach.