### PR TITLE
fix(uninstall): drain stdin between app scan and selector (closes #726)

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -1029,6 +1029,11 @@ main() {
             return 1
         fi
 
+        # Keystrokes typed during the scan/load phase must not leak into the
+        # selector. A queued Enter would confirm whichever app is highlighted
+        # first and drop the user straight into the destructive path. See #726.
+        drain_pending_input
+
         set +e
         select_apps_for_uninstall
         local exit_code=$?

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -705,3 +705,43 @@ EOF
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"count=1"* ]]
 }
+
+# Regression for #726: Enter keystrokes queued while the app scanner runs
+# must not flow into select_apps_for_uninstall — otherwise the first app
+# is auto-selected and the destructive path is entered without the user
+# ever seeing the list.
+@test "uninstall drains queued stdin before opening the app selector (#726)" {
+	run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/ui.sh"
+
+# Simulate the scan/load phase holding stdin briefly while the user
+# mashes Enter, then the drain boundary, then a read that stands in
+# for select_apps_for_uninstall's first key read.
+(printf '\n\n\n\n'; sleep 0.2) | {
+	drain_pending_input
+	if IFS= read -r -s -n 1 -t 0.2 leftover; then
+		printf 'LEAKED:%q\n' "$leftover"
+		exit 1
+	fi
+	printf 'CLEAN\n'
+}
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"CLEAN"* ]]
+}
+
+# Structural lock-in for #726: the drain call must sit between the loader
+# and the selector. A well-meaning refactor that moves it or drops it
+# would silently reintroduce the bug.
+@test "uninstall.sh keeps drain between load_applications and select_apps_for_uninstall (#726)" {
+	awk '
+		/load_applications "\$apps_file"/ { seen_load = 1; next }
+		seen_load && /drain_pending_input/ { saw_drain = 1; next }
+		seen_load && /select_apps_for_uninstall/ {
+			if (saw_drain) { print "OK"; exit 0 }
+			print "MISSING"; exit 1
+		}
+	' "$PROJECT_ROOT/bin/uninstall.sh" | grep -q '^OK$'
+}


### PR DESCRIPTION
## Summary

`mo uninstall` could skip the app selector entirely when the user pressed Enter during the scan/load phase. Any queued Enter keystrokes were consumed by the first key-read inside `select_apps_for_uninstall`, which highlight-confirms whichever app sits at the top of the list — dropping the user straight into the destructive confirmation flow without ever seeing the selection UI.

## Root cause

The interactive flow in `bin/uninstall.sh` goes:

```
scan_applications → load_applications → select_apps_for_uninstall
```

…but there was no `drain_pending_input` call at that boundary. Other nearby transitions (batch confirmation, completion picker, purge flow) already call it. This PR adds it at the missing boundary.

`drain_pending_input` is bounded and non-blocking, so it's safe to call on each iteration of the outer loop. No visible UX change for the common path; it only drops keystrokes the user typed before the selector was ready to receive them.

## Change

- `bin/uninstall.sh`: add `drain_pending_input` between `load_applications` success and `select_apps_for_uninstall`.

## Test plan

Two regression tests in `tests/uninstall.bats`:

- [x] **Functional**: queues `\n\n\n\n` into stdin, runs `drain_pending_input`, asserts a subsequent `read -t 0.2` sees nothing — i.e. the queued Enters did not leak across the boundary.
- [x] **Structural lock-in**: `awk`-based check that the drain call sits between `load_applications` and `select_apps_for_uninstall` in the source. A well-meaning refactor that drops or moves the call would fail this test.

Full bats suite (`bats tests/uninstall.bats`) passes locally.

## Notes

No behavioral change beyond discarding stray keypresses at the list boundary. The destructive confirmation in `batch_uninstall_applications` still requires an explicit `yes` — this PR only prevents the user from landing there without ever seeing the selector.