### PR TITLE
fix(clean): respect whitelist when cleaning Go caches

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -106,8 +106,50 @@ clean_dev_python() {
 # Go build/module caches.
 clean_dev_go() {
     if command -v go > /dev/null 2>&1; then
-        clean_tool_cache "Go cache" bash -c 'go clean -modcache > /dev/null 2>&1 || true; go clean -cache > /dev/null 2>&1 || true'
-        note_activity
+        # Get Go cache paths
+        local go_build_cache
+        local go_mod_cache
+        go_build_cache=$(go env GOCACHE 2> /dev/null || echo "$HOME/Library/Caches/go-build")
+        go_mod_cache=$(go env GOMODCACHE 2> /dev/null || echo "$HOME/go/pkg/mod")
+
+        # Check if Go caches are whitelisted
+        local build_protected=false
+        local mod_protected=false
+
+        if is_path_whitelisted "$go_build_cache"; then
+            build_protected=true
+        fi
+
+        if is_path_whitelisted "$go_mod_cache"; then
+            mod_protected=true
+        fi
+
+        # Only clean if not protected by whitelist
+        if [[ "$build_protected" == "true" && "$mod_protected" == "true" ]]; then
+            if [[ "$DRY_RUN" == "true" ]]; then
+                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Go cache · would skip (whitelist)"
+            else
+                echo -e "  ${BLUE}${ICON_SKIP}${NC} Go cache · protected by whitelist"
+            fi
+        elif [[ "$build_protected" == "true" ]]; then
+            # Only clean module cache
+            clean_tool_cache "Go module cache" bash -c 'go clean -modcache > /dev/null 2>&1 || true'
+            if [[ "$DRY_RUN" != "true" ]]; then
+                echo -e "  ${BLUE}${ICON_SKIP}${NC} Go build cache · protected by whitelist"
+            fi
+            note_activity
+        elif [[ "$mod_protected" == "true" ]]; then
+            # Only clean build cache
+            clean_tool_cache "Go build cache" bash -c 'go clean -cache > /dev/null 2>&1 || true'
+            if [[ "$DRY_RUN" != "true" ]]; then
+                echo -e "  ${BLUE}${ICON_SKIP}${NC} Go module cache · protected by whitelist"
+            fi
+            note_activity
+        else
+            # Clean both caches
+            clean_tool_cache "Go cache" bash -c 'go clean -modcache > /dev/null 2>&1 || true; go clean -cache > /dev/null 2>&1 || true'
+            note_activity
+        fi
     fi
 }
 # Rust/cargo caches.

--- a/lib/manage/whitelist.sh
+++ b/lib/manage/whitelist.sh
@@ -94,8 +94,8 @@ VS Code extension and update cache|$HOME/Library/Application Support/Code/Cached
 VS Code system cache (Cursor, VSCodium)|$HOME/Library/Caches/com.microsoft.VSCode/*|ide_cache
 Cursor editor cache|$HOME/Library/Caches/com.todesktop.230313mzl4w4u92/*|ide_cache
 Bazel build cache|$HOME/.cache/bazel/*|compiler_cache
-Go build cache and module cache|$HOME/Library/Caches/go-build/*|compiler_cache
-Go module cache|$HOME/go/pkg/mod/cache/*|compiler_cache
+Go build cache|$HOME/Library/Caches/go-build/*|compiler_cache
+Go module cache|$HOME/go/pkg/mod/*|compiler_cache
 Rust Cargo registry cache|$HOME/.cargo/registry/cache/*|compiler_cache
 Rust documentation cache|$HOME/.rustup/toolchains/*/share/doc/*|compiler_cache
 Rustup toolchain downloads|$HOME/.rustup/downloads/*|compiler_cache


### PR DESCRIPTION
## Summary

Fixes the issue where Go module cache whitelist entries are ignored during `mo clean dev` operations.

Fixes #521

## Problem

When users add Go cache paths to the whitelist:
- `~/Library/Caches/go-build/*` (Go build cache)
- `~/go/pkg/mod/*` (Go module cache)

The `mo clean dev` command still deletes these caches because `clean_dev_go()` runs `go clean -modcache` without checking the whitelist first.

## Root Cause

The `clean_dev_go()` function in `lib/clean/dev.sh` unconditionally runs:
- `go clean -cache` (deletes build cache)
- `go clean -modcache` (deletes module cache)

This breaks user trust in the whitelist protection system.

## Changes

### 1. Add Whitelist Checking to `clean_dev_go()`
- Get Go cache paths from `go env GOCACHE` and `go env GOMODCACHE`
- Check if each cache is whitelisted using `is_path_whitelisted()`
- Only clean caches that are NOT protected
- Show appropriate messages for protected caches

### 2. Fix Whitelist Pattern
- Changed from `~/go/pkg/mod/cache/*` to `~/go/pkg/mod/*`
- Split into separate entries for build cache and module cache
- More accurate descriptions

## Testing

✅ All 442 existing tests pass
✅ Code quality checks pass (shellcheck)
✅ Whitelist protection now works correctly for Go caches

## Backward Compatibility

✅ **Zero breaking changes**
✅ Default behavior unchanged (cleans Go caches if not whitelisted)
✅ Only affects behavior when Go caches are explicitly whitelisted

## Example Behavior

**Before (Bug):**
```bash
# User adds Go cache to whitelist
mo whitelist  # Select "Go module cache"

# But it still gets deleted!
mo clean dev  # ❌ Deletes ~/go/pkg/mod/* anyway
```

**After (Fixed):**
```bash
# User adds Go cache to whitelist
mo whitelist  # Select "Go module cache"

# Now it's protected
mo clean dev  # ✅ Skips Go module cache, shows "Protected by whitelist"
```

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass (`./scripts/test.sh`)
- [x] Code quality checks pass (`./scripts/check.sh`)
- [x] Commit messages follow conventional commits format
- [x] PR targets `dev` branch (not `main`)
- [x] No breaking changes
- [x] Fixes critical whitelist trust issue