### PR TITLE
feat(clean): add JetBrains IDE cache and log cleanup

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -972,6 +972,12 @@ clean_dev_jetbrains_toolbox() {
     _restore_whitelist
 }
 
+# JetBrains IDE caches and logs (DataGrip, IntelliJ, PyCharm, WebStorm, GoLand, etc.).
+clean_dev_jetbrains_caches() {
+    safe_clean ~/Library/Caches/JetBrains/* "JetBrains IDE cache"
+    safe_clean ~/Library/Logs/JetBrains/* "JetBrains IDE logs"
+}
+
 # Other language tool caches.
 clean_dev_other_langs() {
     safe_clean ~/.bundle/cache/* "Ruby Bundler cache"
@@ -1108,6 +1114,7 @@ clean_developer_tools() {
     clean_dev_mobile
     clean_dev_jvm
     clean_dev_jetbrains_toolbox
+    clean_dev_jetbrains_caches
     clean_dev_other_langs
     clean_dev_cicd
     clean_dev_database


### PR DESCRIPTION
## Summary

- Add cleanup of JetBrains IDE caches (`~/Library/Caches/JetBrains/*`) and logs (`~/Library/Logs/JetBrains/*`)
- Covers all JetBrains IDEs installed via Toolbox or standalone: DataGrip, IntelliJ, PyCharm, WebStorm, GoLand, CLion, Rider, PhpStorm
- Complements existing `clean_dev_jetbrains_toolbox` which only removes old Toolbox versions

## Why

JetBrains IDE caches can grow to several GB (1.8 GB observed with just DataGrip). These are safe to remove — the IDEs regenerate them on next launch. Currently `mo clean` handles Toolbox old versions but not the IDE caches themselves.

## Safety Review

- This change only adds new `safe_clean` targets for caches and logs.
- No changes to path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity.

## Tests

- `./scripts/check.sh` passes (ShellCheck, syntax, optimizations 5/5).
- `./scripts/test.sh` passes.
- Manual dry-run verification with `mo clean --dry-run`.