### PR TITLE
fix(purge): deduplicate paths with different casing on case-insensitive FS

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1033,13 +1033,22 @@ clean_project_artifacts() {
 
     # Collect all results and deduplicate (overlapping search roots on
     # case-insensitive filesystems can produce identical canonical paths).
-    local -A _seen_items=()
+    # Uses a simple linear search instead of associative arrays for bash 3 compat.
     for scan_output in "${scan_temps[@]+"${scan_temps[@]}"}"; do
         if [[ -f "$scan_output" ]]; then
             while IFS= read -r item; do
-                if [[ -n "$item" && -z "${_seen_items[$item]+x}" ]]; then
-                    _seen_items["$item"]=1
-                    all_found_items+=("$item")
+                if [[ -n "$item" ]]; then
+                    local _already_seen=false
+                    local _existing
+                    for _existing in "${all_found_items[@]+"${all_found_items[@]}"}"; do
+                        if [[ "$_existing" == "$item" ]]; then
+                            _already_seen=true
+                            break
+                        fi
+                    done
+                    if [[ "$_already_seen" == "false" ]]; then
+                        all_found_items+=("$item")
+                    fi
                 fi
             done < "$scan_output"
             rm -f "$scan_output"

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -75,7 +75,9 @@ discover_project_dirs() {
 
     for path in "${DEFAULT_PURGE_SEARCH_PATHS[@]}"; do
         if [[ -d "$path" ]]; then
-            discovered+=("$path")
+            # Resolve to canonical casing to avoid duplicates on
+            # case-insensitive filesystems (macOS APFS).
+            discovered+=("$(mole_purge_resolve_path_case "$path")")
         fi
     done
 
@@ -84,9 +86,11 @@ discover_project_dirs() {
     for dir in "$HOME"/*/; do
         [[ ! -d "$dir" ]] && continue
         dir="${dir%/}" # Remove trailing slash
+        # Resolve casing so that ~/code and ~/Code compare equal.
+        dir=$(mole_purge_resolve_path_case "$dir")
 
         local already_found=false
-        for existing in "${DEFAULT_PURGE_SEARCH_PATHS[@]}"; do
+        for existing in "${discovered[@]+"${discovered[@]}"}"; do
             if [[ "$dir" == "$existing" ]]; then
                 already_found=true
                 break
@@ -1027,11 +1031,14 @@ clean_project_artifacts() {
         sleep 0.2
     fi
 
-    # Collect all results
+    # Collect all results and deduplicate (overlapping search roots on
+    # case-insensitive filesystems can produce identical canonical paths).
+    local -A _seen_items=()
     for scan_output in "${scan_temps[@]+"${scan_temps[@]}"}"; do
         if [[ -f "$scan_output" ]]; then
             while IFS= read -r item; do
-                if [[ -n "$item" ]]; then
+                if [[ -n "$item" && -z "${_seen_items[$item]+x}" ]]; then
+                    _seen_items["$item"]=1
                     all_found_items+=("$item")
                 fi
             done < "$scan_output"

--- a/lib/clean/purge_shared.sh
+++ b/lib/clean/purge_shared.sh
@@ -124,6 +124,19 @@ mole_purge_quick_hint_target_names() {
     done
 }
 
+# Resolve a directory path to its canonical filesystem casing.
+# On case-insensitive macOS (APFS), ~/Code and ~/code point to the same
+# directory but with different display names.  This function returns the
+# real (on-disk) path so that string comparisons work correctly for dedup.
+mole_purge_resolve_path_case() {
+    local path="$1"
+    if [[ -d "$path" ]]; then
+        (cd "$path" 2>/dev/null && pwd -P) || printf '%s\n' "$path"
+    else
+        printf '%s\n' "$path"
+    fi
+}
+
 mole_purge_read_paths_config() {
     local config_file="${1:-$HOME/.config/mole/purge_paths}"
     [[ -f "$config_file" ]] || return 0
@@ -134,6 +147,7 @@ mole_purge_read_paths_config() {
         line="${line%"${line##*[![:space:]]}"}"
         [[ -z "$line" || "$line" =~ ^# ]] && continue
         line="${line/#\~/$HOME}"
+        line=$(mole_purge_resolve_path_case "$line")
         printf '%s\n' "$line"
     done < "$config_file"
 }

--- a/tests/purge_config_paths.bats
+++ b/tests/purge_config_paths.bats
@@ -108,8 +108,52 @@ EOF
     echo "# Just a comment" > "$config_file"
 
     run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${PURGE_SEARCH_PATHS[*]}\""
-    
+
     [ "$status" -eq 0 ]
-    
+
     [[ "$output" == *"$HOME/Projects"* ]]
+}
+
+@test "load_purge_config deduplicates case variants on case-insensitive FS" {
+    # Create a real directory so resolve_path_case can cd into it
+    mkdir -p "$HOME/code"
+
+    local config_file="$HOME/.config/mole/purge_paths"
+    cat > "$config_file" << EOF
+$HOME/code
+$HOME/Code
+EOF
+
+    run env HOME="$HOME" bash -c "source '$PROJECT_ROOT/lib/clean/project.sh'; echo \"\${#PURGE_SEARCH_PATHS[@]}\""
+
+    [ "$status" -eq 0 ]
+
+    # On case-insensitive FS (macOS default) both resolve to the same path,
+    # so count should be 1. On case-sensitive FS, Code doesn't exist, so
+    # resolve_path_case returns it unchanged — count may be 2 which is correct
+    # since they really are different directories.
+    if [[ -d "$HOME/Code" && "$(cd "$HOME/Code" && pwd -P)" == "$(cd "$HOME/code" && pwd -P)" ]]; then
+        [ "$output" = "1" ]
+    fi
+}
+
+@test "discover_project_dirs deduplicates default Code vs actual code" {
+    # Simulate: $HOME/code exists (actual dir), $HOME/Code is in defaults
+    mkdir -p "$HOME/code/myproject"
+    touch "$HOME/code/myproject/package.json"
+
+    # No config file — triggers discovery
+    run env HOME="$HOME" bash -c "
+        source '$PROJECT_ROOT/lib/clean/project.sh'
+        discover_project_dirs
+    "
+
+    [ "$status" -eq 0 ]
+
+    # On case-insensitive FS, $HOME/code should appear only once
+    if [[ -d "$HOME/Code" && "$(cd "$HOME/Code" && pwd -P)" == "$(cd "$HOME/code" && pwd -P)" ]]; then
+        local count
+        count=$(echo "$output" | grep -c "$HOME/code" || true)
+        [ "$count" -le 1 ]
+    fi
 }


### PR DESCRIPTION
Closes #702

## Summary
- On macOS APFS (case-insensitive by default), `~/Code` and `~/code` resolve to the same directory but the purge selector showed both variants as separate entries
- Added `mole_purge_resolve_path_case()` helper that resolves paths to canonical filesystem casing via `cd + pwd -P`
- Applied normalization when reading config paths and during directory discovery, plus a dedup safety net when merging scan results

## Test plan
- [x] New BATS test: config with `~/code` and `~/Code` deduplicates to 1 entry on case-insensitive FS
- [x] New BATS test: `discover_project_dirs` doesn't duplicate `Code` vs `code`
- [x] All existing purge config tests pass (8/8)
- [x] No regressions in purge.bats (same 4 pre-existing failures)