### PR TITLE
fix(core): downgrade misleading path validation error for protected paths (closes #766)

### DIFF
--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -312,7 +312,11 @@ safe_sudo_remove() {
     local path="$1"
 
     if ! validate_path_for_deletion "$path"; then
-        log_error "Path validation failed for sudo remove: $path"
+        if declare -f should_protect_path > /dev/null 2>&1 && should_protect_path "$path"; then
+            debug_log "Skipped sudo remove for protected path: $path"
+        else
+            log_error "Path validation failed for sudo remove: $path"
+        fi
         return 1
     fi
 


### PR DESCRIPTION
## Summary

Fixes #766 (re-report of #733). When `safe_sudo_remove` hits a path that `validate_path_for_deletion` rejects because `should_protect_path` matched it, the function logs `Path validation failed for sudo remove: <path>` at `log_error`. The rejection is policy, not a failure, and users see it after a cleanup that actually succeeded — as reported for `/Library/PrivilegedHelperTools/com.adobe.*`:

```
Path validation: protected path skipped: /Library/PrivilegedHelperTools/com.adobe.ARMDC.SMJobBlessHelper
☻ Path validation failed for sudo remove: /Library/PrivilegedHelperTools/com.adobe.ARMDC.SMJobBlessHelper
…
✓ Cleaned 3 orphaned services, about 932KB
```

This PR distinguishes the two cases. Genuine validation failures (absolute-path, traversal, symlink target, critical system dir) still log at error level. Protected-path rejections drop to `debug_log`, matching the existing debug-only `log_warning` emitted inside `validate_path_for_deletion` itself.

## Change

`lib/core/file_ops.sh`, `safe_sudo_remove`:

```bash
if ! validate_path_for_deletion "$path"; then
    if declare -f should_protect_path > /dev/null 2>&1 && should_protect_path "$path"; then
        debug_log "Skipped sudo remove for protected path: $path"
    else
        log_error "Path validation failed for sudo remove: $path"
    fi
    return 1
fi
```

`declare -f` guard mirrors the pattern already used at line 169 so the helper degrades safely when `app_protection.sh` isn't loaded.

## Test plan

- [x] `shellcheck lib/core/file_ops.sh` — clean
- [x] `bash -n lib/core/file_ops.sh` — syntax OK on bash 3.2
- [x] `bats tests/core_safe_functions.bats tests/file_ops_mole_delete.bats tests/user_file_ops.bats` — 59/59 pass
- [x] `bats tests/clean_core.bats tests/clean_apps.bats tests/clean_system_caches.bats tests/manage_sudo.bats` — 61/61 pass
- [x] `./scripts/check.sh --no-format` — all quality gates green