### PR TITLE
fix: clear queued input before uninstall selection

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -1029,6 +1029,8 @@ main() {
             return 1
         fi
 
+        drain_pending_input
+
         set +e
         select_apps_for_uninstall
         local exit_code=$?

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -307,6 +307,47 @@ EOF
 	[[ "$output" != *"more files"* ]]
 }
 
+@test "main clears pending input before app selection after scan" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+
+trace_file="$HOME/uninstall-trace.log"
+app_cache_file="$HOME/apps-cache.txt"
+touch "$app_cache_file"
+
+log_operation_session_start() { :; }
+show_uninstall_help() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+clear_screen() { :; }
+scan_applications() { printf '%s\n' "$app_cache_file"; }
+load_applications() {
+    printf 'load\n' >> "$trace_file"
+    return 0
+}
+drain_pending_input() {
+    printf 'drain\n' >> "$trace_file"
+}
+select_apps_for_uninstall() {
+    printf 'select\n' >> "$trace_file"
+    return 1
+}
+
+eval "$(sed -n '/^main()/,/^main \"\\$@\"/p' "$PROJECT_ROOT/bin/uninstall.sh" | sed '$d')"
+
+main
+
+expected=$(printf 'load\ndrain\nselect\n')
+actual=$(cat "$trace_file")
+[[ "$actual" == "$expected" ]] || {
+    printf 'unexpected trace:\n%s\n' "$actual" >&2
+    exit 1
+}
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "safe_remove can remove a simple directory" {
 	mkdir -p "$HOME/test_dir"
 	touch "$HOME/test_dir/file.txt"


### PR DESCRIPTION
## Summary

`mo uninstall` could carry queued `Enter` presses from the scan/loading phase into the app selector. In practice that can auto-select the first app if the UI stalls for a moment and the user keeps hitting `Enter`.

This change clears pending input right after `load_applications` and before `select_apps_for_uninstall`, so the selector only reacts to fresh input.

## What changed

- call `drain_pending_input` before entering the uninstall app selector
- add a regression test around the scan -> selector transition in `main()`

Fixes #726
