### PR TITLE
feat: add commands help flag

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1077,6 +1077,18 @@ perform_cleanup() {
 main() {
     for arg in "$@"; do
         case "$arg" in
+            "--help" | "-h")
+                echo "Usage: mo clean [OPTIONS]"
+                echo ""
+                echo "Clean up disk space by removing caches, logs, and temporary files."
+                echo ""
+                echo "Options:"
+                echo "  --dry-run, -n     Preview cleanup without making changes"
+                echo "  --whitelist       Manage protected paths"
+                echo "  --debug           Show detailed operation logs"
+                echo "  -h, --help        Show this help message"
+                exit 0
+                ;;
             "--debug")
                 export MO_DEBUG=1
                 ;;

--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -668,6 +668,16 @@ show_summary() {
 main() {
     for arg in "$@"; do
         case "$arg" in
+            "--help" | "-h")
+                echo "Usage: mo installer [OPTIONS]"
+                echo ""
+                echo "Find and remove installer files (.dmg, .pkg, .iso, .xip, .zip)."
+                echo ""
+                echo "Options:"
+                echo "  --debug           Show detailed operation logs"
+                echo "  -h, --help        Show this help message"
+                exit 0
+                ;;
             "--debug")
                 export MO_DEBUG=1
                 ;;

--- a/bin/optimize.sh
+++ b/bin/optimize.sh
@@ -373,6 +373,18 @@ main() {
     local health_json
     for arg in "$@"; do
         case "$arg" in
+            "--help" | "-h")
+                echo "Usage: mo optimize [OPTIONS]"
+                echo ""
+                echo "Check and maintain system health, apply optimizations."
+                echo ""
+                echo "Options:"
+                echo "  --dry-run         Preview optimization without making changes"
+                echo "  --whitelist       Manage protected items"
+                echo "  --debug           Show detailed operation logs"
+                echo "  -h, --help        Show this help message"
+                exit 0
+                ;;
             "--debug")
                 export MO_DEBUG=1
                 ;;

--- a/bin/touchid.sh
+++ b/bin/touchid.sh
@@ -306,6 +306,22 @@ main() {
     local command="${1:-}"
 
     case "$command" in
+        "--help" | "-h")
+            echo "Usage: mo touchid [COMMAND]"
+            echo ""
+            echo "Configure Touch ID for sudo authentication."
+            echo ""
+            echo "Commands:"
+            echo "  enable            Enable Touch ID for sudo"
+            echo "  disable           Disable Touch ID for sudo"
+            echo "  status            Show current Touch ID status"
+            echo ""
+            echo "Options:"
+            echo "  -h, --help        Show this help message"
+            echo ""
+            echo "If no command is provided, an interactive menu is shown."
+            exit 0
+            ;;
         enable)
             enable_touchid
             ;;

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -391,6 +391,16 @@ main() {
     # Global flags
     for arg in "$@"; do
         case "$arg" in
+            "--help" | "-h")
+                echo "Usage: mo uninstall [OPTIONS]"
+                echo ""
+                echo "Interactively remove applications and their leftover files."
+                echo ""
+                echo "Options:"
+                echo "  --debug           Show detailed operation logs"
+                echo "  -h, --help        Show this help message"
+                exit 0
+                ;;
             "--debug")
                 export MO_DEBUG=1
                 ;;


### PR DESCRIPTION
Hi @tw93 thanks for the great tool!

I found that when I run `mo clean --help`, I want to see more details, but it runs the clean command directly. I think it should support the help flag, following most common CLI conventions, so I added it to most commands. Now it looks like this:

```sh
❯ ./bin/clean.sh --help

Usage: mo clean [OPTIONS]

Clean up disk space by removing caches, logs, and temporary files.

Options:
  --dry-run, -n     Preview cleanup without making changes
  --whitelist       Manage protected paths
  --debug           Show detailed operation logs
  -h, --help        Show this help message
```
