### PR TITLE
fix: align APFS disk stats with df

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1167,6 +1167,12 @@ perform_cleanup() {
         summary_details+=("Free space now: $(get_free_space)")
     fi
 
+    if [[ "$DRY_RUN" != "true" && -z "$EXTERNAL_VOLUME_TARGET" ]]; then
+        local snapshot_space_note
+        snapshot_space_note=$(get_apfs_snapshot_space_note || true)
+        [[ -n "$snapshot_space_note" ]] && summary_details+=("$snapshot_space_note")
+    fi
+
     if [[ $had_errexit -eq 1 ]]; then
         set -e
     fi

--- a/cmd/status/metrics_disk.go
+++ b/cmd/status/metrics_disk.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/disk"
@@ -80,18 +79,12 @@ func collectDisks() ([]DiskStatus, error) {
 		if seenVolume[volKey] {
 			continue
 		}
-		used := usage.Used
-		usedPercent := usage.UsedPercent
-		if runtime.GOOS == "darwin" && strings.ToLower(part.Fstype) == "apfs" {
-			used, usedPercent = correctAPFSDiskUsage(part.Mountpoint, total, usage.Used)
-		}
-
 		disks = append(disks, DiskStatus{
 			Mount:       part.Mountpoint,
 			Device:      part.Device,
-			Used:        used,
+			Used:        usage.Used,
 			Total:       total,
-			UsedPercent: usedPercent,
+			UsedPercent: usedPercentFromBytes(usage.Used, total),
 			Fstype:      part.Fstype,
 		})
 		seenDevice[baseDevice] = true
@@ -149,12 +142,6 @@ var (
 	lastDiskCacheAt time.Time
 	diskTypeCache   = make(map[string]bool)
 	diskCacheTTL    = 2 * time.Minute
-
-	// Finder startup disk usage cache (macOS APFS purgeable-aware).
-	finderDiskCacheMu  sync.Mutex
-	finderDiskCachedAt time.Time
-	finderDiskFree     uint64
-	finderDiskTotal    uint64
 )
 
 func annotateDiskTypes(disks []DiskStatus) {
@@ -265,95 +252,11 @@ func getDiskutilTotalBytes(mountpoint string) (uint64, error) {
 	return extractPlistUint(out, "TotalSize", "DiskSize", "Size")
 }
 
-// correctAPFSDiskUsage returns Finder-accurate used bytes and percent for an
-// APFS volume, accounting for purgeable caches and APFS local snapshots that
-// statfs incorrectly counts as "used". Uses a three-tier fallback:
-//  1. Finder via osascript (startup disk only) — exact match with macOS Finder
-//  2. diskutil APFSContainerFree — corrects APFS snapshot space
-//  3. Raw gopsutil values — original statfs-based calculation
-func correctAPFSDiskUsage(mountpoint string, total, rawUsed uint64) (used uint64, usedPercent float64) {
-	// Tier 1: Finder via osascript (startup disk at "/" only).
-	if mountpoint == "/" && commandExists("osascript") {
-		if finderFree, finderTotal, err := getFinderStartupDiskFreeBytes(); err == nil &&
-			finderTotal > 0 && finderFree <= finderTotal {
-			used = finderTotal - finderFree
-			usedPercent = float64(used) / float64(finderTotal) * 100.0
-			return
-		}
+func usedPercentFromBytes(used, total uint64) float64 {
+	if total == 0 {
+		return 0
 	}
-
-	// Tier 2: diskutil APFSContainerFree (corrects APFS local snapshots).
-	if commandExists("diskutil") {
-		if containerFree, err := getAPFSContainerFreeBytes(mountpoint); err == nil && containerFree <= total {
-			corrected := total - containerFree
-			// Only apply if it meaningfully differs (>1GB) from raw to avoid noise.
-			if rawUsed > corrected && rawUsed-corrected > 1<<30 {
-				used = corrected
-				usedPercent = float64(used) / float64(total) * 100.0
-				return
-			}
-		}
-	}
-
-	// Tier 3: fall back to raw gopsutil values.
-	return rawUsed, float64(rawUsed) / float64(total) * 100.0
-}
-
-// getAPFSContainerFreeBytes returns the APFS container free space (including
-// purgeable snapshot space) by parsing `diskutil info -plist`. This corrects
-// for APFS local snapshots which statfs counts as used.
-func getAPFSContainerFreeBytes(mountpoint string) (uint64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	out, err := runCmd(ctx, "diskutil", "info", "-plist", mountpoint)
-	if err != nil {
-		return 0, err
-	}
-
-	return extractPlistUint(out, "APFSContainerFree")
-}
-
-// getFinderStartupDiskFreeBytes queries Finder via osascript for the startup
-// disk free space. Finder's value includes purgeable caches and APFS snapshots,
-// matching the "X GB of Y GB used" display. Results are cached for 2 minutes.
-func getFinderStartupDiskFreeBytes() (free, total uint64, err error) {
-	finderDiskCacheMu.Lock()
-	defer finderDiskCacheMu.Unlock()
-
-	if !finderDiskCachedAt.IsZero() && time.Since(finderDiskCachedAt) < diskCacheTTL {
-		return finderDiskFree, finderDiskTotal, nil
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	// Single call returns both values as a comma-separated pair.
-	out, err := runCmd(ctx, "osascript", "-e",
-		`tell application "Finder" to return {free space of startup disk, capacity of startup disk}`)
-	if err != nil {
-		// Cache the failure timestamp so repeated calls within diskCacheTTL
-		// return immediately instead of each waiting the full 5s timeout.
-		finderDiskCachedAt = time.Now()
-		return 0, 0, err
-	}
-
-	// Output format: "3.2489E+11, 4.9438E+11" or "324892202048, 494384795648"
-	parts := strings.SplitN(strings.TrimSpace(out), ",", 2)
-	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("unexpected osascript output: %q", out)
-	}
-
-	freeF, err1 := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-	totalF, err2 := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-	if err1 != nil || err2 != nil || freeF <= 0 || totalF <= 0 {
-		return 0, 0, fmt.Errorf("failed to parse osascript output: %q", out)
-	}
-
-	finderDiskFree = uint64(freeF)
-	finderDiskTotal = uint64(totalF)
-	finderDiskCachedAt = time.Now()
-	return finderDiskFree, finderDiskTotal, nil
+	return float64(used) / float64(total) * 100.0
 }
 
 func extractPlistUint(plist string, keys ...string) (uint64, error) {

--- a/cmd/status/metrics_disk_test.go
+++ b/cmd/status/metrics_disk_test.go
@@ -148,3 +148,18 @@ func TestCorrectDiskTotalBytes(t *testing.T) {
 		}
 	})
 }
+
+func TestUsedPercentFromBytesUsesRawUsage(t *testing.T) {
+	const total = 460 * uint64(1<<30)
+	const rawUsed = 392 * uint64(1<<30)
+
+	got := usedPercentFromBytes(rawUsed, total)
+	want := float64(rawUsed) / float64(total) * 100.0
+	if got != want {
+		t.Fatalf("usedPercentFromBytes() = %f, want %f", got, want)
+	}
+
+	if got < 85.0 || got > 85.3 {
+		t.Fatalf("usedPercentFromBytes() = %f, want df-style raw APFS usage near 85%%", got)
+	}
+}

--- a/lib/clean/system.sh
+++ b/lib/clean/system.sh
@@ -456,3 +456,21 @@ clean_local_snapshots() {
         note_activity
     fi
 }
+
+get_apfs_snapshot_space_note() {
+    if ! command -v tmutil > /dev/null 2>&1; then
+        return 0
+    fi
+    if ! defaults read /Library/Preferences/com.apple.TimeMachine AutoBackup 2> /dev/null | grep -qE '^[01]$'; then
+        return 0
+    fi
+
+    local snapshot_list snapshot_count
+    snapshot_list=$(run_with_timeout 3 tmutil listlocalsnapshots / 2> /dev/null || true)
+    [[ -z "$snapshot_list" ]] && return 0
+
+    snapshot_count=$(echo "$snapshot_list" | { grep -Eo 'com\.apple\.TimeMachine\.[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}' || true; } | wc -l | awk '{print $1}')
+    if [[ "$snapshot_count" =~ ^[0-9]+$ && "$snapshot_count" -gt 0 ]]; then
+        printf 'Finder may show more available space than df while %s APFS snapshots remain purgeable; Mole reports df-style free space.\n' "$snapshot_count"
+    fi
+}

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -347,6 +347,46 @@ EOF
     [[ "$output" != *"Time Machine local snapshots"* ]]
 }
 
+@test "get_apfs_snapshot_space_note explains Finder df gap when snapshots exist" {
+    run bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+defaults() { echo "1"; }
+tmutil() { :; }
+run_with_timeout() {
+    printf '%s\n' \
+        "com.apple.TimeMachine.2023-10-25-120000" \
+        "com.apple.TimeMachine.2023-10-24-120000"
+}
+
+get_apfs_snapshot_space_note
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Finder may show more available space than df"* ]]
+    [[ "$output" == *"2 APFS snapshots"* ]]
+    [[ "$output" == *"Mole reports df-style free space"* ]]
+}
+
+@test "get_apfs_snapshot_space_note is quiet when no snapshots exist" {
+    run bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+defaults() { echo "1"; }
+tmutil() { :; }
+run_with_timeout() { echo "Snapshots for disk /:"; }
+
+get_apfs_snapshot_space_note
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
 @test "clean_homebrew skips when cleaned recently" {
     run bash --noprofile --norc << 'EOF'
 set -euo pipefail


### PR DESCRIPTION
Use raw filesystem usage for APFS stats so Mole matches df, and explain Finder differences when local snapshots exist.

Fixes #784.

Tests: ./scripts/check.sh, go test ./..., bats tests/clean_system_maintenance.bats, bats tests/cli.bats

Note: ./scripts/test.sh still has unrelated failures in tests/clean_browser_versions.bats.