### PR TITLE
refactor: use builtin max instead of maxInt

### DIFF
--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -142,7 +142,7 @@ func (m model) View() string {
 	header := renderHeader(m.metrics, m.errMessage, m.animFrame, m.width, m.catHidden)
 	cardWidth := 0
 	if m.width > 80 {
-		cardWidth = maxInt(24, m.width/2-4)
+		cardWidth = max(24, m.width/2-4)
 	}
 	cards := buildCards(m.metrics, cardWidth)
 

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -763,7 +763,7 @@ func renderTwoColumns(cards []cardData, width int) string {
 		if i+1 < len(cards) {
 			right = renderCard(cards[i+1], cw, 0)
 		}
-		targetHeight := maxInt(lipgloss.Height(left), lipgloss.Height(right))
+		targetHeight := max(lipgloss.Height(left), lipgloss.Height(right))
 		left = renderCard(cards[i], cw, targetHeight)
 		if right != "" {
 			right = renderCard(cards[i+1], cw, targetHeight)
@@ -781,11 +781,4 @@ func renderTwoColumns(cards []cardData, width int) string {
 		spacedRows = append(spacedRows, r)
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, spacedRows...)
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -822,32 +822,6 @@ func TestGetScoreStyle(t *testing.T) {
 	}
 }
 
-func TestMaxInt(t *testing.T) {
-	tests := []struct {
-		name string
-		a    int
-		b    int
-		want int
-	}{
-		{"a greater", 10, 5, 10},
-		{"b greater", 3, 8, 8},
-		{"equal", 7, 7, 7},
-		{"negative a greater", -5, -10, -5},
-		{"negative b greater", -10, -5, -5},
-		{"zero vs positive", 0, 5, 5},
-		{"zero vs negative", 0, -5, 0},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := maxInt(tt.a, tt.b)
-			if got != tt.want {
-				t.Errorf("maxInt(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestSparkline(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
`maxInt` is redundant and can be replaced with [`max`](https://pkg.go.dev/builtin#max).