### PR TITLE
fix(clean): protect CUPS printing prefs from orphan sweep (#731)

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -56,6 +56,11 @@ readonly SYSTEM_CRITICAL_BUNDLES_FAST=(
     "GlobalPreferences"
     ".GlobalPreferences"
     "org.pqrs.Karabiner*"
+    # CUPS printing subsystem ships with macOS; there is no parent .app to
+    # anchor it, so org.cups.* prefs always look "orphaned" to bundle-ID
+    # matching. Deleting them wipes the default printer and recent-printer
+    # list, which users see as lost saved printers. See #731.
+    "org.cups.*"
 )
 
 # Detailed list for uninstall protection
@@ -663,6 +668,12 @@ should_protect_data() {
 
     case "$bundle_id" in
         com.apple.* | loginwindow | dock | systempreferences | finder | safari)
+            return 0
+            ;;
+        # CUPS is an OS-provided subsystem with no user-facing app; without this
+        # guard `~/Library/Preferences/org.cups.PrintingPrefs.plist` (which holds
+        # the default printer and recent printers) looks orphaned. See #731.
+        org.cups.*)
             return 0
             ;;
         backgroundtaskmanagement* | keychain* | security* | bluetooth* | wifi* | network* | tcc)

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -189,6 +189,17 @@ EOF
     [ "$result" = "not-protected" ]
 }
 
+# Regression: CUPS prefs have a bundle-ID-style name but no parent .app,
+# so the orphan sweep deleted them and users lost their default printer
+# and recent-printer list. See #731.
+@test "should_protect_data protects CUPS printing prefs (#731)" {
+    result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data 'org.cups.PrintingPrefs' && echo 'protected' || echo 'not-protected'")
+    [ "$result" = "protected" ]
+
+    result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data 'org.cups.printers' && echo 'protected' || echo 'not-protected'")
+    [ "$result" = "protected" ]
+}
+
 @test "input methods are protected during cleanup but allowed for uninstall" {
     result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data 'com.tencent.inputmethod.QQInput' && echo 'protected' || echo 'not-protected'")
     [ "$result" = "protected" ]


### PR DESCRIPTION
## Root cause

`clean_orphaned_app_data` walks `~/Library/Preferences/` with the generic
`com.*:org.*:net.*:io.*` patterns and, for every match whose bundle ID is
not backed by an installed `.app`, treats it as an orphan and deletes it.

`~/Library/Preferences/org.cups.PrintingPrefs.plist` ships with macOS as
part of the CUPS subsystem — **there is no parent `.app` to anchor it**
— so `is_bundle_orphaned \"org.cups.PrintingPrefs\"` returned true and the
file was removed on `mo clean`. That plist holds the user's default
printer and recent-printers list, which users experience as \"Mole
deleted my saved printers\".

Walkthrough of what let it through each protection layer:

1. `should_protect_data \"org.cups.PrintingPrefs\"` — no CUPS case, false.
2. `ORPHAN_NEVER_DELETE_PATTERNS` — no printer/CUPS entries, no match.
3. `grep installed_bundles` — CUPS is not a `.app`, not found.
4. Hardcoded system components — not listed.
5. `mdfind kMDItemCFBundleIdentifier == 'org.cups.PrintingPrefs'` — no hit.
6. Returns `0` → orphan → deleted.

## Fix

Add `org.cups.*` to both `SYSTEM_CRITICAL_BUNDLES_FAST` and the
`should_protect_data` fast-path case. The orphan sweep now short-circuits
on step 1 for any CUPS-owned pref.

The fix is deliberately narrow: it only covers `org.cups.*`, not vendor
printer bundle IDs like `com.hp.*` or `com.canon.*`. Those can legitimately
become orphaned if a user uninstalls the vendor app, so keeping them
uncovered preserves the existing cleanup behavior.

## Test

Regression test at `tests/core_common.bats` verifies
`should_protect_data` returns true for both `org.cups.PrintingPrefs` and
`org.cups.printers`. Full bats suite passes (628/628).

## Issue

Closes #731