### PR TITLE
feat(analyze): add Quick Look file preview with P key

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -839,6 +839,25 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.status = fmt.Sprintf("Showing %s in Finder...", selected.Name)
 			}
 		}
+	case "p", "P":
+		// Quick Look preview (single file only, no multi-select).
+		if m.showLargeFiles {
+			if len(m.largeFiles) > 0 {
+				selected := m.largeFiles[m.largeSelected]
+				go func(path string) {
+					_ = safePreview(path)
+				}(selected.Path)
+				m.status = fmt.Sprintf("Previewing %s...", selected.Name)
+			}
+		} else if len(m.entries) > 0 {
+			selected := m.entries[m.selected]
+			if !selected.IsDir {
+				go func(path string) {
+					_ = safePreview(path)
+				}(selected.Path)
+				m.status = fmt.Sprintf("Previewing %s...", selected.Name)
+			}
+		}
 	case " ":
 		// Toggle multi-select (paths as keys).
 		if m.showLargeFiles {
@@ -1231,4 +1250,18 @@ func safeOpen(path string, reveal bool) error {
 		args = []string{"-R", path}
 	}
 	return exec.CommandContext(ctx, "open", args...).Run()
+}
+
+// safePreview opens a Quick Look preview via qlmanage.
+// Stdout/stderr are suppressed to avoid corrupting the TUI.
+func safePreview(path string) error {
+	if err := validatePath(path); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "qlmanage", "-p", path)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
 }

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -1253,18 +1253,24 @@ func safeOpen(path string, reveal bool) error {
 }
 
 // safePreview opens a Quick Look preview via qlmanage.
-// Stdout/stderr are suppressed to avoid corrupting the TUI.
-// A new process group is used so that a qlmanage crash (e.g. on
-// video files) does not take down the parent process.
+// If qlmanage crashes (e.g. on video files), it falls back to
+// revealing the file in Finder with "open -R".
 func safePreview(path string) error {
 	if err := validatePath(path); err != nil {
 		return err
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "qlmanage", "-p", path)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		// qlmanage crashed or timed out — reveal in Finder instead.
+		ctx2, cancel2 := context.WithTimeout(context.Background(), openCommandTimeout)
+		defer cancel2()
+		return exec.CommandContext(ctx2, "open", "-R", path).Run()
+	}
+	return nil
 }

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
-	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -1253,34 +1252,12 @@ func safeOpen(path string, reveal bool) error {
 	return exec.CommandContext(ctx, "open", args...).Run()
 }
 
-// safePreview opens a Quick Look preview via qlmanage.
-// Media files that crash qlmanage are revealed in Finder instead.
+// safePreview opens the file with the default macOS application.
 func safePreview(path string) error {
 	if err := validatePath(path); err != nil {
 		return err
 	}
-
-	if isMediaFile(path) {
-		ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
-		defer cancel()
-		return exec.CommandContext(ctx, "open", "-R", path).Run()
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "qlmanage", "-p", path)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	return cmd.Run()
-}
-
-var mediaExts = map[string]bool{
-	".mp4": true, ".mov": true, ".avi": true, ".mkv": true, ".wmv": true,
-	".flv": true, ".webm": true, ".m4v": true, ".mp3": true, ".wav": true,
-	".aac": true, ".flac": true, ".ogg": true, ".m4a": true,
-}
-
-func isMediaFile(path string) bool {
-	return mediaExts[strings.ToLower(filepath.Ext(path))]
+	return exec.CommandContext(ctx, "open", path).Run()
 }

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -1254,6 +1254,8 @@ func safeOpen(path string, reveal bool) error {
 
 // safePreview opens a Quick Look preview via qlmanage.
 // Stdout/stderr are suppressed to avoid corrupting the TUI.
+// A new process group is used so that a qlmanage crash (e.g. on
+// video files) does not take down the parent process.
 func safePreview(path string) error {
 	if err := validatePath(path); err != nil {
 		return err
@@ -1263,5 +1265,6 @@ func safePreview(path string) error {
 	cmd := exec.CommandContext(ctx, "qlmanage", "-p", path)
 	cmd.Stdout = nil
 	cmd.Stderr = nil
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return cmd.Run()
 }

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -1253,11 +1254,16 @@ func safeOpen(path string, reveal bool) error {
 }
 
 // safePreview opens a Quick Look preview via qlmanage.
-// If qlmanage crashes (e.g. on video files), it falls back to
-// revealing the file in Finder with "open -R".
+// Media files that crash qlmanage are revealed in Finder instead.
 func safePreview(path string) error {
 	if err := validatePath(path); err != nil {
 		return err
+	}
+
+	if isMediaFile(path) {
+		ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
+		defer cancel()
+		return exec.CommandContext(ctx, "open", "-R", path).Run()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), openCommandTimeout)
@@ -1266,11 +1272,15 @@ func safePreview(path string) error {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	if err := cmd.Run(); err != nil {
-		// qlmanage crashed or timed out — reveal in Finder instead.
-		ctx2, cancel2 := context.WithTimeout(context.Background(), openCommandTimeout)
-		defer cancel2()
-		return exec.CommandContext(ctx2, "open", "-R", path).Run()
-	}
-	return nil
+	return cmd.Run()
+}
+
+var mediaExts = map[string]bool{
+	".mp4": true, ".mov": true, ".avi": true, ".mkv": true, ".wmv": true,
+	".flv": true, ".webm": true, ".m4v": true, ".mp3": true, ".wav": true,
+	".aac": true, ".flac": true, ".ogg": true, ".m4a": true,
+}
+
+func isMediaFile(path string) bool {
+	return mediaExts[strings.ToLower(filepath.Ext(path))]
 }

--- a/cmd/analyze/view.go
+++ b/cmd/analyze/view.go
@@ -338,31 +338,31 @@ func (m model) View() string {
 	fmt.Fprintln(&b)
 	if m.inOverviewMode() {
 		if len(m.history) > 0 {
-			fmt.Fprintf(&b, "%s↑↓←→ | Enter | R Refresh | O Open | F File | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
+			fmt.Fprintf(&b, "%s↑↓←→ | Enter | R Refresh | O Open | P Preview | F File | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
 		} else {
-			fmt.Fprintf(&b, "%s↑↓→ | Enter | R Refresh | O Open | F File | Esc/Q Quit%s\n", colorGray, colorReset)
+			fmt.Fprintf(&b, "%s↑↓→ | Enter | R Refresh | O Open | P Preview | F File | Esc/Q Quit%s\n", colorGray, colorReset)
 		}
 	} else if m.showLargeFiles {
 		selectCount := len(m.largeMultiSelected)
 		if selectCount > 0 {
-			fmt.Fprintf(&b, "%s↑↓← | Space Select | R Refresh | O Open | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
+			fmt.Fprintf(&b, "%s↑↓← | Space Select | R Refresh | O Open | P Preview | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
 		} else {
-			fmt.Fprintf(&b, "%s↑↓← | Space Select | R Refresh | O Open | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
+			fmt.Fprintf(&b, "%s↑↓← | Space Select | R Refresh | O Open | P Preview | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
 		}
 	} else {
 		largeFileCount := len(m.largeFiles)
 		selectCount := len(m.multiSelected)
 		if selectCount > 0 {
 			if largeFileCount > 0 {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | F File | ⌫ Del %d | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, largeFileCount, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del %d | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, largeFileCount, colorReset)
 			} else {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
 			}
 		} else {
 			if largeFileCount > 0 {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | F File | ⌫ Del | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, largeFileCount, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, largeFileCount, colorReset)
 			} else {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #704

## Summary
- Press `P` in `mo analyze` to open macOS Quick Look preview on the selected file
- Works in both directory view and large files view
- Skips directories (only previews files)
- Stdout/stderr suppressed to avoid corrupting the BubbleTea TUI
- Follows existing patterns from `O` (Open) and `F` (Finder reveal)
- Uses `open` (default macOS app) instead of `qlmanage` — no crashes, no `[DEBUG]` prefix

## Changes
- `main.go` — `P` key handler + `safePreview()` function using `open`
- `view.go` — `P Preview` added to all help bar variants

## Test plan
- [x] `go build ./cmd/analyze/` — builds clean
- [x] `go test ./cmd/analyze/` — 175 tests pass
- [x] Run `mo analyze`, navigate to a file, press `P` — opens with default app
- [x] Press `P` on a directory — no action (correct)
- [x] Press `P` in large files view — opens file
- [x] Verify TUI redraws correctly after closing preview