### PR TITLE
fix(uninstall): drop privileges when running brew under sudo (closes #768)

### DIFF
--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -888,7 +888,7 @@ batch_uninstall_applications() {
     if [[ $brew_apps_removed -gt 0 && "${MOLE_DRY_RUN:-0}" != "1" ]]; then
         (
             HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_AUTO_UPDATE=1 NONINTERACTIVE=1 \
-                run_with_timeout 30 brew autoremove > /dev/null 2>&1 || true
+                run_with_timeout 30 mole_brew autoremove > /dev/null 2>&1 || true
         ) &
         disown $! 2> /dev/null || true
     fi

--- a/lib/uninstall/brew.sh
+++ b/lib/uninstall/brew.sh
@@ -35,6 +35,27 @@ is_homebrew_available() {
     command -v brew > /dev/null 2>&1
 }
 
+# Run brew, dropping privileges when invoked as root.
+# Homebrew refuses to run under EUID 0 ("Running Homebrew as root is extremely
+# dangerous..."). When mole is launched via `sudo mo …`, transparently re-run
+# brew as the invoking user so uninstall/list operations succeed.
+# Exits non-zero (and prints an error) when root but no SUDO_USER is available.
+mole_brew() {
+    if [[ "$(id -u)" -ne 0 ]]; then
+        brew "$@"
+        return
+    fi
+
+    local drop_user="${SUDO_USER:-}"
+    if [[ -z "$drop_user" || "$drop_user" == "root" ]]; then
+        printf 'Error: Homebrew cannot run as root. Re-run mole without sudo.\n' >&2
+        return 1
+    fi
+
+    sudo --preserve-env=HOMEBREW_NO_ENV_HINTS,HOMEBREW_NO_AUTO_UPDATE,HOMEBREW_NO_ANALYTICS,NONINTERACTIVE \
+        -u "$drop_user" -H -- brew "$@"
+}
+
 # Check whether a cask is still recorded as installed in Homebrew.
 # Exit codes:
 #   0 - cask is installed
@@ -46,7 +67,7 @@ is_brew_cask_installed() {
     is_homebrew_available || return 2
 
     local cask_list
-    cask_list=$(HOMEBREW_NO_ENV_HINTS=1 brew list --cask 2> /dev/null) || return 2
+    cask_list=$(HOMEBREW_NO_ENV_HINTS=1 mole_brew list --cask 2> /dev/null) || return 2
     grep -qxF "$cask_name" <<< "$cask_list"
 }
 
@@ -116,7 +137,7 @@ _detect_cask_via_caskroom_search() {
 
     # Only succeed if exactly one unique token found and it's installed
     if ((${#uniq[@]} == 1)) && [[ -n "${uniq[0]}" ]]; then
-        HOMEBREW_NO_ENV_HINTS=1 brew list --cask 2> /dev/null | grep -qxF "${uniq[0]}" || return 1
+        HOMEBREW_NO_ENV_HINTS=1 mole_brew list --cask 2> /dev/null | grep -qxF "${uniq[0]}" || return 1
         echo "${uniq[0]}"
         return 0
     fi
@@ -142,10 +163,10 @@ _detect_cask_via_brew_list() {
     app_name_lower=$(echo "${app_bundle_name%.app}" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 
     local cask_name
-    cask_name=$(HOMEBREW_NO_ENV_HINTS=1 brew list --cask 2> /dev/null | grep -Fix "$app_name_lower") || return 1
+    cask_name=$(HOMEBREW_NO_ENV_HINTS=1 mole_brew list --cask 2> /dev/null | grep -Fix "$app_name_lower") || return 1
 
     # Verify this cask actually owns this app path
-    HOMEBREW_NO_ENV_HINTS=1 brew info --cask "$cask_name" 2> /dev/null | grep -qF "$app_path" || return 1
+    HOMEBREW_NO_ENV_HINTS=1 mole_brew info --cask "$cask_name" 2> /dev/null | grep -qF "$app_path" || return 1
     echo "$cask_name"
 }
 
@@ -211,7 +232,7 @@ brew_uninstall_cask() {
     # Run with timeout to prevent hangs from problematic cask scripts
     local brew_exit=0
     if HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_AUTO_UPDATE=1 NONINTERACTIVE=1 \
-        run_with_timeout "$timeout" brew uninstall --cask --zap "$cask_name" 2>&1; then
+        run_with_timeout "$timeout" mole_brew uninstall --cask --zap "$cask_name" 2>&1; then
         uninstall_ok=true
     else
         brew_exit=$?

--- a/tests/brew_uninstall.bats
+++ b/tests/brew_uninstall.bats
@@ -27,6 +27,64 @@ setup() {
     mkdir -p "$HOME/Caskroom/test-app/1.2.3/TestApp.app"
 }
 
+@test "mole_brew calls brew directly when not running as root" {
+    run bash <<EOF
+source "$PROJECT_ROOT/lib/core/common.sh" > /dev/null 2>&1
+source "$PROJECT_ROOT/lib/uninstall/brew.sh" > /dev/null 2>&1
+
+id() { echo "501"; }
+export -f id
+brew() { echo "brew-call:\$*"; }
+export -f brew
+
+mole_brew list --cask
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"brew-call:list --cask"* ]]
+}
+
+@test "mole_brew refuses to run as root without SUDO_USER" {
+    run bash <<EOF
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/brew.sh"
+
+id() { echo "0"; }
+export -f id
+unset SUDO_USER
+brew() { echo "should-not-run"; }
+export -f brew
+
+mole_brew list --cask
+EOF
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Homebrew cannot run as root"* ]]
+    [[ "$output" != *"should-not-run"* ]]
+}
+
+@test "mole_brew drops privileges via sudo -u when run as root" {
+    run bash <<EOF
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/brew.sh"
+
+id() { echo "0"; }
+export -f id
+export SUDO_USER="testuser"
+sudo() { echo "sudo $*"; }
+export -f sudo
+brew() { echo "should-not-run-directly"; }
+export -f brew
+
+mole_brew uninstall --cask --zap claude
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"-u testuser"* ]]
+    [[ "$output" == *"-- brew uninstall --cask --zap claude"* ]]
+    [[ "$output" != *"should-not-run-directly"* ]]
+}
+
 @test "get_brew_cask_name detects app in Caskroom (simulated)" {
     # Create fake Caskroom structure with symlink (modern Homebrew style)
     mkdir -p "$HOME/Caskroom/test-app/1.0.0"


### PR DESCRIPTION
## Summary

Fixes #768 — `mo uninstall` fails on Homebrew-managed apps when launched via `sudo` with the error:

> Error: Running Homebrew as root is extremely dangerous and no longer supported.

Homebrew refuses any operation under EUID 0. When a user runs `sudo mo uninstall` (a common instinct for anything that deletes from `/Applications`), `brew uninstall --cask --zap <token>` aborts and the cask is left in place with a misleading "brew uninstall failed, package still installed" message.

## Fix

Added a `mole_brew` wrapper in `lib/uninstall/brew.sh` that routes brew calls through `sudo -u "$SUDO_USER" -H --` whenever mole is running as root. Highlights:

- Transparent for non-root runs — just calls `brew "$@"`.
- When root with a real `SUDO_USER`, drops privileges and preserves the relevant env vars (`HOMEBREW_NO_ENV_HINTS`, `HOMEBREW_NO_AUTO_UPDATE`, `HOMEBREW_NO_ANALYTICS`, `NONINTERACTIVE`) via `sudo --preserve-env`.
- When root with no usable `SUDO_USER`, fails fast with a clear message ("Homebrew cannot run as root. Re-run mole without sudo.") instead of letting brew's wall-of-text error surface.

All uninstall-path brew invocations now go through the wrapper:

- `is_brew_cask_installed` (list --cask)
- `_detect_cask_via_caskroom_search` (list --cask verify)
- `_detect_cask_via_brew_list` (list + info)
- `brew_uninstall_cask` (uninstall --cask --zap)
- post-uninstall `brew autoremove` in `batch.sh`

## Test plan

- [x] `bats tests/brew_uninstall.bats` — 11/11 pass (3 new tests cover the wrapper's non-root, root-without-SUDO_USER, and root-with-SUDO_USER branches)
- [x] `bats tests/uninstall.bats` — 36/36 pass (no regressions on the broader uninstall suite)
- [x] `bash -n` syntax check on both modified scripts

## Notes

- Scope intentionally limited to the uninstall path (where the bug was reported). `lib/clean/brew.sh` also shells out to `brew autoremove` and would fail under `sudo mo clean`, but that's a separate report.
- The wrapper lives in `lib/uninstall/brew.sh` and is already in scope for `batch.sh` via the existing `source` on line 10, so no extra plumbing required.