### PR TITLE
fix(optimize): skip periodic maintenance when command is unavailable (closes #767)

### DIFF
--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -956,6 +956,11 @@ opt_periodic_maintenance() {
     fi
 
     if [[ "${MOLE_DRY_RUN:-0}" != "1" ]]; then
+        # macOS 26+ removed /usr/sbin/periodic and /etc/periodic; skip gracefully.
+        if ! command -v periodic &> /dev/null && [[ ! -x /usr/sbin/periodic ]]; then
+            opt_msg "Periodic maintenance unavailable (removed in macOS 26+)"
+            return 0
+        fi
         if ! sudo -n true 2> /dev/null; then
             opt_msg "Periodic maintenance skipped (requires sudo)"
             return 0


### PR DESCRIPTION
## Summary

Fixes #767. macOS 26+ removed `/usr/sbin/periodic` and `/etc/periodic/`, so `mo optimize` reports `Failed to run periodic maintenance (exit=1)` with stderr `sudo: periodic: command not found`.

Guard the `sudo periodic` call with a cheap existence check (`command -v periodic` + `-x /usr/sbin/periodic`) so affected systems skip the step cleanly, matching the existing pattern for the `sudo` availability check a few lines below.

## Change

`lib/optimize/tasks.sh`, `opt_periodic_maintenance`:

```bash
if ! command -v periodic &> /dev/null && [[ ! -x /usr/sbin/periodic ]]; then
    opt_msg "Periodic maintenance unavailable (removed in macOS 26+)"
    return 0
fi
```

Placed inside the non-dry-run branch so `MOLE_DRY_RUN=1` paths remain unchanged.

## Test plan

- [x] `shellcheck lib/optimize/tasks.sh` — clean
- [x] `bash -n lib/optimize/tasks.sh` — syntax OK on bash 3.2
- [x] `bats tests/optimize.bats` — 34/34 pass (including the 4 periodic-specific tests)
- [x] `./scripts/check.sh --no-format` — all quality gates green
- [x] Guard logic smoke-tested against a missing binary and an existing one