### PR TITLE
feat(check): detect stale Homebrew taps

### DIFF
--- a/lib/check/all.sh
+++ b/lib/check/all.sh
@@ -842,7 +842,7 @@ check_brew_health() {
         # Skip the core taps — they are always needed.
         [[ "$tap" == "homebrew/core" || "$tap" == "homebrew/cask" ]] && continue
         local count
-        count=$(brew list --full-name 2>/dev/null | grep -c "^${tap}/" || echo "0")
+        count=$(brew list --full-name 2>/dev/null | grep -c "^${tap}/" || true)
         if [[ "$count" -eq 0 ]]; then
             stale_taps+=("$tap")
         fi

--- a/lib/check/all.sh
+++ b/lib/check/all.sh
@@ -837,7 +837,7 @@ check_brew_health() {
     # Detect taps with no installed formulae or casks.
     local -a stale_taps=()
     local installed
-    installed=$(brew list --full-name 2>/dev/null || true)
+    installed=$(run_with_timeout 5 brew list --full-name 2> /dev/null || true)
     local tap
     while IFS= read -r tap; do
         [[ -z "$tap" ]] && continue
@@ -846,7 +846,7 @@ check_brew_health() {
         if ! printf '%s\n' "$installed" | grep -q "^${tap}/"; then
             stale_taps+=("$tap")
         fi
-    done < <(brew tap 2>/dev/null)
+    done < <(run_with_timeout 5 brew tap 2> /dev/null)
 
     local n=${#stale_taps[@]}
     if [[ $n -eq 0 ]]; then

--- a/lib/check/all.sh
+++ b/lib/check/all.sh
@@ -836,14 +836,14 @@ check_brew_health() {
 
     # Detect taps with no installed formulae or casks.
     local -a stale_taps=()
+    local installed
+    installed=$(brew list --full-name 2>/dev/null || true)
     local tap
     while IFS= read -r tap; do
         [[ -z "$tap" ]] && continue
         # Skip the core taps — they are always needed.
         [[ "$tap" == "homebrew/core" || "$tap" == "homebrew/cask" ]] && continue
-        local count
-        count=$(brew list --full-name 2>/dev/null | grep -c "^${tap}/" || true)
-        if [[ "$count" -eq 0 ]]; then
+        if ! printf '%s\n' "$installed" | grep -q "^${tap}/"; then
             stale_taps+=("$tap")
         fi
     done < <(brew tap 2>/dev/null)

--- a/lib/check/all.sh
+++ b/lib/check/all.sh
@@ -829,6 +829,37 @@ check_orphan_launch_agents() {
 check_brew_health() {
     # Check whitelist
     if command -v is_whitelisted > /dev/null && is_whitelisted "check_brew_health"; then return; fi
+
+    if ! command -v brew > /dev/null 2>&1; then
+        return
+    fi
+
+    # Detect taps with no installed formulae or casks.
+    local -a stale_taps=()
+    local tap
+    while IFS= read -r tap; do
+        [[ -z "$tap" ]] && continue
+        # Skip the core taps — they are always needed.
+        [[ "$tap" == "homebrew/core" || "$tap" == "homebrew/cask" ]] && continue
+        local count
+        count=$(brew list --full-name 2>/dev/null | grep -c "^${tap}/" || echo "0")
+        if [[ "$count" -eq 0 ]]; then
+            stale_taps+=("$tap")
+        fi
+    done < <(brew tap 2>/dev/null)
+
+    local n=${#stale_taps[@]}
+    if [[ $n -eq 0 ]]; then
+        echo -e "  ${GREEN}✓${NC} Brew Taps    All taps in use"
+    else
+        local s=""
+        ((n > 1)) && s="s"
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Brew Taps    ${YELLOW}${n} unused tap${s}${NC}"
+        local preview="${stale_taps[0]}"
+        ((n > 1)) && preview="${preview}, ${stale_taps[1]}"
+        ((n > 2)) && preview="${preview} +$((n - 2))"
+        echo -e "    ${GRAY}${preview}${NC}"
+    fi
 }
 
 check_system_health() {
@@ -839,6 +870,7 @@ check_system_health() {
     check_login_items
     check_disk_smart
     check_orphan_launch_agents
+    check_brew_health
     check_cache_size
     # Time Machine check is optional; skip by default to avoid noise on systems without backups
 }


### PR DESCRIPTION
## Summary
- Populates the empty `check_brew_health()` stub to detect taps with no installed formulae or casks
- Skips `homebrew/core` and `homebrew/cask` (always needed)
- Follows the existing display pattern from `check_orphan_launch_agents` (count + name preview)
- Wired into `check_system_health` between orphan launch agents and cache size

## Impact
Homebrew taps accumulate over time — abandoned taps slow down `brew update` and add noise. This flags unused ones so users can `brew untap` them.

## Test plan
- [x] `bash -n lib/check/all.sh` — syntax OK
- [x] `bats tests/clean_core.bats` — 17/17 pass
- [x] Manual: `mo check` shows "Brew Taps" line with count of unused taps
- [x] Manual: system with no stale taps shows "All taps in use"