### PR TITLE
fix(windows): update hardcoded version fallback to 1.29.1

### DIFF
--- a/lib/core/version.ps1
+++ b/lib/core/version.ps1
@@ -9,7 +9,7 @@ if ((Get-Variable -Name 'MOLE_VERSION_HELPERS_LOADED' -Scope Script -ErrorAction
 }
 $script:MOLE_VERSION_HELPERS_LOADED = $true
 
-$script:MoleDefaultVersion = "1.29.0"
+$script:MoleDefaultVersion = "1.29.1"
 
 function Get-MoleVersionFilePath {
     param([string]$RootDir)


### PR DESCRIPTION
## Summary
- Updates the hardcoded fallback version in `lib/core/version.ps1` from `1.29.0` to `1.29.1`
- The `VERSION` file was updated for v1.29.1 but the `$script:MoleDefaultVersion` fallback was not, causing `mole --version` to report `1.29.0` when the `VERSION` file is absent (e.g., in the built release)

Fixes #635

## Test plan
- [ ] Build the Windows release and verify `mole --version` outputs `1.29.1`
- [ ] Verify the `VERSION` file path is still respected when present