### PR TITLE
Add Cursor IDE cache cleanup

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1117,6 +1117,14 @@ clean_dev_editors() {
     clean_service_worker_cache "VS Code" "$HOME/Library/Application Support/Code/Service Worker/CacheStorage"
     safe_clean ~/Library/Application\ Support/Code/Service\ Worker/ScriptCache/* "VS Code Service Worker ScriptCache"
     safe_clean ~/Library/Caches/Zed/* "Zed cache"
+    safe_clean ~/Library/Caches/Cursor/* "Cursor cache"
+    safe_clean ~/Library/Application\ Support/Cursor/CachedData/* "Cursor cached data"
+    safe_clean ~/Library/Application\ Support/Cursor/CachedExtensionVSIXs/* "Cursor extension cache"
+    safe_clean ~/Library/Application\ Support/Cursor/GPUCache/* "Cursor GPU cache"
+    safe_clean ~/Library/Application\ Support/Cursor/DawnGraphiteCache/* "Cursor Dawn cache"
+    safe_clean ~/Library/Application\ Support/Cursor/DawnWebGPUCache/* "Cursor WebGPU cache"
+    clean_service_worker_cache "Cursor" "$HOME/Library/Application Support/Cursor/Service Worker/CacheStorage"
+    safe_clean ~/Library/Application\ Support/Cursor/Service\ Worker/ScriptCache/* "Cursor Service Worker ScriptCache"
 }
 # Main developer tools cleanup sequence.
 clean_developer_tools() {


### PR DESCRIPTION
Cursor is a widely used Electron-based editor not currently covered by `clean_dev_editors`. Its cache structure mirrors VS Code exactly, so this adds the same set of cache paths with `Cursor` in place of `Code`.

Paths cleaned:
- `~/Library/Caches/Cursor/`
- `~/Library/Application Support/Cursor/CachedData/`
- `~/Library/Application Support/Cursor/CachedExtensionVSIXs/`
- `~/Library/Application Support/Cursor/GPUCache/`
- `~/Library/Application Support/Cursor/DawnGraphiteCache/`
- `~/Library/Application Support/Cursor/DawnWebGPUCache/`
- `~/Library/Application Support/Cursor/Service Worker/CacheStorage/`
- `~/Library/Application Support/Cursor/Service Worker/ScriptCache/`