### PR TITLE
add .gitattributes to normalize line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.ps1 text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ mole_guidelines.md
 run_tests.ps1
 session.json
 journal/2026-03-11-safe-remove-design.md
+mole.cmd
+mo.cmd


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` to enforce consistent LF line endings for `.ps1` files and CRLF for `.cmd` files
- Adds `mole.cmd` and `mo.cmd` to `.gitignore` to prevent generated launchers from appearing as tracked changes

## Why
Without `.gitattributes`, Windows users with `core.autocrlf=true` (the default) can get false-positive dirty git status on a clean install, causing `mo update` to fail with "Local tracked changes detected" even though no files were manually modified. Fixes #618.