### PR TITLE
fix(clean): respect whitelist in clean_service_worker_cache()

### DIFF
--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -68,6 +68,10 @@ clean_service_worker_cache() {
                 break
             fi
         done
+        # Respect user whitelist (~/.config/mole/whitelist)
+        if [[ "$is_protected" == "false" ]] && declare -f is_path_whitelisted > /dev/null 2>&1 && is_path_whitelisted "$cache_dir"; then
+            is_protected=true
+        fi
         if [[ "$is_protected" == "false" ]]; then
             if [[ "$DRY_RUN" != "true" ]]; then
                 safe_remove "$cache_dir" true || true

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -866,8 +866,13 @@ is_path_whitelisted() {
     local target_path="$1"
     [[ -z "$target_path" ]] && return 1
 
-    # Normalize path (remove trailing slash)
+    # Normalize path (remove trailing slash and consecutive slashes)
     local normalized_target="${target_path%/}"
+    # Collapse consecutive slashes (e.g. /path//to -> /path/to)
+    # Glob-based paths from shell expansions like "$dir"/*/subpath produce double slashes
+    while [[ "$normalized_target" == *"//"* ]]; do
+        normalized_target="${normalized_target//\/\///}"
+    done
 
     # Empty whitelist means nothing is protected
     [[ ${#WHITELIST_PATTERNS[@]} -eq 0 ]] && return 1


### PR DESCRIPTION
## Summary

`mo clean` running while Chrome is open deletes Chrome Service Worker caches, causing MV3 extensions (e.g. uBlock Origin Lite) to stop working mid-session. Adding paths to `~/.config/mole/whitelist` had no effect due to two bugs:

1. `clean_service_worker_cache()` in `lib/clean/caches.sh` calls `safe_remove()` directly without calling `is_path_whitelisted()`, so the whitelist is never consulted for CacheStorage subdirectories
2. `is_path_whitelisted()` in `lib/core/app_protection.sh` does not normalize consecutive slashes in the target path — the Chrome profile glob (`*/;`) produces trailing-slash paths, and appending `/Service Worker/...` creates `//`, which never matches the single-slash whitelist entry

Fixes #724

## Change

**`lib/clean/caches.sh`** — add whitelist check in `clean_service_worker_cache()` after the `PROTECTED_SW_DOMAINS` loop, consistent with how `safe_clean()` already handles whitelist protection:

bash

```bash
# Respect user whitelist (~/.config/mole/whitelist)
if [[ "$is_protected" == "false" ]] && declare -f is_path_whitelisted > /dev/null 2>&1 && is_path_whitelisted "$cache_dir"; then
    is_protected=true
fi
```

**`lib/core/app_protection.sh`** — normalize consecutive slashes in `is_path_whitelisted()` before path comparison:

bash

```bash
# Collapse consecutive slashes (e.g. /path//to -> /path/to)
# Glob-based paths from shell expansions like "$dir"/*/subpath produce double slashes
while [[ "$normalized_target" == *"//"* ]]; do
    normalized_target="${normalized_target//\/\///}"
done
```

## Test plan

- [ ]  Add Chrome SW paths to `~/.config/mole/whitelist`, run `mo clean` while Chrome is open → Chrome Service Worker lines absent from output (all protected, nothing deleted)
- [ ]  Chrome extensions (uBlock Origin Lite, etc.) remain functional after `mo clean`
- [ ]  Non-whitelisted Chrome caches (e.g. GPU cache) still cleaned normally
- [ ]  `mo clean` without a whitelist entry → Chrome SW caches cleaned as before (no behavior change for users who do not use the whitelist)