### PR TITLE
feat(clean): add confirmation prompt before cleanup

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1217,7 +1217,7 @@ main() {
         echo -ne "${PURPLE}${ICON_ARROW}${NC} Proceed with cleanup? ${GREEN}Enter${NC} continue, ${GRAY}Esc${NC} cancel: "
         local confirm
         confirm=$(read_key)
-        if [[ "$confirm" == "QUIT" ]]; then
+        if [[ "$confirm" != "ENTER" ]]; then
             echo -e " ${GRAY}Canceled${NC}"
             exit 0
         fi

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1211,6 +1211,19 @@ main() {
     done
 
     start_cleanup
+
+    # Final confirmation before cleanup (interactive, non-dry-run only).
+    if [[ "$DRY_RUN" != "true" && -t 0 && -z "$EXTERNAL_VOLUME_TARGET" ]]; then
+        echo -ne "${PURPLE}${ICON_ARROW}${NC} Proceed with cleanup? ${GREEN}Enter${NC} continue, ${GRAY}Esc${NC} cancel: "
+        local confirm
+        confirm=$(read_key)
+        if [[ "$confirm" == "QUIT" ]]; then
+            echo -e " ${GRAY}Canceled${NC}"
+            exit 0
+        fi
+        printf "\r\033[K"
+    fi
+
     hide_cursor
     perform_cleanup
     show_cursor


### PR DESCRIPTION
## Summary
- Adds a final confirmation prompt (`Enter` to proceed, any other key cancels) before `mo clean` executes
- Only shown in interactive, non-dry-run mode (skipped for `--dry-run`, piped input, and external volumes)
- Uses existing `read_key` helper, matching the sudo prompt UX pattern

## Motivation
Closes #645 — users requested a single confirmation gate before cleanup runs, as a safety net against accidental execution.

## Test plan
- [ ] `mo clean` shows confirmation prompt before cleanup
- [ ] Any key except `Enter` at prompt cancels without cleaning
- [ ] `Enter` at prompt proceeds normally
- [x] `mo clean --dry-run` skips confirmation (no prompt shown)
- [x] Non-interactive mode (piped) skips confirmation
- [x] All existing tests pass (`bats tests/clean_core.bats`)