### PR TITLE
protect macOS wallpaper assets from default cleanup

### DIFF
--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -444,19 +444,22 @@ clean_support_app_data() {
         safe_find_delete "$crash_reporter_dir" "*" "$support_age_days" "f" || true
     fi
 
-    # Keep recent wallpaper assets to avoid large re-downloads.
+    # Wallpaper assets are user-downloaded resources. Protect them by default
+    # via the whitelist to avoid expensive re-downloads, while still allowing
+    # advanced users to opt out of protection manually.
     local idle_assets_dir="$HOME/Library/Application Support/com.apple.idleassetsd"
     if [[ -d "$idle_assets_dir" && ! -L "$idle_assets_dir" ]]; then
         safe_find_delete "$idle_assets_dir" "*" "$support_age_days" "f" || true
     fi
 
-    # Clean system-level idle/aerial screensaver videos (macOS re-downloads as needed).
+    # System-level idle assets are also protected by the default whitelist.
     local sys_idle_assets_dir="/Library/Application Support/com.apple.idleassetsd/Customer"
     if sudo test -d "$sys_idle_assets_dir" 2> /dev/null; then
         safe_sudo_find_delete "$sys_idle_assets_dir" "*" "$support_age_days" "f" || true
     fi
 
-    # Clean old aerial wallpaper videos (can be large, safe to remove).
+    # Downloaded aerial wallpaper videos are protected by default whitelist
+    # entries because users expect them to persist after cleanup.
     safe_clean ~/Library/Application\ Support/com.apple.wallpaper/aerials/videos/* "Aerial wallpaper videos"
 
     # Do not touch Messages attachments, only preview/sticker caches.

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -105,6 +105,9 @@ declare -a DEFAULT_WHITELIST_PATTERNS=(
     "$HOME/Library/Caches/com.apple.spotlight*"
     "$HOME/Library/Caches/com.apple.Spotlight*"
     "$HOME/Library/Caches/CloudKit*"
+    "$HOME/Library/Application Support/com.apple.wallpaper/*"
+    "$HOME/Library/Application Support/com.apple.idleassetsd/*"
+    "/Library/Application Support/com.apple.idleassetsd/Customer/*"
     "$FINDER_METADATA_SENTINEL"
 )
 

--- a/lib/manage/whitelist.sh
+++ b/lib/manage/whitelist.sh
@@ -78,6 +78,9 @@ get_all_cache_items() {
     # Format: "display_name|pattern|category"
     cat << 'EOF'
 Apple Mail cache|$HOME/Library/Caches/com.apple.mail/*|system_cache
+macOS downloaded wallpaper assets|$HOME/Library/Application Support/com.apple.wallpaper/*|system_cache
+macOS user wallpaper idle assets|$HOME/Library/Application Support/com.apple.idleassetsd/*|system_cache
+macOS system wallpaper idle assets|/Library/Application Support/com.apple.idleassetsd/Customer/*|system_cache
 Gradle build cache (Android Studio, Gradle projects)|$HOME/.gradle/caches/*|ide_cache
 Gradle daemon processes cache|$HOME/.gradle/daemon/*|ide_cache
 Xcode DerivedData (build outputs, indexes)|$HOME/Library/Developer/Xcode/DerivedData/*|ide_cache


### PR DESCRIPTION
Fixes #577

## Summary

  Protect downloaded macOS wallpaper assets from default cleanup.

  `mo clean` currently cleans wallpaper-related assets under:

  - `~/Library/Application Support/com.apple.wallpaper/aerials/videos/*`
  - `~/Library/Application Support/com.apple.idleassetsd/*`
  - `/Library/Application Support/com.apple.idleassetsd/Customer/*`

  In practice, these behave more like user-downloaded system assets than disposable cache. When they are
  removed, macOS needs to download them again from System Settings > Wallpaper.

  ## What this PR changes

  - add wallpaper asset paths to the default cleanup whitelist
  - add corresponding entries to `mo clean --whitelist`
  - update nearby comments to reflect the more conservative default behavior

  ## Why

  On my machine, `mo clean` removed multiple files from:

  `~/Library/Application Support/com.apple.wallpaper/aerials/videos/`

  That caused previously downloaded wallpapers to disappear and require large re-downloads.

  Mole already uses safety-first defaults in many other places. This change makes the wallpaper behavior more
  consistent with that approach and avoids surprising data loss from a user perspective.

  ## Notes

  This PR does not remove the underlying cleanup logic. It only protects these paths by default, so advanced
  users can still opt out if they explicitly want to clean them.