### PR TITLE
fix: support both GNU sed and BSD sed in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,22 @@ maybe_sudo() {
     fi
 }
 
+sed_inplace() {
+    if sed --version 2>/dev/null | grep -q "GNU sed"; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+maybe_sudo_sed_inplace() {
+    if sed --version 2>/dev/null | grep -q "GNU sed"; then
+        maybe_sudo sed -i "$@"
+    else
+        maybe_sudo sed -i '' "$@"
+    fi
+}
+
 resolve_source_dir() {
     if [[ -n "$SOURCE_DIR" && -d "$SOURCE_DIR" && -f "$SOURCE_DIR/mole" ]]; then
         return 0
@@ -604,7 +620,7 @@ install_files() {
     fi
 
     if [[ "$source_dir_abs" != "$install_dir_abs" ]]; then
-        maybe_sudo sed -i '' "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"$CONFIG_DIR\"|" "$INSTALL_DIR/mole"
+        maybe_sudo_sed_inplace "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"$CONFIG_DIR\"|" "$INSTALL_DIR/mole"
     fi
 
     if ! download_binary "analyze"; then


### PR DESCRIPTION
sed -i '' in install.sh is BSD-only syntax. When GNU sed is installed (e.g. via Nix or Homebrew), the empty string is misinterpreted as the script argument, causing mo update to fail with sed: can't read s|SCRIPT_DIR=...|: No such file or directory

Fix:

GNU sed treats -i as a flag with no argument, while BSD sed requires -i '' (empty backup suffix). The helpers check sed --version to detect GNU sed and call the appropriate form.

Test plan:

Tested mo update locally with GNU sed 4.9 (via Nix)
Verified sed_inplace produces correct output
Audited all other sed -i usages — only autofix.sh remains, which is macOS-only (Touch ID PAM) and correct as-is

fix: support both GNU sed and BSD sed in install.sh#432
