### PR TITLE
feat(clean): add --trash option to move cleaned files to Trash instead of deleting

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -22,6 +22,7 @@ source "$SCRIPT_DIR/../lib/clean/user.sh"
 
 SYSTEM_CLEAN=false
 DRY_RUN=false
+USE_TRASH=false
 PROTECT_FINDER_METADATA=false
 IS_M_SERIES=$([[ "$(uname -m)" == "arm64" ]] && echo "true" || echo "false")
 
@@ -705,7 +706,7 @@ start_cleanup() {
     echo ""
 
     if [[ "$DRY_RUN" != "true" && -t 0 ]]; then
-        echo -e "${GRAY}${ICON_WARNING} Use --dry-run to preview, --whitelist to manage protected paths${NC}"
+        echo -e "${GRAY}${ICON_WARNING} Use --dry-run to preview, --trash to move to Trash, --whitelist to manage protected paths${NC}"
     fi
 
     if [[ "$DRY_RUN" == "true" ]]; then
@@ -1088,6 +1089,10 @@ main() {
             "--dry-run" | "-n")
                 DRY_RUN=true
                 export MOLE_DRY_RUN=1
+                ;;
+            "--trash" | "-t")
+                USE_TRASH=true
+                export MOLE_USE_TRASH=1
                 ;;
             "--whitelist")
                 source "$SCRIPT_DIR/../lib/manage/whitelist.sh"

--- a/lib/core/help.sh
+++ b/lib/core/help.sh
@@ -7,6 +7,7 @@ show_clean_help() {
     echo ""
     echo "Options:"
     echo "  --dry-run, -n     Preview cleanup without making changes"
+    echo "  --trash, -t       Move cleaned files to Trash instead of permanently removing (macOS)"
     echo "  --whitelist       Manage protected paths"
     echo "  --debug           Show detailed operation logs"
     echo "  -h, --help        Show this help message"

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -45,6 +45,15 @@ setup() {
     [ -f "$HOME/Library/Caches/TestApp/cache.tmp" ]
 }
 
+@test "mo clean --dry-run --trash runs without deleting" {
+    mkdir -p "$HOME/Library/Caches/TrashTestApp"
+    echo "trash test" > "$HOME/Library/Caches/TrashTestApp/cache.tmp"
+
+    run env HOME="$HOME" MOLE_TEST_MODE=1 "$PROJECT_ROOT/mole" clean --dry-run --trash
+    [ "$status" -eq 0 ]
+    [ -f "$HOME/Library/Caches/TrashTestApp/cache.tmp" ]
+}
+
 @test "mo clean honors whitelist entries" {
     mkdir -p "$HOME/Library/Caches/WhitelistedApp"
     echo "keep me" > "$HOME/Library/Caches/WhitelistedApp/data.tmp"

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -56,6 +56,13 @@ setup() {
     [[ "$output" == *"mo analyze"* ]]
 }
 
+@test "mo clean --help shows --trash option" {
+    run env HOME="$HOME" "$PROJECT_ROOT/mole" clean --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--trash"* ]]
+    [[ "$output" == *"Trash"* ]]
+}
+
 @test "mole --version reports script version" {
     expected_version="$(grep '^VERSION=' "$PROJECT_ROOT/mole" | head -1 | sed 's/VERSION=\"\(.*\)\"/\1/')"
     run env HOME="$HOME" "$PROJECT_ROOT/mole" --version

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -115,6 +115,14 @@ teardown() {
     [ "$status" -eq 1 ]
 }
 
+@test "safe_remove with MOLE_USE_TRASH=1 removes file (trash or fallback)" {
+    local test_file="$TEST_DIR/trash_test.txt"
+    echo "trash test" > "$test_file"
+
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; MOLE_USE_TRASH=1 safe_remove '$test_file' true"
+    [ "$status" -eq 0 ]
+    [ ! -f "$test_file" ]
+}
 
 @test "safe_find_delete validates base directory" {
     run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; safe_find_delete '/nonexistent' '*.tmp' 7 'f' 2>&1"


### PR DESCRIPTION
## Summary
Adds an option to move cleaned files to the system Trash instead of permanently removing them, so users can recover items if needed.

Closes #439

## Changes
- **`lib/core/file_ops.sh`**
  - Add `safe_move_to_trash()` that uses macOS Finder (osascript) to move paths to Trash.
  - When `MOLE_USE_TRASH=1`, `safe_remove()` tries trash first and falls back to `rm` if trash fails (e.g. headless or permission).
  - Dry-run messages show "Would move to Trash" when `--trash` is used.
- **`bin/clean.sh`**
  - Add `--trash` / `-t` flag and set `MOLE_USE_TRASH=1`.
  - Update footer hint to mention `--trash`.
- **`lib/core/help.sh`**
  - Document `--trash, -t` in clean help.

## Usage
- `mo clean --dry-run` — preview (no changes)
- `mo clean --dry-run --trash` — preview move to Trash
- `mo clean --trash` — clean and move items to Trash
- `mo clean` — default: permanent removal (unchanged)

## Notes
- Trash is only used for user-level paths that go through `safe_remove()`. `safe_sudo_remove()` (system paths) is unchanged and still permanently removes.
- On non-macOS or when osascript is unavailable, the code falls back to permanent removal.

## Testing
- `tests/cli.bats`: `mo clean --help` shows `--trash`.
- `tests/clean_core.bats`: `mo clean --dry-run --trash` does not delete files.
- `tests/core_safe_functions.bats`: `safe_remove` with `MOLE_USE_TRASH=1` removes the file (trash or fallback).