### PR TITLE
fix: add Yarn v1 global cache cleanup

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -173,6 +173,7 @@ clean_dev_npm() {
     safe_clean ~/.tnpm/_cacache/* "tnpm cache directory"
     safe_clean ~/.tnpm/_logs/* "tnpm logs"
     safe_clean ~/.yarn/cache/* "Yarn cache"
+    safe_clean ~/Library/Caches/Yarn/* "Yarn v1 cache"
 }
 # Python/pip ecosystem caches.
 clean_dev_python() {


### PR DESCRIPTION
## Summary

- Add cleanup for Yarn v1 global cache at `~/Library/Caches/Yarn/` in `clean_dev_npm()`
- The existing `~/.yarn/cache/*` only covers Yarn v2+ (Berry), missing the Yarn v1 (Classic) cache path on macOS
- This cache can grow to several GB over time (5.9 GB in my case) and is never cleaned by `mo clean`

## Safety Review

- **Does this change affect cleanup behavior?** Yes — adds one new `safe_clean` target to the existing `clean_dev_npm()` function.
- **Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?** No. It uses the same `safe_clean` mechanism as all other cache paths, which respects whitelist and dry-run modes.
- The new path `~/Library/Caches/Yarn/*` is a well-known macOS cache directory used exclusively by Yarn v1. It contains downloaded package tarballs that are re-fetched on demand, so deletion is safe and non-destructive.

## Tests

- Verified `~/Library/Caches/Yarn/` exists on a macOS machine that has used Yarn v1
- Confirmed `mo clean --dry-run` does not currently list this path
- Confirmed the change correctly adds it to the dry-run output after patching
- Verified whitelist and `--dry-run` are respected (uses existing `safe_clean` helper)

## Safety-related changes

- None. Uses the same `safe_clean` function as all other cache cleanup targets.