### PR TITLE
feat(ui): add Ctrl+P/Ctrl+N navigation to menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Review [SECURITY.md](SECURITY.md) and [SECURITY_AUDIT.md](SECURITY_AUDIT.md) for
 
 - Video tutorial: Watch the [Mole tutorial video](https://www.youtube.com/watch?v=UEe9-w4CcQ0), thanks to PAPAYA 電腦教室.
 - Safety and logs: `clean`, `uninstall`, `purge`, `installer`, and `remove` are destructive. Review with `--dry-run` first, and add `--debug` when needed. File operations are logged to `~/Library/Logs/mole/operations.log`. Disable with `MO_NO_OPLOG=1`. Review [SECURITY.md](SECURITY.md) and [SECURITY_AUDIT.md](SECURITY_AUDIT.md).
-- Navigation: Mole supports arrow keys and Vim bindings `h/j/k/l`.
+- Navigation: Mole supports arrow keys, `Ctrl+P`/`Ctrl+N`, and Vim bindings `h/j/k/l`.
 
 ## Features in Detail
 

--- a/lib/core/ui.sh
+++ b/lib/core/ui.sh
@@ -169,6 +169,8 @@ read_key() {
         }
         case "$key" in
             $'\n' | $'\r') echo "ENTER" ;;
+            $'\x0e') echo "DOWN" ;; # Ctrl+N
+            $'\x10') echo "UP" ;;   # Ctrl+P
             $'\x7f' | $'\x08') echo "DELETE" ;;
             $'\x15') echo "CLEAR_LINE" ;; # Ctrl+U (often mapped from Cmd+Delete in terminals)
             $'\x1b')
@@ -229,6 +231,8 @@ read_key() {
         'k' | 'K') echo "UP" ;;
         'h' | 'H') echo "LEFT" ;;
         'l' | 'L') echo "RIGHT" ;;
+        $'\x0e') echo "DOWN" ;; # Ctrl+N
+        $'\x10') echo "UP" ;;   # Ctrl+P
         $'\x03') echo "QUIT" ;;
         $'\x7f' | $'\x08') echo "DELETE" ;;
         $'\x15') echo "CLEAR_LINE" ;; # Ctrl+U

--- a/lib/ui/menu_paginated.sh
+++ b/lib/ui/menu_paginated.sh
@@ -444,7 +444,7 @@ paginated_multi_select() {
             for ((i = 0; i < items_per_page; i++)); do
                 printf "${clear_line}\n" >&2
             done
-            printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}  |  Space  |  Enter  |  Q Exit${NC}\n" >&2
+            printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}/Ctrl+P/N  |  Space  |  Enter  |  Q Exit${NC}\n" >&2
             printf "${clear_line}" >&2
             return
         fi
@@ -501,7 +501,7 @@ paginated_multi_select() {
         }
 
         # Common menu items
-        local nav="${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}${NC}"
+        local nav="${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}/Ctrl+P/N${NC}"
         local space_select="${GRAY}Space Select${NC}"
         local enter="${GRAY}Enter${NC}"
         local exit="${GRAY}Q Exit${NC}"

--- a/lib/ui/menu_simple.sh
+++ b/lib/ui/menu_simple.sh
@@ -212,7 +212,7 @@ paginated_multi_select() {
 
         # Clear any remaining lines at bottom
         printf "${clear_line}\n" >&2
-        printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN} | Space | Enter | Q Exit${NC}\n" >&2
+        printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}/Ctrl+P/N | Space | Enter | Q Exit${NC}\n" >&2
 
         # Clear one more line to ensure no artifacts
         printf "${clear_line}" >&2

--- a/mole
+++ b/mole
@@ -759,7 +759,7 @@ show_main_menu() {
 
     if [[ -t 0 ]]; then
         printf '\r\033[2K\n'
-        local controls="${GRAY}↑↓  |  Enter  |  M More"
+        local controls="${GRAY}↑↓/Ctrl+P/N  |  Enter  |  M More"
         if ! is_touchid_configured; then
             controls="${controls}  |  T TouchID"
         elif [[ "${MAIN_MENU_SHOW_UPDATE:-false}" == "true" ]]; then

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -290,7 +290,23 @@ EOF
     [ "$output" = "UP" ]
 }
 
+@test "read_key maps Ctrl+N/Ctrl+P to navigation" {
+    run bash -c "export MOLE_BASE_LOADED=1; source '$PROJECT_ROOT/lib/core/ui.sh'; printf '\016' | read_key"
+    [ "$output" = "DOWN" ]
+
+    run bash -c "export MOLE_BASE_LOADED=1; source '$PROJECT_ROOT/lib/core/ui.sh'; printf '\020' | read_key"
+    [ "$output" = "UP" ]
+}
+
 @test "read_key respects MOLE_READ_KEY_FORCE_CHAR" {
     run bash -c "export MOLE_BASE_LOADED=1; export MOLE_READ_KEY_FORCE_CHAR=1; source '$PROJECT_ROOT/lib/core/ui.sh'; echo -n 'j' | read_key"
     [ "$output" = "CHAR:j" ]
+}
+
+@test "read_key maps Ctrl+N/Ctrl+P in forced char mode" {
+    run bash -c "export MOLE_BASE_LOADED=1; export MOLE_READ_KEY_FORCE_CHAR=1; source '$PROJECT_ROOT/lib/core/ui.sh'; printf '\016' | read_key"
+    [ "$output" = "DOWN" ]
+
+    run bash -c "export MOLE_BASE_LOADED=1; export MOLE_READ_KEY_FORCE_CHAR=1; source '$PROJECT_ROOT/lib/core/ui.sh'; printf '\020' | read_key"
+    [ "$output" = "UP" ]
 }


### PR DESCRIPTION
## Summary

Add `Ctrl+N` and `Ctrl+P` support to Mole's interactive menus through the shared key reader.

## Motivation

Mole already supports arrow keys and Vim-style bindings for menu navigation. This change extends that keyboard support with `Ctrl+N` and `Ctrl+P`, which are familiar navigation shortcuts in terminal and Readline-style workflows.

The goal is not to replace the current controls, but to make the interface more flexible for users who already rely on those shortcuts as part of their normal terminal muscle memory.

## Changes

- map `Ctrl+N` to next-item navigation
- map `Ctrl+P` to previous-item navigation
- preserve existing arrow-key and Vim-style navigation
- update menu hints to show the new shortcuts
- update README navigation documentation
- add key-mapping coverage for normal and forced-char modes