### PR TITLE
fix: fall back to defrag.exe when WMI cannot resolve volume

### DIFF
--- a/bin/optimize.ps1
+++ b/bin/optimize.ps1
@@ -158,7 +158,17 @@ function Optimize-DiskDrive {
     try {
         $systemDriveLetter = Get-SystemDriveLetter
         Write-Host "  Running Windows default optimization on drive ${systemDriveLetter}:..."
-        $null = Optimize-Volume -DriveLetter $systemDriveLetter -ErrorAction Stop
+
+        $volume = Get-Volume -DriveLetter $systemDriveLetter -ErrorAction SilentlyContinue
+        if ($volume) {
+            $null = Optimize-Volume -DriveLetter $systemDriveLetter -ErrorAction Stop
+        } else {
+            $result = & defrag "${systemDriveLetter}:" /U /V 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "defrag.exe exited with code $LASTEXITCODE"
+            }
+        }
+
         Write-Host "  $esc[32m$($script:Icons.Success)$esc[0m Drive optimization completed"
         $script:OptimizationsApplied++
     }


### PR DESCRIPTION
## Description

Fixes disk optimization failure when `Optimize-Volume` throws:
> No MSFT_Volume object with the property 'DriveLetter' equal to 'C' was found

**Root cause:** `Optimize-Volume` queries `MSFT_Volume` via the WMI Storage provider. On certain Windows configurations the provider fails to resolve the volume.

**Fix:** Call `Get-Volume` first to check if the volume is accessible via WMI. If it is, proceed with `Optimize-Volume` as before. If not, fall back to `defrag.exe` directly, which does not depend on the WMI Storage provider.

Closes #604