### PR TITLE
feat(clean): add deep Brave Browser cleanup support

### DIFF
--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -396,6 +396,88 @@ clean_edge_updater_old_versions() {
     fi
 }
 
+# Remove old Brave Browser versions while keeping Current.
+clean_brave_old_versions() {
+    local -a app_paths=(
+        "/Applications/Brave Browser.app"
+        "$HOME/Applications/Brave Browser.app"
+    )
+
+    # Match the exact Brave process name to avoid false positives
+    if pgrep -x "Brave Browser" > /dev/null 2>&1; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Brave Browser running · old versions cleanup skipped"
+        return 0
+    fi
+
+    local cleaned_count=0
+    local total_size=0
+    local cleaned_any=false
+
+    for app_path in "${app_paths[@]}"; do
+        [[ -d "$app_path" ]] || continue
+
+        local versions_dir="$app_path/Contents/Frameworks/Brave Browser Framework.framework/Versions"
+        [[ -d "$versions_dir" ]] || continue
+
+        local current_link="$versions_dir/Current"
+        [[ -L "$current_link" ]] || continue
+
+        local current_version
+        current_version=$(readlink "$current_link" 2> /dev/null || true)
+        current_version="${current_version##*/}"
+        [[ -n "$current_version" ]] || continue
+
+        local -a old_versions=()
+        local dir name
+        for dir in "$versions_dir"/*; do
+            [[ -d "$dir" ]] || continue
+            name=$(basename "$dir")
+            [[ "$name" == "Current" ]] && continue
+            [[ "$name" == "$current_version" ]] && continue
+            if is_path_whitelisted "$dir"; then
+                continue
+            fi
+            old_versions+=("$dir")
+        done
+
+        if [[ ${#old_versions[@]} -eq 0 ]]; then
+            continue
+        fi
+
+        for dir in "${old_versions[@]}"; do
+            local size_kb
+            size_kb=$(get_path_size_kb "$dir" || echo 0)
+            size_kb="${size_kb:-0}"
+            total_size=$((total_size + size_kb))
+            cleaned_count=$((cleaned_count + 1))
+            cleaned_any=true
+            if [[ "$DRY_RUN" != "true" ]]; then
+                if has_sudo_session; then
+                    safe_sudo_remove "$dir" > /dev/null 2>&1 || true
+                else
+                    safe_remove "$dir" true > /dev/null 2>&1 || true
+                fi
+            fi
+        done
+    done
+
+    if [[ "$cleaned_any" == "true" ]]; then
+        local size_human
+        size_human=$(bytes_to_human "$((total_size * 1024))")
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Brave old versions${NC}, ${YELLOW}${cleaned_count} dirs, $size_human dry${NC}"
+        else
+            local line_color
+            line_color=$(cleanup_result_color_kb "$total_size")
+            echo -e "  ${line_color}${ICON_SUCCESS}${NC} Brave old versions${NC}, ${line_color}${cleaned_count} dirs, $size_human${NC}"
+        fi
+        files_cleaned=$((files_cleaned + cleaned_count))
+        total_size_cleaned=$((total_size_cleaned + total_size))
+        total_items=$((total_items + 1))
+        note_activity
+    fi
+}
+
 scan_external_volumes() {
     [[ -d "/Volumes" ]] || return 0
     local -a candidate_volumes=()
@@ -999,6 +1081,12 @@ clean_browsers() {
     safe_clean ~/Library/Caches/company.thebrowser.Browser/* "Arc cache"
     safe_clean ~/Library/Caches/company.thebrowser.dia/* "Dia cache"
     safe_clean ~/Library/Caches/BraveSoftware/Brave-Browser/* "Brave cache"
+    safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/Application\ Cache/* "Brave app cache"
+    safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/GPUCache/* "Brave GPU cache"
+    safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/component_crx_cache/* "Brave component CRX cache"
+    safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/ShaderCache/* "Brave shader cache"
+    safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/GrShaderCache/* "Brave GR shader cache"
+    safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/GraphiteDawnCache/* "Brave Dawn cache"
     # Helium Browser.
     safe_clean ~/Library/Caches/net.imput.helium/* "Helium cache"
     safe_clean ~/Library/Application\ Support/net.imput.helium/*/GPUCache/* "Helium GPU cache"
@@ -1036,6 +1124,7 @@ clean_browsers() {
     clean_chrome_old_versions
     clean_edge_old_versions
     clean_edge_updater_old_versions
+    clean_brave_old_versions
 }
 
 # Cloud storage caches.


### PR DESCRIPTION
## Summary
- Adds deep cache cleaning for Brave Browser: app cache, GPU cache, component CRX cache, shader cache, GR shader cache, and Dawn cache — matching existing Chrome and Helium depth
- Adds `clean_brave_old_versions()` to remove stale framework versions from `Brave Browser Framework.framework/Versions/` while keeping `Current` — matching existing Chrome/Edge old version cleanup
- Respects whitelist, dry-run mode, process-running check, and sudo session

Closes #632

## Test plan
- [ ] Verify `./scripts/check.sh` passes (shellcheck, shfmt, syntax)
- [ ] Verify `./scripts/test.sh` has no new failures
- [ ] Test with Brave Browser installed — confirm caches are cleaned
- [ ] Test with Brave Browser running — confirm old versions cleanup is skipped with warning
- [ ] Test with `--dry-run` — confirm sizes are reported without deletion