### PR TITLE
fix: pass through sudo's native prompt instead of hardcoding 'Password:'

### DIFF
--- a/lib/core/sudo.sh
+++ b/lib/core/sudo.sh
@@ -57,6 +57,8 @@ _request_password() {
 
     echo -e "${PURPLE}${ICON_ARROW}${NC} Enter your credentials:" > "$tty_path"
 
+    # shellcheck disable=SC2024,SC2094
+    # Intentionally route sudo's native prompt to the same TTY device it reads from.
     if sudo -v < "$tty_path" > /dev/null 2> "$tty_path"; then
         return 0
     fi
@@ -118,10 +120,14 @@ request_sudo_access() {
 
     # Check if in clamshell mode - if yes, skip Touch ID entirely
     if is_clamshell_mode; then
+        local clear_lines=3
+        if check_touchid_support; then
+            clear_lines=4
+        fi
         echo -e "${PURPLE}${ICON_ARROW}${NC} ${prompt_msg}"
         if _request_password "$tty_path"; then
             # Clear all prompt lines (use safe clearing method)
-            safe_clear_lines 3 "$tty_path"
+            safe_clear_lines "$clear_lines" "$tty_path"
             return 0
         fi
         return 1

--- a/tests/manage_sudo.bats
+++ b/tests/manage_sudo.bats
@@ -70,3 +70,59 @@ setup() {
     result=$(bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; source '$PROJECT_ROOT/lib/core/sudo.sh'; echo \$MOLE_SUDO_ESTABLISHED")
     [[ "$result" == "false" ]] || [[ -z "$result" ]]
 }
+
+@test "request_sudo_access clears four lines in clamshell mode when Touch ID hint is shown" {
+    run bash -c '
+        source "'"$PROJECT_ROOT"'/lib/core/common.sh"
+        source "'"$PROJECT_ROOT"'/lib/core/sudo.sh"
+
+        tty_file="$(mktemp)"
+        chmod 600 "$tty_file"
+
+        sudo() {
+            case "$1" in
+                -n) return 1 ;;
+                -k) return 0 ;;
+                *) return 1 ;;
+            esac
+        }
+        tty() { printf "%s\n" "$tty_file"; }
+        is_clamshell_mode() { return 0; }
+        check_touchid_support() { return 0; }
+        _request_password() { return 0; }
+        safe_clear_lines() { printf "CLEAR:%s\n" "$1"; }
+
+        request_sudo_access "Admin access required"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CLEAR:4"* ]]
+}
+
+@test "request_sudo_access keeps three-line cleanup in clamshell mode without Touch ID" {
+    run bash -c '
+        source "'"$PROJECT_ROOT"'/lib/core/common.sh"
+        source "'"$PROJECT_ROOT"'/lib/core/sudo.sh"
+
+        tty_file="$(mktemp)"
+        chmod 600 "$tty_file"
+
+        sudo() {
+            case "$1" in
+                -n) return 1 ;;
+                -k) return 0 ;;
+                *) return 1 ;;
+            esac
+        }
+        tty() { printf "%s\n" "$tty_file"; }
+        is_clamshell_mode() { return 0; }
+        check_touchid_support() { return 1; }
+        _request_password() { return 0; }
+        safe_clear_lines() { printf "CLEAR:%s\n" "$1"; }
+
+        request_sudo_access "Admin access required"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CLEAR:3"* ]]
+}


### PR DESCRIPTION
Fixes #597

Previously `_request_password` hardcoded `Password:` as the prompt, which is wrong for auth methods like YubiKey that expect a PIN prompt.

Now we call `sudo -v` directly on the TTY and let it handle everything — prompting, echo, and retries. The correct prompt (whatever PAM outputs) shows up naturally.