### PR TITLE
test: add tests for byte formatters and disk helpers

### DIFF
--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -112,3 +112,170 @@ func TestHumanBytesShort(t *testing.T) {
 		})
 	}
 }
+
+func TestHumanBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input uint64
+		want  string
+	}{
+		// Zero and small values.
+		{"zero", 0, "0 B"},
+		{"one byte", 1, "1 B"},
+		{"1023 bytes", 1023, "1023 B"},
+
+		// Kilobyte boundaries (uses > not >=).
+		{"exactly 1KB", 1 << 10, "1024 B"},
+		{"just over 1KB", (1 << 10) + 1, "1.0 KB"},
+		{"1.5KB", 1536, "1.5 KB"},
+
+		// Megabyte boundaries (uses > not >=).
+		{"exactly 1MB", 1 << 20, "1024.0 KB"},
+		{"just over 1MB", (1 << 20) + 1, "1.0 MB"},
+		{"500MB", 500 << 20, "500.0 MB"},
+
+		// Gigabyte boundaries (uses > not >=).
+		{"exactly 1GB", 1 << 30, "1024.0 MB"},
+		{"just over 1GB", (1 << 30) + 1, "1.0 GB"},
+		{"100GB", 100 << 30, "100.0 GB"},
+
+		// Terabyte boundaries (uses > not >=).
+		{"exactly 1TB", 1 << 40, "1024.0 GB"},
+		{"just over 1TB", (1 << 40) + 1, "1.0 TB"},
+		{"2TB", 2 << 40, "2.0 TB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := humanBytes(tt.input)
+			if got != tt.want {
+				t.Errorf("humanBytes(%d) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHumanBytesCompact(t *testing.T) {
+	tests := []struct {
+		name  string
+		input uint64
+		want  string
+	}{
+		// Zero and small values.
+		{"zero", 0, "0"},
+		{"one byte", 1, "1"},
+		{"1023 bytes", 1023, "1023"},
+
+		// Kilobyte boundaries (uses >= not >).
+		{"exactly 1KB", 1 << 10, "1.0K"},
+		{"1.5KB", 1536, "1.5K"},
+
+		// Megabyte boundaries.
+		{"exactly 1MB", 1 << 20, "1.0M"},
+		{"500MB", 500 << 20, "500.0M"},
+
+		// Gigabyte boundaries.
+		{"exactly 1GB", 1 << 30, "1.0G"},
+		{"100GB", 100 << 30, "100.0G"},
+
+		// Terabyte boundaries.
+		{"exactly 1TB", 1 << 40, "1.0T"},
+		{"2TB", 2 << 40, "2.0T"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := humanBytesCompact(tt.input)
+			if got != tt.want {
+				t.Errorf("humanBytesCompact(%d) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitDisks(t *testing.T) {
+	tests := []struct {
+		name         string
+		disks        []DiskStatus
+		wantInternal int
+		wantExternal int
+	}{
+		{
+			name:         "empty slice",
+			disks:        []DiskStatus{},
+			wantInternal: 0,
+			wantExternal: 0,
+		},
+		{
+			name: "all internal",
+			disks: []DiskStatus{
+				{Mount: "/", External: false},
+				{Mount: "/System", External: false},
+			},
+			wantInternal: 2,
+			wantExternal: 0,
+		},
+		{
+			name: "all external",
+			disks: []DiskStatus{
+				{Mount: "/Volumes/USB", External: true},
+				{Mount: "/Volumes/Backup", External: true},
+			},
+			wantInternal: 0,
+			wantExternal: 2,
+		},
+		{
+			name: "mixed",
+			disks: []DiskStatus{
+				{Mount: "/", External: false},
+				{Mount: "/Volumes/USB", External: true},
+				{Mount: "/System", External: false},
+			},
+			wantInternal: 2,
+			wantExternal: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			internal, external := splitDisks(tt.disks)
+			if len(internal) != tt.wantInternal {
+				t.Errorf("splitDisks() internal count = %d, want %d", len(internal), tt.wantInternal)
+			}
+			if len(external) != tt.wantExternal {
+				t.Errorf("splitDisks() external count = %d, want %d", len(external), tt.wantExternal)
+			}
+		})
+	}
+}
+
+func TestDiskLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		index  int
+		total  int
+		want   string
+	}{
+		// Single disk — no numbering.
+		{"single disk", "INTR", 0, 1, "INTR"},
+		{"single external", "EXTR", 0, 1, "EXTR"},
+
+		// Multiple disks — numbered (1-indexed).
+		{"first of two", "INTR", 0, 2, "INTR1"},
+		{"second of two", "INTR", 1, 2, "INTR2"},
+		{"third of three", "EXTR", 2, 3, "EXTR3"},
+
+		// Edge case: total 0 treated as single.
+		{"total zero", "DISK", 0, 0, "DISK"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diskLabel(tt.prefix, tt.index, tt.total)
+			if got != tt.want {
+				t.Errorf("diskLabel(%q, %d, %d) = %q, want %q", tt.prefix, tt.index, tt.total, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add unit tests for additional utility functions in `cmd/status/view_test.go`:
- `humanBytes`: byte formatting with decimals and units
- `humanBytesCompact`: compact byte formatting
- `splitDisks`: separates internal/external disks
- `diskLabel`: generates numbered disk labels

Coverage for `cmd/status` improved from 6.9% to 8.4%.