### PR TITLE
fix(purge): sort `item_display_paths` by size

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1465,6 +1465,7 @@ clean_project_artifacts() {
         local -a sorted_item_sizes=()
         local -a sorted_item_size_unknown_flags=()
         local -a sorted_item_recent_flags=()
+        local -a sorted_item_display_paths=()
 
         for idx in "${sorted_indices[@]}"; do
             sorted_menu_options+=("${menu_options[idx]}")
@@ -1472,6 +1473,7 @@ clean_project_artifacts() {
             sorted_item_sizes+=("${item_sizes[idx]}")
             sorted_item_size_unknown_flags+=("${item_size_unknown_flags[idx]}")
             sorted_item_recent_flags+=("${item_recent_flags[idx]}")
+            sorted_item_display_paths+=("${item_display_paths[idx]}")
         done
 
         # Replace original arrays with sorted versions
@@ -1480,6 +1482,7 @@ clean_project_artifacts() {
         item_sizes=("${sorted_item_sizes[@]}")
         item_size_unknown_flags=("${sorted_item_size_unknown_flags[@]}")
         item_recent_flags=("${sorted_item_recent_flags[@]}")
+        item_display_paths=("${sorted_item_display_paths[@]}")
     fi
     if [[ -t 1 ]]; then
         stop_inline_spinner

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -954,3 +954,143 @@ EOF
 	rm -f "$scan_output"
 	[[ "$result" == "SKIPPED" ]]
 }
+
+# ---------------------------------------------------------------------------
+# Regression tests: sort-order consistency in clean_project_artifacts
+#
+# Bug: after sorting artifacts by size (descending), item_display_paths was
+# not included in the reorder, so PURGE_CATEGORY_FULL_PATHS_ARRAY ended up
+# in the original discovery order (alphabetical) while every other parallel
+# array (menu_options, item_paths, item_sizes, …) was in size order.
+# Effect: the "Full path" footer showed the wrong project for the highlighted
+# item, and the confirmation dialog listed paths that did not match the
+# selection. See https://github.com/tw93/Mole/issues/647
+#
+# These tests run clean_project_artifacts under a pseudo-terminal (so the
+# interactive code path is taken and select_purge_categories is called).
+# The function is overridden to capture PURGE_CATEGORY_FULL_PATHS_ARRAY and
+# PURGE_CATEGORY_SIZES without performing any actual deletion.
+# ---------------------------------------------------------------------------
+
+# Run a bash script file under a pseudo-terminal so that [[ -t 0 ]] is true
+# inside the script. Required to exercise the interactive branch of
+# clean_project_artifacts, which only calls select_purge_categories when
+# stdin is a tty.
+_run_in_pty() {
+	local script_file="$1"
+	script -q /dev/null bash --noprofile --norc "$script_file" 2>/dev/null
+}
+
+@test "sort: PURGE_CATEGORY_FULL_PATHS_ARRAY[0] is the largest artifact after size-descending sort" {
+	# alpha = small (~5 KB), beta = large (~200 KB).
+	# Alphabetical discovery order puts alpha first; size order puts beta first.
+	# After the sort, PURGE_CATEGORY_FULL_PATHS_ARRAY[0] must be beta's path.
+	mkdir -p "$HOME/www/alpha/node_modules"
+	mkdir -p "$HOME/www/beta/node_modules"
+	echo '{}' > "$HOME/www/alpha/package.json"
+	echo '{}' > "$HOME/www/beta/package.json"
+	dd if=/dev/zero of="$HOME/www/alpha/node_modules/data" bs=1024 count=5   2>/dev/null
+	dd if=/dev/zero of="$HOME/www/beta/node_modules/data"  bs=1024 count=200 2>/dev/null
+
+	local capture_file script_file
+	capture_file=$(mktemp "$HOME/sort_capture.XXXXXX")
+	script_file=$(mktemp  "$HOME/sort_script.XXXXXX.sh")
+
+	cat > "$script_file" << SCRIPT
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+mkdir -p "$HOME/.cache/mole"
+export XDG_CACHE_HOME="$HOME/.cache"
+export TERM="dumb"
+PURGE_SEARCH_PATHS=("$HOME/www")
+
+# Override the interactive selector: dump the full-path array to the capture
+# file then cancel (return 1) so nothing is deleted.
+select_purge_categories() {
+	printf '%s\n' "\${PURGE_CATEGORY_FULL_PATHS_ARRAY[@]}" > "$capture_file"
+	PURGE_SELECTION_RESULT=""
+	return 1
+}
+
+clean_project_artifacts 2>/dev/null || true
+SCRIPT
+
+	_run_in_pty "$script_file"
+	rm -f "$script_file"
+
+	if [[ ! -s "$capture_file" ]]; then
+		rm -f "$capture_file"
+		fail "capture file is empty – select_purge_categories was never called (stdin was not a tty?)"
+	fi
+
+	local first_path
+	first_path=$(head -1 "$capture_file")
+	rm -f "$capture_file"
+
+	# With the bug item_display_paths is not sorted, so alpha (alphabetically
+	# first) appears at index 0 → [[ ... == *beta* ]] fails.
+	# After the fix beta (largest) is at index 0 → test passes.
+	[[ "$first_path" == *"beta"* ]]
+}
+
+@test "sort: PURGE_CATEGORY_FULL_PATHS_ARRAY and PURGE_CATEGORY_SIZES indices are consistent" {
+	mkdir -p "$HOME/www/alpha/node_modules"
+	mkdir -p "$HOME/www/beta/node_modules"
+	echo '{}' > "$HOME/www/alpha/package.json"
+	echo '{}' > "$HOME/www/beta/package.json"
+	dd if=/dev/zero of="$HOME/www/alpha/node_modules/data" bs=1024 count=5   2>/dev/null
+	dd if=/dev/zero of="$HOME/www/beta/node_modules/data"  bs=1024 count=200 2>/dev/null
+
+	local capture_file script_file
+	capture_file=$(mktemp "$HOME/sort_capture.XXXXXX")
+	script_file=$(mktemp  "$HOME/sort_script.XXXXXX.sh")
+
+	cat > "$script_file" << SCRIPT
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+mkdir -p "$HOME/.cache/mole"
+export XDG_CACHE_HOME="$HOME/.cache"
+export TERM="dumb"
+PURGE_SEARCH_PATHS=("$HOME/www")
+
+select_purge_categories() {
+	echo "SIZES=\${PURGE_CATEGORY_SIZES:-}" > "$capture_file"
+	local i=0
+	for p in "\${PURGE_CATEGORY_FULL_PATHS_ARRAY[@]}"; do
+		echo "PATH[\$i]=\$p" >> "$capture_file"
+		i=\$((i + 1))
+	done
+	PURGE_SELECTION_RESULT=""
+	return 1
+}
+
+clean_project_artifacts 2>/dev/null || true
+SCRIPT
+
+	_run_in_pty "$script_file"
+	rm -f "$script_file"
+
+	if [[ ! -s "$capture_file" ]]; then
+		rm -f "$capture_file"
+		fail "capture file is empty – select_purge_categories was never called (stdin was not a tty?)"
+	fi
+
+	local sizes_csv
+	sizes_csv=$(grep '^SIZES=' "$capture_file" | cut -d= -f2-)
+	IFS=',' read -r -a sizes <<< "$sizes_csv"
+
+	local path0 path1
+	path0=$(grep '^PATH\[0\]=' "$capture_file" | head -1 | cut -d= -f2-)
+	path1=$(grep '^PATH\[1\]=' "$capture_file" | head -1 | cut -d= -f2-)
+	rm -f "$capture_file"
+
+	# PURGE_CATEGORY_SIZES must be sorted descending (largest first).
+	[ "${sizes[0]}" -gt "${sizes[1]}" ]
+
+	# Index 0 → largest artifact → beta's path.
+	# With the bug path0 = alpha (discovery order) → [[ ... == *beta* ]] fails.
+	[[ "$path0" == *"beta"* ]]
+
+	# Index 1 → smaller artifact → alpha's path.
+	[[ "$path1" == *"alpha"* ]]
+}


### PR DESCRIPTION
closes #647

## Summary

Fixes a sort-order mismatch in `mo purge` where the "Full path" footer and the confirmation dialog showed paths that didn't correspond to the highlighted/selected items.

## Root cause

`clean_project_artifacts` sorts all discovered artifacts by size (descending) before showing the interactive selector. During this reorder, `item_display_paths` — the array used to populate `PURGE_CATEGORY_FULL_PATHS_ARRAY` (the
"Full path" footer) and the confirmation dialog — was not included in the sort loop. Every other parallel array (`menu_options`, `item_paths`, `item_sizes`, `item_size_unknown_flags`, `item_recent_flags`) was reordered
correctly, leaving `item_display_paths` stuck in the original alphabetical discovery order.

## What broke

- **"Full path" footer** showed the path for a different item than the one currently highlighted.
- **Confirmation dialog** listed display paths that didn't match what the user had selected.

## Fix

Added `item_display_paths` / `sorted_item_display_paths` to the sort loop in `lib/clean/project.sh`, keeping it in sync with all other parallel arrays.

## Tests

Two regression tests added to `tests/purge.bats`:

- **`sort: PURGE_CATEGORY_FULL_PATHS_ARRAY[0] is the largest artifact after size-descending sort`** — creates a small project (`alpha`) and a large project (`beta`), runs `clean_project_artifacts` under a pseudo-terminal,
intercepts `select_purge_categories` to capture `PURGE_CATEGORY_FULL_PATHS_ARRAY`, and asserts index 0 is `beta` (the largest).
- **`sort: PURGE_CATEGORY_FULL_PATHS_ARRAY and PURGE_CATEGORY_SIZES indices are consistent`** — same setup, additionally asserts that sizes are sorted descending and that every path index aligns with the corresponding size
index.

Both tests failed before the fix and pass after.
