### PR TITLE
feat(optimize): add broken LaunchAgent cleanup

### DIFF
--- a/lib/check/health_json.sh
+++ b/lib/check/health_json.sh
@@ -143,6 +143,7 @@ EOF
     items+=('disk_permissions_repair|Permission Repair|Fix user directory permission issues|true')
     items+=('bluetooth_reset|Bluetooth Refresh|Restart Bluetooth module to fix connectivity (skips if in use)|true')
     items+=('spotlight_index_optimize|Spotlight Optimization|Rebuild index if search is slow (smart detection)|true')
+    items+=('launch_agents_cleanup|Launch Agents Cleanup|Remove broken LaunchAgents whose binaries no longer exist|true')
 
     # Removed high-risk optimizations:
     # - startup_items_cleanup: Risk of deleting legitimate app helpers

--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -858,6 +858,46 @@ opt_dock_refresh() {
     opt_msg "Dock refreshed"
 }
 
+# Broken LaunchAgent cleanup.
+opt_launch_agents_cleanup() {
+    local agents_dir="$HOME/Library/LaunchAgents"
+
+    if [[ ! -d "$agents_dir" ]]; then
+        opt_msg "Launch Agents all healthy"
+        return 0
+    fi
+
+    local broken_count=0
+    local -a broken_plists=()
+
+    for plist in "$agents_dir"/*.plist; do
+        [[ -f "$plist" ]] || continue
+
+        local binary=""
+        binary=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$plist" 2> /dev/null || true)
+        if [[ -z "$binary" ]]; then
+            binary=$(/usr/libexec/PlistBuddy -c "Print :Program" "$plist" 2> /dev/null || true)
+        fi
+
+        if [[ -n "$binary" && ! -e "$binary" ]]; then
+            broken_count=$((broken_count + 1))
+            broken_plists+=("$plist")
+        fi
+    done
+
+    if [[ $broken_count -eq 0 ]]; then
+        opt_msg "Launch Agents all healthy"
+        return 0
+    fi
+
+    for plist in "${broken_plists[@]}"; do
+        run_launchctl_unload "$plist"
+        safe_remove "$plist" true > /dev/null 2>&1 || true
+    done
+
+    opt_msg "Cleaned $broken_count broken Launch Agent(s)"
+}
+
 # Dispatch optimization by action name.
 execute_optimization() {
     local action="$1"
@@ -879,6 +919,7 @@ execute_optimization() {
         disk_permissions_repair) opt_disk_permissions_repair ;;
         bluetooth_reset) opt_bluetooth_reset ;;
         spotlight_index_optimize) opt_spotlight_index_optimize ;;
+        launch_agents_cleanup) opt_launch_agents_cleanup ;;
         *)
             echo -e "${YELLOW}${ICON_ERROR}${NC} Unknown action: $action"
             return 1

--- a/tests/optimize.bats
+++ b/tests/optimize.bats
@@ -312,3 +312,87 @@ EOF
     [[ "$output" == *"lsregister not found"* ]]
     [[ "$output" == *"survived"* ]]
 }
+
+@test "opt_launch_agents_cleanup reports healthy when no directory" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/optimize/tasks.sh"
+opt_launch_agents_cleanup
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Launch Agents all healthy"* ]]
+}
+
+@test "opt_launch_agents_cleanup detects broken agents" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/optimize/tasks.sh"
+# Create mock LaunchAgents with a broken binary reference.
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$HOME/Library/LaunchAgents/com.test.broken.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.test.broken</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/nonexistent/binary</string>
+    </array>
+</dict>
+</plist>
+PLIST
+safe_remove() { return 0; }
+opt_launch_agents_cleanup
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleaned 1 broken Launch Agent"* ]]
+}
+
+@test "opt_launch_agents_cleanup skips healthy agents" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/optimize/tasks.sh"
+# Clean up any leftover plists from previous tests.
+rm -f "$HOME/Library/LaunchAgents"/*.plist 2>/dev/null || true
+# Create mock LaunchAgent pointing to an existing binary.
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$HOME/Library/LaunchAgents/com.test.healthy.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.test.healthy</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+    </array>
+</dict>
+</plist>
+PLIST
+opt_launch_agents_cleanup
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Launch Agents all healthy"* ]]
+}
+
+@test "execute_optimization dispatches launch_agents_cleanup" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/optimize/tasks.sh"
+opt_launch_agents_cleanup() { echo "launch_agents"; }
+execute_optimization launch_agents_cleanup
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"launch_agents"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a new optimization task that detects and removes broken LaunchAgent plists — plist files in `~/Library/LaunchAgents/` whose referenced binary no longer exists on disk.

These orphaned plists accumulate when apps are uninstalled without proper cleanup, causing `launchd` errors on every login and wasting system resources on failed launch attempts.

## Before

`mo check` already detects broken LaunchAgents via `check_launch_agents()`, but `mo optimize` had no way to clean them up:

```
  ⚠ Launch Agents  2 broken
    com.removed.app, com.old.helper
```

## After

`mo optimize` now includes a cleanup step:

```
  ✓ Cleaned 2 broken Launch Agent(s)
```

When all agents are healthy:
```
  ✓ Launch Agents all healthy
```

## What changed

| File | Change |
|------|--------|
| `lib/optimize/tasks.sh` | New `opt_launch_agents_cleanup()` — scans plists, checks binary existence via PlistBuddy, unloads and removes broken ones |
| `lib/check/health_json.sh` | Register `launch_agents_cleanup` in optimization item list |
| `tests/optimize.bats` | 4 new tests: no directory, broken agent detection, healthy agent skip, dispatch |

## Safety

- Only removes plists whose `ProgramArguments:0` or `Program` binary **does not exist** on disk
- Unloads via `launchctl unload` before removal (uses existing `run_launchctl_unload`)
- Removal via `safe_remove` (respects dry-run, path validation, whitelist)
- Healthy agents with valid binaries are never touched
- Same detection logic as existing `check_launch_agents()` in `lib/check/dev_environment.sh`

## Test plan

- [x] `bats tests/optimize.bats` — 23/23 pass
- [x] No directory → reports "all healthy"
- [x] Broken plist (binary missing) → cleaned and reported
- [x] Healthy plist (`/bin/bash`) → skipped, reports "all healthy"
- [x] `execute_optimization launch_agents_cleanup` dispatches correctly
- [x] No regressions in existing optimize tests