### PR TITLE
ci: add Swift menubar build verification (#501)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,11 @@ jobs:
           source lib/core/common.sh
           echo "✓ Successfully loaded on ${{ matrix.os }}"
 
+      - name: Build Swift menubar
+        run: |
+          cd cmd/menubar && swift build -c release
+          echo "✓ Swift menubar builds on ${{ matrix.os }}"
+
   security:
     name: Security Checks
     runs-on: macos-latest


### PR DESCRIPTION
Closes #501

## Summary

Add a `swift build -c release` step to the compatibility job in the test
workflow. This ensures the Swift menubar component at `cmd/menubar/` compiles
successfully on both macOS 14 and macOS 15 for every PR.

## Why

The CI currently verifies Go code (build, vet, format, tests) and shell
scripts (ShellCheck, syntax), but does not build the Swift menubar. This
means Swift compilation errors would only be caught during the release
workflow, which is too late.

## Changes

- `.github/workflows/test.yml` — Add "Build Swift menubar" step to the
  compatibility matrix job (macos-14, macos-15)