### PR TITLE
feat(check): add dev environment checks to optimize and check

### DIFF
--- a/bin/check.sh
+++ b/bin/check.sh
@@ -14,6 +14,7 @@ source "$SCRIPT_DIR/lib/manage/update.sh"
 source "$SCRIPT_DIR/lib/manage/autofix.sh"
 
 source "$SCRIPT_DIR/lib/check/all.sh"
+source "$SCRIPT_DIR/lib/check/dev_environment.sh"
 
 cleanup_all() {
     stop_inline_spinner 2> /dev/null || true
@@ -42,6 +43,7 @@ main() {
     local health_file=$(mktemp_file)
     local security_file=$(mktemp_file)
     local config_file=$(mktemp_file)
+    local dev_file=$(mktemp_file)
 
     # Run all checks in parallel with spinner
     if [[ -t 1 ]]; then
@@ -58,6 +60,7 @@ main() {
         check_system_health > "$health_file" 2>&1 &
         check_all_security > "$security_file" 2>&1 &
         check_all_config > "$config_file" 2>&1 &
+        check_all_dev_environment > "$dev_file" 2>&1 &
         wait
     }
 
@@ -66,21 +69,20 @@ main() {
         printf '\n'
     fi
 
-    # Display results
-    echo -e "${BLUE}${ICON_ARROW}${NC} System updates"
+    # Display results (headers are printed by the check_all_* functions)
     cat "$updates_file"
 
     printf '\n'
-    echo -e "${BLUE}${ICON_ARROW}${NC} System health"
     cat "$health_file"
 
     printf '\n'
-    echo -e "${BLUE}${ICON_ARROW}${NC} Security posture"
     cat "$security_file"
 
     printf '\n'
-    echo -e "${BLUE}${ICON_ARROW}${NC} Configuration"
     cat "$config_file"
+
+    printf '\n'
+    cat "$dev_file"
 
     # Show suggestions
     show_suggestions

--- a/bin/optimize.sh
+++ b/bin/optimize.sh
@@ -21,6 +21,7 @@ source "$SCRIPT_DIR/lib/optimize/maintenance.sh"
 source "$SCRIPT_DIR/lib/optimize/tasks.sh"
 source "$SCRIPT_DIR/lib/check/health_json.sh"
 source "$SCRIPT_DIR/lib/check/all.sh"
+source "$SCRIPT_DIR/lib/check/dev_environment.sh"
 source "$SCRIPT_DIR/lib/manage/whitelist.sh"
 
 print_header() {
@@ -127,6 +128,8 @@ run_system_checks() {
 
     check_all_config
     echo ""
+
+    check_all_dev_environment
 
     show_suggestions
 

--- a/lib/check/dev_environment.sh
+++ b/lib/check/dev_environment.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Dev Environment Checks Module
+# Surfaces developer-relevant system health information.
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+_extract_major_minor() {
+    printf '%s' "$1" | sed -E 's/^[^0-9]*//' | grep -oE '^[0-9]+\.[0-9]+'
+}
+
+# ============================================================================
+# Dev Environment Checks
+# ============================================================================
+
+check_launch_agents() {
+    # Check whitelist
+    if command -v is_whitelisted > /dev/null && is_whitelisted "check_launch_agents"; then return; fi
+
+    local agents_dir="$HOME/Library/LaunchAgents"
+
+    if [[ ! -d "$agents_dir" ]]; then
+        echo -e "  ${GREEN}✓${NC} Launch Agents All healthy"
+        return
+    fi
+
+    local broken_count=0
+    local -a broken_labels=()
+
+    for plist in "$agents_dir"/*.plist; do
+        [[ -f "$plist" ]] || continue
+
+        local label
+        label=$(basename "$plist" .plist)
+
+        local binary=""
+        binary=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$plist" 2> /dev/null || true)
+        if [[ -z "$binary" ]]; then
+            binary=$(/usr/libexec/PlistBuddy -c "Print :Program" "$plist" 2> /dev/null || true)
+        fi
+
+        if [[ -n "$binary" && ! -e "$binary" ]]; then
+            broken_count=$((broken_count + 1))
+            broken_labels+=("$label")
+        fi
+    done
+
+    if [[ $broken_count -eq 0 ]]; then
+        echo -e "  ${GREEN}✓${NC} Launch Agents All healthy"
+    else
+        printf "  ${GRAY}%s${NC} %-14s ${YELLOW}%s${NC}\n" "$ICON_WARNING" "Launch Agents" "${broken_count} broken"
+
+        local preview_limit=3
+        ((preview_limit > broken_count)) && preview_limit=$broken_count
+
+        local detail=""
+        for ((i = 0; i < preview_limit; i++)); do
+            if [[ $i -eq 0 ]]; then
+                detail="${broken_labels[$i]}"
+            else
+                detail="${detail}, ${broken_labels[$i]}"
+            fi
+        done
+
+        if ((broken_count > preview_limit)); then
+            local remaining=$((broken_count - preview_limit))
+            detail="${detail} +${remaining}"
+        fi
+
+        echo -e "    ${GRAY}${detail}${NC}"
+    fi
+}
+
+check_dev_tools() {
+    # Check whitelist
+    if command -v is_whitelisted > /dev/null && is_whitelisted "check_dev_tools"; then return; fi
+
+    local -a tools=(git node python3 brew docker go xcode-select)
+    local -a missing=()
+
+    for tool in "${tools[@]}"; do
+        if ! command -v "$tool" > /dev/null 2>&1; then
+            missing+=("$tool")
+        fi
+    done
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        echo -e "  ${GREEN}✓${NC} Dev Tools      All present"
+    else
+        local missing_list
+        missing_list=$(printf '%s, ' "${missing[@]}")
+        missing_list="${missing_list%, }"
+        printf "  ${GRAY}%s${NC} %-14s ${YELLOW}%s${NC}\n" "$ICON_WARNING" "Dev Tools" "${#missing[@]} not found (${missing_list})"
+    fi
+}
+
+check_version_mismatches() {
+    # Check whitelist
+    if command -v is_whitelisted > /dev/null && is_whitelisted "check_version_mismatches"; then return; fi
+
+    local -a conflicts=()
+
+    # Check psql client vs postgres server
+    if command -v psql > /dev/null 2>&1 && command -v postgres > /dev/null 2>&1; then
+        local psql_ver postgres_ver
+        psql_ver=$(_extract_major_minor "$(psql --version 2> /dev/null || true)")
+        postgres_ver=$(_extract_major_minor "$(postgres --version 2> /dev/null || true)")
+        if [[ -n "$psql_ver" && -n "$postgres_ver" && "$psql_ver" != "$postgres_ver" ]]; then
+            conflicts+=("psql ${psql_ver} vs server ${postgres_ver}")
+        fi
+    fi
+
+    # Check node vs nvm default
+    local nvm_sh="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+    if command -v node > /dev/null 2>&1 && [[ -f "$nvm_sh" ]]; then
+        local node_ver nvm_default_ver
+        node_ver=$(_extract_major_minor "$(node --version 2> /dev/null || true)")
+        nvm_default_ver=$(bash -c "source \"$nvm_sh\" 2>/dev/null && nvm version default 2>/dev/null" || true)
+        nvm_default_ver=$(_extract_major_minor "$nvm_default_ver")
+        if [[ -n "$node_ver" && -n "$nvm_default_ver" && "$node_ver" != "$nvm_default_ver" ]]; then
+            conflicts+=("node ${node_ver} vs nvm default ${nvm_default_ver}")
+        fi
+    fi
+
+    # Check python3 vs pyenv
+    if command -v python3 > /dev/null 2>&1 && command -v pyenv > /dev/null 2>&1; then
+        local python_ver pyenv_ver
+        python_ver=$(_extract_major_minor "$(python3 --version 2> /dev/null || true)")
+        pyenv_ver=$(pyenv version 2> /dev/null | awk '{print $1}' || true)
+        if [[ -n "$pyenv_ver" && "$pyenv_ver" != "system" ]]; then
+            pyenv_ver=$(_extract_major_minor "$pyenv_ver")
+            if [[ -n "$python_ver" && -n "$pyenv_ver" && "$python_ver" != "$pyenv_ver" ]]; then
+                conflicts+=("python3 ${python_ver} vs pyenv ${pyenv_ver}")
+            fi
+        fi
+    fi
+
+    if [[ ${#conflicts[@]} -eq 0 ]]; then
+        echo -e "  ${GREEN}✓${NC} Versions       No conflicts"
+    else
+        local description
+        description=$(printf '%s; ' "${conflicts[@]}")
+        description="${description%; }"
+        printf "  ${GRAY}%s${NC} %-14s ${YELLOW}%s${NC}\n" "$ICON_WARNING" "Versions" "$description"
+    fi
+}
+
+check_all_dev_environment() {
+    echo -e "${BLUE}${ICON_ARROW}${NC} Dev Environment"
+    check_launch_agents
+    check_dev_tools
+    check_version_mismatches
+}

--- a/tests/dev_environment.bats
+++ b/tests/dev_environment.bats
@@ -1,0 +1,226 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-devenv.XXXXXX")"
+    export HOME
+
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+# ============================================================================
+# Launch Agents tests
+# ============================================================================
+
+@test "check_launch_agents reports healthy when no broken agents" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$HOME/Library/LaunchAgents/com.test.valid.plist" << 'INNER_PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.test.valid</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+    </array>
+</dict>
+</plist>
+INNER_PLIST
+check_launch_agents
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"All healthy"* ]]
+}
+
+@test "check_launch_agents detects broken agent" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$HOME/Library/LaunchAgents/com.test.broken.plist" << 'INNER_PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.test.broken</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/nonexistent/path/to/binary</string>
+    </array>
+</dict>
+</plist>
+INNER_PLIST
+check_launch_agents
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1 broken"* ]]
+    [[ "$output" == *"com.test.broken"* ]]
+}
+
+@test "check_launch_agents healthy when directory missing" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+rm -rf "$HOME/Library/LaunchAgents"
+check_launch_agents
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"All healthy"* ]]
+}
+
+# ============================================================================
+# Dev Tools tests
+# ============================================================================
+
+@test "check_dev_tools detects missing tools" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+command() {
+    if [[ "$1" == "-v" ]]; then
+        case "$2" in
+            docker|go) return 1 ;;
+            *) builtin command "$@" ;;
+        esac
+    else
+        builtin command "$@"
+    fi
+}
+export -f command
+check_dev_tools
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+# ============================================================================
+# Version Mismatches tests
+# ============================================================================
+
+@test "check_version_mismatches detects psql mismatch" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" NVM_DIR="/nonexistent" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+psql() { echo "psql (PostgreSQL) 16.2"; }
+postgres() { echo "postgres (PostgreSQL) 14.1"; }
+export -f psql postgres
+command() {
+    if [[ "$1" == "-v" ]]; then
+        case "$2" in
+            psql|postgres) return 0 ;;
+            pyenv) return 1 ;;
+            *) builtin command "$@" ;;
+        esac
+    else
+        builtin command "$@"
+    fi
+}
+export -f command
+check_version_mismatches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"psql 16.2 vs server 14.1"* ]]
+}
+
+@test "check_version_mismatches reports no conflicts when versions match" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" NVM_DIR="/nonexistent" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+psql() { echo "psql (PostgreSQL) 16.2"; }
+postgres() { echo "postgres (PostgreSQL) 16.2"; }
+export -f psql postgres
+command() {
+    if [[ "$1" == "-v" ]]; then
+        case "$2" in
+            psql|postgres) return 0 ;;
+            pyenv) return 1 ;;
+            *) builtin command "$@" ;;
+        esac
+    else
+        builtin command "$@"
+    fi
+}
+export -f command
+check_version_mismatches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No conflicts"* ]]
+}
+
+@test "_extract_major_minor handles version strings" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+result1=$(_extract_major_minor "v18.17.1")
+result2=$(_extract_major_minor "PostgreSQL 16.2")
+result3=$(_extract_major_minor "Python 3.12.1")
+echo "r1:$result1"
+echo "r2:$result2"
+echo "r3:$result3"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"r1:18.17"* ]]
+    [[ "$output" == *"r2:16.2"* ]]
+    [[ "$output" == *"r3:3.12"* ]]
+}
+
+# ============================================================================
+# Aggregator test
+# ============================================================================
+
+@test "check_all_dev_environment runs all three checks" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" NVM_DIR="/nonexistent" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/check/dev_environment.sh"
+mkdir -p "$HOME/Library/LaunchAgents"
+command() {
+    if [[ "$1" == "-v" ]]; then
+        case "$2" in
+            psql|postgres|pyenv) return 1 ;;
+            *) builtin command "$@" ;;
+        esac
+    else
+        builtin command "$@"
+    fi
+}
+export -f command
+check_all_dev_environment
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Launch Agents"* || "$output" == *"All healthy"* ]]
+    [[ "$output" == *"Dev Tools"* || "$output" == *"All present"* ]]
+    [[ "$output" == *"Versions"* || "$output" == *"No conflicts"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a new **Dev Environment** section to `mo optimize` and `mo check` that surfaces developer-relevant system health information. These checks are purely informational — they show, don't fix.

Discussed in #659 as features that fit naturally inside existing commands.

## New checks

### Launch Agents
Scans `~/Library/LaunchAgents/*.plist` for broken entries — plists whose `ProgramArguments` binary no longer exists on disk. Common after uninstalling apps.

### Dev Tools
Verifies presence of common developer tools: `git`, `node`, `python3`, `brew`, `docker`, `go`, `xcode-select`. Only reports missing tools.

### Version Mismatches
Detects conflicts between co-installed tool versions (only checked when both sides are installed):

| Pair | How detected |
|------|-------------|
| psql client vs server | `psql --version` vs `postgres --version` |
| node vs nvm default | `node --version` vs `nvm version default` |
| python3 vs pyenv | `python3 --version` vs `pyenv version` |

## Behavior

- Checks only run when relevant tools are installed
- Each check respects the existing whitelist system
- Runs in parallel in `mo check`, sequentially in `mo optimize`
- No new dependencies — uses only built-in macOS commands

## Visual preview

All healthy:
```
➤ Dev Environment
  ✓ Launch Agents All healthy
  ✓ Dev Tools      All present
  ✓ Versions       No conflicts
```

With issues:
```
➤ Dev Environment
  ◎ Launch Agents  2 broken
    com.old.removed.app, com.sketch.service
  ◎ Dev Tools      2 not found (docker, xcode-select)
  ◎ Versions       psql 16.2 vs server 14.1
```

## What changed

| File | Change |
|------|--------|
| `lib/check/dev_environment.sh` | New module: 3 check functions + aggregator |
| `bin/check.sh` | Source new module, run in parallel, display results |
| `bin/optimize.sh` | Source new module, run in `run_system_checks()` |
| `tests/dev_environment.bats` | 8 new tests with mocked system commands |

## Test plan

- [x] `bash -n lib/check/dev_environment.sh` — clean syntax
- [x] `bash -n bin/check.sh && bash -n bin/optimize.sh` — clean syntax
- [x] `bats tests/dev_environment.bats` — all 8 tests pass
- [x] `mo optimize` — Dev Environment section appears after System Configuration
- [x] `bash bin/check.sh` — Dev Environment section appears after Configuration
- [x] Checks only display when tools are installed
- [x] Whitelist keys: `check_launch_agents`, `check_dev_tools`, `check_version_mismatches`