### PR TITLE
fix(bundle_resolver): keep filesystem fallback alive when mdfind times out

### DIFF
--- a/lib/core/bundle_resolver.sh
+++ b/lib/core/bundle_resolver.sh
@@ -35,11 +35,14 @@ bundle_has_installed_app() {
     # Fast path: Spotlight. Gated with a timeout because mdfind has been known
     # to wedge on misconfigured indexes.
     if command -v mdfind > /dev/null 2>&1; then
-        local hit
+        # `|| true` guards against two failure modes under `set -e` + `pipefail`:
+        # run_with_timeout returning 124 on timeout, and mdfind itself exiting
+        # non-zero. Both must fall through to the filesystem scan below.
+        local hit=""
         if declare -f run_with_timeout > /dev/null 2>&1; then
-            hit=$(run_with_timeout 2 mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1)
+            hit=$(run_with_timeout 2 mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1) || true
         else
-            hit=$(mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1)
+            hit=$(mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null | head -1) || true
         fi
         [[ -n "$hit" ]] && return 0
     fi

--- a/tests/bundle_resolver.bats
+++ b/tests/bundle_resolver.bats
@@ -71,6 +71,33 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "bundle_has_installed_app falls back after run_with_timeout returns 124 (set -e + pipefail regression)" {
+    # Regression for the flake that blocked PR #770: under `set -euo pipefail`,
+    # `hit=$(run_with_timeout ... | head -1)` inside a command substitution
+    # killed the shell when run_with_timeout exited 124 on timeout. Forcing the
+    # timeout path here proves the filesystem fallback still executes.
+    make_app "$FAKE_APPS/KeePassXC.app" "org.keepassxc.KeePassXC"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/base.sh"
+source "$PROJECT_ROOT/lib/core/timeout.sh"
+source "$PROJECT_ROOT/lib/core/bundle_resolver.sh"
+
+# Make Spotlight appear available but force the timeout path to return 124.
+mdfind() { return 0; }
+export -f mdfind
+run_with_timeout() { return 124; }
+export -f run_with_timeout
+
+_MOLE_BUNDLE_RESOLVER_APP_ROOTS=("$FAKE_APPS")
+
+bundle_has_installed_app "org.keepassxc.KeePassXC"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "bundle_has_installed_app finds an SMJobBless privileged helper inside a parent app" {
     # Simulate Adobe Acrobat DC shipping its ARMDC helper at
     # Contents/Library/LaunchServices/com.adobe.ARMDC.SMJobBlessHelper.


### PR DESCRIPTION
## Summary

Under `set -euo pipefail`, `hit=$(run_with_timeout 2 mdfind ... | head -1)` kills the shell when `run_with_timeout` returns 124 (timeout). That's exactly the case the timeout was supposed to survive — the resolver should fall through to its direct filesystem scan, not die.

Appending `|| true` to both `hit=$(...)` assignments in `bundle_has_installed_app` preserves the fast-path attempt but lets both mdfind failures and timeout-driven 124 exits fall through to the Info.plist walk below.

## Why this showed up now

This has been surfacing as a CI failure on `macos-latest` for PR #770 (and blocking #772 / #773 rebases). The failing test is `bundle_has_installed_app finds an app by CFBundleIdentifier (Spotlight miss)` — test #9 in the `Unit & Integration Tests` job. It's not a flake: `mdfind` can legitimately time out on hosted runners and trip exactly this path.

Repro without the fix:

```bash
set -euo pipefail
run_with_timeout() { return 124; }
hit=$(run_with_timeout 2 mdfind "x" 2>/dev/null | head -1)   # shell exits here
echo "never reached"
```

## Test plan

- [x] Added `bundle_has_installed_app falls back after run_with_timeout returns 124 (set -e + pipefail regression)` to `tests/bundle_resolver.bats`. Mocks `run_with_timeout` to return 124 and asserts the filesystem fallback still finds the app.
- [x] Verified the new test fails on `upstream/main` (reproducing the CI failure) and passes with the fix.
- [x] Full `bats tests/bundle_resolver.bats` green (8/8) locally.