### PR TITLE
fix(check): detect Touch ID in sudo_local for modern macOS

### DIFF
--- a/lib/check/all.sh
+++ b/lib/check/all.sh
@@ -39,7 +39,8 @@ check_touchid_sudo() {
     if command -v is_whitelisted > /dev/null && is_whitelisted "check_touchid"; then return; fi
     # Check if Touch ID is configured for sudo
     local pam_file="/etc/pam.d/sudo"
-    if [[ -f "$pam_file" ]] && grep -q "pam_tid.so" "$pam_file" 2> /dev/null; then
+    local pam_local="/etc/pam.d/sudo_local"
+    if grep -q "pam_tid.so" "$pam_file" "$pam_local" 2> /dev/null; then
         echo -e "  ${GREEN}✓${NC} Touch ID     Biometric authentication enabled"
     else
         # Check if Touch ID is supported


### PR DESCRIPTION
## Summary
- macOS configures `pam_tid.so` in `/etc/pam.d/sudo_local` (included via `sudo`), not directly in `/etc/pam.d/sudo`
- `mo check` was only checking `/etc/pam.d/sudo`, so Touch ID showed as "Not configured" even when working
- Now checks both files

## Test plan
- [x] `mo check` — Touch ID now shows "Biometric authentication enabled" ✓
- [x] Existing checks (FileVault, Firewall, Gatekeeper, SIP) unaffected
- [x] Tested locally on macOS with Touch ID configured via `sudo_local`