### PR TITLE
feat: Exclude External Disks from Analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ mo optimize --dry-run        # Preview optimization actions
 mo optimize --debug          # Run with detailed operation logs
 mo optimize --whitelist      # Manage protected optimization rules
 mo purge --paths             # Configure project scan directories
+mo analyze --exclude-volumes # Skip external drives under /Volumes in overview
 ```
 
 ## Tips
@@ -148,6 +149,8 @@ Use `mo optimize --whitelist` to exclude specific optimizations.
 ```
 
 ### Disk Space Analyzer
+
+Use `--exclude-volumes` to skip external drives under `/Volumes` in the overview (faster when many volumes are attached).
 
 ```bash
 $ mo analyze

--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -332,8 +332,8 @@ func removeOverviewSnapshot(path string) {
 }
 
 // prefetchOverviewCache warms overview cache in background.
-func prefetchOverviewCache(ctx context.Context) {
-	entries := createOverviewEntries()
+func prefetchOverviewCache(ctx context.Context, excludeVolumes bool) {
+	entries := createOverviewEntries(excludeVolumes)
 
 	var needScan []string
 	for _, entry := range entries {

--- a/mole
+++ b/mole
@@ -223,6 +223,7 @@ show_help() {
     printf "  %s%-28s%s %s\n" "$GREEN" "mo optimize --dry-run" "$NC" "Preview optimization"
     printf "  %s%-28s%s %s\n" "$GREEN" "mo optimize --whitelist" "$NC" "Manage protected items"
     printf "  %s%-28s%s %s\n" "$GREEN" "mo purge --paths" "$NC" "Configure scan directories"
+    printf "  %s%-28s%s %s\n" "$GREEN" "mo analyze --exclude-volumes" "$NC" "Skip external drives in overview"
     printf "  %s%-28s%s %s\n" "$GREEN" "mo update --force" "$NC" "Force reinstall latest version"
     echo
     printf "%s%s%s\n" "$BLUE" "OPTIONS" "$NC"


### PR DESCRIPTION
Created optional flag `--exclude-volumes` for `mo analyze` to consent the users to analyze the filesystem without taking in consideration attached Volumes. Normal behaviour (with volumes included) is left untouched.

Issue: #426 

[15:32] iamxorum@xrm-mac-pro ~/Desktop/XRM/Personal/Contributions/Mole git:(feat-426)
➜ ./bin/analyze-go --exclude-volumes
<img width="647" height="176" alt="image" src="https://github.com/user-attachments/assets/caa26771-56b9-425a-9bdf-d56ec0e107be" />

[15:32] iamxorum@xrm-mac-pro ~/Desktop/XRM/Personal/Contributions/Mole git:(feat-426)
➜ ./bin/analyze-go
<img width="601" height="189" alt="image" src="https://github.com/user-attachments/assets/32656022-4f85-41e8-89c2-ea2d1fd21a00" />

