### PR TITLE
fix(optimize): skip periodic maintenance when sudo is unavailable

### DIFF
--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -956,6 +956,10 @@ opt_periodic_maintenance() {
     fi
 
     if [[ "${MOLE_DRY_RUN:-0}" != "1" ]]; then
+        if ! sudo -n true 2> /dev/null; then
+            echo -e "  ${YELLOW}${ICON_WARNING}${NC} Periodic maintenance skipped · requires sudo"
+            return 0
+        fi
         if sudo periodic daily weekly monthly 2> /dev/null; then
             opt_msg "Periodic maintenance triggered"
         else

--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -956,6 +956,10 @@ opt_periodic_maintenance() {
     fi
 
     if [[ "${MOLE_DRY_RUN:-0}" != "1" ]]; then
+        if ! command -v periodic > /dev/null 2>&1; then
+            opt_msg "Periodic maintenance not available on this macOS version"
+            return 0
+        fi
         if ! sudo -n true 2> /dev/null; then
             echo -e "  ${YELLOW}${ICON_WARNING}${NC} Periodic maintenance skipped · requires sudo"
             return 0


### PR DESCRIPTION
Fixes #718

## Summary
- Detect missing `periodic` command on modern macOS and skip gracefully with informative message
- Check `sudo -n true` before running `sudo periodic` to show "skipped · requires sudo" instead of vague "Failed to run periodic maintenance"
- Apple removed the `periodic` utility in recent macOS versions, which is the root cause of this bug

## Test plan
- [x] `bats tests/optimize.bats --filter periodic` — 4/4 pass
- [x] Dry-run bypasses both checks (unchanged behavior)
- [x] Fresh log file returns "already current" (unchanged behavior)
- [x] Manual: on macOS without `periodic` → shows "not available on this macOS version"
- [x] Manual: `sudo -k` then run → shows "skipped · requires sudo"