### PR TITLE
fix(clean): accept valid special-char whitelist paths

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -73,7 +73,8 @@ if [[ -f "$HOME/.config/mole/whitelist" ]]; then
         fi
 
         if [[ "$line" != "$FINDER_METADATA_SENTINEL" ]]; then
-            if [[ ! "$line" =~ ^[a-zA-Z0-9/_.@\ *-]+$ ]]; then
+            if [[ "$line" == *$'
+'* || "$line" == *$''* || "$line" == *$'	'* ]]; then
                 WHITELIST_WARNINGS+=("Invalid path format: $line")
                 continue
             fi

--- a/tests/manage_whitelist.bats
+++ b/tests/manage_whitelist.bats
@@ -116,6 +116,35 @@ setup() {
     [ "$status" -eq 1 ]
 }
 
+
+
+@test "mo clean accepts valid whitelist paths with special and non-ASCII characters (#749)" {
+    local status
+    if HOME="$HOME" bash --noprofile --norc -c "
+        mkdir -p \"\$HOME/.config/mole\"
+        printf '%s\n' \"\$HOME/Library/Application Support/Foo & Bar\" \"\$HOME/Library/Caches/บริษัท\" > \"\$HOME/.config/mole/whitelist\"
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/bin/clean.sh'
+        printf 'COUNT=%s\n' \"\${#WHITELIST_PATTERNS[@]}\"
+        printf 'WARN=%s\n' \"\${WHITELIST_WARNINGS[*]}\"
+        printf 'ENTRY1=%s\n' \"\${WHITELIST_PATTERNS[0]}\"
+        printf 'ENTRY2=%s\n' \"\${WHITELIST_PATTERNS[1]}\"
+    " > "$HOME/whitelist-parse.txt"; then
+        status=0
+    else
+        status=$?
+    fi
+    [ "$status" -eq 0 ]
+    run grep -Fx "COUNT=2" "$HOME/whitelist-parse.txt"
+    [ "$status" -eq 0 ]
+    run grep -F "Invalid path format" "$HOME/whitelist-parse.txt"
+    [ "$status" -eq 1 ]
+    run grep -F "ENTRY1=$HOME/Library/Application Support/Foo & Bar" "$HOME/whitelist-parse.txt"
+    [ "$status" -eq 0 ]
+    run grep -F "ENTRY2=$HOME/Library/Caches/บริษัท" "$HOME/whitelist-parse.txt"
+    [ "$status" -eq 0 ]
+}
+
 @test "is_path_whitelisted protects parent directories of whitelisted nested paths" {
     local status
     if HOME="$HOME" bash --noprofile --norc -c "


### PR DESCRIPTION
## Summary

Accept valid `mo clean` whitelist paths containing special or non-ASCII characters.

## Reproduction

Whitelist entries were being validated with an ASCII-only allowlist regex in `bin/clean.sh`, which rejected legitimate macOS paths such as:

- `~/Library/Application Support/Foo & Bar`
- `~/Library/Caches/com.example+beta`
- non-ASCII paths such as `~/Library/Caches/บริษัท`

As a result, Mole emitted `Invalid path format` and silently skipped those protection rules.

## Analysis

The parser was blocking many valid filesystem characters up front even though later whitelist matching is based on normalized path comparisons.

For this safety feature, the safer boundary is to reject only actually unsafe cases rather than maintaining a narrow filename character allowlist.

## Patch Summary

- replace the ASCII-only path regex check with a control-character guard
- continue rejecting non-absolute paths, traversal (`..`), protected system paths, and consecutive slashes
- add a regression test covering `&` and non-ASCII whitelist paths

## Risks

- Low risk and localized to whitelist parsing.
- This makes protection rules less unexpectedly restrictive without weakening the existing path-safety boundaries.

## Tests

Automated / local:

- `./scripts/check.sh`
- added regression test in `tests/manage_whitelist.bats`

Manual / focused:

- verified with a temporary HOME that valid entries containing `&` and non-ASCII characters are accepted with no `Invalid path format` warning

## Safety-related changes

Whitelist parsing now rejects control characters rather than rejecting broad classes of valid macOS filename characters. Existing safety checks for absolute paths, traversal, protected system paths, and consecutive slashes remain intact.
