### PR TITLE
feat(purge): add common React Native targets

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -40,6 +40,10 @@ readonly PURGE_TARGETS=(
     ".svelte-kit"   # SvelteKit
     ".astro"        # Astro
     "coverage"      # Code coverage reports
+    "DerivedData"   # Xcode
+    "Pods"          # CocoaPods
+    ".cxx"          # Android
+    ".expo"         # Expo
 )
 # Minimum age in days before considering for cleanup.
 readonly MIN_AGE_DAYS=7


### PR DESCRIPTION
Added common build artifacts folders for React Native projects. That `super-app` folder dropped from 6+ GB to 10 MB.

<img width="661" height="460" alt="image" src="https://github.com/user-attachments/assets/808f64e0-e2bc-4641-b9be-45224d61aa97" />
