### PR TITLE
fix(uninstall): include .diag files in diagnostic report cleanup matching

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1266,7 +1266,7 @@ get_diagnostic_report_paths_for_app() {
             *) continue ;;
         esac
         case "$base" in
-            *.ips | *.crash | *.spin) ;;
+            *.ips | *.crash | *.spin | *.diag) ;;
             *) continue ;;
         esac
         printf '%s\n' "$f"

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -81,14 +81,18 @@ cat > "$app_dir/Contents/Info.plist" << 'PLIST'
 PLIST
 
 touch "$diag_dir/Foo.crash"
+touch "$diag_dir/Foo.diag"
 touch "$diag_dir/Foo_2026-01-01-120000_host.ips"
 touch "$diag_dir/Foobar.crash"
+touch "$diag_dir/Foobar.diag"
 touch "$diag_dir/Foobar_2026-01-01-120001_host.ips"
 
 result=$(get_diagnostic_report_paths_for_app "$app_dir" "Foo" "$diag_dir")
 [[ "$result" == *"Foo.crash"* ]] || exit 1
+[[ "$result" == *"Foo.diag"* ]] || exit 1
 [[ "$result" == *"Foo_2026-01-01-120000_host.ips"* ]] || exit 1
 [[ "$result" != *"Foobar.crash"* ]] || exit 1
+[[ "$result" != *"Foobar.diag"* ]] || exit 1
 [[ "$result" != *"Foobar_2026-01-01-120001_host.ips"* ]] || exit 1
 EOF
 


### PR DESCRIPTION
## Summary

- Issue: #747
- Added `.diag` to uninstall diagnostic report matching so cleanup discovery now includes `.ips`, `.crash`, `.spin`, and `.diag` files.
- Updated the regression test to verify `.diag` matching for the target app prefix and to prevent prefix-collision false positives.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
   - Yes. It affects uninstall discovery behavior by expanding recognized diagnostic report extensions during app-related file lookup.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
   - No changes to path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity.
- If yes, describe the new boundary or risk change clearly.
   - New boundary: uninstall diagnostic-report discovery now includes `.diag` files in addition to existing extensions. Risk change is low and scoped to matching logic only.

## Tests

- List the automated tests you ran.
   - `bats tests/uninstall.bats --filter "get_diagnostic_report_paths_for_app avoids executable prefix collisions"`
   - `bats tests/uninstall.bats --filter "find_app_files discovers user-level leftovers|get_diagnostic_report_paths_for_app avoids executable prefix collisions"`
- List any manual checks for high-risk paths or destructive flows.
   - No additional manual destructive-flow checks were run for this patch.

## Safety-related changes

- None.

