### PR TITLE
feat(uninstall): support direct uninstall by app name

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -834,7 +834,8 @@ main() {
     export MOLE_CURRENT_COMMAND="uninstall"
     log_operation_session_start "uninstall"
 
-    # Global flags
+    # Global flags and positional app names
+    local -a target_app_names=()
     for arg in "$@"; do
         case "$arg" in
             "--help" | "-h")
@@ -859,9 +860,8 @@ main() {
                 exit 1
                 ;;
             *)
-                echo "Unknown uninstall argument: $arg"
-                echo "Use 'mo uninstall --help' for supported options."
-                exit 1
+                local cleaned_arg="${arg%.app}"
+                target_app_names+=("$cleaned_arg")
                 ;;
         esac
     done
@@ -870,6 +870,92 @@ main() {
     if [[ "${MOLE_DRY_RUN:-0}" == "1" ]]; then
         echo -e "${YELLOW}${ICON_DRY_RUN} DRY RUN MODE${NC}, No app files or settings will be modified"
         printf '\n'
+    fi
+
+    # Direct uninstall by app name(s)
+    # TODO: optimize direct lookup to skip full scan (walk dirs + match only targeted names)
+    if [[ ${#target_app_names[@]} -gt 0 ]]; then
+        local apps_file=""
+        if ! apps_file=$(scan_applications); then
+            show_cursor
+            return 1
+        fi
+        if [[ ! -f "$apps_file" ]]; then
+            show_cursor
+            return 1
+        fi
+        if ! load_applications "$apps_file"; then
+            rm -f "$apps_file"
+            show_cursor
+            return 1
+        fi
+
+        selected_apps=()
+        local -a not_found=()
+        for target in "${target_app_names[@]}"; do
+            local target_lower
+            target_lower=$(printf '%s' "$target" | tr '[:upper:]' '[:lower:]')
+            local found=false
+            local -a matches=()
+            for app_entry in "${apps_data[@]}"; do
+                IFS='|' read -r _ _ app_name _ _ _ _ <<< "$app_entry"
+                local name_lower
+                name_lower=$(printf '%s' "$app_name" | tr '[:upper:]' '[:lower:]')
+                if [[ "$name_lower" == "$target_lower" ]]; then
+                    matches+=("$app_entry")
+                    found=true
+                fi
+            done
+            if [[ "$found" == "false" ]]; then
+                not_found+=("$target")
+            elif [[ ${#matches[@]} -gt 1 ]]; then
+                echo -e "${YELLOW}${ICON_WARNING}${NC} Multiple apps match '$target':"
+                local mi=1
+                for m in "${matches[@]}"; do
+                    IFS='|' read -r _ m_path m_name _ _ _ _ <<< "$m"
+                    printf "  %d. %s (%s)\n" "$mi" "$m_name" "$m_path"
+                    ((mi++))
+                done
+                echo "  Using first match. Use the interactive selector for precise control."
+                selected_apps+=("${matches[0]}")
+            else
+                selected_apps+=("${matches[0]}")
+            fi
+        done
+
+        if [[ ${#not_found[@]} -gt 0 ]]; then
+            for name in "${not_found[@]}"; do
+                echo -e "${RED}${ICON_ERROR}${NC} App not found: $name"
+            done
+        fi
+
+        if [[ ${#selected_apps[@]} -eq 0 ]]; then
+            echo "No matching apps found to uninstall."
+            rm -f "$apps_file"
+            show_cursor
+            return 1
+        fi
+
+        show_cursor
+        local selection_count=${#selected_apps[@]}
+        echo -e "${BLUE}${ICON_CONFIRM}${NC} Selected ${selection_count} app(s):"
+        local index=1
+        for selected_app in "${selected_apps[@]}"; do
+            IFS='|' read -r _ _ app_name _ size last_used _ <<< "$selected_app"
+            local size_display
+            size_display=$(uninstall_normalize_size_display "$size")
+            local last_display
+            last_display=$(uninstall_normalize_last_used_display "$last_used")
+            printf "%d. %s  %s  |  Last: %s\n" "$index" "$app_name" "$size_display" "$last_display"
+            ((index++))
+        done
+
+        batch_uninstall_applications
+        rm -f "$apps_file"
+        if [[ ${#not_found[@]} -gt 0 ]]; then
+            return 1
+        fi
+        return 0
     fi
 
     local first_scan=true

--- a/lib/core/help.sh
+++ b/lib/core/help.sh
@@ -54,10 +54,18 @@ show_touchid_help() {
 }
 
 show_uninstall_help() {
-    echo "Usage: mo uninstall [OPTIONS]"
+    echo "Usage: mo uninstall [APP_NAME...] [OPTIONS]"
     echo ""
-    echo "Interactively remove applications and their leftover files."
+    echo "Remove applications and their leftover files."
+    echo "Without app names, launches interactive selector."
+    echo "With app names, directly uninstalls the matching apps."
     echo "For leftovers from apps that are already gone, use mo clean."
+    echo ""
+    echo "Examples:"
+    echo "  mo uninstall                   Interactive app selector"
+    echo "  mo uninstall WeChat            Uninstall WeChat directly"
+    echo "  mo uninstall WeChat Slack      Uninstall multiple apps"
+    echo "  mo uninstall --dry-run WeChat  Preview without changes"
     echo ""
     echo "Options:"
     echo "  --dry-run         Preview app uninstallation without making changes"

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -589,3 +589,117 @@ EOF
 	[[ "$output" != *"$fake_global_bin/mo"* ]]
 	[[ "$output" != *"brew uninstall --force mole"* ]]
 }
+
+# ── Direct uninstall by name (mo uninstall <appname>) ──────────────────
+
+@test "mo uninstall <name> finds matching app case-insensitively" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/core/help.sh"
+
+# Simulate apps_data with pipe-delimited entries
+declare -a apps_data=(
+    "1000|/Applications/WeChat.app|WeChat|com.tencent.xinWeChat|500 MB|2026-01-01|512000"
+    "1001|/Applications/Slack.app|Slack|com.tinyspeck.slackmacgap|300 MB|2026-02-01|307200"
+)
+
+# Test case-insensitive matching
+target="wechat"
+target_lower=$(printf '%s' "$target" | tr '[:upper:]' '[:lower:]')
+found=false
+for app_entry in "${apps_data[@]}"; do
+    IFS='|' read -r _ _ app_name _ _ _ _ <<< "$app_entry"
+    name_lower=$(printf '%s' "$app_name" | tr '[:upper:]' '[:lower:]')
+    if [[ "$name_lower" == "$target_lower" ]]; then
+        found=true
+        echo "MATCH:$app_name"
+        break
+    fi
+done
+[[ "$found" == "true" ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"MATCH:WeChat"* ]]
+}
+
+@test "mo uninstall <name> reports not found for unknown app" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+declare -a apps_data=(
+    "1000|/Applications/WeChat.app|WeChat|com.tencent.xinWeChat|500 MB|2026-01-01|512000"
+)
+
+target="NonExistentApp"
+target_lower=$(printf '%s' "$target" | tr '[:upper:]' '[:lower:]')
+found=false
+for app_entry in "${apps_data[@]}"; do
+    IFS='|' read -r _ _ app_name _ _ _ _ <<< "$app_entry"
+    name_lower=$(printf '%s' "$app_name" | tr '[:upper:]' '[:lower:]')
+    if [[ "$name_lower" == "$target_lower" ]]; then
+        found=true
+        break
+    fi
+done
+echo "FOUND:$found"
+[[ "$found" == "false" ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"FOUND:false"* ]]
+}
+
+@test "mo uninstall <name> detects duplicate app names" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+declare -a apps_data=(
+    "1000|/Applications/MyApp.app|MyApp|com.example.myapp|100 MB|2026-01-01|102400"
+    "1001|$HOME/Applications/MyApp.app|MyApp|com.example.myapp2|50 MB|2026-02-01|51200"
+)
+
+target="myapp"
+target_lower=$(printf '%s' "$target" | tr '[:upper:]' '[:lower:]')
+declare -a matches=()
+for app_entry in "${apps_data[@]}"; do
+    IFS='|' read -r _ _ app_name _ _ _ _ <<< "$app_entry"
+    name_lower=$(printf '%s' "$app_name" | tr '[:upper:]' '[:lower:]')
+    if [[ "$name_lower" == "$target_lower" ]]; then
+        matches+=("$app_entry")
+    fi
+done
+echo "COUNT:${#matches[@]}"
+[[ ${#matches[@]} -eq 2 ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"COUNT:2"* ]]
+}
+
+@test "mo uninstall strips .app suffix from input" {
+	run env HOME="$HOME" bash --noprofile --norc <<'EOF'
+arg="WeChat.app"
+cleaned="${arg%.app}"
+echo "CLEANED:$cleaned"
+[[ "$cleaned" == "WeChat" ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"CLEANED:WeChat"* ]]
+}
+
+@test "mo uninstall --help shows app name usage" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/core/help.sh"
+show_uninstall_help
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"APP_NAME"* ]]
+	[[ "$output" == *"mo uninstall WeChat"* ]]
+}


### PR DESCRIPTION
Support `mo uninstall <appname>` to remove apps directly by name, skipping the interactive selector.

```bash
mo uninstall WeChat            # uninstall by name
mo uninstall WeChat Slack      # multiple apps
mo uninstall --dry-run WeChat  # preview mode
mo uninstall                   # interactive selector (unchanged)
```

- Case-insensitive exact match, `.app` suffix auto-stripped
- Warns on duplicate names across directories, suggests interactive selector
- Returns non-zero when any name not found
- Reuses existing `batch_uninstall_applications` confirmation (Enter/ESC)
- 5 new tests for matching, not-found, duplicates, suffix stripping, help text

Closes #707