### PR TITLE
fix(optimize): remove disk verify that can freeze system on damaged volumes

### DIFF
--- a/lib/check/health_json.sh
+++ b/lib/check/health_json.sh
@@ -145,7 +145,6 @@ EOF
     items+=('spotlight_index_optimize|Spotlight Optimization|Rebuild index if search is slow (smart detection)|true')
     items+=('periodic_maintenance|Periodic Maintenance|Run macOS daily/weekly/monthly maintenance scripts if stale|true')
     items+=('shared_file_list_repair|Shared File Lists|Repair corrupted Finder favorites and recent documents|true')
-    items+=('disk_verify|Disk Health|Verify filesystem integrity|true')
     items+=('login_items_audit|Login Items|Audit login items for broken entries|true')
 
     # System database cleanup (auto-run, low risk)

--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -1035,30 +1035,6 @@ opt_notification_cleanup() {
     fi
 }
 
-# Verify filesystem integrity via diskutil.
-opt_disk_verify() {
-    if [[ "${MOLE_DRY_RUN:-0}" == "1" ]]; then
-        opt_msg "Disk verify · skipped in dry-run"
-        return 0
-    fi
-
-    if [[ -t 1 ]]; then
-        MOLE_SPINNER_PREFIX="  " start_inline_spinner "Verifying disk filesystem..."
-    fi
-    local output
-    output=$(run_with_timeout 30 diskutil verifyVolume / 2>&1 || true)
-    if [[ -t 1 ]]; then
-        stop_inline_spinner
-    fi
-
-    if echo "$output" | grep -qi "appears to be OK\|volume appears to be ok"; then
-        opt_msg "Disk filesystem verified OK"
-    elif echo "$output" | grep -qi "error\|corrupt\|invalid"; then
-        echo -e "  ${YELLOW}${ICON_WARNING}${NC} Disk issues detected · run: sudo diskutil repairVolume /"
-    else
-        opt_msg "Disk verify complete"
-    fi
-}
 
 # Clean Knowledge/CoreDuet usage tracking databases.
 opt_coreduet_cleanup() {
@@ -1205,7 +1181,6 @@ execute_optimization() {
         periodic_maintenance) opt_periodic_maintenance ;;
         shared_file_list_repair) opt_shared_file_list_repair ;;
         notification_cleanup) opt_notification_cleanup ;;
-        disk_verify) opt_disk_verify ;;
         coreduet_cleanup) opt_coreduet_cleanup ;;
         login_items_audit) opt_login_items_audit ;;
         *)


### PR DESCRIPTION
Fixes #717

## Summary
- Remove `opt_disk_verify()` which runs `diskutil verifyVolume /` during optimize
- On volumes with APFS inconsistencies, this triggers kernel-level I/O that cannot be stopped by killing the client process, freezing the entire system and requiring a hard reset
- The 30s timeout is cosmetic — it kills the `diskutil` client but `diskmanagementd` and kernel work continue indefinitely
- Filesystem verification is outside Mole's scope as a maintenance/cleaning tool

## Test plan
- [x] `bats tests/optimize.bats` — 34/34 pass
- [x] No remaining references to `disk_verify` or `opt_disk_verify` in codebase
- [x] Removed from health_json.sh task list