### PR TITLE
fix(uninstall): prevent hang on non-writable metadata cache file (closes #722)

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -186,6 +186,31 @@ uninstall_release_metadata_lock() {
     [[ -d "$lock_dir" ]] && rmdir "$lock_dir" 2> /dev/null || true
 }
 
+# Atomically replace the metadata cache file, healing stale root-owned copies.
+# stdin is closed so BSD mv/cp never blocks prompting on a non-writable target.
+uninstall_persist_cache_file() {
+    local src="$1"
+    local dst="$2"
+
+    [[ -s "$src" ]] || {
+        rm -f "$src" 2> /dev/null || true
+        return 0
+    }
+
+    # Heal stale file the user cannot write to (e.g. root-owned from a prior
+    # sudo run). The parent dir is user-owned, so rm succeeds regardless.
+    if [[ -e "$dst" && ! -w "$dst" ]]; then
+        rm -f "$dst" 2> /dev/null || true
+    fi
+
+    # shellcheck disable=SC2217 # BSD mv/cp read stdin when prompting; close it to avoid hang.
+    mv -f "$src" "$dst" < /dev/null 2> /dev/null || {
+        # shellcheck disable=SC2217
+        cp -f "$src" "$dst" < /dev/null 2> /dev/null || true
+        rm -f "$src" 2> /dev/null || true
+    }
+}
+
 uninstall_collect_inline_metadata() {
     local app_path="$1"
     local app_mtime="${2:-0}"
@@ -332,10 +357,7 @@ start_uninstall_metadata_refresh() {
             }
         ' "$updates_file" "$MOLE_UNINSTALL_META_CACHE_FILE" > "$merged_file"
 
-        mv "$merged_file" "$MOLE_UNINSTALL_META_CACHE_FILE" 2> /dev/null || {
-            cp "$merged_file" "$MOLE_UNINSTALL_META_CACHE_FILE" 2> /dev/null || true
-            rm -f "$merged_file"
-        }
+        uninstall_persist_cache_file "$merged_file" "$MOLE_UNINSTALL_META_CACHE_FILE"
 
         uninstall_release_metadata_lock "$MOLE_UNINSTALL_META_CACHE_LOCK"
         rm -f "$updates_file"
@@ -750,10 +772,7 @@ scan_applications() {
     update_scan_status "Updating cache..." "0" "0"
     if [[ -s "$cache_snapshot_file" ]]; then
         if uninstall_acquire_metadata_lock "$MOLE_UNINSTALL_META_CACHE_LOCK"; then
-            mv "$cache_snapshot_file" "$MOLE_UNINSTALL_META_CACHE_FILE" 2> /dev/null || {
-                cp "$cache_snapshot_file" "$MOLE_UNINSTALL_META_CACHE_FILE" 2> /dev/null || true
-                rm -f "$cache_snapshot_file"
-            }
+            uninstall_persist_cache_file "$cache_snapshot_file" "$MOLE_UNINSTALL_META_CACHE_FILE"
             uninstall_release_metadata_lock "$MOLE_UNINSTALL_META_CACHE_LOCK"
         fi
     fi

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -307,6 +307,78 @@ EOF
 	[[ "$output" != *"more files"* ]]
 }
 
+@test "uninstall_persist_cache_file heals non-writable destination" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+
+# Source only the helper by evaluating its function definition.
+eval "$(sed -n '/^uninstall_persist_cache_file()/,/^}$/p' "$PROJECT_ROOT/bin/uninstall.sh")"
+
+src="$HOME/cache.src"
+dst="$HOME/cache.dst"
+printf 'fresh-data\n' > "$src"
+printf 'stale-data\n' > "$dst"
+chmod 0444 "$dst"
+[[ ! -w "$dst" ]] || { echo "precondition: dst should be read-only" >&2; exit 1; }
+
+uninstall_persist_cache_file "$src" "$dst"
+
+[[ ! -e "$src" ]] || { echo "src should be gone" >&2; exit 1; }
+[[ -f "$dst" ]] || { echo "dst missing" >&2; exit 1; }
+grep -q 'fresh-data' "$dst" || { echo "dst not updated"; exit 1; }
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
+@test "uninstall_persist_cache_file does not hang when mv would prompt (stdin closed)" {
+	# Regression for #722: BSD mv without -f prompts on non-writable dst and
+	# blocks reading stdin. The helper must close stdin and use -f.
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+eval "$(sed -n '/^uninstall_persist_cache_file()/,/^}$/p' "$PROJECT_ROOT/bin/uninstall.sh")"
+
+src="$HOME/snap.src"
+dst="$HOME/snap.dst"
+printf 'x\n' > "$src"
+printf 'y\n' > "$dst"
+chmod 0444 "$dst"
+
+# Run helper in background with a watchdog. If it hangs reading stdin it
+# will be killed and the test fails.
+printf 'n\nn\nn\n' | uninstall_persist_cache_file "$src" "$dst" &
+pid=$!
+( sleep 5 && kill -9 "$pid" 2>/dev/null && echo HANG ) &
+watchdog=$!
+wait "$pid"
+rc=$?
+kill "$watchdog" 2>/dev/null || true
+exit "$rc"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" != *"HANG"* ]]
+}
+
+@test "uninstall_persist_cache_file is a no-op when source is empty" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+eval "$(sed -n '/^uninstall_persist_cache_file()/,/^}$/p' "$PROJECT_ROOT/bin/uninstall.sh")"
+
+src="$HOME/empty.src"
+dst="$HOME/keep.dst"
+: > "$src"
+printf 'untouched\n' > "$dst"
+
+uninstall_persist_cache_file "$src" "$dst"
+
+[[ ! -e "$src" ]] || exit 1
+grep -q 'untouched' "$dst" || exit 1
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "safe_remove can remove a simple directory" {
 	mkdir -p "$HOME/test_dir"
 	touch "$HOME/test_dir/file.txt"

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -334,26 +334,39 @@ EOF
 @test "uninstall_persist_cache_file does not hang when mv would prompt (stdin closed)" {
 	# Regression for #722: BSD mv without -f prompts on non-writable dst and
 	# blocks reading stdin. The helper must close stdin and use -f.
+	#
+	# The hang detector uses a marker file rather than a PID-based watchdog:
+	# PIDs get recycled quickly on CI and a stale `kill -9 $pid` can succeed
+	# against an unrelated process, producing a false HANG. The marker
+	# approach only cares about whether the helper itself completed.
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
 eval "$(sed -n '/^uninstall_persist_cache_file()/,/^}$/p' "$PROJECT_ROOT/bin/uninstall.sh")"
 
 src="$HOME/snap.src"
 dst="$HOME/snap.dst"
+done_marker="$HOME/snap.done"
 printf 'x\n' > "$src"
 printf 'y\n' > "$dst"
 chmod 0444 "$dst"
 
-# Run helper in background with a watchdog. If it hangs reading stdin it
-# will be killed and the test fails.
-printf 'n\nn\nn\n' | uninstall_persist_cache_file "$src" "$dst" &
-pid=$!
-( sleep 5 && kill -9 "$pid" 2>/dev/null && echo HANG ) &
-watchdog=$!
-wait "$pid"
-rc=$?
-kill "$watchdog" 2>/dev/null || true
-exit "$rc"
+(
+    printf 'n\nn\nn\n' | uninstall_persist_cache_file "$src" "$dst"
+    : > "$done_marker"
+) &
+bgpid=$!
+
+# Poll for completion marker for up to ~5s.
+for _ in $(seq 1 50); do
+    [[ -e "$done_marker" ]] && break
+    sleep 0.1
+done
+
+if [[ ! -e "$done_marker" ]]; then
+    kill -9 "$bgpid" 2>/dev/null || true
+    echo HANG
+fi
+wait "$bgpid" 2>/dev/null || true
 EOF
 
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

`mo uninstall` hung forever on **"Updating cache..."** when `~/.cache/mole/uninstall_app_metadata_v1` existed but was not writable by the current user (e.g. root-owned from an earlier sudo-adjacent run).

Root cause: BSD `mv` prompts on stderr (`override rw------- root/wheel for <file>?`) and reads stdin for `y`/`n` on a non-writable destination. The existing call only suppressed stderr with `2>/dev/null`, so the prompt text was hidden but `mv` still blocked on `read()` from the parent terminal. Sampling the hung `mv` showed all samples in `getchar → __srget → __sread → __read_nocancel`. Full analysis in #722.

## Change

New helper `uninstall_persist_cache_file` that replaces the two inline `mv ... || { cp ... ; rm ... }` patterns and adds three hardenings:

- `< /dev/null` — never block on a prompt read
- `-f` on `mv`/`cp` — never prompt in the first place
- Pre-remove a stale non-writable destination. Safe because the parent dir `~/.cache/mole/` is user-owned, so `rm` succeeds regardless of file ownership.

Applied at both metadata-cache write sites:

- `scan_applications()` (foreground, line 753) — the path that was hanging
- `start_uninstall_metadata_refresh()` (background, line 335) — same pattern, hardened for consistency and to avoid stuck background processes

## Test plan

Three bats tests in `tests/uninstall.bats`:

- [x] `heals non-writable destination` — dst is read-only, helper replaces it with fresh contents
- [x] `does not hang when mv would prompt (stdin closed)` — watchdog kills the helper if it blocks; exits cleanly with no `HANG` marker
- [x] `is a no-op when source is empty` — empty snapshot does not clobber existing cache

Manual repro from the issue also verified:

```bash
mkdir -p ~/.cache/mole
sudo touch ~/.cache/mole/uninstall_app_metadata_v1
sudo chmod 600 ~/.cache/mole/uninstall_app_metadata_v1
mo uninstall   # previously hung on "Updating cache..."; now proceeds.
```

## Notes

- The reporter (@aditya in #722) proposed both `mv -f` and integrating with `ensure_user_file`. This PR takes the lighter path: the helper lives next to the callers, keeps behavior local to the uninstall flow, and doesn't widen the contract of the shared `ensure_user_file`. If you prefer the `ensure_user_file` route I can rework it.
- `shellcheck` SC2217 is disabled on the stdin-redirect lines with an inline reason (BSD `mv`/`cp` really do read stdin when prompting; that's the bug).