### PR TITLE
Add support for nix package manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,42 @@ jobs:
           draft: false
           prerelease: false
 
+  update-flake:
+    name: Update Nix Flake Hashes
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          ref: main
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          VERSION=${TAG#V}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update flake hashes
+        run: ./scripts/update-flake-hashes.sh "${{ steps.version.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Commit updated flake.nix
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "flake: update hashes for V${{ steps.version.outputs.version }}"
+            git push origin main
+          fi
+
   update-formula:
     runs-on: ubuntu-latest
     needs: release

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,133 @@
+{
+  description = "Mole - Deep clean and optimize your Mac";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachSystem [ "x86_64-darwin" "aarch64-darwin" ] (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = "1.30.0";
+
+        archSuffix = if system == "aarch64-darwin" then "arm64" else "amd64";
+
+        # Prebuilt Go binaries from GitHub releases
+        analyzeBin = pkgs.fetchurl {
+          url = "https://github.com/tw93/Mole/releases/download/V${version}/analyze-darwin-${archSuffix}";
+          sha256 = if archSuffix == "arm64"
+            then "sha256-jktoZmP5Kv04z3+HqXeHrYm0ZIkpH3+NxusZNly7YfA="
+            else "sha256-7ve81TtA08vBy8pXbVEaTuR9MPFvSj7yfJcHWYfq+lo=";
+        };
+
+        statusBin = pkgs.fetchurl {
+          url = "https://github.com/tw93/Mole/releases/download/V${version}/status-darwin-${archSuffix}";
+          sha256 = if archSuffix == "arm64"
+            then "sha256-owoPwOigBTBiC6Jzp/ex312rnEE/kdZY8OEhNKZu+U8="
+            else "sha256-+uy6EKVvX4BGD3KbAMLNcbVJBBPUHnUoqXy/nu65h/o=";
+        };
+
+        runtimeDeps = with pkgs; [ bash coreutils curl gnugrep gnused ];
+
+        # Shared install logic for both variants
+        mkMole = { goBinaries }:
+          pkgs.stdenv.mkDerivation {
+            pname = "mole";
+            inherit version;
+            src = ./.;
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+
+            dontBuild = true;
+
+            installPhase = ''
+              runHook preInstall
+
+              # Set up the SCRIPT_DIR layout expected by mole
+              mkdir -p $out/share/mole/bin $out/share/mole/lib $out/bin
+
+              # Install shell libraries
+              cp -r lib/* $out/share/mole/lib/
+
+              # Install bin/ shell scripts (subcommand entry points)
+              cp bin/*.sh $out/share/mole/bin/
+              chmod +x $out/share/mole/bin/*.sh
+
+              # Install Go binaries
+              install -m755 ${goBinaries.analyze} $out/share/mole/bin/analyze-go
+              install -m755 ${goBinaries.status} $out/share/mole/bin/status-go
+
+              # Install main script with SCRIPT_DIR patched
+              substitute mole $out/share/mole/mole \
+                --replace-fail 'SCRIPT_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")" && pwd)"' \
+                               'SCRIPT_DIR="'"$out"'/share/mole"'
+              chmod +x $out/share/mole/mole
+
+              # Install mo alias with patched path
+              substitute mo $out/share/mole/mo \
+                --replace-fail 'SCRIPT_DIR="$(cd "$(dirname "''${BASH_SOURCE[0]}")" && pwd)"' \
+                               'SCRIPT_DIR="'"$out"'/share/mole"'
+              chmod +x $out/share/mole/mo
+
+              # Create wrapped executables in $out/bin
+              # --run ensures the log directory exists before mole runs
+              makeWrapper $out/share/mole/mole $out/bin/mole \
+                --prefix PATH : ${pkgs.lib.makeBinPath runtimeDeps} \
+                --run 'mkdir -p "$HOME/Library/Logs/mole"'
+
+              makeWrapper $out/share/mole/mo $out/bin/mo \
+                --prefix PATH : ${pkgs.lib.makeBinPath runtimeDeps} \
+                --run 'mkdir -p "$HOME/Library/Logs/mole"'
+
+              runHook postInstall
+            '';
+
+            meta = with pkgs.lib; {
+              description = "Deep clean and optimize your Mac";
+              homepage = "https://github.com/tw93/Mole";
+              license = licenses.mit;
+              platforms = [ "x86_64-darwin" "aarch64-darwin" ];
+              mainProgram = "mole";
+            };
+          };
+
+        # Go binaries built from source
+        goBinariesFromSource =
+          let
+            goMod = pkgs.buildGoModule {
+              pname = "mole-go";
+              inherit version;
+              src = ./.;
+              vendorHash = "sha256-LznLZ0NO8VBWP95ReAVORUMIDhh7/pgTY5mGNN2tND8=";
+              ldflags = [ "-s" "-w" ];
+              subPackages = [ "cmd/analyze" "cmd/status" ];
+            };
+          in {
+            analyze = "${goMod}/bin/analyze";
+            status = "${goMod}/bin/status";
+          };
+
+      in {
+        packages = {
+          # Default: uses prebuilt binaries from GitHub releases
+          default = mkMole {
+            goBinaries = {
+              analyze = analyzeBin;
+              status = statusBin;
+            };
+          };
+
+          # Build Go components from source
+          from-source = mkMole {
+            goBinaries = goBinariesFromSource;
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [ go bash shellcheck bats ];
+        };
+      }
+    );
+}

--- a/scripts/update-flake-hashes.sh
+++ b/scripts/update-flake-hashes.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Updates flake.nix hashes from GitHub release asset digests.
+# Usage: ./scripts/update-flake-hashes.sh [version]
+# If no version is given, uses the latest release.
+
+set -euo pipefail
+
+# Portable in-place sed (BSD on macOS needs -i '', GNU on Linux needs -i)
+sedi() {
+    if sed --version &>/dev/null; then
+        sedi "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
+REPO="tw93/Mole"
+FLAKE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/flake.nix"
+
+if [[ ! -f "$FLAKE" ]]; then
+    echo "Error: flake.nix not found at $FLAKE" >&2
+    exit 1
+fi
+
+if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI is required" >&2
+    exit 1
+fi
+
+# Resolve version
+if [[ -n "${1:-}" ]]; then
+    VERSION="$1"
+else
+    VERSION=$(gh api "repos/$REPO/releases/latest" --jq '.tag_name' | sed 's/^V//')
+fi
+
+echo "Updating flake.nix for version $VERSION"
+
+# Fetch digests from GitHub API
+get_digest() {
+    local name="$1"
+    gh api "repos/$REPO/releases/tags/V${VERSION}" \
+        --jq ".assets[] | select(.name == \"$name\") | .digest" \
+        | sed 's/^sha256:/sha256:/'
+}
+
+hex_to_sri() {
+    local hex="$1"
+    # Convert hex to binary then base64 for SRI format
+    local b64
+    b64=$(echo "$hex" | sed 's/^sha256://' | xxd -r -p | base64)
+    echo "sha256-${b64}"
+}
+
+echo "Fetching digests from GitHub..."
+ANALYZE_AMD64=$(hex_to_sri "$(get_digest "analyze-darwin-amd64")")
+ANALYZE_ARM64=$(hex_to_sri "$(get_digest "analyze-darwin-arm64")")
+STATUS_AMD64=$(hex_to_sri "$(get_digest "status-darwin-amd64")")
+STATUS_ARM64=$(hex_to_sri "$(get_digest "status-darwin-arm64")")
+
+echo "  analyze-amd64: $ANALYZE_AMD64"
+echo "  analyze-arm64: $ANALYZE_ARM64"
+echo "  status-amd64:  $STATUS_AMD64"
+echo "  status-arm64:  $STATUS_ARM64"
+
+# Update flake.nix using sed
+# Version
+sedi "s|version = \".*\";|version = \"${VERSION}\";|" "$FLAKE"
+
+# analyzeBin hashes (arm64 line comes first in the if/then/else)
+# Pattern: the analyzeBin block has arm64 then amd64
+sedi "/analyzeBin/,/};/ {
+    s|then \"sha256-[^\"]*\"|then \"${ANALYZE_ARM64}\"|
+    s|else \"sha256-[^\"]*\"|else \"${ANALYZE_AMD64}\"|
+}" "$FLAKE"
+
+# statusBin hashes
+sedi "/statusBin/,/};/ {
+    s|then \"sha256-[^\"]*\"|then \"${STATUS_ARM64}\"|
+    s|else \"sha256-[^\"]*\"|else \"${STATUS_AMD64}\"|
+}" "$FLAKE"
+
+echo ""
+echo "Updated flake.nix to version $VERSION"
+echo ""
+echo "NOTE: If Go dependencies changed, the vendorHash also needs updating."
+echo "      Run 'nix build .#from-source' — if it fails, replace vendorHash"
+echo "      with the hash from the error message."


### PR DESCRIPTION
## Summary

New flake will prefer to use prebuilt binaries from Github. However this requires updating to hash with every release. A script to do so is provided with this commit. The CI/CD workflow has been updated to call this script.

Fixes issue https://github.com/tw93/Mole/issues/448

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
No

- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
No

- If yes, describe the new boundary or risk change clearly.

## Tests

- List the automated tests you ran.
All existing automated tests pass

- List any manual checks for high-risk paths or destructive flows.

| Test                                   | Result                              |
|----------------------------------------|-------------------------------------|
| nix build (prebuilt)                   | Pass                                |
| nix build .#from-source                | Pass                                |
| mole --version (default)               | 1.30.0                              |
| mole --version (from-source)           | 1.30.0                              |
| mo --version (alias)                   | 1.30.0                              |
| Go binaries present (analyze-go, status-go) | Pass                           |
| Shell libs installed                   | Pass                                |
| update-flake-hashes.sh                 | Pass                                |
| nix develop (devShell)                 | Pass (Go 1.25.7, Bash 5.3, shellcheck, bats) |


## Safety-related changes

- None.
