### PR TITLE
feat: alias `mo analyse`

### DIFF
--- a/mole
+++ b/mole
@@ -923,7 +923,7 @@ main() {
         "uninstall")
             exec "$SCRIPT_DIR/bin/uninstall.sh" "${args[@]:1}"
             ;;
-        "analyze")
+        "analyze" | "analyse")
             exec "$SCRIPT_DIR/bin/analyze.sh" "${args[@]:1}"
             ;;
         "status")


### PR DESCRIPTION
## Summary

This PR introduce a simple alias for the `mo analyze` command to `mo analyse` to account for spelling the command the British-English way (as I tend to do). The alternative is to alias this command locally, but I don't think there's any harm in adding this to the package.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
- If yes, describe the new boundary or risk change clearly.

## Tests

- List the automated tests you ran.
- List any manual checks for high-risk paths or destructive flows.

## Safety-related changes

- None.


