### PR TITLE
fix(status): enable network data in JSON mode

### DIFF
--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -212,6 +212,14 @@ func animTickWithSpeed(cpuUsage float64) tea.Cmd {
 // runJSONMode collects metrics once and outputs as JSON.
 func runJSONMode() {
 	collector := NewCollector()
+
+	// First collection initializes network state (returns nil for network)
+	_, _ = collector.Collect()
+
+	// Wait 1 second for network rate calculation
+	time.Sleep(1 * time.Second)
+
+	// Second collection has actual network data
 	data, err := collector.Collect()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error collecting metrics: %v\n", err)


### PR DESCRIPTION
## Problem

Network rate calculation requires two samples to compute the delta (current - previous) / time. In JSON mode, the collector was only called once, causing the `network` field to always return `nil`.

## Solution

This PR adds a second collection call with a 1-second interval in `runJSONMode()`, allowing the network rates to be calculated properly.

## Changes

- First `Collect()` call initializes network state
- Wait 1 second for network traffic accumulation  
- Second `Collect()` call returns actual network data

## Testing

Before:
```bash
mole status --json | jq '.network'
# Output: null
```

After:
```bash
mole status --json | jq '.network'
# Output: [{"name": "en0", "rx_rate_mbs": 0.009, "tx_rate_mbs": 0.114, ...}]
```

## Impact

- Execution time increases by ~1.5 seconds (necessary for rate calculation)
- TUI mode is not affected
- Other JSON fields are not affected