### PR TITLE
fix: silent exit on permission denied during App State Cleanup (#438)

### DIFF
--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -164,7 +164,7 @@ opt_cache_refresh() {
                 if [[ "$size_kb" =~ ^[0-9]+$ ]]; then
                     total_cache_size=$((total_cache_size + size_kb))
                 fi
-                safe_remove "$target_path" true > /dev/null 2>&1
+                safe_remove "$target_path" true > /dev/null 2>&1 || true
             fi
         fi
     done
@@ -195,7 +195,7 @@ opt_saved_state_cleanup() {
             if should_protect_path "$state_path"; then
                 continue
             fi
-            safe_remove "$state_path" true > /dev/null 2>&1
+            safe_remove "$state_path" true > /dev/null 2>&1 || true
         done < <(command find "$state_dir" -type d -name "*.savedState" -mtime "+$MOLE_SAVED_STATE_AGE_DAYS" -print0 2> /dev/null)
     fi
 

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -500,6 +500,23 @@ EOF
     [[ "$output" == *"App saved states optimized"* ]]
 }
 
+@test "opt_saved_state_cleanup continues on permission denied (silent exit)" {
+    local state_dir="$HOME/Library/Saved Application State"
+    mkdir -p "$state_dir/com.example.old.savedState"
+    touch -t 202301010000 "$state_dir/com.example.old.savedState" 2>/dev/null || true
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/optimize/tasks.sh"
+safe_remove() { return 1; }
+opt_saved_state_cleanup
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"App saved states optimized"* ]]
+}
+
 @test "opt_cache_refresh cleans Quick Look cache" {
     mkdir -p "$HOME/Library/Caches/com.apple.QuickLook.thumbnailcache"
     touch "$HOME/Library/Caches/com.apple.QuickLook.thumbnailcache/test.db"


### PR DESCRIPTION
Fixes #438

## Problem

`mo optimize` exits with code 1 during "App State Cleanup" when it hits a `.savedState` directory that needs Full Disk Access (e.g. `net.maxon.appinstaller.savedState`). With `set -euo pipefail`, the failing `safe_remove` stops the script instead of skipping the protected directory.

## Solution

Add `|| true` after `safe_remove` calls in `opt_saved_state_cleanup` and `opt_cache_refresh`, matching the Pipefail Safety pattern in CONTRIBUTING.md:

> All commands that might fail must be handled
>
> find /nonexistent -name "*.cache" 2>/dev/null || true
> 