### PR TITLE
feat: Add '$HOME/Developer' to common development paths

### DIFF
--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -102,6 +102,7 @@ clean_project_caches() {
         "$HOME/work"
         "$HOME/src"
         "$HOME/repos"
+        "$HOME/Developer"
         "$HOME/Development"
         "$HOME/www"
         "$HOME/golang"


### PR DESCRIPTION
Add `$HOME/Developer` as it is a convention-based workspace directory on macOS.

Creating a `Developer` directory in the home directory causes macOS Finder to display it with a hammer icon, indicating that it is a designated location for development-related files and projects. I think it makes sense to include this folder in the list.

<img width="107" height="105" alt="image" src="https://github.com/user-attachments/assets/270d596b-e48e-4f3d-a710-b663941d0fa4" />

https://discussions.apple.com/thread/253927888