### PR TITLE
feat(clean): add PCSX2 (PS2) and RPCS3 (PS3) emulator cache cleanup

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -186,6 +186,11 @@ clean_gaming_platforms() {
     safe_clean ~/.lunarclient/logs/* "Lunar Client logs"
     safe_clean ~/.lunarclient/offline/*/logs/* "Lunar Client offline logs"
     safe_clean ~/.lunarclient/offline/files/*/logs/* "Lunar Client offline file logs"
+    safe_clean ~/Library/Caches/net.pcsx2.PCSX2/* "PCSX2 cache"
+    safe_clean ~/Library/Application\ Support/PCSX2/cache/* "PCSX2 shader cache"
+    safe_clean ~/Library/Logs/PCSX2/* "PCSX2 logs"
+    safe_clean ~/Library/Caches/net.rpcs3.rpcs3/* "RPCS3 cache"
+    safe_clean ~/Library/Application\ Support/rpcs3/logs/* "RPCS3 logs"
 }
 # Translation/dictionary apps.
 clean_translation_apps() {


### PR DESCRIPTION
Add cache, shader cache, and log cleanup for PCSX2 (PS2) and RPCS3 (PS3) emulators to clean_gaming_platforms()

 What's included:
 1) **PCSX2: general cache, shader cache, logs**
 2) **RPCS3: general cache, logs**

Save data and user configurations are intentionally left untouched.

In fact, it's a controversial topic. While working on this, I started thinking about whether Mole should support full removal of everything related to these emulators — not just caches, but also game libraries, firmware dumps (e.g. PS3 dev_flash), BIOS files, custom configs, texture packs, and save states.

On one hand, these files can take up significant disk space — a single RPCS3 game directory can easily be 30-50 GB, and shader caches grow over time. Full cleanup would be genuinely useful for users who are done with emulation.
But on the other hand, some of this data is irreplaceable or hard to obtain:
  - Save states and memory cards — hours of gameplay progress
  - BIOS/firmware files — legally gray area, users can't just re-download these
  - Custom texture packs and patches — community-created, not always easy to find again

It might make sense to handle this more carefully than a typical app — perhaps with an explicit confirmation step or a separate "deep clean" flag. For now, this PR takes the conservative approach: only caches and logs that are
safe to remove and will be regenerated automatically.

**To sum up, I’d love to hear your thoughts on what I’ve shared. I look forward to your feedback!**