### PR TITLE
fix: guard empty array expansion for bash 3.2 compatibility

### DIFF
--- a/lib/core/bundle_resolver.sh
+++ b/lib/core/bundle_resolver.sh
@@ -90,7 +90,7 @@ bundle_has_installed_app() {
             [[ "$app_bundle" == "$bundle_id" ]] && return 0
             [[ -n "$parent_id" && "$app_bundle" == "$parent_id" ]] && return 0
             local mapped_bundle
-            for mapped_bundle in "${mapped_app_bundles[@]}"; do
+            for mapped_bundle in "${mapped_app_bundles[@]+"${mapped_app_bundles[@]}"}"; do
                 [[ "$app_bundle" == "$mapped_bundle" ]] && return 0
             done
         done < <(find "$app_root" -maxdepth 1 -name "*.app" -print0 2> /dev/null)

--- a/tests/bundle_resolver.bats
+++ b/tests/bundle_resolver.bats
@@ -180,6 +180,23 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "bundle_has_installed_app does not crash with unbound variable for unmapped bundle IDs under set -u (issue #790)" {
+    # Regression for issue #790: iterating over an empty mapped_app_bundles array
+    # under `set -euo pipefail` raised "unbound variable" in bash 3.2 (macOS default).
+    # This test forces the code path: a bundle ID with no case-statement mapping and
+    # multiple apps to scan, so the inner for-loop is reached with an empty array.
+    make_app "$FAKE_APPS/SomeApp.app" "com.example.someapp"
+    make_app "$FAKE_APPS/AnotherApp.app" "com.example.otherapp"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "com.example.unmapped.id"
+EOF
+
+    # Must exit cleanly (status 1 = not found) rather than crashing (status 2+ or unbound variable error)
+    [ "$status" -eq 1 ]
+}
+
 @test "bundle_has_installed_app does not use broad Microsoft vendor prefix" {
     make_app "$FAKE_APPS/Microsoft Teams.app" "com.microsoft.teams2"
 


### PR DESCRIPTION
## Summary

macOS ships with bash 3.2, which raises "unbound variable" under `set -u` when expanding an empty array with `"${array[@]}"`, even if the array was declared with `local -a array=()`.

This PR uses the `${array[@]+"${array[@]}"}` idiom so the expansion is skipped safely when `mapped_app_bundles` is empty.

Fixes: https://github.com/tw93/Mole/issues/790

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?

Yes, as it fixes an issue with `mo clean`

- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?

No

- If yes, describe the new boundary or risk change clearly.

N/A

## Tests

- List the automated tests you ran.

I ran the related test suite with `bats tests/bundle_resolver.bats`

- List any manual checks for high-risk paths or destructive flows.

N/A, but I tested to run the `mo clean` again on my MacBook and the error is now gone.

## Safety-related changes

- None.
