### PR TITLE
Add --all flag to mo purge

### DIFF
--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -275,6 +275,7 @@ show_help() {
     echo -e "${YELLOW}Usage:${NC} mo purge [options]"
     echo ""
     echo -e "${YELLOW}Options:${NC}"
+    echo "  --all           Select all artifacts without prompting"
     echo "  --paths         Edit custom scan directories"
     echo "  --dry-run       Preview purge actions without making changes"
     echo "  --debug         Enable debug logging"
@@ -305,6 +306,9 @@ main() {
                 ;;
             "--debug")
                 export MO_DEBUG=1
+                ;;
+            "--all" | "-a")
+                export MOLE_PURGE_ALL=1
                 ;;
             "--dry-run" | "-n")
                 export MOLE_DRY_RUN=1

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1417,7 +1417,13 @@ clean_project_artifacts() {
     # Interactive selection (only if terminal is available)
     PURGE_SELECTION_RESULT=""
     PURGE_CATEGORY_FULL_PATHS_ARRAY=("${item_display_paths[@]}")
-    if [[ -t 0 ]]; then
+    if [[ "${MOLE_PURGE_ALL:-0}" == "1" ]]; then
+        # --all flag: select everything (including recent items)
+        for ((i = 0; i < ${#menu_options[@]}; i++)); do
+            [[ -n "$PURGE_SELECTION_RESULT" ]] && PURGE_SELECTION_RESULT+=","
+            PURGE_SELECTION_RESULT+="$i"
+        done
+    elif [[ -t 0 ]]; then
         if ! select_purge_categories "${menu_options[@]}"; then
             PURGE_CATEGORY_FULL_PATHS_ARRAY=()
             unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_SELECTION_RESULT
@@ -1454,7 +1460,7 @@ clean_project_artifacts() {
         selected_display_paths+=("${item_display_paths[idx]}")
     done
 
-    if [[ -t 0 ]]; then
+    if [[ "${MOLE_PURGE_ALL:-0}" != "1" && -t 0 ]]; then
         if ! confirm_purge_cleanup "${#selected_indices[@]}" "$selected_total_kb" "$selected_unknown_count" "${selected_display_paths[@]}"; then
             echo -e "${GRAY}Purge cancelled${NC}"
             printf '\n'

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -846,6 +846,44 @@ EOF
 	[[ "$output" == *"DRY RUN MODE"* ]] || [[ "$output" == *"Dry run complete"* ]]
 }
 
+@test "mo purge: accepts --all flag" {
+	if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+		skip "gtimeout/timeout not available"
+	fi
+
+	timeout_cmd="timeout"
+	command -v timeout >/dev/null 2>&1 || timeout_cmd="gtimeout"
+
+	run bash -c "
+        export HOME='$HOME'
+        $timeout_cmd 5 '$PROJECT_ROOT/mole' purge --all --dry-run 2>&1 || true
+    "
+
+	[[ "$output" == *"DRY RUN MODE"* ]] || [[ "$output" == *"Dry run complete"* ]]
+}
+
+@test "clean_project_artifacts: --all selects all items including recent" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_PURGE_ALL=1 bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+mkdir -p "$HOME/.cache/mole"
+echo "0" > "$HOME/.cache/mole/purge_stats"
+echo "0" > "$HOME/.cache/mole/purge_count"
+
+mkdir -p "$HOME/www/test-project/node_modules"
+echo "test data" > "$HOME/www/test-project/node_modules/file.js"
+touch "$HOME/www/test-project/package.json"
+
+PURGE_SEARCH_PATHS=("$HOME/www")
+export MOLE_DRY_RUN=1
+clean_project_artifacts
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "mo purge: creates cache directory for stats" {
 	if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
 		skip "gtimeout/timeout not available"


### PR DESCRIPTION
## Summary

- Adds `--all` (`-a`) flag to `mo purge` that selects all discovered artifacts (including recent ones) and skips both the interactive picker and confirmation prompt
- Useful for scripting and automation (e.g. running `mo purge --all` in a cleanup script) where interactive selection is not practical
- Can be combined with `--dry-run` to preview what would be cleaned: `mo purge --all --dry-run`

## Changes

- `bin/purge.sh`: Parse `--all`/`-a` flag, export `MOLE_PURGE_ALL=1`, update help text
- `lib/clean/project.sh`: When `MOLE_PURGE_ALL=1`, select all items (including recent) and skip interactive prompt + confirmation
- `tests/purge.bats`: Added 2 tests for the new flag

## Test plan

- [x] All 59 existing tests pass
- [x] New test: `mo purge: accepts --all flag`
- [x] New test: `clean_project_artifacts: --all selects all items including recent`
- [x] Manual test: `mo purge --all --dry-run` shows all items selected without prompting
- [x] Manual test: `mo purge --all` cleans everything without prompting
- [x] Manual test: `mo purge` (without --all) still shows interactive picker as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)