### PR TITLE
fix: mo purge crashes with unbound variable when no artifacts found

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1310,6 +1310,14 @@ clean_project_artifacts() {
     if [[ -t 1 ]]; then
         stop_inline_spinner
     fi
+    # Exit early if no artifacts were found to avoid unbound variable errors
+    # when expanding empty arrays with set -u active.
+    if [[ ${#menu_options[@]} -eq 0 ]]; then
+        echo ""
+        echo -e "${GRAY}No artifacts found to purge${NC}"
+        printf '\n'
+        return 0
+    fi
     # Set global vars for selector
     export PURGE_CATEGORY_SIZES=$(
         IFS=,


### PR DESCRIPTION
`mo purge` crashes immediately when there are no artifacts to clean:

```
mo purge
Purge Project Artifacts
/opt/homebrew/Cellar/mole/1.29.0/libexec/bin/../lib/clean/project.sh: line 1325: menu_options[@]: unbound variable
```

The script uses `set -euo pipefail` at the top. When the scan finds nothing, `menu_options` stays empty. Bash throws an "unbound variable" error when you try to expand an empty array with `set -u` active — which is exactly what happens at line 1325 when passing `${menu_options[@]}` to `select_purge_categories`.

The fix is a simple early return after the spinner stops: if `menu_options` is empty, show a friendly message and exit cleanly instead of crashing.

Fixes #546