### PR TITLE
fix(uninstall): detect bundle-id-prefixed launch daemons

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1347,6 +1347,18 @@ find_app_system_files() {
         system_files+=("$p")
     done
 
+    # System LaunchAgents/LaunchDaemons often use bundle-id-derived helper
+    # labels (for example "<bundle>.ProxyConfigHelper.plist"), so scan for
+    # validated reverse-DNS bundle-id prefixes before falling back to app name.
+    if [[ -n "$bundle_id" && "$bundle_id" != "unknown" &&
+        "$bundle_id" =~ ^[a-zA-Z0-9][-a-zA-Z0-9]*(\.[a-zA-Z0-9][-a-zA-Z0-9]*)+$ ]]; then
+        for base in /Library/LaunchAgents /Library/LaunchDaemons; do
+            [[ -d "$base" ]] && while IFS= read -r -d '' plist; do
+                system_files+=("$plist")
+            done < <(command find "$base" -maxdepth 1 -name "${bundle_id}*.plist" -print0 2> /dev/null)
+        done
+    fi
+
     # System LaunchAgents/LaunchDaemons by name
     if [[ ${#app_name} -gt 3 ]]; then
         for base in /Library/LaunchAgents /Library/LaunchDaemons; do

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -60,6 +60,33 @@ EOF
 	[[ "$result" == *"LaunchAgents/com.example.TestApp.plist"* ]]
 }
 
+@test "find_app_system_files discovers bundle-id-prefixed LaunchDaemons" {
+	fakebin="$HOME/fakebin"
+	mkdir -p "$fakebin"
+
+	cat > "$fakebin/find" <<'SCRIPT'
+#!/bin/sh
+args="$*"
+
+case "$args" in
+  *"/Library/LaunchDaemons"*' -name com.west2online.ClashXPro*.plist '*)
+    printf '%s\0' "/Library/LaunchDaemons/com.west2online.ClashXPro.ProxyConfigHelper.plist"
+    ;;
+esac
+SCRIPT
+	chmod +x "$fakebin/find"
+
+	run env HOME="$HOME" PATH="$fakebin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+result=$(find_app_system_files "com.west2online.ClashXPro" "ClashX Pro")
+[[ "$result" == *"/Library/LaunchDaemons/com.west2online.ClashXPro.ProxyConfigHelper.plist"* ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "get_diagnostic_report_paths_for_app avoids executable prefix collisions" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Scan `/Library/LaunchAgents` and `/Library/LaunchDaemons` with validated `${bundle_id}*.plist` prefixes before app-name matching so helper labels like `com.west2online.ClashXPro.ProxyConfigHelper.plist` are included in uninstall remnant discovery.
- Align system remnant discovery with the existing `launchctl unload` and `PrivilegedHelperTools` prefix matching logic to avoid leaving helper daemons behind when the plist name extends the main bundle ID.
- Add a regression test covering a bundle-id-prefixed `LaunchDaemon` helper.

## Safety Review

- Yes. This change affects `uninstall` remnant discovery for system-level `LaunchAgents` and `LaunchDaemons`.
- The boundary change is narrow: it adds `${bundle_id}*.plist` prefix matching only for validated reverse-DNS bundle IDs, before the existing app-name matching path.
- This does not broaden deletion to new directories, does not change sudo boundaries, and does not change path validation or symlink handling.
- The intent is to make system remnant discovery consistent with the existing `launchctl unload` and `PrivilegedHelperTools/$bundle_id*` behavior, reducing false negatives for helper plists whose names extend the main bundle ID.

## Tests

- Ran `bash scripts/test.sh tests/uninstall.bats`
- Ran `bash -n lib/core/app_protection.sh tests/uninstall.bats`
- Manually verified that `find_app_system_files "com.west2online.ClashXPro" "ClashX Pro"` now returns `/Library/LaunchDaemons/com.west2online.ClashXPro.ProxyConfigHelper.plist` in a targeted stubbed test environment
- Note: `bats` was not installed in the local environment, so the `.bats` suite was skipped by the test runner

## Safety-related changes

- None.
