### PR TITLE
fix(sudo): add GUI mode support for non-TTY environments

### DIFF
--- a/lib/core/sudo.sh
+++ b/lib/core/sudo.sh
@@ -108,14 +108,41 @@ request_sudo_access() {
         return 0
     fi
 
-    # Get TTY path
+    # Detect if running in TTY environment
     local tty_path="/dev/tty"
+    local is_gui_mode=false
+
     if [[ ! -r "$tty_path" || ! -w "$tty_path" ]]; then
         tty_path=$(tty 2> /dev/null || echo "")
         if [[ -z "$tty_path" || ! -r "$tty_path" || ! -w "$tty_path" ]]; then
-            log_error "No interactive terminal available"
+            is_gui_mode=true
+        fi
+    fi
+
+    # GUI mode: use osascript for password dialog
+    if [[ "$is_gui_mode" == true ]]; then
+        # Clear sudo cache before attempting authentication
+        sudo -k 2> /dev/null
+
+        # Display native macOS password dialog
+        local password
+        password=$(osascript -e "display dialog \"$prompt_msg\" default answer \"\" with title \"Mole\" with icon caution with hidden answer" -e 'text returned of result' 2> /dev/null)
+
+        if [[ -z "$password" ]]; then
+            # User cancelled the dialog
+            unset password
             return 1
         fi
+
+        # Attempt sudo authentication with the provided password
+        if printf '%s\n' "$password" | sudo -S -p "" -v > /dev/null 2>&1; then
+            unset password
+            return 0
+        fi
+
+        # Password was incorrect
+        unset password
+        return 1
     fi
 
     sudo -k


### PR DESCRIPTION
## Problem

When Mole is called from GUI applications (e.g., macOS SwiftUI apps), commands requiring sudo access fail with the error:
```
/dev/tty: Device not configured
```

This occurs because `/dev/tty` is not available in non-TTY environments, causing `request_sudo_access()` in `lib/core/sudo.sh` to fail.

## Solution

This PR adds automatic environment detection to `request_sudo_access()`:

- **TTY mode** (terminal): Preserves all existing behavior including Touch ID support
- **GUI mode** (non-TTY): Uses macOS native password dialog via `osascript`

## Changes

- Detect TTY availability before attempting terminal-based authentication
- Display native macOS password dialog when running in GUI mode
- Maintain backward compatibility with all terminal workflows
- Ensure secure password handling (variables unset after use)

## Testing

- ✅ Passes `./scripts/check.sh` (formatting, linting, syntax)
- ✅ Terminal usage unchanged (Touch ID still works)
- ✅ GUI applications can now request sudo access via native dialog

## Affected Commands

This fix enables the following commands to work from GUI applications:
- `mole clean`
- `mole optimize`
- `mole purge`
- `mole uninstall`
- Any other command requiring sudo access