### PR TITLE
fix(status): pad View output to terminal height to prevent ghost lines on resize

### DIFF
--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -165,6 +165,7 @@ func (m model) View() string {
 
 	header, mole := renderHeader(m.metrics, m.errMessage, m.animFrame, termWidth, m.catHidden)
 
+	var cardContent string
 	if termWidth <= 80 {
 		cardWidth := termWidth
 		if cardWidth > 2 {
@@ -179,27 +180,31 @@ func (m model) View() string {
 			}
 			rendered = append(rendered, renderCard(c, cardWidth, 0))
 		}
-		// Combine header, mole, and cards with consistent spacing
-		var content []string
-		content = append(content, header)
-		if mole != "" {
-			content = append(content, mole)
-		}
-		content = append(content, lipgloss.JoinVertical(lipgloss.Left, rendered...))
-		return lipgloss.JoinVertical(lipgloss.Left, content...)
+		cardContent = lipgloss.JoinVertical(lipgloss.Left, rendered...)
+	} else {
+		cardWidth := max(24, termWidth/2-4)
+		cards := buildCards(m.metrics, cardWidth)
+		cardContent = renderTwoColumns(cards, termWidth)
 	}
 
-	cardWidth := max(24, termWidth/2-4)
-	cards := buildCards(m.metrics, cardWidth)
-	twoCol := renderTwoColumns(cards, termWidth)
 	// Combine header, mole, and cards with consistent spacing
-	var content []string
-	content = append(content, header)
+	parts := []string{header}
 	if mole != "" {
-		content = append(content, mole)
+		parts = append(parts, mole)
 	}
-	content = append(content, twoCol)
-	return lipgloss.JoinVertical(lipgloss.Left, content...)
+	parts = append(parts, cardContent)
+	output := lipgloss.JoinVertical(lipgloss.Left, parts...)
+
+	// Pad output to exactly fill the terminal height so every frame fully
+	// overwrites the alt screen buffer, preventing ghost lines on resize.
+	if m.height > 0 {
+		contentHeight := lipgloss.Height(output)
+		if contentHeight < m.height {
+			output += strings.Repeat("\n", m.height-contentHeight)
+		}
+	}
+
+	return output
 }
 
 func (m model) collectCmd() tea.Cmd {

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -809,16 +809,16 @@ func TestFormatDiskLine(t *testing.T) {
 			if expectedLabel == "" {
 				expectedLabel = "DISK"
 			}
-			if !contains(got, expectedLabel) {
+			if !strings.Contains(got, expectedLabel) {
 				t.Errorf("formatDiskLine(%q, ...) = %q, should contain label %q", tt.label, got, expectedLabel)
 			}
-			if !contains(got, tt.wantUsed) {
+			if !strings.Contains(got, tt.wantUsed) {
 				t.Errorf("formatDiskLine(%q, ...) = %q, should contain used value %q", tt.label, got, tt.wantUsed)
 			}
-			if !contains(got, tt.wantFree) {
+			if !strings.Contains(got, tt.wantFree) {
 				t.Errorf("formatDiskLine(%q, ...) = %q, should contain free value %q", tt.label, got, tt.wantFree)
 			}
-			if tt.wantNoSubstr != "" && contains(got, tt.wantNoSubstr) {
+			if tt.wantNoSubstr != "" && strings.Contains(got, tt.wantNoSubstr) {
 				t.Errorf("formatDiskLine(%q, ...) = %q, should not contain %q", tt.label, got, tt.wantNoSubstr)
 			}
 		})
@@ -1133,6 +1133,37 @@ func TestRenderMemoryCardShowsSwapSizeOnWideWidth(t *testing.T) {
 	}
 }
 
+func TestModelViewPadsToTerminalHeight(t *testing.T) {
+	tests := []struct {
+		name   string
+		width  int
+		height int
+	}{
+		{"narrow terminal", 60, 40},
+		{"wide terminal", 120, 40},
+		{"tall terminal", 120, 80},
+		{"short terminal", 120, 10},
+		{"zero height", 120, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model{
+				width:   tt.width,
+				height:  tt.height,
+				ready:   true,
+				metrics: MetricsSnapshot{},
+			}
+
+			view := m.View()
+			got := lipgloss.Height(view)
+			if got < tt.height {
+				t.Errorf("View() height = %d, want >= %d (terminal height)", got, tt.height)
+			}
+		})
+	}
+}
+
 func TestModelViewErrorRendersSingleMole(t *testing.T) {
 	m := model{
 		width:      120,
@@ -1168,17 +1199,4 @@ func stripANSI(s string) string {
 		}
 	}
 	return result.String()
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsMiddle(s, substr)))
-}
-
-func containsMiddle(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

- Fix ghost/stale lines appearing below `mo status` dashboard when terminal is resized taller. Pads `View()` output to fill terminal height so the alt screen buffer is fully overwritten each frame.
- Closes #600 

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior? **No.**
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity? **No.**
- This is a display-only fix in the Go TUI (`cmd/status/main.go`).

## Tests

- `go test -v ./cmd/status/` — all pass
- `golangci-lint run ./cmd/status/...` — 0 issues
- `go vet ./cmd/status/...` — clean
- `make build` — success
- Manual: resized terminal taller, shorter, narrower, wider while `mo status` was running — no ghost lines

## Safety-related changes

- None.