### PR TITLE
fix(analyze): subtract deleted size instead of rescanning (closes #764)

### DIFF
--- a/cmd/analyze/delete.go
+++ b/cmd/analyze/delete.go
@@ -22,12 +22,16 @@ const trashTimeout = 30 * time.Second
 func deletePathCmd(path string, counter *int64) tea.Cmd {
 	return func() tea.Msg {
 		count, err := trashPathWithProgress(path, counter)
-		return deleteProgressMsg{
+		msg := deleteProgressMsg{
 			done:  true,
 			err:   err,
 			count: count,
 			path:  path,
 		}
+		if err == nil {
+			msg.paths = []string{path}
+		}
+		return msg
 	}
 }
 
@@ -43,6 +47,7 @@ func deleteMultiplePathsCmd(paths []string, counter *int64) tea.Cmd {
 			return strings.Count(pathsToDelete[i], string(filepath.Separator)) > strings.Count(pathsToDelete[j], string(filepath.Separator))
 		})
 
+		var removed []string
 		for _, path := range pathsToDelete {
 			count, err := trashPathWithProgress(path, counter)
 			totalCount += count
@@ -51,7 +56,9 @@ func deleteMultiplePathsCmd(paths []string, counter *int64) tea.Cmd {
 					continue
 				}
 				errors = append(errors, err.Error())
+				continue
 			}
+			removed = append(removed, path)
 		}
 
 		var resultErr error
@@ -64,6 +71,7 @@ func deleteMultiplePathsCmd(paths []string, counter *int64) tea.Cmd {
 			err:   resultErr,
 			count: totalCount,
 			path:  "",
+			paths: removed,
 		}
 	}
 }

--- a/cmd/analyze/incremental_delete_test.go
+++ b/cmd/analyze/incremental_delete_test.go
@@ -1,0 +1,240 @@
+//go:build darwin
+
+package main
+
+import (
+	"sync/atomic"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestDeleteProgressMsgDoesNotTriggerRescan(t *testing.T) {
+	childPath := "/tmp/mole-incremental-delete/child"
+	parentPath := "/tmp/mole-incremental-delete"
+
+	var filesScanned, dirsScanned, bytesScanned int64
+	m := model{
+		path: parentPath,
+		entries: []dirEntry{
+			{Path: childPath, Size: 2_000_000, IsDir: true},
+			{Path: parentPath + "/other", Size: 500_000, IsDir: true},
+		},
+		totalSize:          2_500_000,
+		totalFiles:         42,
+		cache:              map[string]historyEntry{},
+		multiSelected:      map[string]bool{},
+		largeMultiSelected: map[string]bool{},
+		filesScanned:       &filesScanned,
+		dirsScanned:        &dirsScanned,
+		bytesScanned:       &bytesScanned,
+	}
+
+	msg := deleteProgressMsg{
+		done:  true,
+		count: 5,
+		path:  childPath,
+		paths: []string{childPath},
+	}
+
+	updated, cmd := m.Update(msg)
+	got, ok := updated.(model)
+	if !ok {
+		t.Fatalf("unexpected model type: %T", updated)
+	}
+
+	if got.scanning {
+		t.Errorf("delete triggered a rescan (scanning=true); expected incremental update")
+	}
+	// A persist command may be returned to write the updated cache off the
+	// UI thread; it must not produce a follow-up message (no rescan/tick).
+	if cmd != nil {
+		if followup := cmd(); followup != nil {
+			t.Errorf("delete's follow-up cmd should be fire-and-forget, got %T", followup)
+		}
+	}
+
+	if len(got.entries) != 1 || got.entries[0].Path != parentPath+"/other" {
+		t.Errorf("entries not pruned after delete: %+v", got.entries)
+	}
+	if got.totalSize != 500_000 {
+		t.Errorf("totalSize not decremented: got %d, want 500000", got.totalSize)
+	}
+	if got.status == "" {
+		t.Errorf("status should report deletion count")
+	}
+}
+
+func TestDeleteProgressMsgMultiPathSubtractsAll(t *testing.T) {
+	a := "/tmp/mole-multi-delete/a"
+	b := "/tmp/mole-multi-delete/b"
+
+	var filesScanned, dirsScanned, bytesScanned int64
+	m := model{
+		path: "/tmp/mole-multi-delete",
+		entries: []dirEntry{
+			{Path: a, Size: 1_000_000, IsDir: true},
+			{Path: b, Size: 2_000_000, IsDir: true},
+			{Path: "/tmp/mole-multi-delete/keep", Size: 300_000, IsDir: true},
+		},
+		totalSize:          3_300_000,
+		cache:              map[string]historyEntry{},
+		multiSelected:      map[string]bool{a: true, b: true},
+		largeMultiSelected: map[string]bool{},
+		filesScanned:       &filesScanned,
+		dirsScanned:        &dirsScanned,
+		bytesScanned:       &bytesScanned,
+	}
+
+	msg := deleteProgressMsg{
+		done:  true,
+		count: 7,
+		path:  "",
+		paths: []string{a, b},
+	}
+
+	updated, _ := m.Update(msg)
+	got := updated.(model)
+
+	if got.scanning {
+		t.Errorf("multi-delete triggered a rescan; expected incremental update")
+	}
+	if len(got.entries) != 1 {
+		t.Fatalf("expected 1 entry after multi-delete, got %d: %+v", len(got.entries), got.entries)
+	}
+	if got.totalSize != 300_000 {
+		t.Errorf("totalSize after multi-delete: got %d, want 300000", got.totalSize)
+	}
+	if len(got.multiSelected) != 0 {
+		t.Errorf("multiSelected not cleared: %+v", got.multiSelected)
+	}
+}
+
+func TestSubtractFromAncestorsUpdatesHistoryAndCache(t *testing.T) {
+	deleted := "/Users/me/Library/Caches/big"
+	size := int64(5_000_000)
+
+	m := model{
+		history: []historyEntry{
+			{
+				Path: "/Users/me/Library",
+				Entries: []dirEntry{
+					{Path: "/Users/me/Library/Caches", Size: 8_000_000, IsDir: true},
+					{Path: "/Users/me/Library/Other", Size: 1_000_000, IsDir: true},
+				},
+				TotalSize: 9_000_000,
+			},
+			{
+				Path: "/Users/other",
+				Entries: []dirEntry{
+					{Path: "/Users/other/x", Size: 100, IsDir: true},
+				},
+				TotalSize: 100,
+			},
+		},
+		cache: map[string]historyEntry{
+			"/Users/me/Library/Caches": {
+				Path: "/Users/me/Library/Caches",
+				Entries: []dirEntry{
+					{Path: deleted, Size: size, IsDir: true},
+				},
+				TotalSize: size,
+			},
+		},
+	}
+
+	m.subtractFromAncestors(deleted, size)
+
+	libHistory := m.history[0]
+	if libHistory.TotalSize != 4_000_000 {
+		t.Errorf("history TotalSize: got %d, want 4000000", libHistory.TotalSize)
+	}
+	if !libHistory.NeedsRefresh {
+		t.Errorf("history ancestor should be flagged NeedsRefresh")
+	}
+	// The top-level Caches entry shrank from 8MB to 3MB.
+	var cachesSize int64
+	for _, e := range libHistory.Entries {
+		if e.Path == "/Users/me/Library/Caches" {
+			cachesSize = e.Size
+		}
+	}
+	if cachesSize != 3_000_000 {
+		t.Errorf("top-level Caches entry size: got %d, want 3000000", cachesSize)
+	}
+
+	otherHistory := m.history[1]
+	if otherHistory.TotalSize != 100 || otherHistory.NeedsRefresh {
+		t.Errorf("unrelated ancestor should be untouched: %+v", otherHistory)
+	}
+
+	cached := m.cache["/Users/me/Library/Caches"]
+	if cached.TotalSize != 0 {
+		t.Errorf("cache TotalSize after full delete: got %d, want 0", cached.TotalSize)
+	}
+	if !cached.NeedsRefresh {
+		t.Errorf("cache ancestor should be flagged NeedsRefresh")
+	}
+	if len(cached.Entries) != 0 {
+		t.Errorf("cache should have dropped the deleted entry, got: %+v", cached.Entries)
+	}
+}
+
+func TestIsAncestorOf(t *testing.T) {
+	cases := []struct {
+		ancestor, child string
+		want            bool
+	}{
+		{"/a", "/a/b", true},
+		{"/a", "/a", false},
+		{"/a", "/ab", false},
+		{"/", "/a", true},
+		{"/", "", false},
+		{"", "/a", false},
+		{"/a/b", "/a/b/c/d", true},
+	}
+	for _, c := range cases {
+		if got := isAncestorOf(c.ancestor, c.child); got != c.want {
+			t.Errorf("isAncestorOf(%q, %q) = %v, want %v", c.ancestor, c.child, got, c.want)
+		}
+	}
+}
+
+func TestDeleteProgressMsgErrorDoesNotMutate(t *testing.T) {
+	entries := []dirEntry{{Path: "/x/y", Size: 100, IsDir: true}}
+	var filesScanned, dirsScanned, bytesScanned int64
+
+	m := model{
+		path:               "/x",
+		entries:            entries,
+		totalSize:          100,
+		cache:              map[string]historyEntry{},
+		multiSelected:      map[string]bool{"/x/y": true},
+		largeMultiSelected: map[string]bool{},
+		filesScanned:       &filesScanned,
+		dirsScanned:        &dirsScanned,
+		bytesScanned:       &bytesScanned,
+	}
+
+	msg := deleteProgressMsg{done: true, err: errBoom{}, path: "/x/y"}
+	updated, _ := m.Update(msg)
+	got := updated.(model)
+
+	if got.totalSize != 100 {
+		t.Errorf("totalSize mutated on error: got %d", got.totalSize)
+	}
+	if len(got.entries) != 1 {
+		t.Errorf("entries mutated on error: %+v", got.entries)
+	}
+	if got.status == "" {
+		t.Errorf("status should describe the failure")
+	}
+
+	// Unused vars to satisfy atomic import-like presence.
+	_ = atomic.LoadInt64(&filesScanned)
+	_ = tea.Batch
+}
+
+type errBoom struct{}
+
+func (errBoom) Error() string { return "boom" }

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -89,6 +90,7 @@ type deleteProgressMsg struct {
 	err   error
 	count int64
 	path  string
+	paths []string
 }
 
 type model struct {
@@ -447,30 +449,55 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.largeMultiSelected = make(map[string]bool)
 			if msg.err != nil {
 				m.status = fmt.Sprintf("Failed to delete: %v", msg.err)
-			} else {
-				if msg.path != "" {
-					m.removePathFromView(msg.path)
-					invalidateCache(msg.path)
-				}
-				invalidateCache(m.path)
-				m.status = fmt.Sprintf("Deleted %d items", msg.count)
-				for i := range m.history {
-					m.history[i].Dirty = true
-				}
-				for path := range m.cache {
-					entry := m.cache[path]
-					entry.Dirty = true
-					m.cache[path] = entry
-				}
-				m.scanning = true
-				atomic.StoreInt64(m.filesScanned, 0)
-				atomic.StoreInt64(m.dirsScanned, 0)
-				atomic.StoreInt64(m.bytesScanned, 0)
-				if m.currentPath != nil {
-					m.currentPath.Store("")
-				}
-				return m, tea.Batch(m.scanCmd(m.path), tickCmd())
+				return m, nil
 			}
+
+			removedPaths := msg.paths
+			if len(removedPaths) == 0 && msg.path != "" {
+				removedPaths = []string{msg.path}
+			}
+
+			// Capture sizes before removePathFromView mutates m.entries.
+			removedSizes := make(map[string]int64, len(removedPaths))
+			for _, p := range removedPaths {
+				for _, e := range m.entries {
+					if e.Path == p {
+						removedSizes[p] = e.Size
+						break
+					}
+				}
+			}
+
+			for _, p := range removedPaths {
+				m.removePathFromView(p)
+				invalidateCache(p)
+			}
+
+			for _, p := range removedPaths {
+				if size := removedSizes[p]; size > 0 {
+					m.subtractFromAncestors(p, size)
+				}
+			}
+
+			m.status = fmt.Sprintf("Deleted %d items", msg.count)
+
+			// Persist updated view off the UI thread; fsync on a large
+			// scanResult can stall the event loop.
+			var persistCmd tea.Cmd
+			if len(removedPaths) > 0 && !m.inOverviewMode() {
+				snapshot := scanResult{
+					Entries:    slices.Clone(m.entries),
+					LargeFiles: slices.Clone(m.largeFiles),
+					TotalSize:  m.totalSize,
+					TotalFiles: m.totalFiles,
+				}
+				path := m.path
+				persistCmd = func() tea.Msg {
+					_ = saveCacheToDiskWithOptions(path, snapshot, true)
+					return nil
+				}
+			}
+			return m, persistCmd
 		}
 		return m, nil
 	case scanResultMsg:
@@ -1224,6 +1251,73 @@ func (m *model) removePathFromView(path string) {
 		m.clampEntrySelection()
 	}
 	m.clampLargeSelection()
+}
+
+// subtractFromAncestors keeps back-navigation approximate after a delete:
+// ancestors of `deleted` lose `size` from their totals and get flagged for
+// background refresh, instead of a full rescan.
+func (m *model) subtractFromAncestors(deleted string, size int64) {
+	if deleted == "" || size <= 0 {
+		return
+	}
+
+	for i := range m.history {
+		entry := &m.history[i]
+		if !isAncestorOf(entry.Path, deleted) {
+			continue
+		}
+		entry.TotalSize = saturatingSub(entry.TotalSize, size)
+		entry.Entries = pruneEntryContaining(entry.Entries, deleted, size)
+		entry.NeedsRefresh = true
+	}
+
+	for path, entry := range m.cache {
+		if !isAncestorOf(path, deleted) {
+			continue
+		}
+		entry.TotalSize = saturatingSub(entry.TotalSize, size)
+		entry.Entries = pruneEntryContaining(entry.Entries, deleted, size)
+		entry.NeedsRefresh = true
+		m.cache[path] = entry
+	}
+}
+
+func saturatingSub(total, sub int64) int64 {
+	if sub >= total {
+		return 0
+	}
+	return total - sub
+}
+
+// isAncestorOf reports whether `ancestor` is a strict prefix directory of
+// `child`. Guards against lexical false positives like "/foo" vs "/foobar".
+func isAncestorOf(ancestor, child string) bool {
+	if ancestor == "" || child == "" || ancestor == child {
+		return false
+	}
+	if ancestor == "/" {
+		return strings.HasPrefix(child, "/")
+	}
+	return strings.HasPrefix(child, ancestor+string(filepath.Separator))
+}
+
+// pruneEntryContaining updates the top-level entry whose path is `deleted`
+// or contains it: drops it if it's the deleted path itself, otherwise
+// clamps its size to saturating(e.Size - size). Keeping the row (even at
+// 0 B) avoids silently vanishing legitimate entries when size accounting
+// drifts (APFS clones, symlinks, count-vs-bytes mismatches); background
+// refresh corrects the number.
+func pruneEntryContaining(entries []dirEntry, deleted string, size int64) []dirEntry {
+	for i, e := range entries {
+		if e.Path == deleted {
+			return append(entries[:i], entries[i+1:]...)
+		}
+		if isAncestorOf(e.Path, deleted) {
+			entries[i].Size = saturatingSub(e.Size, size)
+			return entries
+		}
+	}
+	return entries
 }
 
 func scanOverviewPathCmd(path string, index int) tea.Cmd {


### PR DESCRIPTION
## Summary

Fixes #764 — `mo analyze` rescans the current directory every time the user deletes a folder, making the tool "practically unusable" (reporter's word) on large trees. The reporter cited `/System/Library` at ~184 GB; any click on "delete" kicked off a full rewalk before they could even see the next candidate.

## Root cause

`cmd/analyze/main.go`'s `deleteProgressMsg` handler was doing:

```go
invalidateCache(m.path)             // wipes the parent's cache
for i := range m.history { ... Dirty = true }    // all ancestors dirty
for path := range m.cache { ... Dirty = true }   // everything dirty
m.scanning = true
return m, tea.Batch(m.scanCmd(m.path), tickCmd()) // forced full rescan
```

But `removePathFromView` already subtracts the deleted entry's size from `m.totalSize` and removes it from `m.entries`. The UI model was correct the moment trash succeeded — the rescan was pure waste.

## Fix

**No more rescan on delete.** Instead:

- `subtractFromAncestors(path, size)` walks `m.history` and `m.cache`, subtracts the removed size from every entry whose path is an ancestor of the deleted path, and flags `NeedsRefresh = true`. Background refresh picks up drift; no blocking rescan.
- The top-level entry that contains the deleted path is **clamped to 0 B rather than dropped** when the subtracted size exceeds its tracked size. This survives size-accounting drift (APFS clones, symlinks, count-vs-bytes mismatches) without silently vanishing rows — the refresh corrects the number.
- The current view is persisted as the on-disk cache for `m.path` (with `NeedsRefresh=true`) **off the UI thread via a `tea.Cmd`** — `saveCacheToDiskWithOptions` gob-encodes the full `scanResult`, which on a 184 GB scan isn't free and would stall the event loop if done inline.
- `deleteProgressMsg` gains a `paths []string` field so multi-delete reports every removed path to the handler; `deletePathCmd` and `deleteMultiplePathsCmd` both populate it.

## Files

- `cmd/analyze/main.go` — rewrite delete handler + `subtractFromAncestors`, `isAncestorOf`, `saturatingSub`, `pruneEntryContaining` helpers.
- `cmd/analyze/delete.go` — populate `paths` in both command constructors.
- `cmd/analyze/incremental_delete_test.go` — 5 new tests.

## Test plan

- [x] `go test ./cmd/analyze/ -count=1 -short` → 180/180 pass (5 new: single/multi delete don't rescan, ancestor propagation updates history+cache, `isAncestorOf` edge cases including `/` root and `/foo` vs `/foobar`, error path doesn't mutate state).
- [x] `go build ./cmd/analyze/` + `go vet ./cmd/analyze/` clean.
- [x] Manual verification on `$HOME/Downloads` (~12 GB tree): deleting a subfolder updates the view immediately, no spinner, no progress bar, disk I/O from `mo` drops to idle after trash. Back-navigating to parent shows the reduced total with a silent refresh in the background.

## Known follow-up (separate PR)

Deletions from the **large-files view** don't round-trip through `m.entries`, so `subtractFromAncestors` is a no-op for them today. The `Entries` list is still updated (the file is removed from the view) and on-disk cache for the deleted path is invalidated, so the UI is consistent — but ancestor totals in `m.history` won't decrement until a refresh. Happy to tackle that in a follow-up PR once this lands and we've agreed on the shape.