### PR TITLE
refactor: fix modernize lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
     - errcheck
     - ineffassign
     - unused
+    # Additional linters
+    - modernize
 
   settings:
     govet:

--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -644,7 +644,7 @@ func TestCalculateDirSizeFastHighFanoutCompletes(t *testing.T) {
 
 	// Reproduce high fan-out nested directory pattern that previously risked semaphore deadlock.
 	const fanout = 256
-	for i := 0; i < fanout; i++ {
+	for i := range fanout {
 		nested := filepath.Join(root, fmt.Sprintf("dir-%03d", i), "nested")
 		if err := os.MkdirAll(nested, 0o755); err != nil {
 			t.Fatalf("create nested dir: %v", err)

--- a/cmd/analyze/heap_test.go
+++ b/cmd/analyze/heap_test.go
@@ -70,7 +70,7 @@ func TestEntryHeap(t *testing.T) {
 		heap.Push(h, dirEntry{Name: "c", Size: 100})
 
 		// All have same size, heap property still holds.
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			popped := heap.Pop(h).(dirEntry)
 			if popped.Size != 100 {
 				t.Errorf("Pop() size = %d, want 100", popped.Size)

--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -77,16 +77,7 @@ func scanPathConcurrent(root string, filesScanned, dirsScanned, bytesScanned *in
 	largeFileMinSize := int64(largeFileWarmupMinSize)
 
 	// Worker pool sized for I/O-bound scanning.
-	numWorkers := max(runtime.NumCPU()*cpuMultiplier, minWorkers)
-	if numWorkers > maxWorkers {
-		numWorkers = maxWorkers
-	}
-	if numWorkers > len(children) {
-		numWorkers = len(children)
-	}
-	if numWorkers < 1 {
-		numWorkers = 1
-	}
+	numWorkers := max(min(max(runtime.NumCPU()*cpuMultiplier, minWorkers), maxWorkers, len(children)), 1)
 	sem := make(chan struct{}, numWorkers)
 	dirSem := make(chan struct{}, min(runtime.NumCPU()*2, maxDirWorkers))
 	duSem := make(chan struct{}, min(4, runtime.NumCPU()))        // limits concurrent du processes
@@ -95,13 +86,7 @@ func scanPathConcurrent(root string, filesScanned, dirsScanned, bytesScanned *in
 
 	// Collect results via channels.
 	// Cap buffer size to prevent memory spikes with huge directories.
-	entryBufSize := len(children)
-	if entryBufSize > 4096 {
-		entryBufSize = 4096
-	}
-	if entryBufSize < 1 {
-		entryBufSize = 1
-	}
+	entryBufSize := max(min(len(children), 4096), 1)
 	entryChan := make(chan dirEntry, entryBufSize)
 	largeFileChan := make(chan fileEntry, maxLargeFiles*2)
 

--- a/cmd/status/metrics_network.go
+++ b/cmd/status/metrics_network.go
@@ -261,10 +261,10 @@ func scutilProxyEnabled(out, key string) bool {
 
 func scutilProxyValue(out, key string) string {
 	prefix := key + " :"
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.Lines(out) {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, prefix) {
-			return strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		if after, ok := strings.CutPrefix(line, prefix); ok {
+			return strings.TrimSpace(after)
 		}
 	}
 	return ""

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -261,7 +261,7 @@ func renderCPUCard(cpu CPUStatus, thermal ThermalStatus) cardData {
 		sort.Slice(cores, func(i, j int) bool { return cores[i].val > cores[j].val })
 
 		maxCores := min(len(cores), 3)
-		for i := 0; i < maxCores; i++ {
+		for i := range maxCores {
 			c := cores[i]
 			lines = append(lines, fmt.Sprintf("Core%-2d %s  %5.1f%%", c.idx+1, progressBar(c.val), c.val))
 		}
@@ -403,10 +403,7 @@ func formatDiskLine(label string, d DiskStatus) string {
 }
 
 func ioBar(rate float64) string {
-	filled := min(int(rate/10.0), 5)
-	if filled < 0 {
-		filled = 0
-	}
+	filled := max(min(int(rate/10.0), 5), 0)
 	bar := strings.Repeat("▮", filled) + strings.Repeat("▯", 5-filled)
 	if rate > 80 {
 		return dangerStyle.Render(bar)
@@ -451,10 +448,7 @@ func buildCards(m MetricsSnapshot, width int) []cardData {
 }
 
 func miniBar(percent float64) string {
-	filled := min(int(percent/20), 5)
-	if filled < 0 {
-		filled = 0
-	}
+	filled := max(min(int(percent/20), 5), 0)
 	return colorizePercent(percent, strings.Repeat("▮", filled)+strings.Repeat("▯", 5-filled))
 }
 
@@ -478,13 +472,7 @@ func renderNetworkCard(netStats []NetworkStatus, history NetworkHistory, proxy P
 		// Layout: "Down   " (7) + graph + "  " (2) + rate (approx 10-12)
 		// Safe margin: 22 chars.
 		// We target 16 chars to match progressBar implementation for visual consistency.
-		graphWidth := cardWidth - 22
-		if graphWidth < 5 {
-			graphWidth = 5
-		}
-		if graphWidth > 16 {
-			graphWidth = 16 // Match progressBar fixed width
-		}
+		graphWidth := min(max(cardWidth-22, 5), 16)
 
 		// sparkline graphs
 		rxSparkline := sparkline(history.RxHistory, totalRx, graphWidth)
@@ -536,10 +524,7 @@ func sparkline(history []float64, current float64, width int) string {
 
 	var builder strings.Builder
 	for _, v := range data {
-		level := int((v / maxVal) * float64(len(blocks)-1))
-		if level < 0 {
-			level = 0
-		}
+		level := max(int((v/maxVal)*float64(len(blocks)-1)), 0)
 		if level >= len(blocks) {
 			level = len(blocks) - 1
 		}
@@ -639,10 +624,7 @@ func renderCard(data cardData, width int, height int) string {
 	}
 
 	titleText := data.icon + " " + data.title
-	lineLen := width - lipgloss.Width(titleText) - 2
-	if lineLen < 0 {
-		lineLen = 0
-	}
+	lineLen := max(width-lipgloss.Width(titleText)-2, 0)
 
 	header := titleStyle.Render(titleText)
 	if lineLen > 0 {

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -951,7 +951,7 @@ func TestRenderHeaderWrapsOnNarrowWidth(t *testing.T) {
 	}
 
 	header, _ := renderHeader(m, "", 0, 38, true)
-	for _, line := range strings.Split(header, "\n") {
+	for line := range strings.Lines(header) {
 		if lipgloss.Width(stripANSI(line)) > 38 {
 			t.Fatalf("renderHeader() line exceeds width: %q", line)
 		}
@@ -1021,7 +1021,7 @@ func TestRenderCardWrapsOnNarrowWidth(t *testing.T) {
 	}
 
 	rendered := renderCard(card, 26, 0)
-	for _, line := range strings.Split(rendered, "\n") {
+	for line := range strings.Lines(rendered) {
 		if lipgloss.Width(stripANSI(line)) > 26 {
 			t.Fatalf("renderCard() line exceeds width: %q", line)
 		}


### PR DESCRIPTION
This PR enables [`modernize`](https://golangci-lint.run/docs/linters/configuration/#modernize) linter and applies `golangci-lint run --enable-only modernize --fix` a few times to fix lint issues.