### PR TITLE
Fix --dry-run hiding system cleanup preview

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -717,7 +717,6 @@ start_cleanup() {
     if [[ "$DRY_RUN" == "true" ]]; then
         echo -e "${YELLOW}Dry Run Mode${NC}, Preview only, no deletions"
         echo ""
-        SYSTEM_CLEAN=false
 
         ensure_user_file "$EXPORT_LIST_FILE"
         cat > "$EXPORT_LIST_FILE" << EOF
@@ -732,6 +731,17 @@ start_cleanup() {
 #
 
 EOF
+
+        # Preview system section when sudo is already cached (no password prompt).
+        if sudo -n true 2> /dev/null; then
+            SYSTEM_CLEAN=true
+            echo -e "${GREEN}${ICON_SUCCESS}${NC} Admin access available, system preview included"
+            echo ""
+        else
+            SYSTEM_CLEAN=false
+            echo -e "${GRAY}${ICON_WARNING} System caches need sudo, run ${NC}sudo -v && mo clean --dry-run${GRAY} for full preview${NC}"
+            echo ""
+        fi
         return
     fi
 


### PR DESCRIPTION
## Problem

`mo clean --dry-run` silently skips the entire system cleanup section. The `start_cleanup` function hardcodes `SYSTEM_CLEAN=false` during dry-run, so the system section in `perform_cleanup` never runs. Users can't preview what`/Library/Caches`, `/private/var/log`, diagnostics, or other sudo-required paths would be cleaned before committing to a real run.

This is the only cleanup section with no dry-run visibility — all user-level sections already preview correctly.

## Fix

Instead of hardcoding `SYSTEM_CLEAN=false`, dry-run now checks for a cached sudo session via `sudo -n true`:

- **Sudo cached:** Sets `SYSTEM_CLEAN=true`. The system section runs normally, and `safe_sudo_remove` /
`safe_sudo_find_delete` hit their existing `MOLE_DRY_RUN=1` branches — printing what would be deleted without deleting.
- **Sudo not cached:** Sets `SYSTEM_CLEAN=false` and shows a hint: `sudo -v && mo clean --dry-run`. This caches credentials
without running the script as root (which would change `$HOME` and break user-level paths).

No interactive sudo prompt is ever triggered during dry-run.

## Test plan

- Added two tests in `tests/clean_core.bats` using PATH-shimmed `sudo` to exercise both branches
- Verified no regressions against existing test suite
- `shellcheck` and `bash -n` pass