### PR TITLE
fix(clean): respect whitelist for Chrome MV3 service worker caches (closes #724)

### DIFF
--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -68,6 +68,14 @@ clean_service_worker_cache() {
                 break
             fi
         done
+        # Service Worker cache dirs are keyed by origin hash, so they never
+        # match PROTECTED_SW_DOMAINS even when the user added Chrome SW paths
+        # to their whitelist. Honor the whitelist explicitly — otherwise MV3
+        # extensions lose their registered workers mid-session. See #724.
+        if [[ "$is_protected" == "false" ]] && is_path_whitelisted "$cache_dir"; then
+            is_protected=true
+            protected_count=$((protected_count + 1))
+        fi
         if [[ "$is_protected" == "false" ]]; then
             if [[ "$DRY_RUN" != "true" ]]; then
                 safe_remove "$cache_dir" true || true

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -866,8 +866,20 @@ is_path_whitelisted() {
     local target_path="$1"
     [[ -z "$target_path" ]] && return 1
 
-    # Normalize path (remove trailing slash)
+    # Normalize path (remove trailing slash, collapse consecutive slashes).
+    # Callers sometimes concat a glob expansion that already ends in `/`
+    # with a sub-path that begins with `/`, producing `.../Default//Service
+    # Worker/...`. Without collapsing, those never match a whitelist entry
+    # written with single separators. See #724.
+    #
+    # Note: on bash 3.2 (macOS default), `${var//\/\//\/}` leaves a literal
+    # backslash in the replacement. Indirect variables sidestep that.
+    local _slash_single="/"
+    local _slash_double="//"
     local normalized_target="${target_path%/}"
+    while [[ "$normalized_target" == *"$_slash_double"* ]]; do
+        normalized_target="${normalized_target//$_slash_double/$_slash_single}"
+    done
 
     # Empty whitelist means nothing is protected
     [[ ${#WHITELIST_PATTERNS[@]} -eq 0 ]] && return 1
@@ -875,6 +887,9 @@ is_path_whitelisted() {
     for pattern in "${WHITELIST_PATTERNS[@]}"; do
         # Pattern is already expanded/normalized in bin/clean.sh
         local check_pattern="${pattern%/}"
+        while [[ "$check_pattern" == *"$_slash_double"* ]]; do
+            check_pattern="${check_pattern//$_slash_double/$_slash_single}"
+        done
         local has_glob="false"
         case "$check_pattern" in
             *\** | *\?* | *\[*)

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -118,6 +118,52 @@ setup() {
     rm -rf "$test_cache"
 }
 
+# Regression for #724: MV3 extension SW caches are keyed by origin hash,
+# so the PROTECTED_SW_DOMAINS domain-match never fires for them. The
+# whitelist is the only escape hatch users have — respect it here.
+@test "clean_service_worker_cache honors is_path_whitelisted (#724)" {
+    local test_cache="$HOME/test_sw_cache_wl"
+    mkdir -p "$test_cache/abc123hash_extension"
+    mkdir -p "$test_cache/def456hash_other"
+
+    run bash -c "
+        export DRY_RUN=false
+        export PROTECTED_SW_DOMAINS=(nomatch.invalid)
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/clean/caches.sh'
+        WHITELIST_PATTERNS=('$test_cache/abc123hash_extension')
+        safe_remove() { echo \"REMOVE:\$1\"; return 0; }
+        export -f safe_remove
+        note_activity() { :; }
+        export -f note_activity
+        run_with_timeout() {
+            local timeout=\"\$1\"
+            shift
+            if [[ \"\$1\" == \"sh\" ]]; then
+                printf '%s\n' '$test_cache/abc123hash_extension' '$test_cache/def456hash_other'
+                return 0
+            fi
+            if [[ \"\$1\" == \"du\" ]]; then
+                printf '2048\t%s\n' \"\$3\"
+                return 0
+            fi
+            \"\$@\"
+        }
+        export -f run_with_timeout
+        clean_service_worker_cache 'TestBrowser' '$test_cache'
+    "
+
+    [ "$status" -eq 0 ]
+    # Whitelisted dir must never be passed to safe_remove
+    [[ "$output" != *"REMOVE:$test_cache/abc123hash_extension"* ]]
+    # Non-whitelisted dir must be removed
+    [[ "$output" == *"REMOVE:$test_cache/def456hash_other"* ]]
+    # UI reports the protection count
+    [[ "$output" == *"1 protected"* ]]
+
+    rm -rf "$test_cache"
+}
+
 @test "clean_service_worker_cache colors cleaned size with success color" {
     local test_cache="$HOME/test_sw_cache_colored"
     mkdir -p "$test_cache/abc123_https_example.com_0"

--- a/tests/manage_whitelist.bats
+++ b/tests/manage_whitelist.bats
@@ -146,3 +146,37 @@ setup() {
     fi
     [ "$status" -eq 0 ]
 }
+
+# Regression for #724: when a caller concats a glob expansion that ends
+# in `/` with a sub-path that starts with `/`, the result contains `//`.
+# Without slash collapsing, the comparison with a single-slash whitelist
+# entry always fails and Chrome MV3 service workers get wiped.
+@test "is_path_whitelisted matches entries against paths containing double slashes (#724)" {
+    local status
+    if HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/base.sh'
+        source '$PROJECT_ROOT/lib/core/app_protection.sh'
+        WHITELIST_PATTERNS=(\"\$HOME/Library/Application Support/Google/Chrome/Default/Service Worker/CacheStorage\")
+        is_path_whitelisted \"\$HOME/Library/Application Support/Google/Chrome/Default//Service Worker/CacheStorage\"
+    "; then
+        status=0
+    else
+        status=$?
+    fi
+    [ "$status" -eq 0 ]
+}
+
+@test "is_path_whitelisted collapses slashes in whitelist entries too (#724)" {
+    local status
+    if HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/base.sh'
+        source '$PROJECT_ROOT/lib/core/app_protection.sh'
+        WHITELIST_PATTERNS=(\"\$HOME//Library//Caches//chrome-sw\")
+        is_path_whitelisted \"\$HOME/Library/Caches/chrome-sw\"
+    "; then
+        status=0
+    else
+        status=$?
+    fi
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Closes #724 — `mo clean` silently wipes Chrome MV3 extension service workers on every run, even when the user has added their Chrome SW directory to the whitelist.

Two linked bugs surfaced, both fixed here.

## Bug 1: `clean_service_worker_cache` ignored the whitelist

The function in `lib/clean/caches.sh` protects SW cache folders by regex-extracting a domain from the folder name (e.g. `abc_https_photopea.com_0` → `photopea.com`) and matching against `PROTECTED_SW_DOMAINS`. Works fine for normal sites, but **MV3 extensions live in folders named by origin hash** — `abc123hash_extension`, no domain anywhere. The domain-match path never fires for them.

Fix: after the domain check misses, consult `is_path_whitelisted` on the cache dir itself. Same `protected_count` bookkeeping so UI accounting stays correct.

## Bug 2: `is_path_whitelisted` did not normalize slashes

Callers occasionally build comparison paths by concatenating a glob expansion that ends with `/` and a sub-path that starts with `/`, producing `//`. The exact-string comparison always missed a single-slash whitelist entry.

Fix: collapse consecutive slashes (and strip trailing `/`) on **both** sides before comparing.

> **bash 3.2 gotcha**: `${var//\/\//\/}` leaves a literal backslash in the replacement on macOS's default bash. Used indirect variables (`_slash_single="/"`, `_slash_double="//"`) to sidestep that. Verified on bash 3.2.57 and 5.2.

## Change

- `lib/clean/caches.sh` — `clean_service_worker_cache` now honors `is_path_whitelisted` as a second protection layer.
- `lib/core/app_protection.sh` — `is_path_whitelisted` normalizes `//` → `/` and strips trailing `/` on both target and patterns.

## Test plan

- [x] `tests/manage_whitelist.bats` — `is_path_whitelisted` matches against paths containing `//` (#724)
- [x] `tests/manage_whitelist.bats` — `is_path_whitelisted` collapses slashes in whitelist entries too (#724)
- [x] `tests/clean_system_caches.bats` — `clean_service_worker_cache` honors `is_path_whitelisted` (#724)
- [x] Full `bats tests/manage_whitelist.bats tests/clean_system_caches.bats` — 29/29 green

Manual repro from the issue:

```bash
# Before: every mo clean wipes this, breaking MV3 extensions
echo "$HOME/Library/Application Support/Google/Chrome/Default/Service Worker/CacheStorage" \
  >> ~/.config/mole/whitelist
mo clean
# After: the whitelisted Chrome SW CacheStorage survives
```