### PR TITLE
fix(bundle_resolver): guard empty array iteration under set -u

### DIFF
--- a/lib/core/bundle_resolver.sh
+++ b/lib/core/bundle_resolver.sh
@@ -89,10 +89,12 @@ bundle_has_installed_app() {
             app_bundle=$(plutil -extract CFBundleIdentifier raw "$info" 2> /dev/null || echo "")
             [[ "$app_bundle" == "$bundle_id" ]] && return 0
             [[ -n "$parent_id" && "$app_bundle" == "$parent_id" ]] && return 0
-            local mapped_bundle
-            for mapped_bundle in "${mapped_app_bundles[@]}"; do
-                [[ "$app_bundle" == "$mapped_bundle" ]] && return 0
-            done
+            if (( ${#mapped_app_bundles[@]} > 0 )); then
+                local mapped_bundle
+                for mapped_bundle in "${mapped_app_bundles[@]}"; do
+                    [[ "$app_bundle" == "$mapped_bundle" ]] && return 0
+                done
+            fi
         done < <(find "$app_root" -maxdepth 1 -name "*.app" -print0 2> /dev/null)
     done
 

--- a/tests/bundle_resolver.bats
+++ b/tests/bundle_resolver.bats
@@ -190,3 +190,18 @@ EOF
 
     [ "$status" -ne 0 ]
 }
+
+@test "bundle_has_installed_app handles empty mapped_app_bundles under set -u" {
+    # Regression: bash 3.2 with set -u raises "unbound variable" when iterating
+    # over an empty array. Non-Microsoft bundle IDs leave mapped_app_bundles=().
+    make_app "$FAKE_APPS/SomeApp.app" "com.example.someapp"
+    make_app "$FAKE_APPS/AnotherApp.app" "com.example.otherapp"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "com.example.unmapped.id"
+EOF
+
+    # Exit 1 = not found (expected). Exit 2+ or crash = unbound variable bug.
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

Fixes `unbound variable` error during orphan system services scan when `mapped_app_bundles` array is empty.

**Before (v1.36.0):**
```
➤ App leftovers
  ✓ Found 162 active/installed apps
  \ Scanning orphaned system services.../opt/homebrew/Cellar/mole/1.36.0/libexec/lib/core/bundle_resolver.sh: line 81: mapped_app_bundles[@]: unbound variable
```

**After:**
```
➤ App leftovers
  ✓ Found 162 active/installed apps
  ✓ Orphaned LaunchAgents
  ✓ Orphaned LaunchDaemons
  ✓ Nothing to clean
```

## Root cause

Bash <4.4 with `set -u` (nounset) treats `${array[@]}` on an empty array as an unbound variable. The `mapped_app_bundles` array is only populated for specific Microsoft helper bundle IDs — for all other cases it remains empty, triggering the error.

## Fix

Wrap the loop in a length check:
```bash
if (( ${#mapped_app_bundles[@]} > 0 )); then
    for mapped_bundle in "${mapped_app_bundles[@]}"; do
        ...
    done
fi
```

## Safety Review

- **Scope:** Single guard condition, no behavioral change when array has items
- **Risk:** None — the loop body is unchanged, just skipped when empty
- **Pattern:** Matches existing defensive coding in other `set -u` scripts