### PR TITLE
fix(windows): harden PowerShell startup defaults

### DIFF
--- a/lib/core/base.ps1
+++ b/lib/core/base.ps1
@@ -32,22 +32,24 @@ function Get-MoleDefaultColors {
 # Icon Definitions
 # ============================================================================
 function Get-MoleDefaultIcons {
+    # Keep this block ASCII-only so Windows PowerShell 5.1 does not
+    # mis-parse BOM-less source files and collapse comment lines.
     return @{
-        Confirm  = [char]0x25CE  # ◎
-        Admin    = [char]0x2699  # ⚙
-        Success  = [char]0x2713  # ✓
-        Error    = [char]0x263B  # ☻
-        Warning  = [char]0x25CF  # ●
-        Empty    = [char]0x25CB  # ○
-        Solid    = [char]0x25CF  # ●
-        List     = [char]0x2022  # •
-        Arrow    = [char]0x27A4  # ➤
-        DryRun   = [char]0x2192  # →
-        NavUp    = [char]0x2191  # ↑
-        NavDown  = [char]0x2193  # ↓
-        Folder   = [char]0x25A0  # ■ (folder substitute)
-        File     = [char]0x25A1  # □ (file substitute)
-        Trash    = [char]0x2718  # ✘ (trash substitute)
+        Confirm  = [char]0x25CE  # circle confirm marker
+        Admin    = [char]0x2699  # admin/settings marker
+        Success  = [char]0x2713  # success check
+        Error    = [char]0x263B  # error marker
+        Warning  = [char]0x25CF  # warning dot
+        Empty    = [char]0x25CB  # empty circle
+        Solid    = [char]0x25CF  # solid dot
+        List     = [char]0x2022  # list bullet
+        Arrow    = [char]0x27A4  # navigation arrow
+        DryRun   = [char]0x2192  # dry-run arrow
+        NavUp    = [char]0x2191  # up arrow
+        NavDown  = [char]0x2193  # down arrow
+        Folder   = [char]0x25A0  # folder substitute
+        File     = [char]0x25A1  # file substitute
+        Trash    = [char]0x2718  # trash substitute
     }
 }
 
@@ -229,12 +231,25 @@ function Get-WindowsVersion {
     .SYNOPSIS
         Get Windows version information
     #>
-    $os = Get-WmiObject Win32_OperatingSystem
-    return @{
-        Name    = $os.Caption
-        Version = $os.Version
-        Build   = $os.BuildNumber
-        Arch    = $os.OSArchitecture
+    try {
+        $os = Get-WmiObject Win32_OperatingSystem -ErrorAction Stop
+        return @{
+            Name    = $os.Caption
+            Version = $os.Version
+            Build   = $os.BuildNumber
+            Arch    = $os.OSArchitecture
+        }
+    }
+    catch {
+        $currentVersion = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion" -ErrorAction SilentlyContinue
+        $fallbackVersion = [System.Environment]::OSVersion.Version
+
+        return @{
+            Name    = if ($currentVersion.ProductName) { $currentVersion.ProductName } else { "Windows" }
+            Version = if ($currentVersion.DisplayVersion) { $currentVersion.DisplayVersion } elseif ($currentVersion.CurrentVersion) { $currentVersion.CurrentVersion } else { $fallbackVersion.ToString() }
+            Build   = if ($currentVersion.CurrentBuildNumber) { $currentVersion.CurrentBuildNumber } else { $fallbackVersion.Build.ToString() }
+            Arch    = if ($env:PROCESSOR_ARCHITECTURE) { $env:PROCESSOR_ARCHITECTURE } else { "Unknown" }
+        }
     }
 }
 

--- a/tests/Core.Tests.ps1
+++ b/tests/Core.Tests.ps1
@@ -35,6 +35,18 @@ Describe "Base Module" {
             $script:Icons.Admin | Should -Not -BeNullOrEmpty
             $script:Icons.Trash | Should -Not -BeNullOrEmpty
         }
+
+        It "Should expose the full icon table in Windows PowerShell" {
+            $basePath = (Join-Path $script:LibDir "core\base.ps1").Replace("'", "''")
+            $psCommand = "& { . '$basePath'; `$icons = Get-MoleDefaultIcons; [pscustomobject]@{ Count = `$icons.Count; HasSolid = `$icons.ContainsKey('Solid'); HasAdmin = `$icons.ContainsKey('Admin'); HasSuccess = `$icons.ContainsKey('Success') } | ConvertTo-Json -Compress }"
+            $result = & powershell -NoProfile -ExecutionPolicy Bypass -Command $psCommand
+            $iconInfo = $result | ConvertFrom-Json
+
+            $iconInfo.Count | Should -Be 15
+            $iconInfo.HasSolid | Should -Be $true
+            $iconInfo.HasAdmin | Should -Be $true
+            $iconInfo.HasSuccess | Should -Be $true
+        }
     }
 
     Context "Visual Defaults Initialization" {


### PR DESCRIPTION
## Summary

- fix a Windows PowerShell 5.1 parsing issue that could truncate the default icon table in `lib/core/base.ps1`
- add a regression test to verify the full icon table is available when loading `base.ps1` through `powershell.exe`
- add a fallback in `Get-WindowsVersion` so startup still works when `Get-WmiObject Win32_OperatingSystem` is denied in restricted sessions

## Safety Review

- This change affects `clean` startup behavior because `mo clean --debug` could fail before entering the cleanup flow.
- This does not change cleanup targets, deletion rules, whitelist behavior, protected directory handling, symlink handling, admin boundaries, installer integrity, or release behavior.
- The WMI fallback only changes how Windows version metadata is read during startup. It does not broaden any cleanup or system-operation boundary.

## Tests

- Automated checks:
  - verified `Get-MoleDefaultIcons` returns all expected keys in `powershell.exe`
  - added a regression test in `tests/Core.Tests.ps1` covering the Windows PowerShell icon-table load path
- Manual checks:
  - ran an isolated smoke test for `mole.ps1 clean --debug` with temporary `USERPROFILE`, `APPDATA`, and `LOCALAPPDATA` values to confirm startup succeeds and the command enters the cleanup flow
  - confirmed the missing `Solid` property error no longer occurs during startup
- Not run:
  - full Pester suite was not run locally because the available machine version was Pester 3.4.0, while the repo test files use newer `BeforeAll` semantics

## Safety-related changes

- None.