### PR TITLE
fix(uninstall): enhance display name resolution for versioned apps

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -135,6 +135,17 @@ uninstall_resolve_display_name() {
     if [[ "$display_name" == /* ]]; then
         display_name="$app_name"
     fi
+
+    # Keep versioned app titles from the bundle filename when metadata is generic.
+    # Example: Finder shows "Xcode 16.4" while metadata often collapses to "Xcode".
+    if [[ -n "$display_name" && "$app_name" == "$display_name"* && "$app_name" != "$display_name" ]]; then
+        local suffix
+        suffix="${app_name#"$display_name"}"
+        if [[ "$suffix" == *[0-9]* ]]; then
+            display_name="$app_name"
+        fi
+    fi
+
     display_name="${display_name%.app}"
     display_name="${display_name//|/-}"
     display_name="${display_name//[$'\t\r\n']/}"


### PR DESCRIPTION
## Summary

- Preserve versioned app titles from bundle filenames when metadata display names are too generic.
- Fixes uninstall list entries that were collapsing multiple app versions (for example, multiple Xcode installs) into the same visible name.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
  - Yes. It affects only uninstall list display-name resolution.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
  - No. This change only updates label selection logic for UI display names.
- If yes, describe the new boundary or risk change clearly.
  - No new safety boundary changes. No deletion targets, file paths, or privilege logic were modified.

## Tests

- List the automated tests you ran.
  - `bash -n bin/uninstall.sh`
  - `./scripts/check.sh --no-format`
- List any manual checks for high-risk paths or destructive flows.
  - Ran `./bin/uninstall.sh` and verified versioned app entries are distinguishable in the uninstall app list (including sorted view with `s`).
  - Confirmed no regressions for non-versioned app names in the same list.

## Safety-related changes

- None.

Fixes #615