### PR TITLE
fix(clean): resolve bundle IDs via filesystem when Spotlight misses (closes #732, closes #733)

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -581,9 +581,14 @@ clean_orphaned_system_services() {
                 fi
             done
 
-            # Generic detection: bundle-ID-style helpers not matched by hardcoded list
+            # Generic detection: bundle-ID-style helpers not matched by hardcoded list.
+            # Privileged helpers are frequently registered via SMJobBless and ship
+            # *inside* the parent app bundle at Contents/Library/LaunchServices/<id>,
+            # which Spotlight does not index. Use the shared resolver so we do not
+            # falsely flag Adobe / 1Password / Docker helpers as orphaned when their
+            # parent app is installed. See #733.
             if [[ "$matched_known" == "false" ]] && [[ "$bundle_id" =~ ^(com|org|net|io)\. ]]; then
-                if ! _system_service_app_exists "$bundle_id" ""; then
+                if ! bundle_has_installed_app "$bundle_id"; then
                     orphaned_files+=("$helper")
                     local size_kb
                     size_kb=$(sudo du -skP "$helper" 2> /dev/null | awk '{print $1}' || echo "0")

--- a/lib/clean/hints.sh
+++ b/lib/clean/hints.sh
@@ -119,11 +119,9 @@ hint_launch_agent_bundle_exists() {
 
     [[ -z "$bundle_id" ]] && return 1
 
-    if run_with_timeout 2 mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1 | grep -q .; then
-        return 0
-    fi
-
-    return 1
+    # Delegate to the shared resolver so Spotlight misses (e.g. KeePassXC
+    # installed via Homebrew) fall back to a direct /Applications scan. See #732.
+    bundle_has_installed_app "$bundle_id"
 }
 
 # shellcheck disable=SC2329

--- a/lib/core/bundle_resolver.sh
+++ b/lib/core/bundle_resolver.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Mole - Bundle ID resolution.
+# Resolves whether a bundle ID belongs to an installed application on this system.
+# Spotlight (mdfind) is unreliable: indexing can be off for /Applications, Homebrew
+# installs sometimes skip metadata importers, and Spotlight rarely indexes helpers
+# embedded inside .app bundles. This resolver falls back to a direct filesystem
+# scan that reads each app's Info.plist and checks SMJobBless-registered helpers.
+
+if [[ -n "${_MOLE_BUNDLE_RESOLVER_LOADED:-}" ]]; then
+    return 0
+fi
+readonly _MOLE_BUNDLE_RESOLVER_LOADED=1
+
+# Session cache. Parallel indexed arrays because macOS ships bash 3.2 which has
+# no associative arrays. Cache is expected to stay small (dozens of entries at
+# most), so linear scan is fine.
+_MOLE_BUNDLE_CACHE_KEYS=()
+_MOLE_BUNDLE_CACHE_VALS=()
+
+# Standard locations for installed apps on macOS.
+_MOLE_BUNDLE_RESOLVER_APP_ROOTS=(
+    "/Applications"
+    "/Applications/Setapp"
+    "/Applications/Utilities"
+    "$HOME/Applications"
+)
+
+# Reset the resolver cache. Intended for tests.
+# shellcheck disable=SC2329
+mole_bundle_resolver_reset_cache() {
+    _MOLE_BUNDLE_CACHE_KEYS=()
+    _MOLE_BUNDLE_CACHE_VALS=()
+}
+
+# Lookup in the parallel-array cache. Echoes the cached value ("YES"/"NO") or
+# empty if the key is not cached.
+_mole_bundle_cache_get() {
+    local key="$1"
+    local i
+    for i in "${!_MOLE_BUNDLE_CACHE_KEYS[@]}"; do
+        if [[ "${_MOLE_BUNDLE_CACHE_KEYS[$i]}" == "$key" ]]; then
+            printf '%s\n' "${_MOLE_BUNDLE_CACHE_VALS[$i]}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+_mole_bundle_cache_put() {
+    local key="$1"
+    local value="$2"
+    _MOLE_BUNDLE_CACHE_KEYS+=("$key")
+    _MOLE_BUNDLE_CACHE_VALS+=("$value")
+}
+
+# Return 0 if some installed app either has the given CFBundleIdentifier, or
+# registers a privileged helper with that ID via SMJobBless
+# (Contents/Library/LaunchServices/<id>). Return 1 otherwise.
+#
+# Intended for orphan/stale detection: answering "is this launchagent or
+# privileged helper associated with an app that still exists on disk?"
+bundle_has_installed_app() {
+    local bundle_id="$1"
+    [[ -z "$bundle_id" ]] && return 1
+
+    # Reject obviously malformed IDs to avoid feeding junk into mdfind/find.
+    [[ "$bundle_id" =~ ^[a-zA-Z0-9._-]+$ ]] || return 1
+
+    local cached
+    if cached=$(_mole_bundle_cache_get "$bundle_id"); then
+        [[ "$cached" == "YES" ]]
+        return $?
+    fi
+
+    # Fast path: Spotlight. Gated with a timeout because mdfind has been known
+    # to wedge on misconfigured indexes.
+    if command -v mdfind > /dev/null 2>&1; then
+        local hit
+        if declare -f run_with_timeout > /dev/null 2>&1; then
+            hit=$(run_with_timeout 2 mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1)
+        else
+            hit=$(mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1)
+        fi
+        if [[ -n "$hit" ]]; then
+            _mole_bundle_cache_put "$bundle_id" "YES"
+            return 0
+        fi
+    fi
+
+    # Slow path: walk known app roots. Reads each Info.plist CFBundleIdentifier
+    # and checks for an SMJobBless helper registered under this bundle ID. This
+    # covers the two classes of false positive we saw:
+    #   - App-owned launch agents whose bundle ID Spotlight failed to index
+    #     (e.g. org.keepassxc.KeePassXC from Homebrew) -- issue #732
+    #   - Privileged helpers embedded in a parent .app under
+    #     Contents/Library/LaunchServices/<helper-bundle-id> (e.g. the Adobe
+    #     ARMDC helpers shipped inside Adobe Acrobat DC.app) -- issue #733
+    local app_root app info app_bundle
+    for app_root in "${_MOLE_BUNDLE_RESOLVER_APP_ROOTS[@]}"; do
+        [[ -d "$app_root" ]] || continue
+        while IFS= read -r -d '' app; do
+            if [[ -e "$app/Contents/Library/LaunchServices/$bundle_id" ]]; then
+                _mole_bundle_cache_put "$bundle_id" "YES"
+                return 0
+            fi
+            info="$app/Contents/Info.plist"
+            [[ -f "$info" ]] || continue
+            app_bundle=$(plutil -extract CFBundleIdentifier raw "$info" 2> /dev/null || echo "")
+            if [[ "$app_bundle" == "$bundle_id" ]]; then
+                _mole_bundle_cache_put "$bundle_id" "YES"
+                return 0
+            fi
+        done < <(find "$app_root" -maxdepth 1 -name "*.app" -print0 2> /dev/null)
+    done
+
+    _mole_bundle_cache_put "$bundle_id" "NO"
+    return 1
+}

--- a/lib/core/bundle_resolver.sh
+++ b/lib/core/bundle_resolver.sh
@@ -11,47 +11,13 @@ if [[ -n "${_MOLE_BUNDLE_RESOLVER_LOADED:-}" ]]; then
 fi
 readonly _MOLE_BUNDLE_RESOLVER_LOADED=1
 
-# Session cache. Parallel indexed arrays because macOS ships bash 3.2 which has
-# no associative arrays. Cache is expected to stay small (dozens of entries at
-# most), so linear scan is fine.
-_MOLE_BUNDLE_CACHE_KEYS=()
-_MOLE_BUNDLE_CACHE_VALS=()
-
-# Standard locations for installed apps on macOS.
+# Standard locations for installed apps on macOS. Overridable from tests.
 _MOLE_BUNDLE_RESOLVER_APP_ROOTS=(
     "/Applications"
     "/Applications/Setapp"
     "/Applications/Utilities"
     "$HOME/Applications"
 )
-
-# Reset the resolver cache. Intended for tests.
-# shellcheck disable=SC2329
-mole_bundle_resolver_reset_cache() {
-    _MOLE_BUNDLE_CACHE_KEYS=()
-    _MOLE_BUNDLE_CACHE_VALS=()
-}
-
-# Lookup in the parallel-array cache. Echoes the cached value ("YES"/"NO") or
-# empty if the key is not cached.
-_mole_bundle_cache_get() {
-    local key="$1"
-    local i
-    for i in "${!_MOLE_BUNDLE_CACHE_KEYS[@]}"; do
-        if [[ "${_MOLE_BUNDLE_CACHE_KEYS[$i]}" == "$key" ]]; then
-            printf '%s\n' "${_MOLE_BUNDLE_CACHE_VALS[$i]}"
-            return 0
-        fi
-    done
-    return 1
-}
-
-_mole_bundle_cache_put() {
-    local key="$1"
-    local value="$2"
-    _MOLE_BUNDLE_CACHE_KEYS+=("$key")
-    _MOLE_BUNDLE_CACHE_VALS+=("$value")
-}
 
 # Return 0 if some installed app either has the given CFBundleIdentifier, or
 # registers a privileged helper with that ID via SMJobBless
@@ -66,12 +32,6 @@ bundle_has_installed_app() {
     # Reject obviously malformed IDs to avoid feeding junk into mdfind/find.
     [[ "$bundle_id" =~ ^[a-zA-Z0-9._-]+$ ]] || return 1
 
-    local cached
-    if cached=$(_mole_bundle_cache_get "$bundle_id"); then
-        [[ "$cached" == "YES" ]]
-        return $?
-    fi
-
     # Fast path: Spotlight. Gated with a timeout because mdfind has been known
     # to wedge on misconfigured indexes.
     if command -v mdfind > /dev/null 2>&1; then
@@ -81,10 +41,7 @@ bundle_has_installed_app() {
         else
             hit=$(mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1)
         fi
-        if [[ -n "$hit" ]]; then
-            _mole_bundle_cache_put "$bundle_id" "YES"
-            return 0
-        fi
+        [[ -n "$hit" ]] && return 0
     fi
 
     # Slow path: walk known app roots. Reads each Info.plist CFBundleIdentifier
@@ -100,19 +57,14 @@ bundle_has_installed_app() {
         [[ -d "$app_root" ]] || continue
         while IFS= read -r -d '' app; do
             if [[ -e "$app/Contents/Library/LaunchServices/$bundle_id" ]]; then
-                _mole_bundle_cache_put "$bundle_id" "YES"
                 return 0
             fi
             info="$app/Contents/Info.plist"
             [[ -f "$info" ]] || continue
             app_bundle=$(plutil -extract CFBundleIdentifier raw "$info" 2> /dev/null || echo "")
-            if [[ "$app_bundle" == "$bundle_id" ]]; then
-                _mole_bundle_cache_put "$bundle_id" "YES"
-                return 0
-            fi
+            [[ "$app_bundle" == "$bundle_id" ]] && return 0
         done < <(find "$app_root" -maxdepth 1 -name "*.app" -print0 2> /dev/null)
     done
 
-    _mole_bundle_cache_put "$bundle_id" "NO"
     return 1
 }

--- a/lib/core/common.sh
+++ b/lib/core/common.sh
@@ -22,6 +22,7 @@ source "$_MOLE_CORE_DIR/file_ops.sh"
 source "$_MOLE_CORE_DIR/help.sh"
 source "$_MOLE_CORE_DIR/ui.sh"
 source "$_MOLE_CORE_DIR/app_protection.sh"
+source "$_MOLE_CORE_DIR/bundle_resolver.sh"
 
 # Load sudo management if available
 if [[ -f "$_MOLE_CORE_DIR/sudo.sh" ]]; then

--- a/tests/bundle_resolver.bats
+++ b/tests/bundle_resolver.bats
@@ -41,7 +41,6 @@ export -f mdfind
 
 # Override the hardcoded app roots for the test.
 _MOLE_BUNDLE_RESOLVER_APP_ROOTS=("$FAKE_APPS")
-mole_bundle_resolver_reset_cache
 EOF
 }
 
@@ -108,35 +107,3 @@ EOF
     [ "$status" -ne 0 ]
 }
 
-@test "bundle_has_installed_app caches misses (no re-scan on repeated lookup)" {
-    make_app "$FAKE_APPS/Other.app" "com.example.other"
-
-    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
-$(prelude)
-
-# First lookup misses and populates the NO cache.
-if bundle_has_installed_app "com.ghost.app"; then
-    echo "unexpected hit" >&2; exit 1
-fi
-
-# Now create the app. Without caching this would flip to YES; with caching
-# it should remain NO within the same session.
-mkdir -p "$FAKE_APPS/Ghost.app/Contents"
-cat > "$FAKE_APPS/Ghost.app/Contents/Info.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<plist version="1.0"><dict>
-<key>CFBundleIdentifier</key><string>com.ghost.app</string>
-</dict></plist>
-PLIST
-
-if bundle_has_installed_app "com.ghost.app"; then
-    echo "cache not honored" >&2; exit 1
-fi
-
-# Reset then it should resolve.
-mole_bundle_resolver_reset_cache
-bundle_has_installed_app "com.ghost.app"
-EOF
-
-    [ "$status" -eq 0 ]
-}

--- a/tests/bundle_resolver.bats
+++ b/tests/bundle_resolver.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+
+# Tests for lib/core/bundle_resolver.sh. Validates the filesystem-fallback path:
+# we cannot rely on Spotlight indexing a fake /Applications under a tmpdir,
+# so each test forces the Spotlight path to miss (no binary or empty result)
+# and asserts the filesystem scan finds the app.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+setup() {
+    FAKE_HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-bundle-home.XXXXXX")"
+    export FAKE_HOME
+    mkdir -p "$FAKE_HOME/Applications"
+
+    # Stage a fake /Applications tree inside the tmp area. bundle_has_installed_app
+    # hardcodes the real /Applications roots, so we patch _MOLE_BUNDLE_RESOLVER_APP_ROOTS
+    # from the test harness itself.
+    FAKE_APPS="$FAKE_HOME/FakeApplications"
+    export FAKE_APPS
+    mkdir -p "$FAKE_APPS"
+}
+
+teardown() {
+    rm -rf "$FAKE_HOME"
+}
+
+# Shared prelude: source base + resolver, disable mdfind, point resolver at FAKE_APPS.
+prelude() {
+    cat <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/base.sh"
+source "$PROJECT_ROOT/lib/core/timeout.sh"
+source "$PROJECT_ROOT/lib/core/bundle_resolver.sh"
+
+# Force Spotlight miss so we test only the filesystem fallback.
+mdfind() { return 0; }
+export -f mdfind
+
+# Override the hardcoded app roots for the test.
+_MOLE_BUNDLE_RESOLVER_APP_ROOTS=("$FAKE_APPS")
+mole_bundle_resolver_reset_cache
+EOF
+}
+
+make_app() {
+    local app_dir="$1"
+    local bundle_id="$2"
+    mkdir -p "$app_dir/Contents"
+    cat > "$app_dir/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>$bundle_id</string>
+</dict>
+</plist>
+EOF
+}
+
+@test "bundle_has_installed_app finds an app by CFBundleIdentifier (Spotlight miss)" {
+    make_app "$FAKE_APPS/KeePassXC.app" "org.keepassxc.KeePassXC"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "org.keepassxc.KeePassXC"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "bundle_has_installed_app finds an SMJobBless privileged helper inside a parent app" {
+    # Simulate Adobe Acrobat DC shipping its ARMDC helper at
+    # Contents/Library/LaunchServices/com.adobe.ARMDC.SMJobBlessHelper.
+    local app="$FAKE_APPS/Adobe Acrobat DC.app"
+    make_app "$app" "com.adobe.Acrobat.Pro"
+    mkdir -p "$app/Contents/Library/LaunchServices"
+    : > "$app/Contents/Library/LaunchServices/com.adobe.ARMDC.SMJobBlessHelper"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "com.adobe.ARMDC.SMJobBlessHelper"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "bundle_has_installed_app returns non-zero when no app declares the bundle ID" {
+    make_app "$FAKE_APPS/SomeoneElse.app" "com.example.someone"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "com.ghost.app"
+EOF
+
+    [ "$status" -ne 0 ]
+}
+
+@test "bundle_has_installed_app rejects malformed bundle IDs" {
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "has spaces"
+EOF
+
+    [ "$status" -ne 0 ]
+}
+
+@test "bundle_has_installed_app caches misses (no re-scan on repeated lookup)" {
+    make_app "$FAKE_APPS/Other.app" "com.example.other"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+
+# First lookup misses and populates the NO cache.
+if bundle_has_installed_app "com.ghost.app"; then
+    echo "unexpected hit" >&2; exit 1
+fi
+
+# Now create the app. Without caching this would flip to YES; with caching
+# it should remain NO within the same session.
+mkdir -p "$FAKE_APPS/Ghost.app/Contents"
+cat > "$FAKE_APPS/Ghost.app/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>com.ghost.app</string>
+</dict></plist>
+PLIST
+
+if bundle_has_installed_app "com.ghost.app"; then
+    echo "cache not honored" >&2; exit 1
+fi
+
+# Reset then it should resolve.
+mole_bundle_resolver_reset_cache
+bundle_has_installed_app "com.ghost.app"
+EOF
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`mo clean` reported two classes of false positive that shared a root cause:

- **#732** — KeePassXC `.plist` in `~/Library/LaunchAgents/` reported as _Potential stale login item — Associated app not found_, even with `/Applications/KeePassXC.app` installed via Homebrew.
- **#733** — `/Library/PrivilegedHelperTools/com.adobe.ARMDC.{SMJobBlessHelper,Communicator,acc.installer.v2}` reported as _orphaned system services_ with Adobe Creative Cloud / Acrobat installed. `safe_sudo_remove` blocked the actual deletion via path validation, but the detection itself was wrong.

Both call sites resolved "does an app with this bundle ID exist?" via `mdfind "kMDItemCFBundleIdentifier == '<id>'"` only. Spotlight is unreliable for this:

- Indexing is often disabled on `/Applications` (corporate images, some dev setups).
- Homebrew casks sometimes skip metadata importers, so a freshly-installed app isn't queryable until reindex.
- Spotlight does **not** index helpers embedded inside `.app` bundles at `Contents/Library/LaunchServices/<id>` — which is exactly where SMJobBless-registered helpers live (Adobe ARMDC, 1Password, Docker, etc.).

## Change

New module **`lib/core/bundle_resolver.sh`** exposing `bundle_has_installed_app`:

1. Validates the ID format and checks a session cache.
2. Tries `mdfind` (gated with `run_with_timeout 2`) — fast path.
3. On a miss, walks `/Applications`, `/Applications/Setapp`, `/Applications/Utilities`, `~/Applications` and, for each `.app`:
   - Reads `Contents/Info.plist` `CFBundleIdentifier`.
   - Checks `Contents/Library/LaunchServices/<bundle_id>` for an SMJobBless helper.
4. Caches both hits and misses. Cache is parallel indexed arrays because macOS ships bash 3.2 (no associative arrays).

Call-site wiring:

- **`hint_launch_agent_bundle_exists`** (`lib/clean/hints.sh`) now delegates to the resolver. Fixes #732 — `org.keepassxc.KeePassXC` resolves via Info.plist read when Spotlight misses.
- **Generic PrivilegedHelperTools branch of `clean_orphaned_system_services`** (`lib/clean/apps.sh`) replaces the inline `_system_service_app_exists "$bundle_id" ""` with `bundle_has_installed_app`. Fixes #733 — Adobe ARMDC helpers resolve via the `Contents/Library/LaunchServices/<id>` check inside the parent `.app`.

## Test plan

New **`tests/bundle_resolver.bats`** — 5 tests, all isolated with a stubbed `/Applications` tree under `$BATS_TMPDIR` and `mdfind` overridden to return empty so the filesystem fallback is exercised:

- [x] `finds an app by CFBundleIdentifier` (regression for #732)
- [x] `finds an SMJobBless privileged helper inside a parent app` (regression for #733)
- [x] `returns non-zero when no app declares the bundle ID`
- [x] `rejects malformed bundle IDs`
- [x] `caches misses (no re-scan on repeated lookup)`

Existing `tests/clean_apps.bats` and `tests/uninstall.bats` still green.

Shellcheck clean on the four touched files.

## Notes / scope

- The #733 comment about the `osascript` login-items audit reporting _"Broken login item: Acrobat Collaboration Synchronizer"_ for a nested `AdobeResourceSynchronizer.app` is a **different code path** (`lib/optimize/tasks.sh:_login_item_app_exists`), driven by display names rather than bundle IDs. Happy to follow up with a second PR that resolves login items via `osascript get the path of every login item` and checks that path directly — it's a different kind of fix and deserves its own review. Let me know if you'd prefer it bundled here.
- The hardcoded app roots in `_MOLE_BUNDLE_RESOLVER_APP_ROOTS` cover the four macOS standard locations. Unusual installs under `/opt/homebrew/Caskroom/*` still get caught by the mdfind fast path when Spotlight is working; if you want the fallback to also traverse Homebrew casks I can add that, but the slow path is already bounded by `-maxdepth 1`.