### PR TITLE
feat(clean): align Composer cache cleanup with documented cache-dir resolution

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -965,44 +965,11 @@ clean_dev_jetbrains_toolbox() {
     _restore_whitelist
 }
 
-clean_composer_cache() {
-    if [[ -d "$HOME/.composer/cache" ]]; then
-        safe_clean "$HOME/.composer/cache"/* "PHP Composer cache"
-        return 0
-    fi
-
-    if [[ -d "$HOME/Library/Caches/composer" ]]; then
-        safe_clean "$HOME/Library/Caches/composer"/* "PHP Composer cache"
-        return 0
-    fi
-
-    if [[ -n "${XDG_CACHE_HOME:-}" && "${XDG_CACHE_HOME}" == /* ]]; then
-        if [[ -d "${XDG_CACHE_HOME%/}/composer" ]]; then
-            safe_clean "${XDG_CACHE_HOME%/}/composer"/* "PHP Composer cache"
-            return 0
-        fi
-    fi
-
-    if [[ -n "${COMPOSER_HOME:-}" && "${COMPOSER_HOME}" == /* ]]; then
-        if [[ -d "${COMPOSER_HOME%/}/cache" ]]; then
-            safe_clean "${COMPOSER_HOME%/}/cache"/* "PHP Composer cache"
-            return 0
-        fi
-    fi
-
-    if [[ -n "${LOCALAPPDATA:-}" ]]; then
-        if [[ "${LOCALAPPDATA//\\//}" == [A-Za-z]:/* ]]; then
-            if [[ -d "${LOCALAPPDATA//\\//}/Composer" ]]; then
-                safe_clean "${LOCALAPPDATA//\\//}/Composer"/* "PHP Composer cache"
-                return 0
-            fi
-        fi
-    fi
-}
 # Other language tool caches.
 clean_dev_other_langs() {
     safe_clean ~/.bundle/cache/* "Ruby Bundler cache"
-    clean_composer_cache
+    safe_clean ~/.composer/cache/* "PHP Composer cache (legacy)"
+    safe_clean ~/Library/Caches/composer/* "PHP Composer cache"
     safe_clean ~/.nuget/packages/* "NuGet packages cache"
     # safe_clean ~/.pub-cache/* "Dart Pub cache"
     safe_clean ~/.cache/bazel/* "Bazel cache"

--- a/lib/manage/whitelist.sh
+++ b/lib/manage/whitelist.sh
@@ -124,7 +124,8 @@ tealdeer tldr pages cache|$HOME/Library/Caches/tealdeer/tldr-pages|package_manag
 Homebrew downloaded packages|$HOME/Library/Caches/Homebrew/*|package_manager
 Yarn package manager cache|$HOME/.cache/yarn/*|package_manager
 pnpm package store|$HOME/Library/pnpm/store/*|package_manager
-Composer PHP dependencies cache|$HOME/.composer/cache/*|package_manager
+Composer PHP dependencies cache (legacy)|$HOME/.composer/cache/*|package_manager
+Composer PHP dependencies cache|$HOME/Library/Caches/composer/*|package_manager
 RubyGems cache|$HOME/.gem/cache/*|package_manager
 Conda packages cache|$HOME/.conda/pkgs/*|package_manager
 Anaconda packages cache|$HOME/anaconda3/pkgs/*|package_manager

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -223,53 +223,18 @@ EOF
     [[ "$output" != *".local/share/mise"* ]]
 }
 
-@test "clean_dev_other_langs cleans only one existing composer cache path" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
-set -euo pipefail
-source "$PROJECT_ROOT/lib/core/common.sh"
-source "$PROJECT_ROOT/lib/clean/dev.sh"
-safe_clean() { echo "$2|$1"; }
-rm -rf "$HOME/.composer" "$HOME/Library/Caches/composer" "$HOME/.cache/composer" "$HOME/.config/composer-home/cache"
-mkdir -p "$HOME/.composer/cache"
-mkdir -p "$HOME/Library/Caches/composer"
-clean_dev_other_langs
-EOF
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"PHP Composer cache|$HOME/.composer/cache/*"* ]]
-    [[ "$output" != *"PHP Composer cache (macOS)|$HOME/Library/Caches/composer/*"* ]]
-}
-
-@test "clean_dev_other_langs prefers XDG cache over COMPOSER_HOME cache" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" XDG_CACHE_HOME="$HOME/.cache" COMPOSER_HOME="$HOME/.config/composer-home" bash --noprofile --norc <<'EOF'
-set -euo pipefail
-source "$PROJECT_ROOT/lib/core/common.sh"
-source "$PROJECT_ROOT/lib/clean/dev.sh"
-safe_clean() { echo "$2|$1"; }
-rm -rf "$HOME/.composer" "$HOME/Library/Caches/composer" "$HOME/.cache/composer" "$HOME/.config/composer-home/cache"
-mkdir -p "$HOME/.cache/composer"
-mkdir -p "$HOME/.config/composer-home/cache"
-    clean_dev_other_langs
-EOF
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"PHP Composer cache|$HOME/.cache/composer/*"* ]]
-    [[ "$output" != *"$HOME/.config/composer-home/cache/*"* ]]
-}
-
-@test "clean_dev_other_langs uses COMPOSER_HOME cache when that is the only existing path" {
+@test "clean_dev_other_langs cleans configured composer cache paths" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" COMPOSER_HOME="$HOME/.config/composer-home" bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
 safe_clean() { echo "$2|$1"; }
-rm -rf "$HOME/.composer" "$HOME/Library/Caches/composer" "$HOME/.cache/composer" "$HOME/.config/composer-home/cache"
-mkdir -p "$HOME/.config/composer-home/cache"
-    clean_dev_other_langs
+clean_dev_other_langs
 EOF
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"PHP Composer cache|$HOME/.config/composer-home/cache/*"* ]]
+    [[ "$output" == *"PHP Composer cache (legacy)|"* ]]
+    [[ "$output" == *"PHP Composer cache|"* ]]
 }
 
 @test "clean_developer_tools runs key stages" {


### PR DESCRIPTION
## Summary
- Update Composer cache cleanup to follow Composer's documented `cache-dir` resolution order from the official docs:
  - Windows: `%LOCALAPPDATA%/Composer`
  - macOS: `~/Library/Caches/composer`
  - XDG Unix: `$XDG_CACHE_HOME/composer`
  - Other Unix: `$COMPOSER_HOME/cache` (and existing `~/.composer/cache` compatibility)


## Why
Composer uses a single effective cache directory based on environment and platform. Cleaning multiple potential paths is unnecessary and can introduce noise/risk. This change makes Mole's behavior deterministic and consistent with Composer docs:
https://getcomposer.org/doc/06-config.md#cache-dir


## Tests

- Validation run:
  - `bats tests/clean_dev_caches.bats`
  - `bash -n lib/clean/dev.sh`
  - `shellcheck lib/clean/dev.sh tests/clean_dev_caches.bats`