### PR TITLE
feat(uninstall): Support direct app uninstall by name via CLI

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -829,12 +829,94 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
+# Match app names from scan data against user-provided search terms.
+# Performs case-insensitive substring matching on app display names.
+# Returns matched entries from apps_data in selected_apps.
+match_apps_by_name() {
+    local -a search_terms=("$@")
+    selected_apps=()
+    local -a matched_indices=()
+
+    for search_term in "${search_terms[@]}"; do
+        local search_lower
+        search_lower=$(echo "$search_term" | tr '[:upper:]' '[:lower:]')
+        # Escape glob characters to prevent pattern injection
+        search_lower=${search_lower//\\/\\\\}
+        search_lower=${search_lower//\*/\\*}
+        search_lower=${search_lower//\?/\\?}
+        search_lower=${search_lower//\[/\\[}
+        local found=false
+        local idx=0
+        for app_data in "${apps_data[@]}"; do
+            IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$app_data"
+            local name_lower
+            name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
+            # Also try matching against the .app directory base name
+            local dir_name
+            dir_name=$(basename "$app_path" .app)
+            local dir_lower
+            dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
+
+            if [[ "$name_lower" == "$search_lower" || "$dir_lower" == "$search_lower" ]]; then
+                # Exact match - prefer this
+                local already=false
+                local mi
+                for mi in "${matched_indices[@]+"${matched_indices[@]}"}"; do
+                    [[ -z "$mi" ]] && continue
+                    [[ "$mi" == "$idx" ]] && already=true && break
+                done
+                if [[ "$already" == "false" ]]; then
+                    selected_apps+=("$app_data")
+                    matched_indices+=("$idx")
+                fi
+                found=true
+                break
+            fi
+            idx=$((idx + 1))
+        done
+
+        # If no exact match, try substring match
+        if [[ "$found" == "false" ]]; then
+            idx=0
+            for app_data in "${apps_data[@]}"; do
+                IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$app_data"
+                local name_lower
+                name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
+                local dir_name
+                dir_name=$(basename "$app_path" .app)
+                local dir_lower
+                dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
+
+                if [[ "$name_lower" == *"$search_lower"* || "$dir_lower" == *"$search_lower"* ]]; then
+                    local already=false
+                    local mi
+                    for mi in "${matched_indices[@]+"${matched_indices[@]}"}"; do
+                        [[ -z "$mi" ]] && continue
+                        [[ "$mi" == "$idx" ]] && already=true && break
+                    done
+                    if [[ "$already" == "false" ]]; then
+                        selected_apps+=("$app_data")
+                        matched_indices+=("$idx")
+                    fi
+                    found=true
+                fi
+                idx=$((idx + 1))
+            done
+        fi
+
+        if [[ "$found" == "false" ]]; then
+            echo -e "${YELLOW}Warning:${NC} No application found matching '$search_term'"
+        fi
+    done
+}
+
 main() {
     # Set current command for operation logging
     export MOLE_CURRENT_COMMAND="uninstall"
     log_operation_session_start "uninstall"
 
-    # Global flags
+    # Parse flags and collect app name arguments
+    local -a app_name_args=()
     for arg in "$@"; do
         case "$arg" in
             "--help" | "-h")
@@ -859,9 +941,7 @@ main() {
                 exit 1
                 ;;
             *)
-                echo "Unknown uninstall argument: $arg"
-                echo "Use 'mo uninstall --help' for supported options."
-                exit 1
+                app_name_args+=("$arg")
                 ;;
         esac
     done
@@ -870,6 +950,60 @@ main() {
     if [[ "${MOLE_DRY_RUN:-0}" == "1" ]]; then
         echo -e "${YELLOW}${ICON_DRY_RUN} DRY RUN MODE${NC}, No app files or settings will be modified"
         printf '\n'
+    fi
+
+    # Direct uninstall by app name
+    if [[ ${#app_name_args[@]} -gt 0 ]]; then
+        local apps_file=""
+        if ! apps_file=$(scan_applications); then
+            show_cursor
+            return 1
+        fi
+        if [[ ! -f "$apps_file" ]]; then
+            show_cursor
+            return 1
+        fi
+        if ! load_applications "$apps_file"; then
+            rm -f "$apps_file"
+            show_cursor
+            return 1
+        fi
+
+        match_apps_by_name "${app_name_args[@]}"
+        rm -f "$apps_file"
+
+        if [[ ${#selected_apps[@]} -eq 0 ]]; then
+            show_cursor
+            echo "No matching applications found."
+            return 1
+        fi
+
+        show_cursor
+        clear_screen
+        local selection_count=${#selected_apps[@]}
+        echo -e "${BLUE}${ICON_CONFIRM}${NC} Matched ${selection_count} app(s):"
+        local index=1
+        for selected_app in "${selected_apps[@]}"; do
+            IFS='|' read -r _ app_path app_name _ size last_used _ <<< "$selected_app"
+            local size_display
+            size_display=$(uninstall_normalize_size_display "$size")
+            local last_display
+            last_display=$(uninstall_normalize_last_used_display "$last_used")
+            printf "%d. %s  %s  |  Last: %s\n" "$index" "$app_name" "$size_display" "$last_display"
+            ((index++))
+        done
+
+        printf '\n'
+        printf "Proceed with uninstallation? [y/N] "
+        local confirm
+        read -r confirm
+        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+            echo "Aborted."
+            return 0
+        fi
+
+        batch_uninstall_applications
+        return 0
     fi
 
     local first_scan=true

--- a/lib/core/help.sh
+++ b/lib/core/help.sh
@@ -54,10 +54,17 @@ show_touchid_help() {
 }
 
 show_uninstall_help() {
-    echo "Usage: mo uninstall [OPTIONS]"
+    echo "Usage: mo uninstall [OPTIONS] [APP_NAME ...]"
     echo ""
     echo "Interactively remove applications and their leftover files."
+    echo "Optionally specify one or more app names to uninstall directly."
     echo "For leftovers from apps that are already gone, use mo clean."
+    echo ""
+    echo "Examples:"
+    echo "  mo uninstall                   Open interactive app selector"
+    echo "  mo uninstall slack             Uninstall Slack"
+    echo "  mo uninstall slack zoom        Uninstall Slack and Zoom"
+    echo "  mo uninstall --dry-run slack   Preview Slack uninstallation"
     echo ""
     echo "Options:"
     echo "  --dry-run         Preview app uninstallation without making changes"

--- a/tests/test_match_apps_helper.sh
+++ b/tests/test_match_apps_helper.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Test helper: match_apps_by_name extracted from bin/uninstall.sh for unit testing.
+# Requires apps_data and selected_apps arrays to be defined before sourcing.
+# NOTE: Keep in sync with bin/uninstall.sh match_apps_by_name()
+
+# Declared by caller before sourcing this file
+: "${apps_data?apps_data array must be set before sourcing this file}"
+
+match_apps_by_name() {
+    local -a search_terms=("$@")
+    selected_apps=()
+    local -a matched_indices=()
+
+    for search_term in "${search_terms[@]}"; do
+        local search_lower
+        search_lower=$(echo "$search_term" | tr '[:upper:]' '[:lower:]')
+        # Escape glob characters to prevent pattern injection
+        search_lower=${search_lower//\\/\\\\}
+        search_lower=${search_lower//\*/\\*}
+        search_lower=${search_lower//\?/\\?}
+        search_lower=${search_lower//\[/\\[}
+        local found=false
+        local idx=0
+        for app_data in "${apps_data[@]}"; do
+            IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$app_data"
+            local name_lower
+            name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
+            local dir_name
+            dir_name=$(basename "$app_path" .app)
+            local dir_lower
+            dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
+
+            if [[ "$name_lower" == "$search_lower" || "$dir_lower" == "$search_lower" ]]; then
+                local already=false
+                local mi
+                for mi in "${matched_indices[@]+"${matched_indices[@]}"}"; do
+                    [[ -z "$mi" ]] && continue
+                    [[ "$mi" == "$idx" ]] && already=true && break
+                done
+                if [[ "$already" == "false" ]]; then
+                    selected_apps+=("$app_data")
+                    matched_indices+=("$idx")
+                fi
+                found=true
+                break
+            fi
+            idx=$((idx + 1))
+        done
+
+        # If no exact match, try substring match
+        if [[ "$found" == "false" ]]; then
+            idx=0
+            for app_data in "${apps_data[@]}"; do
+                IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$app_data"
+                local name_lower
+                name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
+                local dir_name
+                dir_name=$(basename "$app_path" .app)
+                local dir_lower
+                dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
+
+                if [[ "$name_lower" == *"$search_lower"* || "$dir_lower" == *"$search_lower"* ]]; then
+                    local already=false
+                    local mi
+                    for mi in "${matched_indices[@]+"${matched_indices[@]}"}"; do
+                        [[ -z "$mi" ]] && continue
+                        [[ "$mi" == "$idx" ]] && already=true && break
+                    done
+                    if [[ "$already" == "false" ]]; then
+                        selected_apps+=("$app_data")
+                        matched_indices+=("$idx")
+                    fi
+                    found=true
+                fi
+                idx=$((idx + 1))
+            done
+        fi
+
+        if [[ "$found" == "false" ]]; then
+            echo "Warning: No application found matching '$search_term'"
+        fi
+    done
+}

--- a/tests/test_match_apps_helper.sh
+++ b/tests/test_match_apps_helper.sh
@@ -1,83 +1,27 @@
 #!/bin/bash
-# Test helper: match_apps_by_name extracted from bin/uninstall.sh for unit testing.
+# Test helper: load match_apps_by_name directly from bin/uninstall.sh for unit testing.
 # Requires apps_data and selected_apps arrays to be defined before sourcing.
-# NOTE: Keep in sync with bin/uninstall.sh match_apps_by_name()
 
 # Declared by caller before sourcing this file
 : "${apps_data?apps_data array must be set before sourcing this file}"
 
-match_apps_by_name() {
-    local -a search_terms=("$@")
-    selected_apps=()
-    local -a matched_indices=()
+_test_helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_repo_root="$(cd "${_test_helper_dir}/.." && pwd)"
+_uninstall_script="${_repo_root}/bin/uninstall.sh"
 
-    for search_term in "${search_terms[@]}"; do
-        local search_lower
-        search_lower=$(echo "$search_term" | tr '[:upper:]' '[:lower:]')
-        # Escape glob characters to prevent pattern injection
-        search_lower=${search_lower//\\/\\\\}
-        search_lower=${search_lower//\*/\\*}
-        search_lower=${search_lower//\?/\\?}
-        search_lower=${search_lower//\[/\\[}
-        local found=false
-        local idx=0
-        for app_data in "${apps_data[@]}"; do
-            IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$app_data"
-            local name_lower
-            name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
-            local dir_name
-            dir_name=$(basename "$app_path" .app)
-            local dir_lower
-            dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
+if [[ ! -f "${_uninstall_script}" ]]; then
+    echo "Error: unable to find ${_uninstall_script}" >&2
+    return 1
+fi
 
-            if [[ "$name_lower" == "$search_lower" || "$dir_lower" == "$search_lower" ]]; then
-                local already=false
-                local mi
-                for mi in "${matched_indices[@]+"${matched_indices[@]}"}"; do
-                    [[ -z "$mi" ]] && continue
-                    [[ "$mi" == "$idx" ]] && already=true && break
-                done
-                if [[ "$already" == "false" ]]; then
-                    selected_apps+=("$app_data")
-                    matched_indices+=("$idx")
-                fi
-                found=true
-                break
-            fi
-            idx=$((idx + 1))
-        done
+# Suppress color codes in test output
+YELLOW=""
+NC=""
 
-        # If no exact match, try substring match
-        if [[ "$found" == "false" ]]; then
-            idx=0
-            for app_data in "${apps_data[@]}"; do
-                IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$app_data"
-                local name_lower
-                name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
-                local dir_name
-                dir_name=$(basename "$app_path" .app)
-                local dir_lower
-                dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
+eval "$(
+    sed -n '/^match_apps_by_name()[[:space:]]*{/,/^}$/p' "${_uninstall_script}"
+)"
 
-                if [[ "$name_lower" == *"$search_lower"* || "$dir_lower" == *"$search_lower"* ]]; then
-                    local already=false
-                    local mi
-                    for mi in "${matched_indices[@]+"${matched_indices[@]}"}"; do
-                        [[ -z "$mi" ]] && continue
-                        [[ "$mi" == "$idx" ]] && already=true && break
-                    done
-                    if [[ "$already" == "false" ]]; then
-                        selected_apps+=("$app_data")
-                        matched_indices+=("$idx")
-                    fi
-                    found=true
-                fi
-                idx=$((idx + 1))
-            done
-        fi
-
-        if [[ "$found" == "false" ]]; then
-            echo "Warning: No application found matching '$search_term'"
-        fi
-    done
-}
+unset _test_helper_dir
+unset _repo_root
+unset _uninstall_script

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -589,3 +589,119 @@ EOF
 	[[ "$output" != *"$fake_global_bin/mo"* ]]
 	[[ "$output" != *"brew uninstall --force mole"* ]]
 }
+@test "match_apps_by_name finds exact match case-insensitively" {
+	run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+selected_apps=()
+apps_data=(
+	"1000|$HOME/Applications/TestApp.app|TestApp|com.example.TestApp|1.2 GB|1000000|1258291"
+	"1001|$HOME/Applications/TestApp2.app|TestApp2|com.example.TestApp2|500 MB|1000001|512000"
+	"1002|$HOME/Applications/TestApp3.app|TestApp3|com.example.TestApp3|300 MB|1000002|307200"
+)
+source "$PROJECT_ROOT/tests/test_match_apps_helper.sh"
+match_apps_by_name "testapp"
+echo "count=${#selected_apps[@]}"
+echo "match=${selected_apps[0]}"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"count=1"* ]]
+	[[ "$output" == *"TestApp"* ]]
+}
+
+@test "match_apps_by_name finds by directory name" {
+	run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+selected_apps=()
+apps_data=(
+	"1002|$HOME/Applications/TestApp.app|Test Application|com.example.TestApp|300 MB|1000002|307200"
+)
+source "$PROJECT_ROOT/tests/test_match_apps_helper.sh"
+match_apps_by_name "TestApp"
+echo "count=${#selected_apps[@]}"
+echo "match=${selected_apps[0]}"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"count=1"* ]]
+	[[ "$output" == *"Test Application"* ]]
+}
+
+@test "match_apps_by_name warns on no match" {
+	run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+selected_apps=()
+apps_data=(
+	"1000|$HOME/Applications/TestApp.app|TestApp|com.example.TestApp|1.2 GB|1000000|1258291"
+)
+source "$PROJECT_ROOT/tests/test_match_apps_helper.sh"
+match_apps_by_name "nonexistent"
+echo "count=${#selected_apps[@]}"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Warning: No application found matching 'nonexistent'"* ]]
+	[[ "$output" == *"count=0"* ]]
+}
+
+@test "match_apps_by_name handles multiple app names" {
+	run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+selected_apps=()
+apps_data=(
+	"1000|$HOME/Applications/TestApp.app|TestApp|com.example.TestApp|1.2 GB|1000000|1258291"
+	"1001|$HOME/Applications/TestApp2.app|TestApp2|com.example.TestApp2|500 MB|1000001|512000"
+	"1002|$HOME/Applications/TestApp3.app|TestApp3|com.example.TestApp3|300 MB|1000002|307200"
+)
+source "$PROJECT_ROOT/tests/test_match_apps_helper.sh"
+match_apps_by_name "testapp2" "testapp3"
+echo "count=${#selected_apps[@]}"
+for app in "${selected_apps[@]}"; do
+    IFS='|' read -r _ _ name _ _ _ _ <<< "$app"
+    echo "matched=$name"
+done
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"count=2"* ]]
+	[[ "$output" == *"matched=TestApp2"* ]]
+	[[ "$output" == *"matched=TestApp3"* ]]
+}
+
+@test "match_apps_by_name falls back to substring match" {
+	run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+selected_apps=()
+apps_data=(
+	"1000|$HOME/Applications/TestApp.app|TestApp|com.example.TestApp|1.2 GB|1000000|1258291"
+	"1001|$HOME/Applications/SlackDesktop.app|Slack|com.tinyspeck.slackmacgap|200 MB|1000001|204800"
+)
+source "$PROJECT_ROOT/tests/test_match_apps_helper.sh"
+match_apps_by_name "test"
+echo "count=${#selected_apps[@]}"
+for app in "${selected_apps[@]}"; do
+    IFS='|' read -r _ _ name _ _ _ _ <<< "$app"
+    echo "matched=$name"
+done
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"count=1"* ]]
+	[[ "$output" == *"matched=TestApp"* ]]
+}
+
+@test "match_apps_by_name does not duplicate when same name given twice" {
+	run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+selected_apps=()
+apps_data=(
+	"1000|$HOME/Applications/TestApp.app|TestApp|com.example.TestApp|1.2 GB|1000000|1258291"
+)
+source "$PROJECT_ROOT/tests/test_match_apps_helper.sh"
+match_apps_by_name "testapp" "testapp"
+echo "count=${#selected_apps[@]}"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"count=1"* ]]
+}


### PR DESCRIPTION
## Summary

Adds support for uninstalling applications directly by name from the command line, bypassing the interactive selector.

```bash
mo uninstall slack
mo uninstall slack zoom
mo uninstall --dry-run slack
```

Issue: #707 

## Safety Review

- **Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?**
  Yes — extends `mo uninstall` to accept positional app name arguments for direct (non-interactive) uninstall.

- **Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?**
  No. The new code path reuses the existing `scan_applications`, `load_applications`, and `batch_uninstall_applications` functions. No new path resolution, symlink handling, or privilege escalation is introduced.

- **New boundary / risk description:**
  - User input used in glob pattern matching is now escaped (`\`, `*`, `?`, `[`) to prevent pattern injection.
  - A confirmation prompt (`y/N`) is required before any uninstallation proceeds.
  - Cursor visibility is restored on all early-exit error paths to prevent terminal state corruption.

**Test:**
- Verified `mo uninstall --help` displays updated usage and examples.
- Verified `mo uninstall nonexistent` shows warning and exits cleanly.
- Verified `mo uninstall --dry-run <app>` previews without modifying files.
- Verified cursor is restored after scan/load failures (Ctrl+C during scan).

## Safety-related changes

- Glob character escaping added to `match_apps_by_name()` to prevent user input from being interpreted as shell glob patterns.
- `show_cursor` added to all early-exit paths in the direct-uninstall flow to prevent hidden cursor on failure.
- Redundant screen-clear escape sequence removed (was sent to both stdout and stderr).
