### PR TITLE
feat: AI-powered system advisor with interactive cleanup recommendations

### DIFF
--- a/bin/advisor.sh
+++ b/bin/advisor.sh
@@ -1,0 +1,665 @@
+#!/bin/bash
+# Mole - AI Advisor Command
+# Analyzes system state using a connected LLM, presents interactive
+# recommendations menu, and executes confirmed deletions via safe ops.
+
+export LC_ALL=C
+export LANG=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/lib/core/common.sh"
+source "$SCRIPT_DIR/lib/core/file_ops.sh"
+source "$SCRIPT_DIR/lib/core/log.sh"
+source "$SCRIPT_DIR/lib/ai/config.sh"
+source "$SCRIPT_DIR/lib/ai/client.sh"
+source "$SCRIPT_DIR/lib/ai/collector.sh"
+source "$SCRIPT_DIR/lib/ai/prompt.sh"
+source "$SCRIPT_DIR/lib/ai/renderer.sh"
+source "$SCRIPT_DIR/lib/ai/executor.sh"
+
+set +e
+
+MOLE_CURRENT_COMMAND="advisor"
+export MOLE_CURRENT_COMMAND
+
+_ADVISOR_STEP_NUM=0
+
+_step() {
+    local label="$1"
+    local detail="${2:-}"
+    _ADVISOR_STEP_NUM=$((_ADVISOR_STEP_NUM + 1))
+    printf '\r\033[2K'
+    if [[ -n "$detail" ]]; then
+        echo -e "  ${GRAY}${_ADVISOR_STEP_NUM}.${NC} ${CYAN}${label}${NC} ${GRAY}${detail}${NC}"
+    else
+        echo -e "  ${GRAY}${_ADVISOR_STEP_NUM}.${NC} ${CYAN}${label}${NC}"
+    fi
+}
+
+_step_ok() {
+    local label="$1"
+    local detail="${2:-}"
+    printf '\r\033[2K'
+    echo -e "  ${GREEN}${ICON_SUCCESS}${NC} ${label} ${GRAY}${detail}${NC}"
+}
+
+_step_fail() {
+    local label="$1"
+    local detail="${2:-}"
+    printf '\r\033[2K'
+    echo -e "  ${RED}${ICON_ERROR}${NC} ${label} ${GRAY}${detail}${NC}"
+}
+
+cleanup_advisor() {
+    stop_inline_spinner 2>/dev/null || true
+    show_cursor 2>/dev/null || true
+    cleanup_temp_files
+}
+
+handle_interrupt() {
+    cleanup_advisor
+    exit 130
+}
+
+trap cleanup_advisor EXIT
+trap handle_interrupt INT TERM
+
+_show_usage() {
+    cat << EOF
+${GREEN}Usage:${NC}
+  ${CYAN}mo advisor${NC}              Open AI advisor menu (interactive)
+  ${CYAN}mo advisor --analyze${NC}    Run analysis directly (skip menu)
+  ${CYAN}mo advisor --setup${NC}      Configure AI endpoint and model
+  ${CYAN}mo advisor --show-config${NC} Show current AI configuration
+  ${CYAN}mo advisor --no-stream${NC}  Wait for full response (no streaming)
+  ${CYAN}mo advisor --dry-run${NC}    Collect data only (no AI call)
+  ${CYAN}mo advisor --auto-safe${NC}  Auto-select SAFE items, skip menu
+  ${CYAN}mo advisor --help${NC}       Show this help message
+
+${GREEN}Interactive menu:${NC}
+  ${CYAN}Setup${NC}        — Configure AI endpoint (Ollama, vLLM, OpenRouter, etc.)
+  ${CYAN}Analyze${NC}      — Collect system data, send to AI, get recommendations
+  ${CYAN}Last Report${NC}  — View cached report from previous analysis
+
+${GREEN}Workflow:${NC}
+  1. AI analyzes your system
+  2. Recommendations appear as an interactive list
+  3. ${CYAN}Space${NC} to toggle items, ${CYAN}A${NC} to toggle all, ${CYAN}F${NC} to filter by risk
+  4. ${CYAN}Enter${NC} to confirm, then type ${GREEN}yes${NC} to execute
+
+${GREEN}Configuration:${NC}
+  Settings are stored in ${GRAY}~/.config/mole/ai.conf${NC}
+  Reports cached in ${GRAY}~/.config/mole/advisor/${NC}
+EOF
+}
+
+_strip_reasoning() {
+    local text="$1"
+    echo "$text" | sed -n '/^##\|^\*\*\|^\| Path\|^\### Section\|^```json/,$p'
+}
+
+_call_ai_with_retry() {
+    local sys_prompt="$1"
+    local user_data="$2"
+    local no_stream_flag="$3"
+    local max_retries=2
+    local attempt=1
+
+    while [[ $attempt -le $max_retries ]]; do
+        local resp_tmp
+        resp_tmp=$(mktemp_file)
+        local ai_exit=0
+
+        if $no_stream_flag; then
+            ai_client_chat "$sys_prompt" "$user_data" > "$resp_tmp" 2>&1
+            ai_exit=$?
+        else
+            ai_client_stream_chat "$sys_prompt" "$user_data" > "$resp_tmp" 2>&1
+            ai_exit=$?
+        fi
+
+        if [[ $ai_exit -eq 0 ]]; then
+            cat "$resp_tmp"
+            rm -f "$resp_tmp"
+            return 0
+        fi
+
+        rm -f "$resp_tmp"
+
+        if [[ $attempt -lt $max_retries ]]; then
+            _step_fail "Attempt $attempt failed, retrying..." "(exit $ai_exit)"
+            sleep 2
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    return 1
+}
+
+_ADVISOR_CACHE_DIR="$HOME/.config/mole/advisor"
+
+_cache_report() {
+    local report_md="$1"
+    local json_block="$2"
+    mkdir -p "$_ADVISOR_CACHE_DIR"
+    echo "$report_md" > "$_ADVISOR_CACHE_DIR/last_report.md"
+    echo "$json_block" > "$_ADVISOR_CACHE_DIR/last_plan.json"
+    date '+%Y-%m-%d %H:%M' > "$_ADVISOR_CACHE_DIR/last_timestamp"
+}
+
+_has_cached_report() {
+    [[ -f "$_ADVISOR_CACHE_DIR/last_report.md" && -f "$_ADVISOR_CACHE_DIR/last_plan.json" ]]
+}
+
+_get_cache_timestamp() {
+    if [[ -f "$_ADVISOR_CACHE_DIR/last_timestamp" ]]; then
+        cat "$_ADVISOR_CACHE_DIR/last_timestamp"
+    else
+        echo "unknown"
+    fi
+}
+
+_show_advisor_submenu() {
+    local selected=1
+    local configured=false
+    ai_config_is_configured 2>/dev/null && configured=true
+    local has_cache=false
+    _has_cached_report && has_cache=true
+
+    hide_cursor
+    trap 'show_cursor; return 1' INT TERM
+
+    while true; do
+        printf '\033[H'
+        printf '\r\033[2K\n'
+        echo -e "${PURPLE_BOLD}${ICON_ARROW} AI Advisor${NC}"
+        printf '\r\033[2K\n'
+
+        if $configured; then
+            echo -e "  ${GRAY}Model:${NC} $(ai_config_get_model)"
+            echo -e "  ${GRAY}Endpoint:${NC} $(ai_config_get_endpoint)"
+        else
+            echo -e "  ${YELLOW}${ICON_WARNING} Not configured — setup required first${NC}"
+        fi
+
+        if $has_cache; then
+            echo -e "  ${GRAY}Last report:${NC} $(_get_cache_timestamp)"
+        fi
+
+        echo -e "  ${GRAY}Read-only analysis. You control all deletions.${NC}"
+
+        printf '\r\033[2K\n'
+
+        printf '\r\033[2K  %s\n' "$(show_menu_option 1 "Setup        Configure AI endpoint and model" "$([[ $selected -eq 1 ]] && echo true || echo false)")"
+        if $configured; then
+            printf '\r\033[2K  %s\n' "$(show_menu_option 2 "Analyze      Run AI system analysis" "$([[ $selected -eq 2 ]] && echo true || echo false)")"
+        else
+            printf '\r\033[2K  %s\n' "$(show_menu_option 2 "${GRAY}Analyze      (requires setup)${NC}" "$([[ $selected -eq 2 ]] && echo true || echo false)")"
+        fi
+        if $has_cache; then
+            printf '\r\033[2K  %s\n' "$(show_menu_option 3 "Last Report  View recent analysis" "$([[ $selected -eq 3 ]] && echo true || echo false)")"
+        else
+            printf '\r\033[2K  %s\n' "$(show_menu_option 3 "${GRAY}Last Report  (no reports yet)${NC}" "$([[ $selected -eq 3 ]] && echo true || echo false)")"
+        fi
+        printf '\r\033[2K  %s\n' "$(show_menu_option 4 "Back         Return to main menu" "$([[ $selected -eq 4 ]] && echo true || echo false)")"
+
+        printf '\r\033[2K\n'
+        printf '\r\033[2K  %s↑↓ Navigate  |  Enter Select  |  Esc Back%s\n' "${GRAY}" "${NC}"
+        printf '\033[J'
+
+        local key
+        key=$(read_key) || continue
+
+        case "$key" in
+            UP)
+                ((selected > 1)) && ((selected--))
+                ;;
+            DOWN)
+                ((selected < 4)) && ((selected++))
+                ;;
+            ENTER)
+                show_cursor
+                case $selected in
+                    1)
+                        clear
+                        ai_config_setup
+                        configured=false
+                        ai_config_is_configured 2>/dev/null && configured=true
+                        echo ""
+                        echo -e "  ${GRAY}Press any key to continue...${NC}"
+                        IFS= read -r -s -n1 -t 30 || true
+                        ;;
+                    2)
+                        if $configured; then
+                            clear
+                            _run_analysis
+                            _has_cached_report && has_cache=true
+                            echo ""
+                            echo -e "  ${GRAY}Press any key to continue...${NC}"
+                            IFS= read -r -s -n1 -t 60 || true
+                        fi
+                        ;;
+                    3)
+                        if $has_cache; then
+                            clear
+                            _show_cached_report
+                            echo ""
+                            echo -e "  ${GRAY}Press any key to continue...${NC}"
+                            IFS= read -r -s -n1 -t 60 || true
+                        fi
+                        ;;
+                    4)
+                        return 0
+                        ;;
+                esac
+                hide_cursor
+                ;;
+            QUIT)
+                show_cursor
+                return 0
+                ;;
+        esac
+
+        drain_pending_input
+    done
+}
+
+_show_cached_report() {
+    local report_md
+    report_md=$(cat "$_ADVISOR_CACHE_DIR/last_report.md")
+    local json_block
+    json_block=$(cat "$_ADVISOR_CACHE_DIR/last_plan.json")
+    local ts
+    ts=$(_get_cache_timestamp)
+
+    echo -e "${PURPLE_BOLD}${ICON_ARROW} Last Report${NC} ${GRAY}($ts)${NC}"
+    echo ""
+    _render_report "$report_md"
+    echo ""
+
+    if ! _load_plan "$json_block"; then
+        echo -e "  ${YELLOW}${ICON_WARNING} Plan data could not be parsed.${NC}"
+        return
+    fi
+
+    local count=${#_PLAN_TITLES[@]}
+    if [[ $count -eq 0 ]]; then
+        echo -e "  ${GREEN}${ICON_SUCCESS} No recommendations were made.${NC}"
+        return
+    fi
+
+    echo -e "  ${PURPLE}${ICON_ARROW} Recommendations from last analysis:${NC}"
+    echo ""
+    local i
+    for ((i = 0; i < count; i++)); do
+        local risk_c
+        risk_c=$(_risk_color "${_PLAN_RISKS[$i]}")
+        echo -e "  ${ICON_LIST} ${_PLAN_TITLES[$i]} ${risk_c}[${_PLAN_RISKS[$i]}]${NC} — ${_PLAN_SIZES[$i]}"
+    done
+    echo ""
+    echo -e "  ${GRAY}Run Analyze again for fresh recommendations with execution.${NC}"
+}
+
+_ADVISOR_TOTAL_SECTIONS=12
+_ADVISOR_CURRENT_STAGE=""
+
+_show_pipeline() {
+    local active_stage="$1"
+    local detail="${2:-}"
+
+    if [[ -n "$_ADVISOR_CURRENT_STAGE" ]]; then
+        printf '\r\033[2K\n' >&2
+    fi
+
+    local -a stages=("Collect" "Analyze" "Report" "Select" "Execute")
+    local line=""
+    local i active_idx
+
+    active_idx=0
+    for ((i = 0; i < ${#stages[@]}; i++)); do
+        [[ "${stages[$i]}" == "$active_stage" ]] && active_idx=$i && break
+    done
+
+    for ((i = 0; i < ${#stages[@]}; i++)); do
+        local s="${stages[$i]}"
+        if [[ "$s" == "$active_stage" ]]; then
+            line="${line}${CYAN}${ICON_SOLID} ${s}${NC}"
+        elif [[ $i -lt $active_idx ]]; then
+            line="${line}${GREEN}${ICON_SUCCESS}${NC}${GRAY} ${s}${NC}"
+        else
+            line="${line}${GRAY}${ICON_EMPTY} ${s}${NC}"
+        fi
+        [[ $i -lt $(( ${#stages[@]} - 1 )) ]] && line="${line} ${GRAY}──${NC} "
+    done
+
+    printf '\r\033[2K  %s\n' "$line" >&2
+    printf '\r\033[2K  %s' "$detail" >&2
+
+    _ADVISOR_CURRENT_STAGE="$active_stage"
+}
+
+_pipeline_detail() {
+    printf '\r\033[2K  %s' "$1" >&2
+}
+
+_pipeline_advance() {
+    printf '\n' >&2
+}
+
+_stream_ai_with_progress() {
+    local sys_prompt="$1"
+    local user_data="$2"
+    local resp_tmp="$3"
+
+    local prompt_tmp="/tmp/mole_adv_prompt_$$.txt"
+    local data_tmp="/tmp/mole_adv_data_$$.txt"
+    printf '%s' "$sys_prompt" > "$prompt_tmp"
+    printf '%s' "$user_data" > "$data_tmp"
+
+    local attempt=1
+    local max_retries=2
+
+    while [[ $attempt -le $max_retries ]]; do
+        rm -f "$resp_tmp"
+
+        bash -c '
+            SCRIPT_DIR="'"$SCRIPT_DIR"'"
+            source "$SCRIPT_DIR/lib/core/common.sh" 2>/dev/null
+            source "$SCRIPT_DIR/lib/ai/config.sh" 2>/dev/null
+            source "$SCRIPT_DIR/lib/ai/client.sh" 2>/dev/null
+            sys_prompt=$(cat "$1")
+            user_data=$(cat "$2")
+            ai_client_stream_chat "$sys_prompt" "$user_data"
+        ' _ "$prompt_tmp" "$data_tmp" > "$resp_tmp" 2>/dev/null &
+        local ai_pid=$!
+
+        local spinner_chars="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+        local si=0
+
+        while kill -0 "$ai_pid" 2>/dev/null; do
+            local sc="${spinner_chars:$((si % 10)):1}"
+            si=$((si + 1))
+
+            local chars=0
+            if [[ -f "$resp_tmp" ]]; then
+                chars=$(wc -c < "$resp_tmp" 2>/dev/null | tr -d '[:space:]' || echo "0")
+            fi
+
+            if [[ "$chars" -gt 0 ]]; then
+                local human_size
+                if [[ "$chars" -gt 1048576 ]]; then
+                    human_size="$((chars / 1048576))MB"
+                elif [[ "$chars" -gt 1024 ]]; then
+                    human_size="$((chars / 1024))KB"
+                else
+                    human_size="${chars}B"
+                fi
+                _pipeline_detail "${CYAN}${sc}${NC} Thinking... ${GRAY}${human_size}${NC}"
+            else
+                _pipeline_detail "${CYAN}${sc}${NC} Waiting for model response..."
+            fi
+
+            sleep 0.3
+        done
+
+        local ai_exit=0
+        wait "$ai_pid" 2>/dev/null || ai_exit=$?
+
+        local final_size=0
+        if [[ -f "$resp_tmp" ]]; then
+            final_size=$(wc -c < "$resp_tmp" 2>/dev/null | tr -d '[:space:]' || echo "0")
+        fi
+
+        if [[ $ai_exit -eq 0 && "$final_size" -gt 100 ]]; then
+            _pipeline_detail "${GREEN}${ICON_SUCCESS}${NC} Response received (${final_size} bytes)"
+            _pipeline_advance
+            rm -f "$prompt_tmp" "$data_tmp"
+            return 0
+        fi
+
+        if [[ $attempt -lt $max_retries ]]; then
+            _pipeline_detail "${YELLOW}${ICON_WARNING}${NC} Attempt ${attempt} failed (exit=${ai_exit}, size=${final_size}), retrying..."
+            sleep 2
+        else
+            _pipeline_detail "${RED}${ICON_ERROR}${NC} Failed after ${max_retries} attempts (exit=${ai_exit}, size=${final_size})"
+            _pipeline_advance
+        fi
+        attempt=$((attempt + 1))
+    done
+
+    rm -f "$prompt_tmp" "$data_tmp"
+    return 1
+}
+
+_collect_with_progress() {
+    local data_tmp="/tmp/mole_advisor_data_$$.txt"
+    local collect_log="/tmp/mole_advisor_collect_log_$$.txt"
+    rm -f "$data_tmp"
+
+    bash -c "source '$SCRIPT_DIR/lib/core/common.sh'; source '$SCRIPT_DIR/lib/ai/collector.sh'; collector_run_all" > "$data_tmp" 2>"$collect_log" &
+    local collect_pid=$!
+
+    local spinner_chars="⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+    local si=0
+
+    _show_pipeline "Collect" "${CYAN}⠋${NC} Starting scan..."
+
+    while kill -0 "$collect_pid" 2>/dev/null; do
+        local section_count=0
+        if [[ -f "$data_tmp" ]]; then
+            section_count=$(grep -c '^=== ' "$data_tmp" 2>/dev/null | tr -d '[:space:]' || echo "0")
+            section_count="${section_count%%[!0-9]*}"
+            [[ -z "$section_count" ]] && section_count=0
+        fi
+
+        local sc="${spinner_chars:$((si % 10)):1}"
+        si=$((si + 1))
+
+        local pct=$((section_count * 100 / _ADVISOR_TOTAL_SECTIONS))
+        [[ $pct -gt 100 ]] && pct=100
+
+        local bar=""
+        local j
+        for ((j = 0; j < section_count; j++)); do bar="${bar}${GREEN}${ICON_SOLID}${NC}"; done
+        for ((j = section_count; j < _ADVISOR_TOTAL_SECTIONS; j++)); do bar="${bar}${GRAY}${ICON_EMPTY}${NC}"; done
+
+        _pipeline_detail "${CYAN}${sc}${NC} Scanning... ${bar} ${section_count}/${_ADVISOR_TOTAL_SECTIONS} (${pct}%)"
+
+        sleep 0.3
+    done
+
+    wait "$collect_pid" 2>/dev/null || true
+
+    local section_count=0
+    if [[ -f "$data_tmp" ]]; then
+        section_count=$(grep -c '^=== ' "$data_tmp" 2>/dev/null | tr -d '[:space:]' || echo "0")
+        section_count="${section_count%%[!0-9]*}"
+        [[ -z "$section_count" ]] && section_count=0
+    fi
+
+    _pipeline_detail "${GREEN}${ICON_SUCCESS}${NC} Collected ${section_count} sections"
+    _pipeline_advance
+    cat "$data_tmp"
+    rm -f "$data_tmp" "$collect_log"
+}
+
+_run_analysis() {
+    if ! ai_config_is_configured; then
+        echo -e "${YELLOW}${ICON_WARNING} AI advisor is not configured.${NC}"
+        echo "Select Setup from the menu first."
+        return 1
+    fi
+
+    clear
+
+    echo -e "  ${PURPLE_BOLD}${ICON_ARROW} Mole AI Advisor${NC}"
+    echo -e "  ${GRAY}Read-only analysis. You decide what to delete.${NC}"
+    echo ""
+    echo -e "  ${GRAY}Model:${NC} $(ai_config_get_model)  ${GRAY}Endpoint:${NC} $(ai_config_get_endpoint)"
+    echo ""
+
+    system_data=$(_collect_with_progress)
+
+    local sys_prompt
+    sys_prompt=$(ai_system_prompt) || true
+
+    _show_pipeline "Analyze" "${GRAY}Sending to model...${NC}"
+
+    local resp_tmp="/tmp/mole_advisor_resp_$$.txt"
+    if ! _stream_ai_with_progress "$sys_prompt" "$system_data" "$resp_tmp"; then
+        echo ""
+        echo -e "  ${RED}AI request failed. Check configuration via Setup.${NC}"
+        rm -f "$resp_tmp"
+        echo -e "  ${GRAY}Press any key to continue...${NC}"
+        return 1
+    fi
+
+    local response
+    response=$(cat "$resp_tmp")
+    rm -f "$resp_tmp"
+
+    _show_pipeline "Report" "${GRAY}Building report...${NC}"
+
+    local json_block
+    json_block=$(_extract_json_plan "$response")
+    if [[ -z "$json_block" ]]; then
+        _show_pipeline "Report" "${RED}${ICON_ERROR}${NC} No structured plan found"
+        echo ""
+        echo "$response"
+        echo ""
+        echo -e "  ${GRAY}Tip: try a different model via Setup.${NC}"
+        return 1
+    fi
+
+    local report_md
+    report_md=$(echo "$response" | sed '/^```json$/,$d' | sed '/^```$/d')
+    report_md=$(_strip_reasoning "$report_md")
+    _cache_report "$report_md" "$json_block"
+
+    _show_pipeline "Report" "${GREEN}${ICON_SUCCESS}${NC} Report ready"
+    _pipeline_advance
+
+    sleep 0.5
+    clear
+
+    echo -e "${PURPLE_BOLD}${ICON_ARROW} System Report${NC}"
+    echo ""
+    _render_report "$report_md"
+    echo ""
+
+    if ! _load_plan "$json_block"; then
+        echo -e "  ${RED}${ICON_ERROR} Parse error${NC}"
+        return 1
+    fi
+
+    local count=${#_PLAN_TITLES[@]}
+    if [[ $count -eq 0 ]]; then
+        echo -e "  ${GREEN}${ICON_SUCCESS} System looks clean! No recommendations.${NC}"
+        return 0
+    fi
+
+    echo -e "  ${GRAY}Press any key to select actions...${NC}"
+    IFS= read -r -s -n1 -t 30 || true
+
+    _show_pipeline "Select" ""
+    sleep 0.3
+    clear
+
+    if ! _interactive_select; then
+        echo ""
+        echo -e "${GRAY}Cancelled.${NC}"
+        return 0
+    fi
+
+    if ! _show_confirmation; then
+        echo ""
+        echo -e "${GRAY}Cancelled.${NC}"
+        return 0
+    fi
+
+    _show_pipeline "Execute" ""
+    sleep 0.3
+    _execute_plan
+}
+
+main() {
+    local do_setup=false
+    local show_config=false
+    local no_stream=false
+    local dry_run=false
+    local show_help=false
+    local auto_safe=false
+    local run_analyze=false
+
+    for arg in "$@"; do
+        case "$arg" in
+            --setup) do_setup=true ;;
+            --show-config) show_config=true ;;
+            --no-stream) no_stream=true ;;
+            --dry-run | -n) dry_run=true ;;
+            --auto-safe) auto_safe=true ;;
+            --analyze) run_analyze=true ;;
+            --help | -h) show_help=true ;;
+            *)
+                echo "Unknown option: $arg"
+                echo "Run: mo advisor --help"
+                exit 1
+                ;;
+        esac
+    done
+
+    $show_help && _show_usage && exit 0
+    $show_config && ai_config_show && exit 0
+    $do_setup && ai_config_setup && exit 0
+
+    if $run_analyze; then
+        _run_analysis
+        exit $?
+    fi
+
+    if $auto_safe || $dry_run; then
+        if ! ai_config_is_configured; then
+            echo -e "${YELLOW}${ICON_WARNING} AI advisor is not configured.${NC}"
+            echo "Run: ${GREEN}mo advisor --setup${NC}"
+            exit 1
+        fi
+    fi
+
+    if $dry_run; then
+        echo -e "${PURPLE_BOLD}${ICON_ARROW} Mole AI Advisor — Dry Run${NC}"
+        echo ""
+        _step "Collecting system data..."
+        local data_tmp="/tmp/mole_advisor_data_$$.txt"
+        local collect_log="/tmp/mole_advisor_collect_log_$$.txt"
+        bash -c "source '$SCRIPT_DIR/lib/core/common.sh'; source '$SCRIPT_DIR/lib/ai/collector.sh'; collector_run_all" > "$data_tmp" 2>"$collect_log" || true
+        system_data=$(cat "$data_tmp")
+        local section_count
+        section_count=$(grep -c '^=== ' "$data_tmp" 2>/dev/null || echo "0")
+        _step_ok "System data collected" "(${#system_data} bytes, ${section_count} sections)"
+        rm -f "$data_tmp" "$collect_log"
+        echo ""
+        echo -e "${YELLOW}${ICON_DRY_RUN} DRY RUN — data that would be sent to AI:${NC}"
+        echo ""
+        echo "$system_data"
+        echo ""
+        echo -e "${GREEN}${ICON_SUCCESS} Dry run complete, no AI request made.${NC}"
+        exit 0
+    fi
+
+    if $auto_safe; then
+        _run_analysis
+        exit $?
+    fi
+
+    if [[ -t 0 && -t 1 ]]; then
+        clear
+        _show_advisor_submenu
+        clear
+        exit 0
+    fi
+
+    echo "Run: mo advisor --help"
+    exit 1
+}
+
+(set +e; main "$@")

--- a/docs/development-plan.xml
+++ b/docs/development-plan.xml
@@ -1,0 +1,360 @@
+<DevelopmentPlan VERSION="1.1.0">
+  <ArchitectureNotes>
+    <objective>Provide a safe, transparent AI-powered system advisor that collects real system data, sends it to a configurable LLM, and executes only user-confirmed deletions through mole's existing safe_remove pipeline.</objective>
+    <non-goal>The advisor does not replace existing mole commands. It augments them with LLM-driven analysis for users who want guided cleanup recommendations.</non-goal>
+    <risk-1>LLM hallucination — model may suggest non-existent paths or dangerous operations. All paths validated before deletion.</risk-1>
+    <risk-2>Collector accuracy — du on SIP-protected dirs returns 0 or hangs. Timeout guards and _fast_du_sk_bg mitigate this.</risk-2>
+  </ArchitectureNotes>
+
+  <Modules>
+
+    <!-- ==================== CORE LAYER (pre-existing, Layer 0) ==================== -->
+
+    <M-BASE NAME="Base" TYPE="UTILITY" LAYER="0" ORDER="1" STATUS="implemented">
+      <contract>
+        <purpose>Fundamental constants, colors, icons, platform detection, and utility functions shared by all modules</purpose>
+      </contract>
+      <target>
+        <source>lib/core/base.sh</source>
+      </target>
+      <notes>
+        <note-1>Pre-existing module. Not part of AI advisor scope but heavily depended upon.</note-1>
+      </notes>
+    </M-BASE>
+
+    <M-COMMON NAME="Common" TYPE="UTILITY" LAYER="0" ORDER="2" STATUS="implemented">
+      <contract>
+        <purpose>Source-chain loader that brings in all core modules. Provides shared initialization and update flow.</purpose>
+      </contract>
+      <target>
+        <source>lib/core/common.sh</source>
+      </target>
+      <notes>
+        <note-1>Contains set -euo pipefail which affects all sourced files. AI advisor must use set +e after sourcing.</note-1>
+      </notes>
+    </M-COMMON>
+
+    <M-FILE-OPS NAME="File Operations" TYPE="CORE_LOGIC" LAYER="0" ORDER="3" STATUS="implemented">
+      <contract>
+        <purpose>safe_remove, validate_path_for_deletion, path size measurement. The trusted deletion pipeline.</purpose>
+      </contract>
+      <target>
+        <source>lib/core/file_ops.sh</source>
+      </target>
+      <notes>
+        <note-1>Critical dependency for AI advisor execution. All deletions go through safe_remove.</note-1>
+      </notes>
+    </M-FILE-OPS>
+
+    <M-UI NAME="UI" TYPE="UTILITY" LAYER="0" ORDER="4" STATUS="implemented">
+      <contract>
+        <purpose>Terminal UI primitives: read_key, hide/show_cursor, spinner, cursor control</purpose>
+      </contract>
+      <target>
+        <source>lib/core/ui.sh</source>
+      </target>
+    </M-UI>
+
+    <M-APP-PROTECTION NAME="App Protection" TYPE="CORE_LOGIC" LAYER="0" ORDER="5" STATUS="implemented">
+      <contract>
+        <purpose>should_protect_path — determines if a path is protected from deletion based on bundle IDs, system components, and critical data patterns</purpose>
+      </contract>
+      <target>
+        <source>lib/core/app_protection.sh</source>
+      </target>
+      <notes>
+        <note-1>Called by validate_path_for_deletion. Protects system settings, Notes, Finder, Dock, Bluetooth, WiFi, iCloud.</note-1>
+      </notes>
+    </M-APP-PROTECTION>
+
+    <!-- ==================== AI ADVISOR LAYER (Layer 1) ==================== -->
+
+    <M-AI-CONFIG NAME="AI Config" TYPE="UTILITY" LAYER="1" ORDER="1" STATUS="implemented">
+      <contract>
+        <purpose>Manage AI advisor configuration: endpoint URL, model name, API key, temperature, max_tokens, timeout. Stored in ~/.config/mole/ai.conf</purpose>
+        <inputs>
+          <param name="key" type="string" />
+          <param name="value" type="string" />
+        </inputs>
+        <outputs>
+          <param name="config_value" type="string" />
+        </outputs>
+      </contract>
+      <interface>
+        <fn-ai_config_get PURPOSE="Read config value by key" />
+        <fn-ai_config_set PURPOSE="Write config value" />
+        <fn-ai_config_setup PURPOSE="Interactive setup wizard" />
+        <fn-ai_config_show PURPOSE="Display current config" />
+        <fn-ai_config_is_configured PURPOSE="Check if endpoint and model are set" />
+      </interface>
+      <depends>M-BASE</depends>
+      <target>
+        <source>lib/ai/config.sh</source>
+      </target>
+      <verification-ref>V-M-AI-CONFIG</verification-ref>
+    </M-AI-CONFIG>
+
+    <M-AI-CLIENT NAME="AI Client" TYPE="INTEGRATION" LAYER="1" ORDER="2" STATUS="implemented">
+      <contract>
+        <purpose>OpenAI-compatible HTTP client for chat completions API. Supports both standard and SSE streaming modes via curl + python3.</purpose>
+        <inputs>
+          <param name="system_prompt" type="string" />
+          <param name="user_message" type="string" />
+        </inputs>
+        <outputs>
+          <param name="response" type="string" />
+        </outputs>
+        <errors>
+          <error code="HTTP_401" description="Invalid API key" />
+          <error code="HTTP_404" description="Model not found at endpoint" />
+          <error code="timeout" description="Request exceeded configured timeout" />
+        </errors>
+      </contract>
+      <interface>
+        <fn-ai_client_chat PURPOSE="Standard (non-streaming) chat completion" />
+        <fn-ai_client_stream_chat PURPOSE="SSE streaming chat completion" />
+        <fn-ai_client_test PURPOSE="Test endpoint connectivity" />
+      </interface>
+      <depends>M-AI-CONFIG</depends>
+      <target>
+        <source>lib/ai/client.sh</source>
+      </target>
+      <verification-ref>V-M-AI-CLIENT</verification-ref>
+    </M-AI-CLIENT>
+
+    <M-AI-COLLECTOR NAME="System Collector" TYPE="INTEGRATION" LAYER="1" ORDER="3" STATUS="implemented">
+      <contract>
+        <purpose>Gather system state: disk usage (user+system dirs), memory, CPU, trash, cleanable items, build artifacts, installer files, network, battery. Auto-sources collector_ext.sh for Docker/Homebrew/Xcode data.</purpose>
+        <inputs>
+          <param name="none" type="none" />
+        </inputs>
+        <outputs>
+          <param name="data" type="string" description="Structured text with === SECTION === headers" />
+        </outputs>
+      </contract>
+      <interface>
+        <fn-collector_run_all PURPOSE="Run all collection sections to stdout, includes extended collectors" />
+        <fn-_fast_du_sk PURPOSE="Get directory size in KB via du -sk" />
+        <fn-_fast_du_sk_bg PURPOSE="Get directory size with background timeout guard" />
+        <fn-_collect_section PURPOSE="Output section header and call collector function" />
+      </interface>
+      <depends>M-BASE</depends>
+      <target>
+        <source>lib/ai/collector.sh</source>
+      </target>
+      <verification-ref>V-M-AI-COLLECTOR</verification-ref>
+      <notes>
+        <note-1>Must run in subprocess (bash -c) due to set -e inheritance from common.sh.</note-1>
+        <note-2>Auto-sources collector_ext.sh at end of collector_run_all.</note-2>
+      </notes>
+    </M-AI-COLLECTOR>
+
+    <M-AI-COLLECTOR-EXT NAME="Extended Collector" TYPE="INTEGRATION" LAYER="1" ORDER="3b" STATUS="implemented">
+      <contract>
+        <purpose>Extended system data collectors: Docker images/containers/volumes, Homebrew cache/outdated/cellar breakdown, Xcode simulators/archives/derived data.</purpose>
+        <inputs>
+          <param name="none" type="none" />
+        </inputs>
+        <outputs>
+          <param name="data" type="string" description="Structured text with === DOCKER/HOMEBREW/XCODE === headers" />
+        </outputs>
+      </contract>
+      <interface>
+        <fn-_collect_docker_info PURPOSE="Docker disk usage, images by size, containers, volumes by size" />
+        <fn-_collect_homebrew_info PURPOSE="Homebrew cache, cellar top packages, outdated packages" />
+        <fn-_collect_xcode_info PURPOSE="Xcode simulators, derived data, archives, device support" />
+        <fn-collector_ext_run_all PURPOSE="Run all extended sections" />
+      </interface>
+      <depends>M-AI-COLLECTOR</depends>
+      <target>
+        <source>lib/ai/collector_ext.sh</source>
+      </target>
+      <verification-ref>V-M-AI-COLLECTOR-EXT</verification-ref>
+    </M-AI-COLLECTOR-EXT>
+
+    <M-AI-PROMPT NAME="AI Prompt" TYPE="UTILITY" LAYER="1" ORDER="4" STATUS="implemented">
+      <contract>
+        <purpose>Define system prompt with risk taxonomy (SAFE/CAUTION/RISKY) and require structured response format: Disk Usage Summary table, Not Recommended section, Low Risk section, Medium/High Risk section, followed by JSON plan block.</purpose>
+        <inputs>
+          <param name="none" type="none" />
+        </inputs>
+        <outputs>
+          <param name="prompt" type="string" description="System prompt text" />
+        </outputs>
+      </contract>
+      <interface>
+        <fn-ai_system_prompt PURPOSE="Output the system prompt to stdout" />
+      </interface>
+      <depends>none</depends>
+      <target>
+        <source>lib/ai/prompt.sh</source>
+      </target>
+    </M-AI-PROMPT>
+
+    <M-AI-RENDERER NAME="AI Renderer" TYPE="CORE_LOGIC" LAYER="2" ORDER="0" STATUS="implemented">
+      <contract>
+        <purpose>Render AI advisor markdown report, parse JSON plan, interactive selection menu with risk filter (F key) and scrolling, confirmation prompt.</purpose>
+        <inputs>
+          <param name="md" type="string" description="Markdown report text" />
+          <param name="json" type="string" description="JSON plan object" />
+        </inputs>
+        <outputs>
+          <param name="arrays" type="parallel arrays" description="_PLAN_TITLES, _PLAN_REASONS, _PLAN_RISKS, _PLAN_PATHS, _PLAN_SIZES, _PLAN_CMDS, _PLAN_SELECTED, _PLAN_VISIBLE" />
+        </outputs>
+      </contract>
+      <interface>
+        <fn-_render_report PURPOSE="Parse LLM markdown and render formatted report sections" />
+        <fn-_extract_json_plan PURPOSE="Extract JSON block from LLM response" />
+        <fn-_parse_plan_items PURPOSE="Parse JSON plan into pipe-delimited lines" />
+        <fn-_load_plan PURPOSE="Load parsed plan into parallel arrays" />
+        <fn-_show_plan_menu PURPOSE="Render [x]/[ ] menu with scrolling and filter label" />
+        <fn-_interactive_select PURPOSE="Keyboard selection with F key risk filter, scrolling" />
+        <fn-_show_confirmation PURPOSE="Typed yes confirmation with paths listing" />
+        <fn-_risk_color PURPOSE="Color code for risk level" />
+        <fn-_risk_icon PURPOSE="Icon for risk level" />
+        <fn-_update_visible_indices PURPOSE="Recalculate visible items for current filter" />
+        <fn-_cycle_risk_filter PURPOSE="Cycle filter: empty -&gt; SAFE -&gt; CAUTION -&gt; RISKY -&gt; empty" />
+      </interface>
+      <depends>M-BASE, M-UI</depends>
+      <target>
+        <source>lib/ai/renderer.sh</source>
+      </target>
+      <verification-ref>V-M-AI-RENDERER</verification-ref>
+    </M-AI-RENDERER>
+
+    <M-AI-EXECUTOR NAME="AI Executor" TYPE="CORE_LOGIC" LAYER="2" ORDER="1" STATUS="implemented">
+      <contract>
+        <purpose>Execute confirmed plan items via safe_remove with glob expansion and per-item progress reporting.</purpose>
+        <inputs>
+          <param name="arrays" type="parallel arrays" description="Reads _PLAN_SELECTED, _PLAN_TITLES, _PLAN_RISKS, _PLAN_PATHS" />
+        </inputs>
+        <outputs>
+          <param name="summary" type="stdout" description="Execution progress and final summary" />
+        </outputs>
+      </contract>
+      <interface>
+        <fn-_expand_glob_paths PURPOSE="Expand glob patterns to filesystem paths" />
+        <fn-_execute_plan PURPOSE="Execute selected items via safe_remove with size tracking" />
+      </interface>
+      <depends>M-BASE, M-FILE-OPS, M-AI-RENDERER</depends>
+      <target>
+        <source>lib/ai/executor.sh</source>
+      </target>
+      <verification-ref>V-M-AI-EXECUTOR</verification-ref>
+    </M-AI-EXECUTOR>
+
+    <M-AI-ADVISOR NAME="AI Advisor CLI" TYPE="ENTRY_POINT" LAYER="2" ORDER="2" STATUS="implemented">
+      <contract>
+        <purpose>Main advisor command. Orchestrates: config check, data collection (subprocess), API call with retry, report rendering, interactive [x]/[ ] menu, confirmation, execution via safe_remove. Supports --auto-safe flag.</purpose>
+        <inputs>
+          <param name="--setup" type="flag" description="Run interactive config wizard" />
+          <param name="--show-config" type="flag" description="Display current AI configuration" />
+          <param name="--no-stream" type="flag" description="Use non-streaming API call" />
+          <param name="--dry-run" type="flag" description="Collect data only, no API call" />
+          <param name="--auto-safe" type="flag" description="Auto-select SAFE items, skip menu" />
+        </inputs>
+        <outputs>
+          <param name="exit_code" type="int" description="0 success, 1 error, 130 interrupt" />
+        </outputs>
+      </contract>
+      <interface>
+        <fn-main PURPOSE="Entry point: parse args, orchestrate flow" />
+        <fn-_call_ai_with_retry PURPOSE="Call AI with up to 2 retries on failure" />
+        <fn-_step PURPOSE="Show numbered progress step" />
+        <fn-_step_ok PURPOSE="Show completed step" />
+        <fn-_step_fail PURPOSE="Show failed step" />
+      </interface>
+      <depends>M-AI-CONFIG, M-AI-CLIENT, M-AI-COLLECTOR, M-AI-COLLECTOR-EXT, M-AI-PROMPT, M-AI-RENDERER, M-AI-EXECUTOR, M-FILE-OPS, M-UI, M-LOG</depends>
+      <target>
+        <source>bin/advisor.sh</source>
+      </target>
+      <verification-ref>V-M-AI-ADVISOR</verification-ref>
+      <notes>
+        <note-1>Default selection is all unchecked. User must actively select items with Space.</note-1>
+        <note-2>Confirmation requires typing "yes" — no accidental Enter confirmations.</note-2>
+        <note-3>Glob paths (ending in /*) expand to directory contents and delete items inside, not the directory itself.</note-3>
+        <note-4>--auto-safe auto-selects only SAFE items and skips interactive menu.</note-4>
+        <note-5>API calls retry up to 2 times on failure with 2-second delay.</note-5>
+      </notes>
+    </M-AI-ADVISOR>
+
+  </Modules>
+
+  <DataFlow>
+    <DF-ADVISE NAME="Full Advisor Flow" TRIGGER="mo advisor">
+      <step-1>User runs `mo advisor`</step-1>
+      <step-2>advisor.sh checks config (M-AI-CONFIG), prompts setup if missing</step-2>
+      <step-3>collector_run_all (M-AI-COLLECTOR) runs in subprocess, auto-sources M-AI-COLLECTOR-EXT for Docker/Homebrew/Xcode</step-3>
+      <step-4>_call_ai_with_retry sends prompt+data via M-AI-CLIENT (up to 2 retries)</step-4>
+      <step-5>Response captured. Markdown report extracted and rendered via M-AI-RENDERER _render_report</step-5>
+      <step-6>JSON plan block extracted via M-AI-RENDERER _extract_json_plan, parsed into arrays</step-6>
+      <step-7>M-AI-RENDERER _interactive_select shows menu with F key risk filter and scrolling</step-7>
+      <step-8>M-AI-RENDERER _show_confirmation lists selected paths, requires typed "yes"</step-8>
+      <step-9>M-AI-EXECUTOR _execute_plan iterates paths, expands globs, calls safe_remove (M-FILE-OPS)</step-9>
+      <step-10>Summary displayed: items removed, space recovered, items skipped</step-10>
+      <evidence>Step progress output, report rendering, menu interaction, execution log</evidence>
+    </DF-ADVISE>
+
+    <DF-CONFIG NAME="Config Setup Flow" TRIGGER="mo advisor --setup">
+      <step-1>User runs `mo advisor --setup`</step-1>
+      <step-2>ai_config_setup prompts for endpoint, model, API key, optional parameters</step-2>
+      <step-3>Values validated and written to ~/.config/mole/ai.conf</step-3>
+      <evidence>Config file created at ~/.config/mole/ai.conf</evidence>
+    </DF-CONFIG>
+
+    <DF-DRY-RUN NAME="Dry Run Flow" TRIGGER="mo advisor --dry-run">
+      <step-1>User runs `mo advisor --dry-run`</step-1>
+      <step-2>collector_run_all runs in subprocess</step-2>
+      <step-3>Collected data printed to terminal</step-3>
+      <step-4>No API call, no menu, no deletions</step-4>
+      <evidence>Terminal output shows all collector sections</evidence>
+    </DF-DRY-RUN>
+  </DataFlow>
+
+  <ImplementationOrder>
+    <Phase-1 name="AI Advisor Core" status="done">
+      <goal>Working AI advisor with data collection, LLM integration, interactive menu, and safe execution</goal>
+      <step-1 module="M-AI-CONFIG" status="done" verification="V-M-AI-CONFIG">Config management module</step-1>
+      <step-2 module="M-AI-CLIENT" status="done" verification="V-M-AI-CLIENT">HTTP client with streaming support</step-2>
+      <step-3 module="M-AI-COLLECTOR" status="done" verification="V-M-AI-COLLECTOR">System data collector</step-3>
+      <step-4 module="M-AI-PROMPT" status="done">System prompt with risk taxonomy</step-4>
+      <step-5 module="M-AI-ADVISOR" status="done" verification="V-M-AI-ADVISOR">Main CLI command with report, menu, execution</step-5>
+    </Phase-1>
+
+    <Phase-2 name="Modularization &amp; Extended Collection" status="done">
+      <goal>Extract renderer/executor into separate modules, add Docker/Homebrew/Xcode collectors, add UX features (risk filter, scrolling, --auto-safe, API retry)</goal>
+      <Phase-2A name="Module Extraction" status="done">
+        <step-1 module="M-AI-RENDERER" status="done" verification="V-M-AI-RENDERER">Extract _render_report, plan parsing, menu, confirmation into lib/ai/renderer.sh</step-1>
+        <step-2 module="M-AI-EXECUTOR" status="done" verification="V-M-AI-EXECUTOR">Extract _execute_plan, _expand_glob_paths into lib/ai/executor.sh</step-2>
+        <step-3 module="M-AI-ADVISOR" status="done">Update bin/advisor.sh to source new modules, remove inline functions</step-3>
+      </Phase-2A>
+      <Phase-2B name="Extended Collection" status="done">
+        <step-1 module="M-AI-COLLECTOR-EXT" status="done" verification="V-M-AI-COLLECTOR-EXT">Docker info collector (images, containers, volumes)</step-1>
+        <step-2 module="M-AI-COLLECTOR-EXT" status="done">Homebrew info collector (cache, cellar, outdated)</step-2>
+        <step-3 module="M-AI-COLLECTOR-EXT" status="done">Xcode info collector (simulators, derived data, archives)</step-3>
+        <step-4 module="M-AI-COLLECTOR" status="done">Auto-source collector_ext.sh in collector_run_all</step-4>
+      </Phase-2B>
+      <Phase-2C name="UX Polish" status="done">
+        <step-1 module="M-AI-ADVISOR" status="done">--auto-safe flag: auto-select SAFE items, skip menu</step-1>
+        <step-2 module="M-AI-ADVISOR" status="done">API retry: up to 2 retries with 2-second delay</step-2>
+        <step-3 module="M-AI-RENDERER" status="done">Risk filter: F key cycles SAFE/CAUTION/RISKY/all</step-3>
+        <step-4 module="M-AI-RENDERER" status="done">Scrolling: page-size 15, scroll offset for large lists</step-4>
+      </Phase-2C>
+    </Phase-2>
+
+    <Phase-3 name="Testing &amp; Distribution" status="done">
+      <goal>Comprehensive test coverage and integration with mole's distribution</goal>
+      <step-1 module="M-AI-COLLECTOR" status="done">bats tests for collector: mock du output, verify section format, timeout behavior</step-1>
+      <step-2 module="M-AI-RENDERER" status="done">bats tests for JSON extraction, plan parsing, risk filter with various LLM response formats</step-2>
+      <step-3 module="M-AI-EXECUTOR" status="done">bats tests for glob expansion, safe_remove integration</step-3>
+      <step-4 module="M-AI-COLLECTOR-EXT" status="done">bats tests for Docker/Homebrew/Xcode collectors with mocked commands</step-4>
+      <step-5 module="M-AI-ADVISOR" status="done">Integration test: full flow with mocked API response</step-5>
+    </Phase-3>
+  </ImplementationOrder>
+
+  <ExecutionPolicy>
+    <default-profile>balanced</default-profile>
+    <controller-owns>docs/development-plan.xml, docs/knowledge-graph.xml, docs/verification-plan.xml</controller-owns>
+    <worker-owns>Only module source files and module-local tests inside the approved write scope.</worker-owns>
+  </ExecutionPolicy>
+</DevelopmentPlan>

--- a/docs/development-plan.xml
+++ b/docs/development-plan.xml
@@ -1,10 +1,31 @@
-<DevelopmentPlan VERSION="1.1.0">
+<DevelopmentPlan VERSION="1.2.0">
   <ArchitectureNotes>
     <objective>Provide a safe, transparent AI-powered system advisor that collects real system data, sends it to a configurable LLM, and executes only user-confirmed deletions through mole's existing safe_remove pipeline.</objective>
     <non-goal>The advisor does not replace existing mole commands. It augments them with LLM-driven analysis for users who want guided cleanup recommendations.</non-goal>
     <risk-1>LLM hallucination — model may suggest non-existent paths or dangerous operations. All paths validated before deletion.</risk-1>
     <risk-2>Collector accuracy — du on SIP-protected dirs returns 0 or hangs. Timeout guards and _fast_du_sk_bg mitigate this.</risk-2>
+    <risk-3>Reasoning models (e.g. glm-5.1) output analysis in reasoning_content, not content. Client must parse both fields. max_tokens=16384 required to avoid truncation.</risk-3>
+    <risk-4>Permission denied during rm -rf on cache files (e.g. npm _cacache) — safe_remove returns generic rc=1, executor shows misleading "Skipped (protected)". Needs MOLE_ERR_PERMISSION_DENIED=13.</risk-4>
   </ArchitectureNotes>
+
+  <PR NUMBER="795" URL="https://github.com/tw93/Mole/pull/795" STATUS="open" DATE="2026-04-26">
+    <summary>AI-powered system advisor — 22 files, +4852 lines, 91 bats tests. Submitted to upstream tw93/mole.</summary>
+    <fork>xronocode/Mole</fork>
+    <branch>feat/ai-advisor</branch>
+  </PR>
+
+  <KnownIssues>
+    <issue-1 MODULE="M-AI-EXECUTOR" SEVERITY="medium" DATE="2026-04-26">
+      <title>executor shows "Skipped (protected)" for permission denied paths</title>
+      <description>_execute_plan in executor.sh shows "Skipped (protected)" when safe_remove returns non-zero for ANY reason. When rm -rf encounters permission denied on individual files (e.g. npm cache _cacache content-v2/index-v5), the path is not protected but deletion fails. The error message is misleading.</description>
+      <root-cause>safe_remove (file_ops.sh) returns rc=1 for both "protected path" and "rm -rf failed". No MOLE_ERR_PERMISSION_DENIED exit code exists. executor.sh _execute_plan treats all non-zero returns as "protected".</root-cause>
+      <fix-plan>
+        <step-1>Add MOLE_ERR_PERMISSION_DENIED=13 to lib/core/file_ops.sh error codes</step-1>
+        <step-2>Update safe_remove to return MOLE_ERR_PERMISSION_DENIED when rm -rf stderr contains "Permission denied"</step-2>
+        <step-3>Update executor.sh _execute_plan to check specific exit codes and show correct messages: "Skipped (protected)" vs "Skipped (permission denied)" vs "Skipped (error)"</step-3>
+      </fix-plan>
+    </issue-1>
+  </KnownIssues>
 
   <Modules>
 
@@ -96,7 +117,7 @@
 
     <M-AI-CLIENT NAME="AI Client" TYPE="INTEGRATION" LAYER="1" ORDER="2" STATUS="implemented">
       <contract>
-        <purpose>OpenAI-compatible HTTP client for chat completions API. Supports both standard and SSE streaming modes via curl + python3.</purpose>
+        <purpose>OpenAI-compatible HTTP client for chat completions API. Supports both standard and SSE streaming modes via curl + python3. Handles reasoning models that output analysis in reasoning_content instead of content.</purpose>
         <inputs>
           <param name="system_prompt" type="string" />
           <param name="user_message" type="string" />
@@ -107,19 +128,26 @@
         <errors>
           <error code="HTTP_401" description="Invalid API key" />
           <error code="HTTP_404" description="Model not found at endpoint" />
+          <error code="HTTP_400" description="JSON parse error — likely unescaped control chars in prompt data" />
           <error code="timeout" description="Request exceeded configured timeout" />
         </errors>
       </contract>
       <interface>
-        <fn-ai_client_chat PURPOSE="Standard (non-streaming) chat completion" />
-        <fn-ai_client_stream_chat PURPOSE="SSE streaming chat completion" />
+        <fn-ai_client_chat PURPOSE="Standard (non-streaming) chat completion. Falls back to reasoning_content if content empty." />
+        <fn-ai_client_stream_chat PURPOSE="SSE streaming chat completion. Outputs both reasoning_content and content chunks to stdout." />
         <fn-ai_client_test PURPOSE="Test endpoint connectivity" />
+        <fn-_build_messages_json PURPOSE="Build JSON messages array" />
+        <fn-_json_escape_string PURPOSE="Escape string for JSON via python3 json.dumps() — handles all control characters" />
       </interface>
       <depends>M-AI-CONFIG</depends>
       <target>
         <source>lib/ai/client.sh</source>
       </target>
       <verification-ref>V-M-AI-CLIENT</verification-ref>
+      <notes>
+        <note-1>_json_escape_string uses python3 json.dumps() with bash-native fallback for \uXXXX. Required because collector data contains ANSI escape sequences and control chars.</note-1>
+        <note-2>max_tokens defaults to 16384 (not 4096) to accommodate reasoning models that spend tokens on analysis before generating content.</note-2>
+      </notes>
     </M-AI-CLIENT>
 
     <M-AI-COLLECTOR NAME="System Collector" TYPE="INTEGRATION" LAYER="1" ORDER="3" STATUS="implemented">
@@ -245,13 +273,14 @@
 
     <M-AI-ADVISOR NAME="AI Advisor CLI" TYPE="ENTRY_POINT" LAYER="2" ORDER="2" STATUS="implemented">
       <contract>
-        <purpose>Main advisor command. Orchestrates: config check, data collection (subprocess), API call with retry, report rendering, interactive [x]/[ ] menu, confirmation, execution via safe_remove. Supports --auto-safe flag.</purpose>
+        <purpose>Main advisor command. Orchestrates: config check, data collection (subprocess), API call with retry, report rendering, interactive [x]/[ ] menu, confirmation, execution via safe_remove. Supports --auto-safe, --analyze, --dry-run, --no-stream flags. Visual pipeline UI: Collect → Analyze → Report → Select → Execute.</purpose>
         <inputs>
           <param name="--setup" type="flag" description="Run interactive config wizard" />
           <param name="--show-config" type="flag" description="Display current AI configuration" />
           <param name="--no-stream" type="flag" description="Use non-streaming API call" />
           <param name="--dry-run" type="flag" description="Collect data only, no API call" />
           <param name="--auto-safe" type="flag" description="Auto-select SAFE items, skip menu" />
+          <param name="--analyze" type="flag" description="Collect and analyze without execution prompt" />
         </inputs>
         <outputs>
           <param name="exit_code" type="int" description="0 success, 1 error, 130 interrupt" />
@@ -260,6 +289,12 @@
       <interface>
         <fn-main PURPOSE="Entry point: parse args, orchestrate flow" />
         <fn-_call_ai_with_retry PURPOSE="Call AI with up to 2 retries on failure" />
+        <fn-_show_pipeline PURPOSE="Render pipeline progress bar to stderr" />
+        <fn-_pipeline_detail PURPOSE="Update detail line below pipeline bar" />
+        <fn-_pipeline_advance PURPOSE="Advance pipeline to next stage" />
+        <fn-_collect_with_progress PURPOSE="Run collector with spinner showing section progress" />
+        <fn-_stream_ai_with_progress PURPOSE="Background streaming via bash -c with temp files" />
+        <fn-_strip_reasoning PURPOSE="Filter reasoning text, keep markdown content" />
         <fn-_step PURPOSE="Show numbered progress step" />
         <fn-_step_ok PURPOSE="Show completed step" />
         <fn-_step_fail PURPOSE="Show failed step" />
@@ -275,6 +310,9 @@
         <note-3>Glob paths (ending in /*) expand to directory contents and delete items inside, not the directory itself.</note-3>
         <note-4>--auto-safe auto-selects only SAFE items and skips interactive menu.</note-4>
         <note-5>API calls retry up to 2 times on failure with 2-second delay.</note-5>
+        <note-6>Pipeline UI writes to stderr. Collector data goes to stdout (captured by $()). Spinner shows N/12 section progress.</note-6>
+        <note-7>_stream_ai_with_progress uses bash -c with temp files for prompt data — subshell cannot inherit sourced functions.</note-7>
+        <note-8>_strip_reasoning filters reasoning model output to extract clean markdown response.</note-8>
       </notes>
     </M-AI-ADVISOR>
 
@@ -284,15 +322,16 @@
     <DF-ADVISE NAME="Full Advisor Flow" TRIGGER="mo advisor">
       <step-1>User runs `mo advisor`</step-1>
       <step-2>advisor.sh checks config (M-AI-CONFIG), prompts setup if missing</step-2>
-      <step-3>collector_run_all (M-AI-COLLECTOR) runs in subprocess, auto-sources M-AI-COLLECTOR-EXT for Docker/Homebrew/Xcode</step-3>
-      <step-4>_call_ai_with_retry sends prompt+data via M-AI-CLIENT (up to 2 retries)</step-4>
-      <step-5>Response captured. Markdown report extracted and rendered via M-AI-RENDERER _render_report</step-5>
-      <step-6>JSON plan block extracted via M-AI-RENDERER _extract_json_plan, parsed into arrays</step-6>
-      <step-7>M-AI-RENDERER _interactive_select shows menu with F key risk filter and scrolling</step-7>
-      <step-8>M-AI-RENDERER _show_confirmation lists selected paths, requires typed "yes"</step-8>
-      <step-9>M-AI-EXECUTOR _execute_plan iterates paths, expands globs, calls safe_remove (M-FILE-OPS)</step-9>
-      <step-10>Summary displayed: items removed, space recovered, items skipped</step-10>
-      <evidence>Step progress output, report rendering, menu interaction, execution log</evidence>
+      <step-3>Pipeline UI renders to stderr: Collect → Analyze → Report → Select → Execute</step-3>
+      <step-4>_collect_with_progress runs collector_run_all (M-AI-COLLECTOR) in subprocess with spinner showing N/12 sections. Auto-sources M-AI-COLLECTOR-EXT for Docker/Homebrew/Xcode</step-4>
+      <step-5>_stream_ai_with_progress sends prompt+data via M-AI-CLIENT in background bash -c with temp files. Both reasoning_content and content captured.</step-5>
+      <step-6>Response captured. _strip_reasoning filters reasoning text. Markdown report rendered via M-AI-RENDERER _render_report</step-6>
+      <step-7>JSON plan block extracted via M-AI-RENDERER _extract_json_plan, parsed into arrays</step-7>
+      <step-8>M-AI-RENDERER _interactive_select shows menu with F key risk filter and scrolling</step-8>
+      <step-9>M-AI-RENDERER _show_confirmation lists selected paths, requires typed "yes"</step-9>
+      <step-10>M-AI-EXECUTOR _execute_plan iterates paths, expands globs, calls safe_remove (M-FILE-OPS)</step-10>
+      <step-11>Summary displayed: items removed, space recovered, items skipped (with reason)</step-11>
+      <evidence>Pipeline bar on stderr, step progress, report rendering, menu interaction, execution log</evidence>
     </DF-ADVISE>
 
     <DF-CONFIG NAME="Config Setup Flow" TRIGGER="mo advisor --setup">

--- a/docs/knowledge-graph.xml
+++ b/docs/knowledge-graph.xml
@@ -1,0 +1,212 @@
+<KnowledgeGraph>
+  <Project NAME="Mole" VERSION="1.0.0">
+    <keywords>macOS, system-maintenance, disk-cleanup, optimization, bash, cli, ai-advisor, llm-integration, openai-compatible, interactive-menu, safe-deletion</keywords>
+    <annotation>macOS system maintenance CLI with AI-powered advisor. Disk cleanup, optimization, health checks, uninstall management, and LLM-driven interactive system analysis with risk-tagged cleanup recommendations.</annotation>
+
+    <!-- ==================== CORE LAYER ==================== -->
+
+    <M-BASE NAME="Base" TYPE="UTILITY" STATUS="implemented">
+      <purpose>Fundamental constants, colors, icons, platform detection, byte conversion utilities</purpose>
+      <path>lib/core/base.sh</path>
+      <depends>none</depends>
+      <annotations>
+        <fn-bytes_to_human PURPOSE="Convert bytes to human-readable format" />
+        <fn-bytes_to_human_kb PURPOSE="Convert KB to human-readable format" />
+        <fn-detect_architecture PURPOSE="Detect Apple Silicon vs Intel" />
+        <fn-get_epoch_seconds PURPOSE="Get current epoch timestamp" />
+      </annotations>
+    </M-BASE>
+
+    <M-COMMON NAME="Common" TYPE="UTILITY" STATUS="implemented">
+      <purpose>Source-chain loader bringing in all core modules. Provides update flow and shared initialization.</purpose>
+      <path>lib/core/common.sh</path>
+      <depends>M-BASE, M-FILE-OPS, M-UI, M-APP-PROTECTION, M-LOG</depends>
+      <notes>
+        <note-1>Contains set -euo pipefail that affects all downstream sources.</note-1>
+      </notes>
+    </M-COMMON>
+
+    <M-FILE-OPS NAME="File Operations" TYPE="CORE_LOGIC" STATUS="implemented">
+      <purpose>safe_remove, validate_path_for_deletion, path size measurement. Trusted deletion pipeline.</purpose>
+      <path>lib/core/file_ops.sh</path>
+      <depends>M-BASE, M-APP-PROTECTION</depends>
+      <annotations>
+        <fn-safe_remove PURPOSE="Validate and delete a path with rm -rf" />
+        <fn-validate_path_for_deletion PURPOSE="Check path against protected patterns, SIP, traversal attempts" />
+        <fn-get_path_size_kb PURPOSE="Get path size in KB" />
+      </annotations>
+    </M-FILE-OPS>
+
+    <M-UI NAME="UI" TYPE="UTILITY" STATUS="implemented">
+      <purpose>Terminal UI primitives: read_key, hide/show cursor, spinner, drain_pending_input</purpose>
+      <path>lib/core/ui.sh</path>
+      <depends>M-BASE</depends>
+      <annotations>
+        <fn-read_key PURPOSE="Read single keypress, return UP/DOWN/ENTER/SPACE/QUIT/CHAR:x" />
+        <fn-hide_cursor PURPOSE="Hide terminal cursor" />
+        <fn-show_cursor PURPOSE="Show terminal cursor" />
+      </annotations>
+    </M-UI>
+
+    <M-APP-PROTECTION NAME="App Protection" TYPE="CORE_LOGIC" STATUS="implemented">
+      <purpose>should_protect_path — validates paths against system-critical and user-critical patterns</purpose>
+      <path>lib/core/app_protection.sh</path>
+      <depends>M-BASE</depends>
+      <annotations>
+        <fn-should_protect_path PURPOSE="Return 0 if path is protected from deletion" />
+      </annotations>
+    </M-APP-PROTECTION>
+
+    <M-LOG NAME="Log" TYPE="UTILITY" STATUS="implemented">
+      <purpose>Logging infrastructure with levels, debug log file support</purpose>
+      <path>lib/core/log.sh</path>
+      <depends>M-BASE</depends>
+    </M-LOG>
+
+    <!-- ==================== AI ADVISOR ==================== -->
+
+    <M-AI-CONFIG NAME="AI Config" TYPE="UTILITY" STATUS="implemented">
+      <purpose>Manage AI endpoint configuration stored in ~/.config/mole/ai.conf</purpose>
+      <path>lib/ai/config.sh</path>
+      <depends>M-BASE</depends>
+      <verification-ref>V-M-AI-CONFIG</verification-ref>
+      <annotations>
+        <fn-ai_config_get PURPOSE="Read config value by key" />
+        <fn-ai_config_set PURPOSE="Write config value" />
+        <fn-ai_config_setup PURPOSE="Interactive setup wizard" />
+        <fn-ai_config_show PURPOSE="Display current config (masks API key)" />
+        <fn-ai_config_is_configured PURPOSE="Check if endpoint and model are set" />
+        <fn-ai_config_get_endpoint PURPOSE="Get API endpoint URL" />
+        <fn-ai_config_get_model PURPOSE="Get model name" />
+        <fn-ai_config_get_api_key PURPOSE="Get API key" />
+        <fn-ai_config_get_max_tokens PURPOSE="Get max_tokens parameter" />
+        <fn-ai_config_get_temperature PURPOSE="Get temperature parameter" />
+        <fn-ai_config_get_timeout PURPOSE="Get request timeout in seconds" />
+      </annotations>
+    </M-AI-CONFIG>
+
+    <M-AI-CLIENT NAME="AI Client" TYPE="INTEGRATION" STATUS="implemented">
+      <purpose>OpenAI-compatible HTTP client with standard and SSE streaming modes</purpose>
+      <path>lib/ai/client.sh</path>
+      <depends>M-AI-CONFIG</depends>
+      <verification-ref>V-M-AI-CLIENT</verification-ref>
+      <annotations>
+        <fn-ai_client_chat PURPOSE="Standard chat completion request" />
+        <fn-ai_client_stream_chat PURPOSE="SSE streaming chat completion" />
+        <fn-ai_client_test PURPOSE="Test endpoint connectivity" />
+        <fn-_build_messages_json PURPOSE="Build JSON messages array from system + user prompts" />
+        <fn-_json_escape_string PURPOSE="Escape string for JSON embedding" />
+      </annotations>
+    </M-AI-CLIENT>
+
+    <M-AI-COLLECTOR NAME="System Collector" TYPE="INTEGRATION" STATUS="implemented">
+      <purpose>Gather system state: disk usage (user+system dirs), memory, CPU, trash, cleanable items, build artifacts, installer files, Docker/Homebrew/cache sizes, network, battery</purpose>
+      <path>lib/ai/collector.sh</path>
+      <depends>M-BASE</depends>
+      <verification-ref>V-M-AI-COLLECTOR</verification-ref>
+      <annotations>
+        <fn-collector_run_all PURPOSE="Run all collection sections to stdout" />
+        <fn-_fast_du_sk PURPOSE="Get directory size in KB via du -sk" />
+        <fn-_fast_du_sk_bg PURPOSE="Get directory size with background timeout guard" />
+        <fn-_collect_section PURPOSE="Output section header and call collector function" />
+        <fn-_collect_disk_usage PURPOSE="Scan user dirs, system dirs, large containers" />
+        <fn-_collect_memory_info PURPOSE="Memory stats from sysctl + vm_stat" />
+        <fn-_collect_cpu_info PURPOSE="CPU info and top processes" />
+        <fn-_collect_uptime_info PURPOSE="Uptime and macOS version" />
+        <fn-_collect_cleanable_items PURPOSE="Cache dirs, system-level cleanable, build artifacts" />
+        <fn-_collect_trash PURPOSE="Trash size and item count" />
+        <fn-_collect_installer_files PURPOSE="DMG/PKG/ZIP files in Downloads" />
+        <fn-_collect_network_info PURPOSE="Active connections and DNS" />
+        <fn-_collect_battery_info PURPOSE="Battery level and status" />
+      </annotations>
+    </M-AI-COLLECTOR>
+
+    <M-AI-PROMPT NAME="AI Prompt" TYPE="UTILITY" STATUS="implemented">
+      <purpose>System prompt with risk taxonomy and required response format (markdown report + JSON plan)</purpose>
+      <path>lib/ai/prompt.sh</path>
+      <depends>none</depends>
+      <annotations>
+        <fn-ai_system_prompt PURPOSE="Output system prompt text to stdout" />
+      </annotations>
+    </M-AI-PROMPT>
+
+    <M-AI-ADVISOR NAME="AI Advisor CLI" TYPE="ENTRY_POINT" STATUS="implemented">
+      <purpose>Main advisor command: collection, API call with retry, report rendering, interactive menu, confirmation, execution. Supports --auto-safe flag.</purpose>
+      <path>bin/advisor.sh</path>
+      <depends>M-AI-CONFIG, M-AI-CLIENT, M-AI-COLLECTOR, M-AI-COLLECTOR-EXT, M-AI-PROMPT, M-AI-RENDERER, M-AI-EXECUTOR, M-FILE-OPS, M-UI, M-LOG</depends>
+      <verification-ref>V-M-AI-ADVISOR</verification-ref>
+      <annotations>
+        <fn-main PURPOSE="Entry point: parse args, collect data, call AI, render report, interactive select, confirm, execute" />
+        <fn-_call_ai_with_retry PURPOSE="Call AI with up to 2 retries on failure" />
+        <fn-_step PURPOSE="Show numbered progress step" />
+        <fn-_step_ok PURPOSE="Show completed step with green checkmark" />
+        <fn-_step_fail PURPOSE="Show failed step with red icon" />
+        <fn-_show_usage PURPOSE="Display help text" />
+      </annotations>
+    </M-AI-ADVISOR>
+
+    <M-AI-RENDERER NAME="AI Renderer" TYPE="CORE_LOGIC" STATUS="implemented">
+      <purpose>Render AI advisor markdown report, parse JSON plan, interactive selection menu with risk filter and scrolling, confirmation prompt</purpose>
+      <path>lib/ai/renderer.sh</path>
+      <depends>M-BASE, M-UI</depends>
+      <verification-ref>V-M-AI-RENDERER</verification-ref>
+      <annotations>
+        <fn-_render_report PURPOSE="Parse LLM markdown and render formatted report sections" />
+        <fn-_extract_json_plan PURPOSE="Extract JSON block from LLM response (sed + python3 fallback)" />
+        <fn-_parse_plan_items PURPOSE="Parse JSON plan into pipe-delimited lines via python3" />
+        <fn-_load_plan PURPOSE="Load parsed plan into parallel arrays (_PLAN_TITLES, etc.)" />
+        <fn-_show_plan_menu PURPOSE="Render [x]/[ ] menu with risk colors, scrolling, filter label" />
+        <fn-_interactive_select PURPOSE="Keyboard-driven selection loop with F key risk filter" />
+        <fn-_show_confirmation PURPOSE="Typed yes confirmation with path listing" />
+        <fn-_risk_color PURPOSE="Return color code for risk level" />
+        <fn-_risk_icon PURPOSE="Return icon for risk level" />
+        <fn-_update_visible_indices PURPOSE="Recalculate visible items based on risk filter" />
+        <fn-_cycle_risk_filter PURPOSE="Cycle risk filter: empty -&gt; SAFE -&gt; CAUTION -&gt; RISKY -&gt; empty" />
+      </annotations>
+    </M-AI-RENDERER>
+
+    <M-AI-EXECUTOR NAME="AI Executor" TYPE="CORE_LOGIC" STATUS="implemented">
+      <purpose>Execute confirmed plan items via safe_remove with glob expansion and progress reporting</purpose>
+      <path>lib/ai/executor.sh</path>
+      <depends>M-BASE, M-FILE-OPS, M-AI-RENDERER</depends>
+      <verification-ref>V-M-AI-EXECUTOR</verification-ref>
+      <annotations>
+        <fn-_expand_glob_paths PURPOSE="Expand glob patterns to actual filesystem paths" />
+        <fn-_execute_plan PURPOSE="Execute selected items via safe_remove with size tracking" />
+      </annotations>
+    </M-AI-EXECUTOR>
+
+    <M-AI-COLLECTOR-EXT NAME="Extended Collector" TYPE="INTEGRATION" STATUS="implemented">
+      <purpose>Extended system data collectors: Docker images/containers/volumes, Homebrew cache/outdated/cellar, Xcode simulators/archives/derived data</purpose>
+      <path>lib/ai/collector_ext.sh</path>
+      <depends>M-AI-COLLECTOR</depends>
+      <verification-ref>V-M-AI-COLLECTOR-EXT</verification-ref>
+      <annotations>
+        <fn-_collect_docker_info PURPOSE="Docker disk usage, images, containers, volumes" />
+        <fn-_collect_homebrew_info PURPOSE="Homebrew cache, cellar breakdown, outdated packages" />
+        <fn-_collect_xcode_info PURPOSE="Xcode simulators, derived data, archives, device support" />
+        <fn-collector_ext_run_all PURPOSE="Run all extended collection sections" />
+      </annotations>
+    </M-AI-COLLECTOR-EXT>
+
+    <!-- ==================== CROSS-LINKS ==================== -->
+
+    <CrossLink from="M-AI-ADVISOR" to="M-AI-CONFIG" relation="reads endpoint, model, api_key" />
+    <CrossLink from="M-AI-ADVISOR" to="M-AI-CLIENT" relation="sends prompt + data, receives response" />
+    <CrossLink from="M-AI-ADVISOR" to="M-AI-COLLECTOR" relation="runs collector in subprocess" />
+    <CrossLink from="M-AI-ADVISOR" to="M-AI-COLLECTOR-EXT" relation="via collector_run_all auto-source" />
+    <CrossLink from="M-AI-ADVISOR" to="M-AI-PROMPT" relation="loads system prompt" />
+    <CrossLink from="M-AI-ADVISOR" to="M-AI-RENDERER" relation="sources for report, plan parsing, menu, confirmation" />
+    <CrossLink from="M-AI-ADVISOR" to="M-AI-EXECUTOR" relation="sources for plan execution" />
+    <CrossLink from="M-AI-ADVISOR" to="M-FILE-OPS" relation="indirect via M-AI-EXECUTOR safe_remove" />
+    <CrossLink from="M-AI-ADVISOR" to="M-UI" relation="uses read_key, cursor control" />
+    <CrossLink from="M-AI-ADVISOR" to="M-COMMON" relation="sources common.sh for module chain" />
+    <CrossLink from="M-AI-EXECUTOR" to="M-AI-RENDERER" relation="reads _PLAN_* arrays and _risk_color" />
+    <CrossLink from="M-AI-EXECUTOR" to="M-FILE-OPS" relation="calls safe_remove, get_path_size_kb, bytes_to_human" />
+    <CrossLink from="M-AI-CLIENT" to="M-AI-CONFIG" relation="reads endpoint, model, api_key, params" />
+    <CrossLink from="M-AI-COLLECTOR" to="M-BASE" relation="uses bytes_to_human_kb, detect_architecture" />
+    <CrossLink from="M-AI-COLLECTOR-EXT" to="M-AI-COLLECTOR" relation="uses _fast_du_sk, _fast_du_sk_bg, _collect_section" />
+    <CrossLink from="M-FILE-OPS" to="M-APP-PROTECTION" relation="calls should_protect_path" />
+
+  </Project>
+</KnowledgeGraph>

--- a/docs/knowledge-graph.xml
+++ b/docs/knowledge-graph.xml
@@ -35,6 +35,9 @@
         <fn-validate_path_for_deletion PURPOSE="Check path against protected patterns, SIP, traversal attempts" />
         <fn-get_path_size_kb PURPOSE="Get path size in KB" />
       </annotations>
+      <known-issues>
+        <issue-1>safe_remove returns generic rc=1 for both "protected" and "permission denied". Needs MOLE_ERR_PERMISSION_DENIED=13 exit code. See VF-004.</issue-1>
+      </known-issues>
     </M-FILE-OPS>
 
     <M-UI NAME="UI" TYPE="UTILITY" STATUS="implemented">
@@ -86,16 +89,16 @@
     </M-AI-CONFIG>
 
     <M-AI-CLIENT NAME="AI Client" TYPE="INTEGRATION" STATUS="implemented">
-      <purpose>OpenAI-compatible HTTP client with standard and SSE streaming modes</purpose>
+      <purpose>OpenAI-compatible HTTP client with standard and SSE streaming modes. Handles reasoning models via reasoning_content fallback. _json_escape_string uses python3 json.dumps() for full control char escaping.</purpose>
       <path>lib/ai/client.sh</path>
       <depends>M-AI-CONFIG</depends>
       <verification-ref>V-M-AI-CLIENT</verification-ref>
       <annotations>
-        <fn-ai_client_chat PURPOSE="Standard chat completion request" />
-        <fn-ai_client_stream_chat PURPOSE="SSE streaming chat completion" />
+        <fn-ai_client_chat PURPOSE="Standard chat completion. Falls back to reasoning_content if content empty." />
+        <fn-ai_client_stream_chat PURPOSE="SSE streaming chat completion. Outputs both reasoning_content and content to stdout." />
         <fn-ai_client_test PURPOSE="Test endpoint connectivity" />
         <fn-_build_messages_json PURPOSE="Build JSON messages array from system + user prompts" />
-        <fn-_json_escape_string PURPOSE="Escape string for JSON embedding" />
+        <fn-_json_escape_string PURPOSE="Escape string for JSON via python3 json.dumps() — handles all control chars" />
       </annotations>
     </M-AI-CLIENT>
 
@@ -131,13 +134,19 @@
     </M-AI-PROMPT>
 
     <M-AI-ADVISOR NAME="AI Advisor CLI" TYPE="ENTRY_POINT" STATUS="implemented">
-      <purpose>Main advisor command: collection, API call with retry, report rendering, interactive menu, confirmation, execution. Supports --auto-safe flag.</purpose>
+      <purpose>Main advisor command: pipeline UI (Collect→Analyze→Report→Select→Execute), streaming with progress, report rendering, interactive menu, confirmation, execution. Supports --auto-safe, --analyze, --dry-run, --no-stream.</purpose>
       <path>bin/advisor.sh</path>
       <depends>M-AI-CONFIG, M-AI-CLIENT, M-AI-COLLECTOR, M-AI-COLLECTOR-EXT, M-AI-PROMPT, M-AI-RENDERER, M-AI-EXECUTOR, M-FILE-OPS, M-UI, M-LOG</depends>
       <verification-ref>V-M-AI-ADVISOR</verification-ref>
       <annotations>
         <fn-main PURPOSE="Entry point: parse args, collect data, call AI, render report, interactive select, confirm, execute" />
         <fn-_call_ai_with_retry PURPOSE="Call AI with up to 2 retries on failure" />
+        <fn-_show_pipeline PURPOSE="Render pipeline progress bar to stderr" />
+        <fn-_pipeline_detail PURPOSE="Update detail line below pipeline bar" />
+        <fn-_pipeline_advance PURPOSE="Advance pipeline to next stage" />
+        <fn-_collect_with_progress PURPOSE="Run collector with spinner showing section progress N/12" />
+        <fn-_stream_ai_with_progress PURPOSE="Background streaming via bash -c with temp files" />
+        <fn-_strip_reasoning PURPOSE="Filter reasoning text, keep markdown content" />
         <fn-_step PURPOSE="Show numbered progress step" />
         <fn-_step_ok PURPOSE="Show completed step with green checkmark" />
         <fn-_step_fail PURPOSE="Show failed step with red icon" />
@@ -174,6 +183,9 @@
         <fn-_expand_glob_paths PURPOSE="Expand glob patterns to actual filesystem paths" />
         <fn-_execute_plan PURPOSE="Execute selected items via safe_remove with size tracking" />
       </annotations>
+      <known-issues>
+        <issue-1>Shows "Skipped (protected)" for permission denied paths. Needs MOLE_ERR_PERMISSION_DENIED=13. See VF-004.</issue-1>
+      </known-issues>
     </M-AI-EXECUTOR>
 
     <M-AI-COLLECTOR-EXT NAME="Extended Collector" TYPE="INTEGRATION" STATUS="implemented">
@@ -190,6 +202,8 @@
     </M-AI-COLLECTOR-EXT>
 
     <!-- ==================== CROSS-LINKS ==================== -->
+
+    <PR-795 URL="https://github.com/tw93/Mole/pull/795" STATUS="open" DATE="2026-04-26" />
 
     <CrossLink from="M-AI-ADVISOR" to="M-AI-CONFIG" relation="reads endpoint, model, api_key" />
     <CrossLink from="M-AI-ADVISOR" to="M-AI-CLIENT" relation="sends prompt + data, receives response" />

--- a/docs/requirements.xml
+++ b/docs/requirements.xml
@@ -18,14 +18,14 @@
       <Goal>Understand what is consuming disk space and receive actionable cleanup recommendations</Goal>
       <Preconditions>AI endpoint configured via `mo advisor --setup`. Terminal with interactive TTY.</Preconditions>
       <AcceptanceCriteria>
-        1. System data is collected (disk, memory, CPU, caches, containers, build artifacts, Docker, Homebrew)
+        1. System data is collected (disk, memory, CPU, caches, containers, build artifacts, Docker, Homebrew, Xcode)
         2. Data is sent to configured LLM endpoint
         3. LLM returns structured report: disk usage summary, items not recommended for deletion, low-risk items, medium/high-risk items
         4. Report is rendered as formatted terminal output
         5. User sees interactive [x]/[ ] selection menu with all recommended actions
         6. User confirms with typed "yes"
         7. Selected items are deleted via safe_remove pipeline
-        8. Execution summary shows items removed, space recovered, items skipped
+        8. Execution summary shows items removed, space recovered, items skipped (with reason: protected / permission denied / error)
       </AcceptanceCriteria>
       <Priority>high</Priority>
       <RelatedFlows>DF-ADVISE</RelatedFlows>
@@ -82,11 +82,13 @@
     <risk-3>set -e in sourced files (common.sh chain) can kill the advisor subprocess. Must be handled with set +e and subprocess isolation.</risk-3>
     <risk-4>LLM response format may vary between models. JSON extraction must be robust with fallbacks.</risk-4>
     <risk-5>SIP-protected directories (Library/Caches root, Application Support) return partial or zero sizes from du.</risk-5>
+    <risk-6>Reasoning models (e.g. glm-5.1) output analysis in reasoning_content delta field, not content. Client must parse both. max_tokens=16384 needed to avoid truncation before content generation.</risk-6>
+    <risk-7>Permission denied during rm -rf on cache files (npm _cacache) causes misleading "Skipped (protected)" message in executor. safe_remove needs specific exit code for permission denied.</risk-7>
   </Risks>
 
   <OpenQuestions>
-    <question-1>Should the advisor support multiple LLM profiles (e.g. fast-local model vs powerful-cloud model)?</question-1>
-    <question-2>Should the advisor remember previous recommendations and skip already-reviewed items?</question-2>
-    <question-3>Should there be a non-interactive mode (e.g. `mo advisor --auto-safe`) that auto-applies only SAFE items?</question-3>
+    <question-1 RESOLUTION="deferred">Should the advisor support multiple LLM profiles (e.g. fast-local model vs powerful-cloud model)? — Not in v1. Single config via ai.conf is sufficient. Can revisit if users request it.</question-1>
+    <question-2 RESOLUTION="implemented">Should the advisor remember previous recommendations and skip already-reviewed items? — Implemented via report cache: ~/.config/mole/advisor/last_report.md, last_plan.json, last_timestamp. Users can re-run and compare.</question-2>
+    <question-3 RESOLUTION="implemented">Should there be a non-interactive mode (e.g. `mo advisor --auto-safe`) that auto-applies only SAFE items? — Implemented: --auto-safe flag auto-selects SAFE items and skips menu. Also --analyze for report-only.</question-3>
   </OpenQuestions>
 </RequirementsAnalysis>

--- a/docs/requirements.xml
+++ b/docs/requirements.xml
@@ -1,0 +1,92 @@
+<RequirementsAnalysis VERSION="1.0.0">
+  <Project>
+    <name>Mole</name>
+    <annotation>macOS system maintenance CLI with AI-powered advisor. Disk cleanup, optimization, health checks, uninstall management, and LLM-driven interactive system analysis with risk-tagged cleanup recommendations.</annotation>
+    <keywords>macOS, system-maintenance, disk-cleanup, optimization, bash, cli, ai-advisor, llm-integration, openai-compatible, interactive-menu, safe-deletion</keywords>
+  </Project>
+
+  <Actors>
+    <actor-User>macOS user running mole commands from Terminal. Interactive selection of AI recommendations.</actor-User>
+    <actor-LLM>External OpenAI-compatible LLM endpoint. Receives system data, returns structured analysis and cleanup plan.</actor-LLM>
+    <actor-System>macOS filesystem, system APIs (sysctl, vm_stat, df, du). Read-only data source for collector.</actor-System>
+  </Actors>
+
+  <UseCases>
+    <UC-001>
+      <Actor>User</Actor>
+      <Action>Run `mo advisor` to get AI-powered system analysis</Action>
+      <Goal>Understand what is consuming disk space and receive actionable cleanup recommendations</Goal>
+      <Preconditions>AI endpoint configured via `mo advisor --setup`. Terminal with interactive TTY.</Preconditions>
+      <AcceptanceCriteria>
+        1. System data is collected (disk, memory, CPU, caches, containers, build artifacts, Docker, Homebrew)
+        2. Data is sent to configured LLM endpoint
+        3. LLM returns structured report: disk usage summary, items not recommended for deletion, low-risk items, medium/high-risk items
+        4. Report is rendered as formatted terminal output
+        5. User sees interactive [x]/[ ] selection menu with all recommended actions
+        6. User confirms with typed "yes"
+        7. Selected items are deleted via safe_remove pipeline
+        8. Execution summary shows items removed, space recovered, items skipped
+      </AcceptanceCriteria>
+      <Priority>high</Priority>
+      <RelatedFlows>DF-ADVISE</RelatedFlows>
+    </UC-001>
+
+    <UC-002>
+      <Actor>User</Actor>
+      <Action>Configure AI endpoint via `mo advisor --setup`</Action>
+      <Goal>Set up LLM connection (endpoint URL, model name, API key, parameters)</Goal>
+      <Preconditions>None</Preconditions>
+      <AcceptanceCriteria>Configuration saved to ~/.config/mole/ai.conf. Values validated on input. Connection test optional.</AcceptanceCriteria>
+      <Priority>high</Priority>
+      <RelatedFlows>DF-CONFIG</RelatedFlows>
+    </UC-002>
+
+    <UC-003>
+      <Actor>User</Actor>
+      <Action>Run `mo advisor --dry-run` to inspect collected data</Action>
+      <Goal>See what system data would be sent to the LLM without making an API call</Goal>
+      <Preconditions>None</Preconditions>
+      <AcceptanceCriteria>All collector sections displayed. No API call made. No deletions proposed.</AcceptanceCriteria>
+      <Priority>medium</Priority>
+    </UC-003>
+
+    <UC-004>
+      <Actor>User</Actor>
+      <Action>Use existing mole commands (clean, optimize, check, manage, uninstall)</Action>
+      <Goal>Perform non-AI system maintenance operations</Goal>
+      <Preconditions>None</Preconditions>
+      <AcceptanceCriteria>Operations execute safely with protected-path validation, sudo when needed, user confirmation for destructive actions.</AcceptanceCriteria>
+      <Priority>high</Priority>
+    </UC-004>
+  </UseCases>
+
+  <NonGoals>
+    <item-1>No background daemon or scheduled cleanup in v1.</item-1>
+    <item-2>No GUI — CLI and interactive terminal only.</item-2>
+    <item-3>No model training or fine-tuning — uses external LLM APIs as-is.</item-3>
+    <item-4>No automatic deletion without user confirmation — always requires interactive approval.</item-4>
+    <item-5>No system-level operations requiring SIP disable.</item-5>
+  </NonGoals>
+
+  <Constraints>
+    <constraint-1>Must run on macOS 13+ (Ventura and later), Apple Silicon and Intel.</constraint-1>
+    <constraint-2>Bash only — no compiled dependencies, only standard macOS CLI tools + python3 for JSON parsing.</constraint-2>
+    <constraint-3>API key must never appear in logs or terminal output.</constraint-3>
+    <constraint-4>Protected paths (system directories, critical user data) must never be deleted, even if LLM recommends them.</constraint-4>
+    <constraint-5>Must work with any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, OpenRouter, etc.).</constraint-5>
+  </Constraints>
+
+  <Risks>
+    <risk-1>LLM may recommend paths that do not exist or are protected. Executor must validate every path before deletion.</risk-1>
+    <risk-2>du -sk on large/protected directories can hang indefinitely. Collector must use timeouts.</risk-2>
+    <risk-3>set -e in sourced files (common.sh chain) can kill the advisor subprocess. Must be handled with set +e and subprocess isolation.</risk-3>
+    <risk-4>LLM response format may vary between models. JSON extraction must be robust with fallbacks.</risk-4>
+    <risk-5>SIP-protected directories (Library/Caches root, Application Support) return partial or zero sizes from du.</risk-5>
+  </Risks>
+
+  <OpenQuestions>
+    <question-1>Should the advisor support multiple LLM profiles (e.g. fast-local model vs powerful-cloud model)?</question-1>
+    <question-2>Should the advisor remember previous recommendations and skip already-reviewed items?</question-2>
+    <question-3>Should there be a non-interactive mode (e.g. `mo advisor --auto-safe`) that auto-applies only SAFE items?</question-3>
+  </OpenQuestions>
+</RequirementsAnalysis>

--- a/docs/technology.xml
+++ b/docs/technology.xml
@@ -1,0 +1,57 @@
+<TechnologyStack VERSION="1.0.0">
+  <Runtime>Bash 3.2+ (macOS system bash)</Runtime>
+  <Language>Bash (POSIX-compatible subset, no bashisms below 3.2)</Language>
+  <Framework>None — custom modular CLI with source-based module loading</Framework>
+
+  <Dependencies>
+    <dep name="curl" version="system" purpose="HTTP client for LLM API calls (SSE streaming + standard)" />
+    <dep name="python3" version="system" purpose="JSON parsing (jq not guaranteed on macOS), response extraction" />
+    <dep name="du/df" version="system" purpose="Disk usage measurement with timeout guards" />
+    <dep name="sysctl/vm_stat" version="system" purpose="Memory, CPU, uptime data collection" />
+    <dep name="find" version="system" purpose="File scanning for build artifacts and cleanable items" />
+    <dep name="perl" version="system" purpose="Not used — previously attempted for du timeouts, removed" />
+  </Dependencies>
+
+  <VersionConstraints>
+    <constraint lib="bash" min="3.2" max="5.x" reason="macOS ships bash 3.2; user may install 5.x via homebrew" />
+    <constraint lib="python3" min="3.6" max="3.x" reason="f-strings used in JSON parsing scripts" />
+  </VersionConstraints>
+
+  <Tooling>
+    <tool name="linter" value="shellcheck" version="0.9+" />
+    <tool name="syntax-check" value="bash -n" />
+    <tool name="test-runner" value="bats (Bash Automated Testing System)" />
+    <tool name="config-format" value="INI-style key=value in ~/.config/mole/ai.conf" />
+  </Tooling>
+
+  <Testing>
+    <module-level>
+      <command>bats tests/unit/ai/*.bats</command>
+      <focus>Unit tests for collector, config, JSON parsing, prompt generation</focus>
+    </module-level>
+    <wave-level>
+      <command>bash -n bin/advisor.sh &amp;&amp; bash -n lib/ai/*.sh</command>
+      <focus>Syntax validation after every edit wave</focus>
+    </wave-level>
+    <phase-level>
+      <command>shellcheck lib/ai/*.sh bin/advisor.sh</command>
+      <focus>Static analysis for common bash pitfalls</focus>
+    </phase-level>
+    <manual-verification>
+      <command>mo advisor --dry-run</command>
+      <focus>Inspect collector output without API call</focus>
+    </manual-verification>
+    <mocking-policy>No mocking framework. Test against real filesystem with temp dirs. Use --dry-run for collector verification.</mocking-policy>
+  </Testing>
+
+  <Observability>
+    <logger>echo/printf to stderr with color codes</logger>
+    <log-prefix>No structured log format. Step-based progress: _step/_step_ok/_step_fail</log-prefix>
+    <error-channels>stderr for errors and warnings, stdout for data and progress</error-channels>
+    <redaction>API key never logged. MO_DEBUG=1 enables verbose output.</redaction>
+  </Observability>
+
+  <DeliveryShape>
+    <shape>Single-user CLI tool. No daemon. No database. Config in ~/.config/mole/ai.conf. Temp files in /tmp/.</shape>
+  </DeliveryShape>
+</TechnologyStack>

--- a/docs/technology.xml
+++ b/docs/technology.xml
@@ -5,11 +5,10 @@
 
   <Dependencies>
     <dep name="curl" version="system" purpose="HTTP client for LLM API calls (SSE streaming + standard)" />
-    <dep name="python3" version="system" purpose="JSON parsing (jq not guaranteed on macOS), response extraction" />
+    <dep name="python3" version="system" purpose="JSON parsing (jq not guaranteed on macOS), response extraction, json.dumps() for control char escaping in _json_escape_string" />
     <dep name="du/df" version="system" purpose="Disk usage measurement with timeout guards" />
     <dep name="sysctl/vm_stat" version="system" purpose="Memory, CPU, uptime data collection" />
     <dep name="find" version="system" purpose="File scanning for build artifacts and cleanable items" />
-    <dep name="perl" version="system" purpose="Not used — previously attempted for du timeouts, removed" />
   </Dependencies>
 
   <VersionConstraints>
@@ -46,12 +45,24 @@
 
   <Observability>
     <logger>echo/printf to stderr with color codes</logger>
-    <log-prefix>No structured log format. Step-based progress: _step/_step_ok/_step_fail</log-prefix>
-    <error-channels>stderr for errors and warnings, stdout for data and progress</error-channels>
+    <log-prefix>No structured log format. Pipeline UI stages: Collect → Analyze → Report → Select → Execute. Step-based progress via _step/_step_ok/_step_fail.</log-prefix>
+    <error-channels>stderr for errors, warnings, and pipeline UI. stdout for collector data and streaming response.</error-channels>
     <redaction>API key never logged. MO_DEBUG=1 enables verbose output.</redaction>
+    <report-cache>~/.config/mole/advisor/last_report.md, last_plan.json, last_timestamp</report-cache>
   </Observability>
 
   <DeliveryShape>
-    <shape>Single-user CLI tool. No daemon. No database. Config in ~/.config/mole/ai.conf. Temp files in /tmp/.</shape>
+    <shape>Single-user CLI tool. No daemon. No database. Config in ~/.config/mole/ai.conf. Report cache in ~/.config/mole/advisor/. Temp files in /tmp/.</shape>
   </DeliveryShape>
+
+  <ReasoningModelNotes>
+    <tested-model>glm-5.1 (reasoning model via OpenAI-compatible endpoint)</tested-model>
+    <behavior>Outputs analysis in delta.reasoning_content SSE field. Final response in delta.content. May spend most tokens on reasoning before generating content.</behavior>
+    <mitigations>
+      <mitigation-1>max_tokens=16384 (not 4096) to ensure content generation completes</mitigation-1>
+      <mitigation-2>client.sh parses both reasoning_content and content fields</mitigation-1>
+      <mitigation-3>_strip_reasoning filters reasoning text from response before rendering</mitigation-3>
+      <mitigation-4>timeout=300s for slow reasoning models</mitigation-4>
+    </mitigations>
+  </ReasoningModelNotes>
 </TechnologyStack>

--- a/docs/verification-plan.xml
+++ b/docs/verification-plan.xml
@@ -1,0 +1,201 @@
+<VerificationPlan VERSION="1.0.0">
+  <GlobalPolicy>
+    <log-format>No structured logs. Step-based progress: _step/_step_ok/_step_fail with numbered output.</log-format>
+    <deterministic-first>true</deterministic-first>
+    <module-level-focus>bash -n syntax check after every edit. Collector output verification via --dry-run.</module-level-focus>
+    <wave-level-focus>Verify all AI modules source without error. Test JSON extraction with sample LLM responses.</wave-level-focus>
+    <phase-level-focus>bats test suite for collector, config, and plan parsing. Full flow integration test with mocked API.</phase-level-focus>
+    <redaction>API key must never appear in test output or logs. Use mock config for tests.</redaction>
+  </GlobalPolicy>
+
+  <CriticalFlows>
+    <VF-001 NAME="Advisor Happy Path" USE_CASES="UC-001" DATA_FLOW="DF-ADVISE" PRIORITY="high">
+      <scenario>User runs mo advisor, sees report, selects items, confirms with "yes", items deleted successfully.</scenario>
+      <expected-outcome>All selected items removed. Summary shows correct count and recovered space.</expected-outcome>
+      <required-signals>
+        <signal-1>Step progress shows all steps completed with _step_ok</signal-1>
+        <signal-2>Report rendered with 4 sections: Disk Usage, Not Recommended, Low Risk, Medium/High Risk</signal-2>
+        <signal-3>Menu shows [x]/[ ] checkboxes with item count</signal-3>
+        <signal-4>Confirmation lists paths and requires typed yes</signal-4>
+        <signal-5>Execution shows per-item removed/skipped status</signal-5>
+      </required-signals>
+    </VF-001>
+
+    <VF-002 NAME="Protected Path Rejection" USE_CASES="UC-001" PRIORITY="high">
+      <scenario>LLM recommends a protected path (e.g. /Users/.../Library/Messages). safe_remove must reject it.</scenario>
+      <expected-outcome>Item shows "Skipped (protected)" in execution summary. No data loss.</expected-outcome>
+      <required-signals>
+        <signal-1>safe_remove returns non-zero for protected paths</signal-1>
+        <signal-2>Skipped items counted separately from removed items</signal-2>
+      </required-signals>
+    </VF-002>
+
+    <VF-003 NAME="Collector Accuracy" USE_CASES="UC-001" PRIORITY="high">
+      <scenario>Collector scans user dirs, system dirs, and large containers with timeout guards.</scenario>
+      <expected-outcome>All 9+ sections output. Sizes are non-zero for existing directories. Timeouts return 0 gracefully.</expected-outcome>
+      <required-signals>
+        <signal-1>=== SECTION === headers present for all sections</signal-1>
+        <signal-2>_fast_du_sk_bg returns 0 on timeout, does not hang</signal-2>
+        <signal-3>Docker, Applications, Homebrew sizes reported when present</signal-3>
+      </required-signals>
+    </VF-003>
+  </CriticalFlows>
+
+  <ModuleVerification>
+
+    <V-M-AI-CONFIG MODULE="M-AI-CONFIG" PRIORITY="high">
+      <test-files>
+        <file>tests/unit/ai/config.bats</file>
+      </test-files>
+      <module-checks>
+        <check-1>bash -n lib/ai/config.sh</check-1>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">ai_config_get returns configured value</scenario-1>
+        <scenario-2 kind="success">ai_config_is_configured returns true when endpoint+model set</scenario-2>
+        <scenario-3 kind="failure">ai_config_is_configured returns false when config missing</scenario-3>
+      </scenarios>
+    </V-M-AI-CONFIG>
+
+    <V-M-AI-CLIENT MODULE="M-AI-CLIENT" PRIORITY="high">
+      <test-files>
+        <file>tests/unit/ai/client.bats</file>
+      </test-files>
+      <module-checks>
+        <check-1>bash -n lib/ai/client.sh</check-1>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">ai_client_chat returns content from mocked 200 response</scenario-1>
+        <scenario-2 kind="failure">ai_client_chat returns error on HTTP 401</scenario-2>
+        <scenario-3 kind="failure">ai_client_chat returns error on timeout</scenario-3>
+      </scenarios>
+    </V-M-AI-CLIENT>
+
+    <V-M-AI-COLLECTOR MODULE="M-AI-COLLECTOR" PRIORITY="high">
+      <test-files>
+        <file>tests/unit/ai/collector.bats</file>
+      </test-files>
+      <module-checks>
+        <check-1>bash -n lib/ai/collector.sh</check-1>
+        <check-2>mo advisor --dry-run (manual — verify all sections present including extended)</check-2>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">collector_run_all outputs all section headers including DOCKER, HOMEBREW, XCODE</scenario-1>
+        <scenario-2 kind="success">_fast_du_sk returns numeric value for known directory</scenario-2>
+        <scenario-3 kind="success">_fast_du_sk_bg returns empty string on timeout</scenario-3>
+        <scenario-4 kind="success">_collect_trash handles permission denied gracefully</scenario-4>
+      </scenarios>
+    </V-M-AI-COLLECTOR>
+
+    <V-M-AI-COLLECTOR-EXT MODULE="M-AI-COLLECTOR-EXT" PRIORITY="medium">
+      <test-files>
+        <file>tests/unit/ai/collector_ext.bats</file>
+      </test-files>
+      <module-checks>
+        <check-1>bash -n lib/ai/collector_ext.sh</check-1>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">_collect_docker_info reports "not installed" when docker absent</scenario-1>
+        <scenario-2 kind="success">_collect_homebrew_info reports cellar breakdown when brew present</scenario-2>
+        <scenario-3 kind="success">_collect_xcode_info reports simulator list and archive sizes</scenario-3>
+      </scenarios>
+    </V-M-AI-COLLECTOR-EXT>
+
+    <V-M-AI-RENDERER MODULE="M-AI-RENDERER" PRIORITY="high">
+      <test-files>
+        <file>tests/unit/ai/renderer.bats</file>
+      </test-files>
+      <module-checks>
+        <check-1>bash -n lib/ai/renderer.sh</check-1>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">_extract_json_plan extracts JSON from markdown + code fence</scenario-1>
+        <scenario-2 kind="success">_parse_plan_items parses JSON plan into pipe-delimited lines</scenario-2>
+        <scenario-3 kind="success">_load_plan populates arrays correctly</scenario-3>
+        <scenario-4 kind="failure">_extract_json_plan returns empty when no JSON block present</scenario-4>
+        <scenario-5 kind="success">_render_report formats table and list items correctly</scenario-5>
+        <scenario-6 kind="success">_cycle_risk_filter cycles through SAFE/CAUTION/RISKY/all</scenario-6>
+        <scenario-7 kind="success">_update_visible_indices filters items by risk level</scenario-7>
+      </scenarios>
+    </V-M-AI-RENDERER>
+
+    <V-M-AI-EXECUTOR MODULE="M-AI-EXECUTOR" PRIORITY="high">
+      <test-files>
+        <file>tests/unit/ai/executor.bats</file>
+      </test-files>
+      <module-checks>
+        <check-1>bash -n lib/ai/executor.sh</check-1>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">_expand_glob_paths expands directory/* to contained items</scenario-1>
+        <scenario-2 kind="success">_execute_plan skips non-existent paths gracefully</scenario-2>
+        <scenario-3 kind="success">_execute_plan reports skipped protected items</scenario-3>
+      </scenarios>
+    </V-M-AI-EXECUTOR>
+
+    <V-M-AI-ADVISOR MODULE="M-AI-ADVISOR" PRIORITY="high">
+      <test-files>
+        <file>tests/unit/ai/advisor.bats</file>
+      </test-files>
+      <module-checks>
+        <check-1>bash -n bin/advisor.sh</check-1>
+        <check-2>bash -n lib/ai/*.sh</check-2>
+      </module-checks>
+      <scenarios>
+        <scenario-1 kind="success">--help shows usage with --auto-safe flag</scenario-1>
+        <scenario-2 kind="success">--auto-safe auto-selects only SAFE items</scenario-2>
+        <scenario-3 kind="success">_call_ai_with_retry retries on first failure</scenario-3>
+        <scenario-4 kind="failure">_call_ai_with_retry returns error after max retries</scenario-4>
+      </scenarios>
+    </V-M-AI-ADVISOR>
+
+  </ModuleVerification>
+
+  <PhaseGates>
+    <Gate-Phase-1 PHASE="Phase-1">
+      <goal>AI advisor core works end-to-end with real LLM endpoint.</goal>
+      <commands>
+        <command-1>bash -n bin/advisor.sh &amp;&amp; bash -n lib/ai/*.sh</command-1>
+        <command-2>mo advisor --dry-run</command-2>
+      </commands>
+      <required-evidence>
+        <evidence-1>All syntax checks pass</evidence-1>
+        <evidence-2>Dry run shows 9+ collector sections</evidence-2>
+        <evidence-3>Full advisor flow tested in terminal with real LLM</evidence-3>
+      </required-evidence>
+    </Gate-Phase-1>
+
+    <Gate-Phase-2 PHASE="Phase-2">
+      <goal>Modularized advisor with extended collection and UX polish.</goal>
+      <commands>
+        <command-1>bash -n bin/advisor.sh &amp;&amp; bash -n lib/ai/*.sh</command-1>
+        <command-2>mo advisor --dry-run (verify DOCKER, HOMEBREW, XCODE sections)</command-2>
+      </commands>
+      <required-evidence>
+        <evidence-1>All 6 lib/ai/*.sh files pass syntax check</evidence-1>
+        <evidence-2>Dry run shows 12+ collector sections (original 9 + Docker, Homebrew, Xcode)</evidence-2>
+        <evidence-3>--auto-safe auto-selects only SAFE items</evidence-3>
+        <evidence-4>F key in menu cycles risk filter</evidence-4>
+        <evidence-5>API retry works on transient failures</evidence-5>
+      </required-evidence>
+    </Gate-Phase-2>
+
+    <Gate-Phase-3 PHASE="Phase-3">
+      <goal>Test coverage and distribution integration.</goal>
+      <commands>
+        <command-1>bats tests/unit/ai/</command-1>
+        <command-2>shellcheck lib/ai/*.sh bin/advisor.sh</command-2>
+      </commands>
+      <required-evidence>
+        <evidence-1>All bats tests pass</evidence-1>
+        <evidence-2>advisor documented in mole help and README</evidence-2>
+      </required-evidence>
+    </Gate-Phase-3>
+  </PhaseGates>
+
+  <FailurePackets>
+    <packet-template>
+      <expected-fields>scenario, expected-evidence, observed-evidence, first-divergent-block, next-action</expected-fields>
+    </packet-template>
+  </FailurePackets>
+</VerificationPlan>

--- a/docs/verification-plan.xml
+++ b/docs/verification-plan.xml
@@ -32,13 +32,28 @@
 
     <VF-003 NAME="Collector Accuracy" USE_CASES="UC-001" PRIORITY="high">
       <scenario>Collector scans user dirs, system dirs, and large containers with timeout guards.</scenario>
-      <expected-outcome>All 9+ sections output. Sizes are non-zero for existing directories. Timeouts return 0 gracefully.</expected-outcome>
+      <expected-outcome>All 12 sections output. Sizes are non-zero for existing directories. Timeouts return 0 gracefully.</expected-outcome>
       <required-signals>
-        <signal-1>=== SECTION === headers present for all sections</signal-1>
+        <signal-1>=== SECTION === headers present for all 12 sections including DOCKER, HOMEBREW, XCODE</signal-1>
         <signal-2>_fast_du_sk_bg returns 0 on timeout, does not hang</signal-2>
         <signal-3>Docker, Applications, Homebrew sizes reported when present</signal-3>
       </required-signals>
     </VF-003>
+
+    <VF-004 NAME="Permission Denied Distinction" USE_CASES="UC-001" PRIORITY="high" STATUS="known-bug">
+      <scenario>safe_remove fails on a non-protected path due to permission denied (e.g. npm cache _cacache). Executor must show "Skipped (permission denied)" not "Skipped (protected)".</scenario>
+      <expected-outcome>Exit code distinguishes protected vs permission denied vs other errors. Executor shows accurate message per failure type.</expected-outcome>
+      <required-signals>
+        <signal-1>MOLE_ERR_PERMISSION_DENIED=13 returned by safe_remove when rm -rf stderr contains "Permission denied"</signal-1>
+        <signal-2>executor.sh _execute_plan checks specific exit codes and shows correct label</signal-2>
+        <signal-3>"Skipped (protected)" only shown when path actually matches protection patterns</signal-3>
+      </required-signals>
+      <fix-required>
+        <fix-1>Add MOLE_ERR_PERMISSION_DENIED=13 to lib/core/file_ops.sh</fix-1>
+        <fix-2>Update safe_remove to detect "Permission denied" in rm stderr and return code 13</fix-2>
+        <fix-3>Update executor.sh _execute_plan to map exit codes to correct messages</fix-3>
+      </fix-required>
+    </VF-004>
   </CriticalFlows>
 
   <ModuleVerification>
@@ -68,6 +83,8 @@
         <scenario-1 kind="success">ai_client_chat returns content from mocked 200 response</scenario-1>
         <scenario-2 kind="failure">ai_client_chat returns error on HTTP 401</scenario-2>
         <scenario-3 kind="failure">ai_client_chat returns error on timeout</scenario-3>
+        <scenario-4 kind="success">ai_client_chat falls back to reasoning_content when content is empty</scenario-4>
+        <scenario-5 kind="success">_json_escape_string escapes control characters (0x1B etc) via python3</scenario-5>
       </scenarios>
     </V-M-AI-CLIENT>
 
@@ -130,6 +147,7 @@
         <scenario-1 kind="success">_expand_glob_paths expands directory/* to contained items</scenario-1>
         <scenario-2 kind="success">_execute_plan skips non-existent paths gracefully</scenario-2>
         <scenario-3 kind="success">_execute_plan reports skipped protected items</scenario-3>
+        <scenario-4 kind="bug">_execute_plan shows "Skipped (protected)" for permission denied paths — known bug, see VF-004</scenario-4>
       </scenarios>
     </V-M-AI-EXECUTOR>
 
@@ -142,10 +160,11 @@
         <check-2>bash -n lib/ai/*.sh</check-2>
       </module-checks>
       <scenarios>
-        <scenario-1 kind="success">--help shows usage with --auto-safe flag</scenario-1>
+        <scenario-1 kind="success">--help shows usage with --auto-safe, --analyze, --dry-run, --no-stream flags</scenario-1>
         <scenario-2 kind="success">--auto-safe auto-selects only SAFE items</scenario-2>
         <scenario-3 kind="success">_call_ai_with_retry retries on first failure</scenario-3>
         <scenario-4 kind="failure">_call_ai_with_retry returns error after max retries</scenario-4>
+        <scenario-5 kind="success">_strip_reasoning filters reasoning text and keeps markdown content</scenario-5>
       </scenarios>
     </V-M-AI-ADVISOR>
 
@@ -187,9 +206,14 @@
         <command-2>shellcheck lib/ai/*.sh bin/advisor.sh</command-2>
       </commands>
       <required-evidence>
-        <evidence-1>All bats tests pass</evidence-1>
-        <evidence-2>advisor documented in mole help and README</evidence-2>
+        <evidence-1>All 91 bats tests pass</evidence-1>
+        <evidence-2>advisor documented in mole help</evidence-2>
+        <evidence-3>Full flow tested with real LLM endpoint (glm-5.1 reasoning model)</evidence-3>
+        <evidence-4>Pipeline UI visible: Collect → Analyze → Report → Select → Execute</evidence-4>
       </required-evidence>
+      <known-gaps>
+        <gap-1>VF-004 (permission denied distinction) — executor shows "Skipped (protected)" for permission denied. Needs MOLE_ERR_PERMISSION_DENIED=13.</gap-1>
+      </known-gaps>
     </Gate-Phase-3>
   </PhaseGates>
 

--- a/lib/ai/client.sh
+++ b/lib/ai/client.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
-# Mole - AI Client
-# OpenAI-compatible chat completions API client (curl-based)
+# FILE: lib/ai/client.sh
+# VERSION: 1.3.0
+# START_MODULE_CONTRACT
+#   PURPOSE: OpenAI-compatible HTTP client for chat completions API (standard + SSE streaming)
+#   SCOPE: Chat completion requests, JSON escaping, response parsing with reasoning_content fallback
+#   DEPENDS: lib/ai/config.sh
+#   LINKS: M-AI-CLIENT
+# END_MODULE_CONTRACT
+#
+# START_MODULE_MAP
+#   ai_client_chat - standard (non-streaming) chat completion with reasoning_content fallback
+#   ai_client_stream_chat - SSE streaming chat completion
+#   ai_client_test - test endpoint connectivity
+#   _build_messages_json - build JSON messages array from system + user prompts
+#   _json_escape_string - escape string for JSON via python3 json.dumps() with bash fallback
+# END_MODULE_MAP
+#
 # START_CHANGE_SUMMARY
-#   LAST_CHANGE: v1.3.0 - Use python3 json.dumps for _json_escape_string to handle
-#   all control characters (ESC, etc.) that broke API JSON parsing. Fallback to
-#   bash-native escape with \uXXXX for chars 0x00-0x1F.
+#   v1.0.0 - Initial module. Basic curl-based OpenAI client.
+#   v1.1.0 - Added reasoning_content fallback for reasoning models.
+#   v1.2.0 - Added SSE streaming support.
+#   v1.3.0 - Rewrote _json_escape_string to use python3 json.dumps() for full control char escaping.
 # END_CHANGE_SUMMARY
 
 set -euo pipefail

--- a/lib/ai/client.sh
+++ b/lib/ai/client.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# Mole - AI Client
+# OpenAI-compatible chat completions API client (curl-based)
+# START_CHANGE_SUMMARY
+#   LAST_CHANGE: v1.3.0 - Use python3 json.dumps for _json_escape_string to handle
+#   all control characters (ESC, etc.) that broke API JSON parsing. Fallback to
+#   bash-native escape with \uXXXX for chars 0x00-0x1F.
+# END_CHANGE_SUMMARY
+
+set -euo pipefail
+
+if [[ -n "${MOLE_AI_CLIENT_LOADED:-}" ]]; then
+    return 0
+fi
+readonly MOLE_AI_CLIENT_LOADED=1
+
+_MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -z "${MOLE_AI_CONFIG_LOADED:-}" ]] && source "$_MOLE_AI_DIR/config.sh"
+
+_json_escape_string() {
+    printf '%s' "$1" | python3 -c '
+import sys, json
+sys.stdout.write(json.dumps(sys.stdin.read())[1:-1])
+' 2>/dev/null || {
+        local str="$1"
+        str="${str//\\/\\\\}"
+        str="${str//\"/\\\"}"
+        str="${str//$'\t'/\\t}"
+        str="${str//$'\n'/\\n}"
+        str="${str//$'\r'/\\r}"
+        local i char code
+        local result=""
+        for ((i = 0; i < ${#str}; i++)); do
+            char="${str:$i:1}"
+            printf -v code '%d' "'$char"
+            if [[ $code -lt 32 && $code -ne 9 && $code -ne 10 && $code -ne 13 ]]; then
+                result+="\\u$(printf '%04x' $code)"
+            else
+                result+="$char"
+            fi
+        done
+        printf '%s' "$result"
+    }
+}
+
+_build_messages_json() {
+    local system_prompt="$1"
+    local user_message="$2"
+    local escaped_system escaped_user
+    escaped_system=$(_json_escape_string "$system_prompt")
+    escaped_user=$(_json_escape_string "$user_message")
+    printf '[{"role":"system","content":"%s"},{"role":"user","content":"%s"}]' "$escaped_system" "$escaped_user"
+}
+
+ai_client_chat() {
+    set +e
+    local system_prompt="$1"
+    local user_message="$2"
+
+    local endpoint model api_key max_tokens temperature timeout
+    endpoint=$(ai_config_get_endpoint)
+    model=$(ai_config_get_model)
+    api_key=$(ai_config_get_api_key)
+    max_tokens=$(ai_config_get_max_tokens)
+    temperature=$(ai_config_get_temperature)
+    timeout=$(ai_config_get_timeout)
+
+    local url="${endpoint%/}/chat/completions"
+    local messages
+    messages=$(_build_messages_json "$system_prompt" "$user_message")
+
+    local -a curl_args=(
+        -sS
+        --connect-timeout 10
+        --max-time "$timeout"
+        -H "Content-Type: application/json"
+    )
+
+    if [[ -n "$api_key" ]]; then
+        curl_args+=(-H "Authorization: Bearer $api_key")
+    fi
+
+    local request_body
+    request_body=$(cat <<EOF
+{
+  "model": "$(_json_escape_string "$model")",
+  "messages": $messages,
+  "max_tokens": $max_tokens,
+  "temperature": $temperature
+}
+EOF
+)
+
+    curl_args+=(-d "$request_body")
+    curl_args+=("$url")
+
+    local response http_code
+    response=$(curl -sS -w "\n%{http_code}" "${curl_args[@]}" 2>&1) || {
+        echo "ERROR: Failed to connect to $url" >&2
+        return 1
+    }
+
+    http_code=$(echo "$response" | tail -1)
+    local body
+    body=$(echo "$response" | sed '$d')
+
+    if [[ "$http_code" != "200" ]]; then
+        echo "ERROR: API returned HTTP $http_code" >&2
+        echo "$body" | head -5 >&2
+        [[ "$http_code" == "401" ]] && echo "HINT: Check your API key (mo advisor --setup)" >&2
+        [[ "$http_code" == "404" ]] && echo "HINT: Model '$model' may not be available at this endpoint" >&2
+        return 1
+    fi
+
+    local content
+    content=$(echo "$body" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    msg = data['choices'][0]['message']
+    content = msg.get('content', '')
+    reasoning = msg.get('reasoning_content', '')
+    if content:
+        print(content)
+    elif reasoning:
+        print(reasoning)
+except Exception:
+    pass
+" 2>/dev/null || true)
+
+    if [[ -z "$content" ]]; then
+        echo "ERROR: Empty response from model" >&2
+        return 1
+    fi
+
+    echo "$content"
+}
+
+ai_client_stream_chat() {
+    set +e
+    local system_prompt="$1"
+    local user_message="$2"
+
+    local endpoint model api_key max_tokens temperature timeout
+    endpoint=$(ai_config_get_endpoint)
+    model=$(ai_config_get_model)
+    api_key=$(ai_config_get_api_key)
+    max_tokens=$(ai_config_get_max_tokens)
+    temperature=$(ai_config_get_temperature)
+    timeout=$(ai_config_get_timeout)
+
+    local url="${endpoint%/}/chat/completions"
+    local messages
+    messages=$(_build_messages_json "$system_prompt" "$user_message")
+
+    local -a curl_args=(
+        -sS
+        --connect-timeout 10
+        --max-time "$timeout"
+        -H "Content-Type: application/json"
+        -N
+    )
+
+    if [[ -n "$api_key" ]]; then
+        curl_args+=(-H "Authorization: Bearer $api_key")
+    fi
+
+    local request_body
+    request_body=$(cat <<EOF
+{
+  "model": "$(_json_escape_string "$model")",
+  "messages": $messages,
+  "max_tokens": $max_tokens,
+  "temperature": $temperature,
+  "stream": true
+}
+EOF
+    )
+
+    curl_args+=(-d "$request_body")
+    curl_args+=("$url")
+
+    local stream_tmp="/tmp/_mole_stream_reason_$$_${RANDOM}"
+    curl "${curl_args[@]}" 2>/dev/null | python3 -u -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if line.startswith('data: '):
+        data = line[6:]
+        if data == '[DONE]':
+            break
+        try:
+            obj = json.loads(data)
+            delta = obj['choices'][0].get('delta', {})
+            content = delta.get('content', '')
+            reasoning = delta.get('reasoning_content', '')
+            if content:
+                sys.stdout.write(content)
+                sys.stdout.flush()
+            elif reasoning:
+                sys.stdout.write(reasoning)
+                sys.stdout.flush()
+        except (json.JSONDecodeError, KeyError, IndexError):
+            pass
+" 2>/dev/null || {
+        echo "ERROR: Stream connection failed" >&2
+        return 1
+    }
+    echo
+}
+
+ai_client_test() {
+    local endpoint model api_key
+    endpoint=$(ai_config_get_endpoint)
+    model=$(ai_config_get_model)
+    api_key=$(ai_config_get_api_key)
+
+    local url="${endpoint%/}/models"
+    local -a curl_args=(
+        -sS
+        --connect-timeout 5
+        --max-time 10
+    )
+
+    if [[ -n "$api_key" ]]; then
+        curl_args+=(-H "Authorization: Bearer $api_key")
+    fi
+    curl_args+=("$url")
+
+    local response
+    response=$(curl "${curl_args[@]}" 2>/dev/null) && return 0
+
+    url="${endpoint%/}/chat/completions"
+    local test_body='{"model":"'"$(_json_escape_string "$model")"'","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'
+    curl_args+=(-H "Content-Type: application/json" -d "$test_body")
+    response=$(curl -sS --connect-timeout 5 --max-time 15 "${curl_args[@]}" 2>/dev/null) && return 0
+
+    return 1
+}

--- a/lib/ai/collector.sh
+++ b/lib/ai/collector.sh
@@ -1,0 +1,397 @@
+#!/bin/bash
+# Mole - System Data Collector for AI Advisor
+# Gathers system state information as structured text for AI analysis
+
+if [[ -n "${MOLE_AI_COLLECTOR_LOADED:-}" ]]; then
+    return 0
+fi
+readonly MOLE_AI_COLLECTOR_LOADED=1
+
+_MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -z "${MOLE_BASE_LOADED:-}" ]] && source "$_MOLE_AI_DIR/../core/base.sh"
+
+_fast_du_sk() {
+    local dir="$1"
+    local size
+    size=$(du -sk "$dir" 2>/dev/null | awk '{print $1}') || size="0"
+    echo "${size:-0}"
+}
+
+_fast_du_sk_bg() {
+    local dir="$1"
+    local timeout_sec="${2:-15}"
+    local tmp="/tmp/_mole_du_$$_${RANDOM}"
+    du -sk "$dir" > "$tmp" 2>/dev/null &
+    local du_pid=$!
+    local elapsed=0
+    while true; do
+        if ! kill -0 "$du_pid" 2>/dev/null; then
+            break
+        fi
+        if [[ $elapsed -ge $timeout_sec ]]; then
+            kill "$du_pid" 2>/dev/null
+            wait "$du_pid" 2>/dev/null
+            rm -f "$tmp"
+            echo ""
+            return
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    wait "$du_pid" 2>/dev/null || true
+    cat "$tmp" 2>/dev/null | awk '{print $1}'
+    rm -f "$tmp"
+}
+
+_collect_section() {
+    local title="$1"
+    shift
+    echo "=== $title ==="
+    "$@" 2>/dev/null || echo "(unavailable)"
+    echo ""
+}
+
+_collect_disk_usage() {
+    echo "All volumes:"
+    df -h 2>/dev/null | grep -E '^/dev/' || true
+    echo ""
+
+    echo "User directories:"
+    local -a user_dirs=(
+        "$HOME/Library/Caches"
+        "$HOME/Library/Logs"
+        "$HOME/Library/Developer"
+        "$HOME/Library/Application Support:20"
+        "$HOME/Library/Containers:20"
+        "$HOME/Library/Mail"
+        "$HOME/Library/Messages"
+        "$HOME/Library/Group Containers"
+        "$HOME/.Trash"
+        "$HOME/Downloads"
+        "$HOME/Documents"
+        "$HOME/Desktop"
+    )
+    for entry in "${user_dirs[@]}"; do
+        local dir="${entry%%:*}"
+        local tout="${entry##*:}"
+        [[ "$tout" == "$dir" ]] && tout=""
+        if [[ -d "$dir" ]]; then
+            local size
+            if [[ -n "$tout" ]]; then
+                size=$(_fast_du_sk_bg "$dir" "$tout")
+            else
+                size=$(_fast_du_sk "$dir")
+            fi
+            [[ -z "$size" || "$size" == "0" ]] && continue
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-50s %s\n" "$dir" "$human"
+        fi
+    done
+
+    echo ""
+    echo "System directories:"
+    local -a sys_dirs=(
+        "/Applications:30"
+        "/Library/Caches"
+        "/Library/Logs"
+        "/Library/Application Support:20"
+        "/opt/homebrew:20"
+        "/opt/homebrew/Cellar:20"
+        "/usr/local/Cellar"
+        "/private/var/folders"
+        "/private/var/log"
+    )
+    for entry in "${sys_dirs[@]}"; do
+        local dir="${entry%%:*}"
+        local tout="${entry##*:}"
+        [[ "$tout" == "$dir" ]] && tout=""
+        if [[ -d "$dir" ]]; then
+            local size
+            if [[ -n "$tout" ]]; then
+                size=$(_fast_du_sk_bg "$dir" "$tout")
+            else
+                size=$(_fast_du_sk "$dir")
+            fi
+            [[ -z "$size" || "$size" == "0" ]] && continue
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-50s %s\n" "$dir" "$human"
+        fi
+    done
+
+    echo ""
+    echo "Large containers:"
+    local -a container_paths=(
+        "$HOME/Library/Containers/com.docker.docker:Docker:20"
+        "$HOME/Library/Containers/com.apple.mail:Apple Mail:15"
+        "$HOME/.docker:Docker CLI:15"
+        "$HOME/.ollama:Ollama models:15"
+        "$HOME/.cargo:Cargo/Rust:15"
+        "$HOME/.rustup:Rustup:15"
+        "$HOME/.go:Go:15"
+        "$HOME/go:Go workspace:15"
+        "$HOME/.cache:User cache root:15"
+    )
+    for entry in "${container_paths[@]}"; do
+        local path="${entry%%:*}"
+        local rest="${entry#*:}"
+        local label="${rest%%:*}"
+        local tout="${rest##*:}"
+        [[ "$tout" == "$rest" ]] && tout=""
+        for expanded in $path; do
+            if [[ -d "$expanded" ]]; then
+                local size
+                if [[ -n "$tout" ]]; then
+                    size=$(_fast_du_sk_bg "$expanded" "$tout")
+                else
+                    size=$(_fast_du_sk "$expanded")
+                fi
+                [[ -z "$size" || "$size" == "0" ]] && continue
+                local human
+                human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+                printf "  %-25s %8s  (%s)\n" "$label" "$human" "$expanded"
+            fi
+        done
+    done
+}
+
+_collect_memory_info() {
+    local total_bytes used_gb total_gb active wired compressed page_size
+    total_bytes=$(sysctl -n hw.memsize 2>/dev/null || echo "0")
+    total_gb=$(LC_ALL=C awk "BEGIN {printf \"%.1f\", $total_bytes / (1024*1024*1024)}" 2>/dev/null || echo "?")
+
+    local vm_output
+    vm_output=$(vm_stat 2>/dev/null || echo "")
+    page_size=4096
+    active=$(echo "$vm_output" | awk '/Pages active:/ {print $NF}' | tr -d '.\n' 2>/dev/null || echo "0")
+    wired=$(echo "$vm_output" | awk '/Pages wired down:/ {print $NF}' | tr -d '.\n' 2>/dev/null || echo "0")
+    compressed=$(echo "$vm_output" | awk '/Pages occupied by compressor:/ {print $NF}' | tr -d '.\n' 2>/dev/null || echo "0")
+    active=${active:-0}; wired=${wired:-0}; compressed=${compressed:-0}
+    local used_bytes=$(( (active + wired + compressed) * page_size ))
+    used_gb=$(LC_ALL=C awk "BEGIN {printf \"%.1f\", $used_bytes / (1024*1024*1024)}" 2>/dev/null || echo "?")
+
+    local swap_used
+    swap_used=$(sysctl -n vm.swapusage 2>/dev/null | awk '/used/ {print $3}' | tr -d 'M' || echo "0")
+
+    local pressure
+    pressure=$(memory_pressure 2>/dev/null | head -1 || echo "unknown")
+
+    echo "Total: ${total_gb}GB"
+    echo "Active+Wired+Compressed: ${used_gb}GB"
+    echo "Swap used: ${swap_used}MB"
+    echo "Pressure: $pressure"
+}
+
+_collect_cpu_info() {
+    local chip cores
+    chip=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "unknown")
+    cores=$(sysctl -n hw.ncpu 2>/dev/null || echo "?")
+
+    local load
+    load=$(uptime 2>/dev/null | sed 's/.*load averages: //' || echo "?")
+
+    local top_procs
+    top_procs=$(ps aux 2>/dev/null | sort -k3 -rn | head -6 || echo "(unavailable)")
+
+    echo "Chip: $chip"
+    echo "Cores: $cores"
+    echo "Load averages: $load"
+    echo "Top CPU processes:"
+    echo "$top_procs" | while IFS= read -r line; do
+        echo "  $line"
+    done
+}
+
+_collect_uptime_info() {
+    local boot_output boot_time
+    boot_output=$(sysctl -n kern.boottime 2>/dev/null || echo "")
+    boot_time=$(echo "$boot_output" | awk -F 'sec = |, usec' '{print $2}' 2>/dev/null || echo "")
+    if [[ -n "$boot_time" && "$boot_time" =~ ^[0-9]+$ ]]; then
+        local now
+        now=$(get_epoch_seconds)
+        local uptime_sec=$((now - boot_time))
+        local days=$((uptime_sec / 86400))
+        local hours=$(( (uptime_sec % 86400) / 3600 ))
+        echo "Uptime: ${days}d ${hours}h"
+    else
+        echo "Uptime: unknown"
+    fi
+
+    local os_ver
+    os_ver=$(sw_vers -productVersion 2>/dev/null || echo "unknown")
+    local arch
+    arch=$(detect_architecture)
+    echo "macOS: $os_ver ($arch)"
+}
+
+_collect_cleanable_items() {
+    echo "User cache/app data:"
+
+    local -a check_paths=(
+        "$HOME/Library/Caches:User caches"
+        "$HOME/Library/Logs:User logs"
+        "$HOME/Library/Mail/V*:Mail data"
+        "$HOME/Library/Messages:Messages data"
+        "$HOME/Library/Developer/Xcode:Xcode data"
+        "$HOME/Library/Caches/com.openai.chat:ChatGPT cache"
+        "$HOME/.npm:NPM cache"
+        "$HOME/.cache/pip:Pip cache"
+        "$HOME/.cache/huggingface:Hugging Face cache"
+        "$HOME/.ollama:Ollama data"
+        "$HOME/.local/share/claude:Claude Code data"
+        "$HOME/.gradle/caches:Gradle cache"
+        "$HOME/.m2/repository:Maven cache"
+        "$HOME/.cargo/registry:Cargo registry"
+        "$HOME/Library/Containers/com.docker.docker:Docker data"
+        "$HOME/.docker:Docker CLI config"
+    )
+
+    for entry in "${check_paths[@]}"; do
+        local path="${entry%%:*}"
+        local label="${entry#*:}"
+        for expanded in $path; do
+            if [[ -d "$expanded" ]]; then
+                local size
+                size=$(_fast_du_sk "$expanded")
+                local human
+                human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+                printf "  %-40s %8s  (%s)\n" "$label" "$human" "$expanded"
+            fi
+        done
+    done
+
+    echo ""
+    echo "System-level cleanable:"
+    local -a sys_clean=(
+        "/Library/Caches:System caches"
+        "/Library/Logs:System logs"
+        "/private/var/log:System var logs"
+        "/opt/homebrew/Cellar:Homebrew cellar"
+    )
+    for entry in "${sys_clean[@]}"; do
+        local path="${entry%%:*}"
+        local label="${entry#*:}"
+        if [[ -d "$path" ]]; then
+            local size
+            size=$(_fast_du_sk "$path")
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-40s %8s  (%s)\n" "$label" "$human" "$path"
+        fi
+    done
+
+    if command -v brew >/dev/null 2>&1; then
+        local brew_cache
+        brew_cache=$(brew --cache 2>/dev/null || echo "")
+        if [[ -n "$brew_cache" && -d "$brew_cache" ]]; then
+            local size
+            size=$(_fast_du_sk "$brew_cache")
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-40s %8s  (%s)\n" "Homebrew cache" "$human" "$brew_cache"
+        fi
+    fi
+
+    echo ""
+    echo "Project build artifacts:"
+
+    local artifact_count=0
+    local -a scan_dirs=("$HOME/Documents" "$HOME/Developer" "$HOME/projects" "$HOME/code" "$HOME/src")
+    for scan_dir in "${scan_dirs[@]}"; do
+        [[ -d "$scan_dir" ]] || continue
+        while IFS= read -r -d '' artifact_dir; do
+            local size
+            size=$(_fast_du_sk "$artifact_dir")
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-40s %8s  (%s)\n" "$(basename "$artifact_dir")" "$human" "$artifact_dir"
+            artifact_count=$((artifact_count + 1))
+            [[ $artifact_count -ge 20 ]] && break
+        done < <(find "$scan_dir" -maxdepth 4 \( -name "node_modules" -o -name ".venv" -o -name "venv" -o -name "target" -o -name "build" -o -name ".gradle" -o -name "__pycache__" \) -type d -prune 2>/dev/null | head -20)
+        [[ $artifact_count -ge 20 ]] && break
+    done
+    [[ $artifact_count -eq 0 ]] && echo "  (none found in common directories)"
+}
+
+_collect_trash() {
+    local trash_size
+    trash_size=$(_fast_du_sk "$HOME/.Trash")
+    local human
+    human=$(bytes_to_human_kb "$trash_size" 2>/dev/null || echo "empty")
+    local count
+    count=$(find "$HOME/.Trash" -maxdepth 1 2>/dev/null | wc -l | tr -d ' \n' 2>/dev/null || echo "0")
+    count="${count:-0}"
+    [[ "$count" =~ ^[0-9]+$ ]] || count=0
+    local items=$((count > 0 ? count - 1 : 0))
+    echo "Trash: $human ($items items)"
+}
+
+_collect_installer_files() {
+    local total=0
+    local found=""
+    local -a exts=("dmg" "pkg" "zip" "ipa")
+    for ext in "${exts[@]}"; do
+        while IFS= read -r -d '' f; do
+            local size
+            size=$($STAT_BSD -f%z "$f" 2>/dev/null || echo "0")
+            total=$((total + size))
+            local human
+            human=$(bytes_to_human "$size" 2>/dev/null || echo "?")
+            found="${found}  $(basename "$f") ($human) — $f\n"
+        done < <(find "$HOME/Downloads" -maxdepth 2 -name "*.${ext}" -type f -print0 2>/dev/null | head -20)
+    done
+    if [[ -n "$found" ]]; then
+        echo -e "$found" | head -20
+        local total_human
+        total_human=$(bytes_to_human "$total" 2>/dev/null || echo "?")
+        echo "Total installer files: $total_human"
+    else
+        echo "No installer files found in Downloads"
+    fi
+}
+
+_collect_network_info() {
+    local connections
+    connections=$(netstat -an 2>/dev/null | awk '/ESTABLISHED/ {count++} END {print count+0}' || echo "?")
+    echo "Active connections: $connections"
+
+    local dns
+    dns=$(scutil --dns 2>/dev/null | grep "nameserver" | head -5 || echo "unknown")
+    echo "DNS servers:"
+    echo "$dns" | while IFS= read -r line; do
+        echo "  $line"
+    done
+}
+
+_collect_battery_info() {
+    if command -v pmset >/dev/null 2>&1; then
+        local batt
+        batt=$(pmset -g batt 2>/dev/null || echo "")
+        if [[ -n "$batt" ]]; then
+            echo "$batt" | tail -1
+        else
+            echo "(no battery)"
+        fi
+    else
+        echo "(unavailable)"
+    fi
+}
+
+collector_run_all() {
+    set +e
+    _collect_section "SYSTEM OVERVIEW" _collect_uptime_info
+    _collect_section "DISK USAGE" _collect_disk_usage
+    _collect_section "MEMORY" _collect_memory_info
+    _collect_section "CPU" _collect_cpu_info
+    _collect_section "TRASH" _collect_trash
+    _collect_section "CLEANABLE ITEMS" _collect_cleanable_items
+    _collect_section "INSTALLER FILES" _collect_installer_files
+    _collect_section "NETWORK" _collect_network_info
+    _collect_section "BATTERY" _collect_battery_info
+
+    [[ -z "${MOLE_AI_COLLECTOR_EXT_LOADED:-}" ]] && source "$_MOLE_AI_DIR/collector_ext.sh"
+    collector_ext_run_all
+
+    return 0
+}

--- a/lib/ai/collector.sh
+++ b/lib/ai/collector.sh
@@ -1,6 +1,32 @@
 #!/bin/bash
-# Mole - System Data Collector for AI Advisor
-# Gathers system state information as structured text for AI analysis
+# FILE: lib/ai/collector.sh
+# VERSION: 1.0.0
+# START_MODULE_CONTRACT
+#   PURPOSE: Gather system state information as structured text for AI analysis
+#   SCOPE: Disk usage, memory, CPU, uptime, trash, cleanable items, installers, network, battery
+#   DEPENDS: lib/core/base.sh
+#   LINKS: M-AI-COLLECTOR
+# END_MODULE_CONTRACT
+#
+# START_MODULE_MAP
+#   collector_run_all - run all collection sections to stdout, auto-sources collector_ext.sh
+#   _fast_du_sk - get directory size in KB via du -sk
+#   _fast_du_sk_bg - get directory size with background timeout guard
+#   _collect_section - output section header and call collector function
+#   _collect_disk_usage - scan user dirs, system dirs, large containers
+#   _collect_memory_info - memory stats from sysctl + vm_stat
+#   _collect_cpu_info - CPU info and top processes
+#   _collect_uptime_info - uptime and macOS version
+#   _collect_cleanable_items - cache dirs, system-level cleanable, build artifacts
+#   _collect_trash - trash size and item count
+#   _collect_installer_files - DMG/PKG/ZIP files in Downloads
+#   _collect_network_info - active connections and DNS
+#   _collect_battery_info - battery level and status
+# END_MODULE_MAP
+#
+# START_CHANGE_SUMMARY
+#   v1.0.0 - Initial module. 9 base collection sections + auto-source collector_ext.sh.
+# END_CHANGE_SUMMARY
 
 if [[ -n "${MOLE_AI_COLLECTOR_LOADED:-}" ]]; then
     return 0

--- a/lib/ai/collector_ext.sh
+++ b/lib/ai/collector_ext.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+# FILE: lib/ai/collector_ext.sh
+# VERSION: 1.0.0
+# START_MODULE_CONTRACT
+#   PURPOSE: Extended system data collectors (Docker, Homebrew, Xcode)
+#   SCOPE: Docker images/containers/volumes, Homebrew cache/outdated, Xcode simulators/archives
+#   DEPENDS: lib/ai/collector.sh (for _fast_du_sk)
+#   LINKS: M-AI-COLLECTOR-EXT
+# END_MODULE_CONTRACT
+#
+# START_MODULE_MAP
+#   _collect_docker_info - Docker disk usage, images, containers, volumes
+#   _collect_homebrew_info - Homebrew cache, outdated packages, cellar breakdown
+#   _collect_xcode_info - Xcode simulators, derived data, archives, device support
+#   collector_ext_run_all - run all extended collectors
+# END_MODULE_MAP
+#
+# START_CHANGE_SUMMARY
+#   v1.0.0 - New module. Docker, Homebrew, Xcode collectors for extended system analysis.
+# END_CHANGE_SUMMARY
+
+set -euo pipefail
+
+if [[ -n "${MOLE_AI_COLLECTOR_EXT_LOADED:-}" ]]; then
+    return 0
+fi
+readonly MOLE_AI_COLLECTOR_EXT_LOADED=1
+
+_MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -z "${MOLE_AI_COLLECTOR_LOADED:-}" ]] && source "$_MOLE_AI_DIR/collector.sh"
+
+# START_CONTRACT: _collect_docker_info
+#   PURPOSE: Collect Docker disk usage, images, containers, and volumes
+#   INPUTS: { none }
+#   OUTPUTS: { String - formatted docker info to stdout }
+#   SIDE_EFFECTS: runs docker commands (safe, read-only)
+#   LINKS: M-AI-COLLECTOR-EXT
+# END_CONTRACT: _collect_docker_info
+_collect_docker_info() {
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "Docker: not installed"
+        return
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        echo "Docker: installed but not running"
+        return
+    fi
+
+    echo "Docker disk usage:"
+    local du_output
+    du_output=$(docker system df 2>/dev/null || echo "(unavailable)")
+    echo "$du_output" | while IFS= read -r line; do
+        echo "  $line"
+    done
+
+    echo ""
+    echo "Docker images (by size):"
+    docker images --format '{{.Repository}}:{{.Tag}}\t{{.Size}}' 2>/dev/null \
+        | sort -t$'\t' -k2 -rh | head -15 | while IFS= read -r line; do
+        echo "  $line"
+    done || echo "  (none)"
+
+    echo ""
+    echo "Docker containers:"
+    local running stopped
+    running=$(docker ps -q 2>/dev/null | wc -l | tr -d ' \n' || echo "0")
+    stopped=$(docker ps -f "status=exited" -q 2>/dev/null | wc -l | tr -d ' \n' || echo "0")
+    echo "  Running: $running, Stopped: $stopped"
+
+    echo ""
+    echo "Docker volumes (by size):"
+    docker volume ls -q 2>/dev/null | head -20 | while IFS= read -r vol; do
+        [[ -z "$vol" ]] && continue
+        local vol_path
+        vol_path=$(docker volume inspect "$vol" --format '{{.Mountpoint}}' 2>/dev/null || echo "")
+        if [[ -n "$vol_path" && -d "$vol_path" ]]; then
+            local size
+            size=$(_fast_du_sk "$vol_path" 2>/dev/null || echo "0")
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-40s %s\n" "$vol" "$human"
+        else
+            printf "  %-40s %s\n" "$vol" "(inaccessible)"
+        fi
+    done || echo "  (none)"
+}
+
+# START_CONTRACT: _collect_homebrew_info
+#   PURPOSE: Collect Homebrew cache size, outdated packages, cellar breakdown
+#   INPUTS: { none }
+#   OUTPUTS: { String - formatted homebrew info to stdout }
+#   SIDE_EFFECTS: runs brew commands (safe, read-only)
+#   LINKS: M-AI-COLLECTOR-EXT
+# END_CONTRACT: _collect_homebrew_info
+_collect_homebrew_info() {
+    if ! command -v brew >/dev/null 2>&1; then
+        echo "Homebrew: not installed"
+        return
+    fi
+
+    local brew_prefix
+    brew_prefix=$(brew --prefix 2>/dev/null || echo "/opt/homebrew")
+
+    echo "Homebrew cache:"
+    local brew_cache
+    brew_cache=$(brew --cache 2>/dev/null || echo "")
+    if [[ -n "$brew_cache" && -d "$brew_cache" ]]; then
+        local size
+        size=$(_fast_du_sk "$brew_cache")
+        local human
+        human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+        printf "  %-40s %s\n" "$brew_cache" "$human"
+    else
+        echo "  (cache not found)"
+    fi
+
+    echo ""
+    echo "Homebrew Cellar (top packages by size):"
+    if [[ -d "$brew_prefix/Cellar" ]]; then
+        local cellar_size
+        cellar_size=$(_fast_du_sk_bg "$brew_prefix/Cellar" 15)
+        local cellar_human
+        cellar_human=$(bytes_to_human_kb "$cellar_size" 2>/dev/null || echo "?")
+        echo "  Total Cellar: $cellar_human"
+
+        du -sk "$brew_prefix/Cellar"/* 2>/dev/null | sort -rn | head -15 | while IFS=$'\t' read -r sz path; do
+            local pkg
+            pkg=$(basename "$path")
+            local human
+            human=$(bytes_to_human_kb "$sz" 2>/dev/null || echo "?")
+            printf "    %-30s %s\n" "$pkg" "$human"
+        done
+    else
+        echo "  (Cellar not found)"
+    fi
+
+    echo ""
+    echo "Outdated packages:"
+    local outdated
+    outdated=$(brew outdated --quiet 2>/dev/null || echo "")
+    if [[ -n "$outdated" ]]; then
+        local outdated_count
+        outdated_count=$(echo "$outdated" | wc -l | tr -d ' \n')
+        echo "  $outdated_count packages outdated:"
+        echo "$outdated" | head -20 | while IFS= read -r line; do
+            echo "    $line"
+        done
+    else
+        echo "  All packages up to date"
+    fi
+}
+
+# START_CONTRACT: _collect_xcode_info
+#   PURPOSE: Collect Xcode simulator, derived data, archives, and device support sizes
+#   INPUTS: { none }
+#   OUTPUTS: { String - formatted Xcode info to stdout }
+#   SIDE_EFFECTS: runs xcrun simctl commands (safe, read-only)
+#   LINKS: M-AI-COLLECTOR-EXT
+# END_CONTRACT: _collect_xcode_info
+_collect_xcode_info() {
+    local dev_dir
+    dev_dir="$HOME/Library/Developer"
+
+    if [[ ! -d "$dev_dir" ]]; then
+        echo "Xcode: no Developer directory"
+        return
+    fi
+
+    echo "Xcode Developer data:"
+    local total_dev_size=0
+
+    local -a xcode_paths=(
+        "$dev_dir/Xcode/UserData:UserData"
+        "$dev_dir/Xcode/DerivedData:DerivedData"
+        "$dev_dir/CoreSimulator:CoreSimulator"
+        "$dev_dir/Xcode/Archives:Archives"
+        "$dev_dir/Xcode/iOS Device Logs:iOS Device Logs"
+        "$dev_dir/Xcode/watchOS Device Logs:watchOS Device Logs"
+        "$dev_dir/Xcode/watchOS DeviceSupport:watchOS DeviceSupport"
+    )
+
+    for entry in "${xcode_paths[@]}"; do
+        local path="${entry%%:*}"
+        local label="${entry#*:}"
+        if [[ -d "$path" ]]; then
+            local size
+            size=$(_fast_du_sk_bg "$path" 10)
+            [[ -z "$size" ]] && size=0
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-35s %s\n" "$label" "$human"
+            [[ "$size" =~ ^[0-9]+$ ]] && total_dev_size=$((total_dev_size + size))
+        fi
+    done
+
+    local total_human
+    total_human=$(bytes_to_human_kb "$total_dev_size" 2>/dev/null || echo "?")
+    echo ""
+    echo "  Total Xcode data: $total_human"
+
+    echo ""
+    echo "iOS Simulators:"
+    if command -v xcrun >/dev/null 2>&1; then
+        xcrun simctl list devices 2>/dev/null | grep -E '(Booted|Shutdown)' | head -15 | while IFS= read -r line; do
+            echo "  $line"
+        done || echo "  (none)"
+    else
+        echo "  (xcrun not found)"
+    fi
+
+    echo ""
+    echo "Xcode Archives:"
+    if [[ -d "$dev_dir/Xcode/Archives" ]]; then
+        find "$dev_dir/Xcode/Archives" -name "*.xcarchive" -maxdepth 3 -type d 2>/dev/null | while IFS= read -r archive; do
+            local size
+            size=$(_fast_du_sk_bg "$archive" 10)
+            local human
+            human=$(bytes_to_human_kb "$size" 2>/dev/null || echo "?")
+            printf "  %-45s %s\n" "$(basename "$archive")" "$human"
+        done || echo "  (none)"
+    else
+        echo "  (no archives)"
+    fi
+}
+
+collector_ext_run_all() {
+    set +e
+    _collect_section "DOCKER" _collect_docker_info
+    _collect_section "HOMEBREW" _collect_homebrew_info
+    _collect_section "XCODE" _collect_xcode_info
+    return 0
+}

--- a/lib/ai/config.sh
+++ b/lib/ai/config.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
-# Mole - AI Advisor Configuration
-# Manages OpenAI-compatible API settings stored in ~/.config/mole/ai.conf
+# FILE: lib/ai/config.sh
+# VERSION: 1.0.0
+# START_MODULE_CONTRACT
+#   PURPOSE: Manage AI advisor configuration stored in ~/.config/mole/ai.conf
+#   SCOPE: Read/write config values, interactive setup wizard, display config
+#   DEPENDS: lib/core/base.sh
+#   LINKS: M-AI-CONFIG
+# END_MODULE_CONTRACT
+#
+# START_MODULE_MAP
+#   ai_config_get - read config value by key with optional default
+#   ai_config_set - write config value to file
+#   ai_config_setup - interactive setup wizard for endpoint/model/api_key
+#   ai_config_show - display current config (masks API key)
+#   ai_config_is_configured - check if endpoint and model are set
+#   ai_config_get_endpoint - get API endpoint URL
+#   ai_config_get_model - get model name
+#   ai_config_get_api_key - get API key
+#   ai_config_get_max_tokens - get max_tokens parameter
+#   ai_config_get_temperature - get temperature parameter
+#   ai_config_get_timeout - get request timeout in seconds
+# END_MODULE_MAP
+#
+# START_CHANGE_SUMMARY
+#   v1.0.0 - Initial module. Config management for AI advisor endpoint/model/api_key.
+# END_CHANGE_SUMMARY
 
 set -euo pipefail
 

--- a/lib/ai/config.sh
+++ b/lib/ai/config.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Mole - AI Advisor Configuration
+# Manages OpenAI-compatible API settings stored in ~/.config/mole/ai.conf
+
+set -euo pipefail
+
+if [[ -n "${MOLE_AI_CONFIG_LOADED:-}" ]]; then
+    return 0
+fi
+readonly MOLE_AI_CONFIG_LOADED=1
+
+_MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -z "${MOLE_BASE_LOADED:-}" ]] && source "$_MOLE_AI_DIR/../core/base.sh"
+
+readonly MOLE_AI_CONFIG_FILE="${MOLE_CONFIG_DIR:-$HOME/.config/mole}/ai.conf"
+
+readonly MOLE_AI_DEFAULT_ENDPOINT="http://localhost:11434/v1"
+readonly MOLE_AI_DEFAULT_MODEL="qwen3:8b"
+readonly MOLE_AI_DEFAULT_MAX_TOKENS=16384
+readonly MOLE_AI_DEFAULT_TEMPERATURE=0.3
+readonly MOLE_AI_DEFAULT_TIMEOUT=300
+
+_ai_config_get_raw() {
+    local key="$1"
+    if [[ ! -f "$MOLE_AI_CONFIG_FILE" ]]; then
+        return 1
+    fi
+    local value
+    value=$(grep -E "^${key}=" "$MOLE_AI_CONFIG_FILE" 2>/dev/null | head -1 | sed "s/^${key}=//" || true)
+    [[ -n "$value" ]] && echo "$value" && return 0
+    return 1
+}
+
+ai_config_get() {
+    local key="$1"
+    local default="${2:-}"
+    local value
+    value=$(_ai_config_get_raw "$key") || true
+    echo "${value:-$default}"
+}
+
+ai_config_set() {
+    local key="$1"
+    local value="$2"
+    ensure_user_dir "$(dirname "$MOLE_AI_CONFIG_FILE")"
+    ensure_user_file "$MOLE_AI_CONFIG_FILE"
+    if _ai_config_get_raw "$key" >/dev/null 2>&1; then
+        local tmp
+        tmp=$(mktemp_file)
+        sed "s|^${key}=.*|${key}=${value}|" "$MOLE_AI_CONFIG_FILE" > "$tmp" || true
+        cat "$tmp" > "$MOLE_AI_CONFIG_FILE"
+    else
+        echo "${key}=${value}" >> "$MOLE_AI_CONFIG_FILE"
+    fi
+}
+
+ai_config_get_endpoint() { ai_config_get "endpoint" "$MOLE_AI_DEFAULT_ENDPOINT"; }
+ai_config_get_model() { ai_config_get "model" "$MOLE_AI_DEFAULT_MODEL"; }
+ai_config_get_api_key() { ai_config_get "api_key" ""; }
+ai_config_get_max_tokens() { ai_config_get "max_tokens" "$MOLE_AI_DEFAULT_MAX_TOKENS"; }
+ai_config_get_temperature() { ai_config_get "temperature" "$MOLE_AI_DEFAULT_TEMPERATURE"; }
+ai_config_get_timeout() { ai_config_get "timeout" "$MOLE_AI_DEFAULT_TIMEOUT"; }
+
+ai_config_is_configured() {
+    local endpoint model
+    endpoint=$(ai_config_get_endpoint)
+    model=$(ai_config_get_model)
+    [[ -n "$endpoint" && -n "$model" ]]
+}
+
+ai_config_show() {
+    if [[ ! -f "$MOLE_AI_CONFIG_FILE" ]]; then
+        echo -e "${YELLOW}AI advisor is not configured yet.${NC}"
+        echo ""
+        echo "Run: ${GREEN}mo advisor --setup${NC}"
+        return 0
+    fi
+    echo -e "${PURPLE_BOLD}AI Advisor Configuration${NC}"
+    echo ""
+    echo -e "  ${ICON_LIST} Endpoint:    ${CYAN}$(ai_config_get_endpoint)${NC}"
+    echo -e "  ${ICON_LIST} Model:       ${CYAN}$(ai_config_get_model)${NC}"
+    local api_key
+    api_key=$(ai_config_get_api_key)
+    if [[ -n "$api_key" ]]; then
+        local masked="${api_key:0:8}...${api_key: -4}"
+        echo -e "  ${ICON_LIST} API Key:     ${CYAN}${masked}${NC}"
+    else
+        echo -e "  ${ICON_LIST} API Key:     ${GRAY}(none)${NC}"
+    fi
+    echo -e "  ${ICON_LIST} Max Tokens:  ${CYAN}$(ai_config_get_max_tokens)${NC}"
+    echo -e "  ${ICON_LIST} Temperature: ${CYAN}$(ai_config_get_temperature)${NC}"
+    echo -e "  ${ICON_LIST} Timeout:     ${CYAN}$(ai_config_get_timeout)s${NC}"
+    echo ""
+    echo -e "  Config file: ${GRAY}${MOLE_AI_CONFIG_FILE}${NC}"
+}
+
+ai_config_setup() {
+    clear
+    echo -e "${PURPLE_BOLD}${ICON_ARROW} AI Advisor Setup${NC}"
+    echo ""
+    echo "Configure an OpenAI-compatible API endpoint."
+    echo "Works with Ollama, vLLM, LM Studio, OpenRouter, or any OpenAI-compatible server."
+    echo ""
+
+    local current_endpoint current_model current_key
+    current_endpoint=$(ai_config_get_endpoint)
+    current_model=$(ai_config_get_model)
+    current_key=$(ai_config_get_api_key)
+
+    echo -ne "  API Endpoint [${GREEN}${current_endpoint}${NC}]: "
+    local endpoint
+    IFS= read -r endpoint || endpoint=""
+    endpoint="${endpoint:-$current_endpoint}"
+    [[ -z "$endpoint" ]] && endpoint="$MOLE_AI_DEFAULT_ENDPOINT"
+
+    echo -ne "  Model name [${GREEN}${current_model}${NC}]: "
+    local model
+    IFS= read -r model || model=""
+    model="${model:-$current_model}"
+    [[ -z "$model" ]] && model="$MOLE_AI_DEFAULT_MODEL"
+
+    local key_prompt="(leave empty if not required)"
+    [[ -n "$current_key" ]] && key_prompt="(current: set)"
+    echo -ne "  API Key ${key_prompt}: "
+    local api_key
+    IFS= read -r api_key || api_key=""
+    [[ -z "$api_key" ]] && api_key="$current_key"
+
+    ai_config_set "endpoint" "$endpoint"
+    ai_config_set "model" "$model"
+    [[ -n "$api_key" ]] && ai_config_set "api_key" "$api_key"
+
+    echo ""
+    echo -e "${GREEN}${ICON_SUCCESS} Configuration saved.${NC}"
+    echo ""
+    echo "Testing connection..."
+    if ai_client_test; then
+        echo -e "${GREEN}${ICON_SUCCESS} Connection successful!${NC}"
+    else
+        echo -e "${YELLOW}${ICON_WARNING} Could not reach the endpoint. Check settings and try again.${NC}"
+        echo "  Run: ${GREEN}mo advisor --setup${NC}"
+    fi
+}

--- a/lib/ai/executor.sh
+++ b/lib/ai/executor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # FILE: lib/ai/executor.sh
-# VERSION: 1.0.0
+# VERSION: 1.1.0
 # START_MODULE_CONTRACT
 #   PURPOSE: Execute confirmed AI advisor plan items via safe_remove
 #   SCOPE: Glob expansion, path resolution, safe deletion execution
@@ -32,13 +32,6 @@ _MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -z "${MOLE_AI_FILEOPS_LOADED:-}" ]] && source "$_MOLE_AI_DIR/../core/file_ops.sh"
 [[ -z "${MOLE_AI_RENDERER_LOADED:-}" ]] && source "$_MOLE_AI_DIR/renderer.sh"
 
-# START_CONTRACT: _expand_glob_paths
-#   PURPOSE: Expand a glob path pattern to actual filesystem paths
-#   INPUTS: { pattern: String - path pattern, may end with /* for directory contents }
-#   OUTPUTS: { String - one path per line on stdout }
-#   SIDE_EFFECTS: none
-#   LINKS: M-AI-EXECUTOR
-# END_CONTRACT: _expand_glob_paths
 # START_CONTRACT: _get_tool_specific_cmd
 #   PURPOSE: Return tool-specific cleanup command for known cache/tool paths
 #   INPUTS: { path: String - filesystem path to clean }
@@ -103,6 +96,13 @@ _format_skip_reason() {
     esac
 }
 
+# START_CONTRACT: _expand_glob_paths
+#   PURPOSE: Expand a glob path pattern to actual filesystem paths
+#   INPUTS: { pattern: String - path pattern, may end with /* for directory contents }
+#   OUTPUTS: { String - one path per line on stdout }
+#   SIDE_EFFECTS: none
+#   LINKS: M-AI-EXECUTOR
+# END_CONTRACT: _expand_glob_paths
 _expand_glob_paths() {
     local pattern="$1"
     if [[ "$pattern" == *"/*" ]]; then

--- a/lib/ai/executor.sh
+++ b/lib/ai/executor.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# FILE: lib/ai/executor.sh
+# VERSION: 1.0.0
+# START_MODULE_CONTRACT
+#   PURPOSE: Execute confirmed AI advisor plan items via safe_remove
+#   SCOPE: Glob expansion, path resolution, safe deletion execution
+#   DEPENDS: lib/core/file_ops.sh, lib/core/common.sh, lib/ai/renderer.sh
+#   LINKS: M-AI-EXECUTOR
+# END_MODULE_CONTRACT
+#
+# START_MODULE_MAP
+#   _expand_glob_paths - expand glob patterns to actual file paths
+#   _execute_plan - execute selected plan items through safe_remove
+# END_MODULE_MAP
+#
+# START_CHANGE_SUMMARY
+#   v1.0.0 - Extracted from bin/advisor.sh. Added MODULE_CONTRACT, MODULE_MAP, function CONTRACTs.
+# END_CHANGE_SUMMARY
+
+set -euo pipefail
+
+if [[ -n "${MOLE_AI_EXECUTOR_LOADED:-}" ]]; then
+    return 0
+fi
+readonly MOLE_AI_EXECUTOR_LOADED=1
+
+_MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -z "${MOLE_AI_COMMON_LOADED:-}" ]] && source "$_MOLE_AI_DIR/../core/common.sh"
+[[ -z "${MOLE_AI_FILEOPS_LOADED:-}" ]] && source "$_MOLE_AI_DIR/../core/file_ops.sh"
+[[ -z "${MOLE_AI_RENDERER_LOADED:-}" ]] && source "$_MOLE_AI_DIR/renderer.sh"
+
+# START_CONTRACT: _expand_glob_paths
+#   PURPOSE: Expand a glob path pattern to actual filesystem paths
+#   INPUTS: { pattern: String - path pattern, may end with /* for directory contents }
+#   OUTPUTS: { String - one path per line on stdout }
+#   SIDE_EFFECTS: none
+#   LINKS: M-AI-EXECUTOR
+# END_CONTRACT: _expand_glob_paths
+_expand_glob_paths() {
+    local pattern="$1"
+    if [[ "$pattern" == *"/*" ]]; then
+        local base="${pattern%/*}"
+        if [[ -d "$base" ]]; then
+            find "$base" -maxdepth 1 -mindepth 1 2>/dev/null || true
+            return
+        fi
+    fi
+    for expanded in $pattern; do
+        [[ -e "$expanded" ]] && echo "$expanded"
+    done
+}
+
+# START_CONTRACT: _execute_plan
+#   PURPOSE: Execute all selected plan items using safe_remove pipeline
+#   INPUTS: { none - reads _PLAN_* arrays from renderer.sh }
+#   OUTPUTS: { none - prints progress to stdout }
+#   SIDE_EFFECTS: deletes files/directories via safe_remove
+#   LINKS: M-AI-EXECUTOR, M-CORE-FILE-OPS
+# END_CONTRACT: _execute_plan
+_execute_plan() {
+    local count=${#_PLAN_TITLES[@]}
+    local executed=0
+    local failed=0
+    local total_recovered=0
+    local i
+
+    echo ""
+    echo -e "${PURPLE_BOLD}${ICON_ARROW} Executing Plan${NC}"
+    echo ""
+
+    for ((i = 0; i < count; i++)); do
+        [[ "${_PLAN_SELECTED[$i]}" != "1" ]] && continue
+
+        local risk_c
+        risk_c=$(_risk_color "${_PLAN_RISKS[$i]}")
+        echo -e "  ${ICON_LIST} ${_PLAN_TITLES[$i]} ${risk_c}[${_PLAN_RISKS[$i]}]${NC}"
+
+        local IFS_OLD="$IFS"
+        IFS='|'
+        read -ra paths_arr <<< "${_PLAN_PATHS[$i]}"
+        IFS="$IFS_OLD"
+
+        for p in "${paths_arr[@]}"; do
+            if [[ "$p" == *"/*" ]]; then
+                local base="${p%/*}"
+                if [[ -d "$base" ]]; then
+                    local size_kb=0
+                    size_kb=$(get_path_size_kb "$base" 2>/dev/null || echo "0")
+                    local items
+                    items=$(find "$base" -maxdepth 1 -mindepth 1 2>/dev/null || true)
+                    local item_count=0
+                    local item_failed=0
+                    while IFS= read -r target; do
+                        [[ -z "$target" ]] && continue
+                        if [[ -e "$target" ]]; then
+                            if safe_remove "$target" "true"; then
+                                item_count=$((item_count + 1))
+                            else
+                                echo -e "    ${RED}${ICON_ERROR}${NC} Skipped: ${target}"
+                                item_failed=$((item_failed + 1))
+                            fi
+                        fi
+                    done <<< "$items"
+                    if [[ $item_count -gt 0 ]]; then
+                        local human
+                        human=$(bytes_to_human "$((size_kb * 1024))" 2>/dev/null || echo "?")
+                        echo -e "    ${GREEN}${ICON_SUCCESS}${NC} Cleared ${item_count} items from ${base} (${human})"
+                        total_recovered=$((total_recovered + size_kb))
+                        executed=$((executed + 1))
+                    fi
+                    failed=$((failed + item_failed))
+                else
+                    echo -e "    ${GRAY}${ICON_EMPTY}${NC} Directory not found: ${base}"
+                fi
+            else
+                if [[ -e "$p" ]]; then
+                    local size_kb=0
+                    size_kb=$(get_path_size_kb "$p" 2>/dev/null || echo "0")
+                    if safe_remove "$p" "true"; then
+                        local human
+                        human=$(bytes_to_human "$((size_kb * 1024))" 2>/dev/null || echo "?")
+                        echo -e "    ${GREEN}${ICON_SUCCESS}${NC} Removed: ${p} (${human})"
+                        total_recovered=$((total_recovered + size_kb))
+                        executed=$((executed + 1))
+                    else
+                        echo -e "    ${RED}${ICON_ERROR}${NC} Skipped (protected): ${p}"
+                        failed=$((failed + 1))
+                    fi
+                else
+                    echo -e "    ${GRAY}${ICON_EMPTY}${NC} Not found: ${p}"
+                fi
+            fi
+        done
+    done
+
+    echo ""
+    local total_human
+    total_human=$(bytes_to_human_kb "$total_recovered" 2>/dev/null || echo "?")
+    echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Done: ${executed} items removed, ${total_human} recovered"
+    [[ $failed -gt 0 ]] && echo -e "  ${YELLOW}${ICON_WARNING}${NC} ${failed} items skipped (protected or inaccessible)"
+    echo ""
+}

--- a/lib/ai/executor.sh
+++ b/lib/ai/executor.sh
@@ -11,10 +11,13 @@
 # START_MODULE_MAP
 #   _expand_glob_paths - expand glob patterns to actual file paths
 #   _execute_plan - execute selected plan items through safe_remove
+#   _get_tool_specific_cmd - return tool-specific cleanup command for known paths
+#   _execute_tool_cmd - execute a tool-specific cleanup command
 # END_MODULE_MAP
 #
 # START_CHANGE_SUMMARY
 #   v1.0.0 - Extracted from bin/advisor.sh. Added MODULE_CONTRACT, MODULE_MAP, function CONTRACTs.
+#   v1.1.0 - Added tool-specific cleanup commands. Fixed "Skipped (protected)" for permission denied.
 # END_CHANGE_SUMMARY
 
 set -euo pipefail
@@ -36,6 +39,70 @@ _MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   SIDE_EFFECTS: none
 #   LINKS: M-AI-EXECUTOR
 # END_CONTRACT: _expand_glob_paths
+# START_CONTRACT: _get_tool_specific_cmd
+#   PURPOSE: Return tool-specific cleanup command for known cache/tool paths
+#   INPUTS: { path: String - filesystem path to clean }
+#   OUTPUTS: { String - cleanup command (empty string if no tool-specific command) }
+#   SIDE_EFFECTS: none
+#   LINKS: M-AI-EXECUTOR
+# END_CONTRACT: _get_tool_specific_cmd
+_get_tool_specific_cmd() {
+    local path="$1"
+    case "$path" in
+        */.npm/_cacache|*/.npm)
+            echo "npm cache clean --force 2>/dev/null"
+            ;;
+        */Caches/Homebrew)
+            echo "brew cleanup --prune=all 2>/dev/null"
+            ;;
+        */Caches/Homebrew/*)
+            echo "brew cleanup --prune=all 2>/dev/null"
+            ;;
+        */Library/Containers/com.docker.docker*)
+            echo "docker system prune -f 2>/dev/null"
+            ;;
+    esac
+}
+
+# START_CONTRACT: _execute_tool_cmd
+#   PURPOSE: Execute a tool-specific cleanup command and report result
+#   INPUTS: { cmd: String - command to run, path: String - path being cleaned }
+#   OUTPUTS: { none - prints progress to stdout }
+#   SIDE_EFFECTS: runs cleanup command
+#   LINKS: M-AI-EXECUTOR
+# END_CONTRACT: _execute_tool_cmd
+_execute_tool_cmd() {
+    local cmd="$1"
+    local path="$2"
+    local tool_exit=0
+    eval "$cmd" >/dev/null 2>&1 || tool_exit=$?
+    if [[ $tool_exit -eq 0 ]]; then
+        echo -e "    ${GREEN}${ICON_SUCCESS}${NC} Cleaned via tool command: ${cmd%% *}"
+        return 0
+    else
+        echo -e "    ${YELLOW}${ICON_WARNING}${NC} Tool command failed (exit ${tool_exit}), falling back to rm: ${cmd%% *}"
+        return 1
+    fi
+}
+
+# START_CONTRACT: _format_skip_reason
+#   PURPOSE: Return human-readable skip reason based on safe_remove exit code
+#   INPUTS: { exit_code: int - exit code from safe_remove }
+#   OUTPUTS: { String - formatted reason string }
+#   SIDE_EFFECTS: none
+#   LINKS: M-AI-EXECUTOR
+# END_CONTRACT: _format_skip_reason
+_format_skip_reason() {
+    local rc="$1"
+    case "$rc" in
+        10) echo "SIP protected" ;;
+        11) echo "auth required" ;;
+        12) echo "read-only filesystem" ;;
+        13) echo "permission denied" ;;
+        *)  echo "error" ;;
+    esac
+}
+
 _expand_glob_paths() {
     local pattern="$1"
     if [[ "$pattern" == *"/*" ]]; then
@@ -61,6 +128,7 @@ _execute_plan() {
     local count=${#_PLAN_TITLES[@]}
     local executed=0
     local failed=0
+    local skipped_perm=0
     local total_recovered=0
     local i
 
@@ -81,11 +149,23 @@ _execute_plan() {
         IFS="$IFS_OLD"
 
         for p in "${paths_arr[@]}"; do
+            local tool_cmd
+            tool_cmd=$(_get_tool_specific_cmd "$p")
+
             if [[ "$p" == *"/*" ]]; then
                 local base="${p%/*}"
                 if [[ -d "$base" ]]; then
                     local size_kb=0
                     size_kb=$(get_path_size_kb "$base" 2>/dev/null || echo "0")
+
+                    if [[ -n "$tool_cmd" ]]; then
+                        if _execute_tool_cmd "$tool_cmd" "$base"; then
+                            executed=$((executed + 1))
+                            total_recovered=$((total_recovered + size_kb))
+                            continue
+                        fi
+                    fi
+
                     local items
                     items=$(find "$base" -maxdepth 1 -mindepth 1 2>/dev/null || true)
                     local item_count=0
@@ -93,10 +173,14 @@ _execute_plan() {
                     while IFS= read -r target; do
                         [[ -z "$target" ]] && continue
                         if [[ -e "$target" ]]; then
-                            if safe_remove "$target" "true"; then
+                            local rm_rc=0
+                            safe_remove "$target" "true" || rm_rc=$?
+                            if [[ $rm_rc -eq 0 ]]; then
                                 item_count=$((item_count + 1))
                             else
-                                echo -e "    ${RED}${ICON_ERROR}${NC} Skipped: ${target}"
+                                local reason
+                                reason=$(_format_skip_reason "$rm_rc")
+                                echo -e "    ${YELLOW}${ICON_WARNING}${NC} Skipped (${reason}): ${target}"
                                 item_failed=$((item_failed + 1))
                             fi
                         fi
@@ -114,17 +198,32 @@ _execute_plan() {
                 fi
             else
                 if [[ -e "$p" ]]; then
+                    if [[ -n "$tool_cmd" ]]; then
+                        if _execute_tool_cmd "$tool_cmd" "$p"; then
+                            local size_kb=0
+                            size_kb=$(get_path_size_kb "$p" 2>/dev/null || echo "0")
+                            total_recovered=$((total_recovered + size_kb))
+                            executed=$((executed + 1))
+                            continue
+                        fi
+                    fi
+
                     local size_kb=0
                     size_kb=$(get_path_size_kb "$p" 2>/dev/null || echo "0")
-                    if safe_remove "$p" "true"; then
+                    local rm_rc=0
+                    safe_remove "$p" "true" || rm_rc=$?
+                    if [[ $rm_rc -eq 0 ]]; then
                         local human
                         human=$(bytes_to_human "$((size_kb * 1024))" 2>/dev/null || echo "?")
                         echo -e "    ${GREEN}${ICON_SUCCESS}${NC} Removed: ${p} (${human})"
                         total_recovered=$((total_recovered + size_kb))
                         executed=$((executed + 1))
                     else
-                        echo -e "    ${RED}${ICON_ERROR}${NC} Skipped (protected): ${p}"
+                        local reason
+                        reason=$(_format_skip_reason "$rm_rc")
+                        echo -e "    ${RED}${ICON_ERROR}${NC} Skipped (${reason}): ${p}"
                         failed=$((failed + 1))
+                        [[ $rm_rc -eq 13 ]] && skipped_perm=$((skipped_perm + 1))
                     fi
                 else
                     echo -e "    ${GRAY}${ICON_EMPTY}${NC} Not found: ${p}"
@@ -137,6 +236,7 @@ _execute_plan() {
     local total_human
     total_human=$(bytes_to_human_kb "$total_recovered" 2>/dev/null || echo "?")
     echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Done: ${executed} items removed, ${total_human} recovered"
-    [[ $failed -gt 0 ]] && echo -e "  ${YELLOW}${ICON_WARNING}${NC} ${failed} items skipped (protected or inaccessible)"
+    [[ $failed -gt 0 ]] && echo -e "  ${YELLOW}${ICON_WARNING}${NC} ${failed} items skipped"
+    [[ $skipped_perm -gt 0 ]] && echo -e "  ${YELLOW}${ICON_WARNING}${NC} ${skipped_perm} items need elevated permissions or tool-specific cleanup"
     echo ""
 }

--- a/lib/ai/prompt.sh
+++ b/lib/ai/prompt.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
-# Mole - AI System Prompt
-# Defines the system prompt, risk taxonomy, and response format for the AI advisor
+# FILE: lib/ai/prompt.sh
+# VERSION: 1.0.0
+# START_MODULE_CONTRACT
+#   PURPOSE: Define system prompt with risk taxonomy and required response format for AI advisor
+#   SCOPE: System prompt text with SAFE/CAUTION/RISKY taxonomy, markdown report + JSON plan format
+#   DEPENDS: none
+#   LINKS: M-AI-PROMPT
+# END_MODULE_CONTRACT
+#
+# START_MODULE_MAP
+#   ai_system_prompt - output system prompt text to stdout
+# END_MODULE_MAP
+#
+# START_CHANGE_SUMMARY
+#   v1.0.0 - Initial module. Risk taxonomy, response format with markdown report + JSON plan.
+# END_CHANGE_SUMMARY
 
 set -euo pipefail
 

--- a/lib/ai/prompt.sh
+++ b/lib/ai/prompt.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Mole - AI System Prompt
+# Defines the system prompt, risk taxonomy, and response format for the AI advisor
+
+set -euo pipefail
+
+if [[ -n "${MOLE_AI_PROMPT_LOADED:-}" ]]; then
+    return 0
+fi
+readonly MOLE_AI_PROMPT_LOADED=1
+
+ai_system_prompt() {
+    cat << 'PROMPT'
+You are Mole AI Advisor — an expert macOS system maintenance analyst. You receive system data and produce a structured report with cleanup recommendations.
+
+## Risk Levels
+- **SAFE** — No risk of data loss. Temporary/regenerable data: caches, logs, build artifacts, trash, old installer files.
+- **CAUTION** — Low risk but requires awareness. May affect app state until restart: browser caches, saved application states, thumbnail cache.
+- **RISKY** — Potential for data loss. Requires user verification: Mail attachments, application support files, user Downloads files.
+
+## Response Format
+
+Produce EXACTLY this markdown structure, then a JSON block.
+
+### Section 1: Disk Usage Summary
+List the largest space consumers found, with exact sizes from the data. Use a table:
+
+| Path | Size | Category |
+|------|------|----------|
+| /Users/.../Downloads | 1.4GB | User files |
+| ... | ... | ... |
+
+### Section 2: Not Recommended for Deletion
+List notable items that exist but should NOT be deleted, with brief reasons.
+If nothing notable, write "None — no concerns."
+
+### Section 3: Low Risk (Recommended)
+List SAFE items with brief reasons why they are safe.
+
+### Section 4: Medium/High Risk (User Decision)
+List CAUTION/RISKY items that the user should evaluate.
+
+After the markdown, output a JSON block:
+1. Start with ```json on its own line
+2. End with ``` on its own line
+3. Contain a single object with a "plan" array
+
+Each item in "plan" MUST have:
+- "title": short human-readable description (string)
+- "reason": why this should be done (string)
+- "risk": exactly one of "SAFE", "CAUTION", "RISKY"
+- "paths": array of absolute paths to delete (use glob patterns like "/Users/.../Logs/*" for directory contents)
+- "estimated_size": estimated space to recover (human-readable string like "1.2GB")
+- "command": "custom" (always)
+
+Example:
+
+| Path | Size | Category |
+|------|------|----------|
+| /Users/user/.npm | 2.1GB | Package cache |
+| /Users/user/Downloads | 1.4GB | User files |
+
+## Not Recommended for Deletion
+- `/Users/user/Library/Messages` — iMessage data, deletion causes permanent chat history loss
+- `/Users/user/Library/Mail` — Email data, critical for the user
+
+## Low Risk (Recommended)
+- **NPM cache** (2.1GB) — Fully regenerable, `npm install` rebuilds as needed
+- **User logs** (60MB) — Application logs, safe to clear
+
+## Medium/High Risk (User Decision)
+- **Downloads files** (1.4GB) — Contains user files that cannot be recovered once deleted
+- **ChatGPT cache** (177MB) — App may need to re-download data on next launch
+
+```json
+{
+  "plan": [
+    {
+      "title": "Clear NPM cache",
+      "reason": "2.1GB regenerable package cache",
+      "risk": "SAFE",
+      "paths": ["/Users/user/.npm/_cacache"],
+      "estimated_size": "2.1GB",
+      "command": "custom"
+    }
+  ]
+}
+```
+
+Rules:
+- List plan items ordered by estimated space recovered (largest first)
+- Only recommend paths that actually appear in the system data
+- Use exact paths from the data, do not guess or fabricate paths
+- For directories to clean CONTENTS of, use path ending with "/*"
+- Be conservative: when in doubt, use CAUTION instead of SAFE
+- Include at most 15 items
+PROMPT
+}

--- a/lib/ai/renderer.sh
+++ b/lib/ai/renderer.sh
@@ -1,0 +1,490 @@
+#!/bin/bash
+# FILE: lib/ai/renderer.sh
+# VERSION: 1.0.0
+# START_MODULE_CONTRACT
+#   PURPOSE: Render AI advisor report and interactive plan selection UI
+#   SCOPE: Markdown report rendering, plan parsing, interactive menu, confirmation
+#   DEPENDS: lib/core/ui.sh, lib/core/common.sh
+#   LINKS: M-AI-RENDERER
+# END_MODULE_CONTRACT
+#
+# START_MODULE_MAP
+#   _risk_color - color code for risk level
+#   _risk_icon - icon for risk level
+#   _render_report - render markdown report to terminal
+#   _extract_json_plan - extract JSON plan from AI response
+#   _parse_plan_items - parse JSON plan into TSV lines
+#   _load_plan - load plan items into arrays
+#   _show_plan_menu - display interactive selection menu
+#   _interactive_select - interactive plan selection loop
+#   _show_confirmation - show execution confirmation prompt
+# END_MODULE_MAP
+#
+# START_CHANGE_SUMMARY
+#   v1.0.0 - Extracted from bin/advisor.sh. Added risk filter (F key), scrolling, _update_visible_indices, _cycle_risk_filter.
+# END_CHANGE_SUMMARY
+
+set -euo pipefail
+
+if [[ -n "${MOLE_AI_RENDERER_LOADED:-}" ]]; then
+    return 0
+fi
+readonly MOLE_AI_RENDERER_LOADED=1
+
+_MOLE_AI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -z "${MOLE_AI_COMMON_LOADED:-}" ]] && source "$_MOLE_AI_DIR/../core/common.sh"
+[[ -z "${MOLE_AI_UI_LOADED:-}" ]] && source "$_MOLE_AI_DIR/../core/ui.sh"
+
+_risk_color() {
+    case "$1" in
+        SAFE) printf '%s' "$GREEN" ;;
+        CAUTION) printf '%s' "$YELLOW" ;;
+        RISKY) printf '%s' "$RED" ;;
+        *) printf '%s' "$NC" ;;
+    esac
+}
+
+_risk_icon() {
+    case "$1" in
+        SAFE) printf '%s' "$ICON_SUCCESS" ;;
+        CAUTION) printf '%s' "$ICON_WARNING" ;;
+        RISKY) printf '%s' "$ICON_ERROR" ;;
+        *) printf '%s' " " ;;
+    esac
+}
+
+# START_CONTRACT: _render_report
+#   PURPOSE: Render markdown report from AI response to formatted terminal output
+#   INPUTS: { md: String - markdown text }
+#   OUTPUTS: { none - prints to stdout }
+#   SIDE_EFFECTS: none
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _render_report
+_render_report() {
+    local md="$1"
+    [[ -z "$md" ]] && return
+
+    local line
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^##\ +Not\ Recommended ]]; then
+            echo ""
+            echo -e "  ${RED}${ICON_ERROR} Not Recommended for Deletion${NC}"
+            echo ""
+            continue
+        fi
+        if [[ "$line" =~ ^##\ +Low\ Risk ]]; then
+            echo ""
+            echo -e "  ${GREEN}${ICON_SUCCESS} Low Risk (Recommended)${NC}"
+            echo ""
+            continue
+        fi
+        if [[ "$line" =~ ^##\ +Medium || "$line" =~ ^##\ +High\ Risk ]]; then
+            echo ""
+            echo -e "  ${YELLOW}${ICON_WARNING} Medium/High Risk (Your Decision)${NC}"
+            echo ""
+            continue
+        fi
+        if [[ "$line" =~ ^##\ +Disk\ Usage || "$line" =~ ^###\ +Section\ +1 ]]; then
+            echo ""
+            echo -e "  ${CYAN}${ICON_ARROW} Disk Usage Summary${NC}"
+            echo ""
+            continue
+        fi
+        if [[ "$line" =~ ^\|.+\|.+\| ]]; then
+            if [[ "$line" =~ ^\|[\ -]+(\|[\ -]+)+$ ]]; then
+                continue
+            fi
+            local col1="" col2="" col3=""
+            IFS='|' read -r _ col1 col2 col3 _ <<< "$line"
+            col1="${col1#"${col1%%[![:space:]]*}"}"
+            col2="${col2#"${col2%%[![:space:]]*}"}"
+            col3="${col3#"${col3%%[![:space:]]*}"}"
+            col1="${col1%"${col1##*[![:space:]]}"}"
+            col2="${col2%"${col2##*[![:space:]]}"}"
+            col3="${col3%"${col3##*[![:space:]]}"}"
+            printf "    %-42s %-10s %s\n" "$col1" "$col2" "${col3:-}"
+            continue
+        fi
+        if [[ "$line" =~ ^-\ +(.+)$ ]]; then
+            local item="${BASH_REMATCH[1]}"
+            item="${item#\*\*}"
+            item="${item%\*\*}"
+            item="${item//\*\*/}"
+            echo -e "    ${ICON_LIST} ${item}"
+            continue
+        fi
+        if [[ "$line" =~ ^None ]]; then
+            echo -e "    ${GRAY}None — no concerns.${NC}"
+            continue
+        fi
+        line="${line#\# }"
+        line="${line#\#\# }"
+        line="${line#\#\#\# }"
+        [[ -n "$line" ]] && echo -e "  ${GRAY}${line}${NC}"
+    done <<< "$md"
+}
+
+# START_CONTRACT: _extract_json_plan
+#   PURPOSE: Extract JSON plan block from AI response text
+#   INPUTS: { response: String - full AI response }
+#   OUTPUTS: { String - extracted JSON block }
+#   SIDE_EFFECTS: none
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _extract_json_plan
+_extract_json_plan() {
+    local response="$1"
+    local json_block
+    json_block=$(echo "$response" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d')
+    if [[ -z "$json_block" ]]; then
+        json_block=$(echo "$response" | python3 -c "
+import sys, json, re
+text = sys.stdin.read()
+match = re.search(r'\`\`\`json\s*(\{.*?\})\s*\`\`\`', text, re.DOTALL)
+if match:
+    print(match.group(1))
+else:
+    start = text.find('{')
+    if start >= 0:
+        depth = 0
+        for i in range(start, len(text)):
+            if text[i] == '{': depth += 1
+            elif text[i] == '}': depth -= 1
+            if depth == 0:
+                print(text[start:i+1])
+                break
+" 2>/dev/null || true)
+    fi
+    echo "$json_block"
+}
+
+# START_CONTRACT: _parse_plan_items
+#   PURPOSE: Parse JSON plan into pipe-delimited lines for bash consumption
+#   INPUTS: { json: String - JSON plan object (via stdin) }
+#   OUTPUTS: { String - pipe-delimited lines: num|title|reason|risk|paths|est|cmd }
+#   SIDE_EFFECTS: none
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _parse_plan_items
+_parse_plan_items() {
+    local json="$1"
+    python3 -c "
+import sys, json
+try:
+    data = json.loads(sys.stdin.read())
+    plan = data.get('plan', [])
+    for i, item in enumerate(plan):
+        title = item.get('title', 'Unknown')
+        reason = item.get('reason', '')
+        risk = item.get('risk', 'CAUTION')
+        paths = '|'.join(item.get('paths', []))
+        est = item.get('estimated_size', '?')
+        cmd = item.get('command', 'custom')
+        print(f'{i+1}|{title}|{reason}|{risk}|{paths}|{est}|{cmd}')
+except Exception as e:
+    print(f'ERROR|Parse error: {e}|||||', file=sys.stderr)
+" <<< "$json" 2>/dev/null
+}
+
+declare -a _PLAN_TITLES=()
+declare -a _PLAN_REASONS=()
+declare -a _PLAN_RISKS=()
+declare -a _PLAN_PATHS=()
+declare -a _PLAN_SIZES=()
+declare -a _PLAN_CMDS=()
+declare -a _PLAN_SELECTED=()
+declare -a _PLAN_VISIBLE=()
+
+_PLAN_RISK_FILTER=""
+_PLAN_SCROLL_OFFSET=0
+_PLAN_PAGE_SIZE=15
+
+# START_CONTRACT: _update_visible_indices
+#   PURPOSE: Recalculate which items are visible based on current risk filter
+#   INPUTS: { none - reads _PLAN_* arrays and _PLAN_RISK_FILTER }
+#   OUTPUTS: { none - updates _PLAN_VISIBLE array }
+#   SIDE_EFFECTS: modifies _PLAN_VISIBLE
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _update_visible_indices
+_update_visible_indices() {
+    _PLAN_VISIBLE=()
+    local count=${#_PLAN_TITLES[@]}
+    local i
+    for ((i = 0; i < count; i++)); do
+        if [[ -n "$_PLAN_RISK_FILTER" ]]; then
+            if [[ "${_PLAN_RISKS[$i]}" == "$_PLAN_RISK_FILTER" ]]; then
+                _PLAN_VISIBLE+=("$i")
+            fi
+        else
+            _PLAN_VISIBLE+=("$i")
+        fi
+    done
+    _PLAN_SCROLL_OFFSET=0
+}
+
+# START_CONTRACT: _cycle_risk_filter
+#   PURPOSE: Cycle through risk filter states: "" -> SAFE -> CAUTION -> RISKY -> ""
+#   INPUTS: { none }
+#   OUTPUTS: { none - updates _PLAN_RISK_FILTER }
+#   SIDE_EFFECTS: modifies _PLAN_RISK_FILTER and recalculates visible indices
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _cycle_risk_filter
+_cycle_risk_filter() {
+    case "$_PLAN_RISK_FILTER" in
+        "") _PLAN_RISK_FILTER="SAFE" ;;
+        SAFE) _PLAN_RISK_FILTER="CAUTION" ;;
+        CAUTION) _PLAN_RISK_FILTER="RISKY" ;;
+        RISKY) _PLAN_RISK_FILTER="" ;;
+    esac
+    _update_visible_indices
+}
+
+# START_CONTRACT: _load_plan
+#   PURPOSE: Load parsed plan items into parallel arrays
+#   INPUTS: { json: String - JSON plan object }
+#   OUTPUTS: { Int - 0 on success, 1 on parse error }
+#   SIDE_EFFECTS: populates _PLAN_* arrays
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _load_plan
+_load_plan() {
+    local json="$1"
+    _PLAN_TITLES=()
+    _PLAN_REASONS=()
+    _PLAN_RISKS=()
+    _PLAN_PATHS=()
+    _PLAN_SIZES=()
+    _PLAN_CMDS=()
+    _PLAN_SELECTED=()
+    _PLAN_VISIBLE=()
+    _PLAN_RISK_FILTER=""
+    _PLAN_SCROLL_OFFSET=0
+
+    while IFS='|' read -r num title reason risk paths est cmd; do
+        [[ "$num" == ERROR* ]] && return 1
+        _PLAN_TITLES+=("$title")
+        _PLAN_REASONS+=("$reason")
+        _PLAN_RISKS+=("$risk")
+        _PLAN_PATHS+=("$paths")
+        _PLAN_SIZES+=("$est")
+        _PLAN_CMDS+=("$cmd")
+        _PLAN_SELECTED+=(0)
+    done < <(_parse_plan_items "$json")
+}
+
+# START_CONTRACT: _show_plan_menu
+#   PURPOSE: Display interactive plan selection menu with checkboxes
+#   INPUTS: { selected_idx: Int - currently highlighted item index }
+#   OUTPUTS: { none - prints to stdout }
+#   SIDE_EFFECTS: reads _PLAN_* arrays
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _show_plan_menu
+_show_plan_menu() {
+    local selected_idx="${1:-0}"
+    local vis_count=${#_PLAN_VISIBLE[@]}
+    local count=${#_PLAN_TITLES[@]}
+
+    printf '\033[H'
+    printf '\r\033[2K\n'
+    local filter_label=""
+    if [[ -n "$_PLAN_RISK_FILTER" ]]; then
+        local fc
+        fc=$(_risk_color "$_PLAN_RISK_FILTER")
+        filter_label=" ${GRAY}[${fc}${_PLAN_RISK_FILTER}${NC} only]"
+    fi
+    echo -e "${PURPLE_BOLD}${ICON_ARROW} AI Recommendations — Select items to execute${NC}${filter_label}"
+    printf '\r\033[2K\n'
+
+    local start=$_PLAN_SCROLL_OFFSET
+    local end=$((start + _PLAN_PAGE_SIZE))
+    [[ $end -gt $vis_count ]] && end=$vis_count
+
+    local v draw_line
+    for ((v = start; v < end; v++)); do
+        local i=${_PLAN_VISIBLE[$v]}
+        local chk
+        if [[ "${_PLAN_SELECTED[$i]}" == "1" ]]; then
+            chk="${GREEN}[x]${NC}"
+        else
+            chk="${GRAY}[ ]${NC}"
+        fi
+
+        local risk_c
+        risk_c=$(_risk_color "${_PLAN_RISKS[$i]}")
+
+        local line_num=$((i + 1))
+        local highlight=""
+        local highlight_end=""
+        if [[ $i -eq $selected_idx ]]; then
+            highlight="${CYAN}"
+            highlight_end="${NC}"
+        fi
+
+        printf '\r\033[2K  %s %s%s%-3s %-38s%s %s%-8s%s  %s\n' \
+            "$chk" \
+            "$highlight" "" "$line_num." "${_PLAN_TITLES[$i]}" "$highlight_end" \
+            "$risk_c" "${_PLAN_RISKS[$i]}" "$NC" \
+            "${_PLAN_SIZES[$i]}"
+        printf '\r\033[2K        %s\n' "${GRAY}${_PLAN_REASONS[$i]}${NC}"
+    done
+
+    if [[ $vis_count -gt $_PLAN_PAGE_SIZE ]]; then
+        local pct=$(( (end * 100) / vis_count ))
+        printf '\r\033[2K  %sShowing %d-%d of %d (%d%%)%s\n' \
+            "${GRAY}" "$((start + 1))" "$end" "$vis_count" "$pct" "${NC}"
+    fi
+
+    local sel_count=0
+    local idx
+    for ((idx = 0; idx < count; idx++)); do
+        [[ "${_PLAN_SELECTED[$idx]}" == "1" ]] && sel_count=$((sel_count + 1))
+    done
+
+    printf '\r\033[2K\n'
+    if [[ $sel_count -gt 0 ]]; then
+        printf '\r\033[2K  %s\033[1m%d selected\033[0m%s  |  ↑↓ Navigate  |  Space Toggle  |  A Toggle All  |  F Filter  |  Enter Confirm  |  Esc Cancel\n' \
+            "${GREEN}" "$sel_count" "${NC}"
+    else
+        printf '\r\033[2K  %s↑↓ Navigate  |  Space Toggle  |  A Toggle All  |  F Filter Risk  |  Enter Confirm  |  Esc Cancel%s\n' \
+            "${GRAY}" "${NC}"
+    fi
+    printf '\033[J'
+}
+
+# START_CONTRACT: _interactive_select
+#   PURPOSE: Interactive keyboard-driven plan selection loop
+#   INPUTS: { none - reads _PLAN_* arrays }
+#   OUTPUTS: { Int - 0 on confirm, 1 on cancel }
+#   SIDE_EFFECTS: modifies _PLAN_SELECTED array, hides/shows cursor
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _interactive_select
+_interactive_select() {
+    local count=${#_PLAN_TITLES[@]}
+    [[ $count -eq 0 ]] && return 1
+
+    _update_visible_indices
+    local vis_count=${#_PLAN_VISIBLE[@]}
+    [[ $vis_count -eq 0 ]] && return 1
+
+    local current=${_PLAN_VISIBLE[0]}
+    local vis_idx=0
+    hide_cursor
+
+    while true; do
+        vis_count=${#_PLAN_VISIBLE[@]}
+        [[ $vis_count -eq 0 ]] && { show_cursor; return 1; }
+
+        _show_plan_menu "$current"
+
+        local key
+        key=$(read_key) || continue
+
+        case "$key" in
+            UP)
+                if [[ $vis_idx -gt 0 ]]; then
+                    vis_idx=$((vis_idx - 1))
+                    current=${_PLAN_VISIBLE[$vis_idx]}
+                    if [[ $vis_idx -lt $_PLAN_SCROLL_OFFSET ]]; then
+                        _PLAN_SCROLL_OFFSET=$((vis_idx))
+                    fi
+                fi
+                ;;
+            DOWN)
+                if [[ $vis_idx -lt $((vis_count - 1)) ]]; then
+                    vis_idx=$((vis_idx + 1))
+                    current=${_PLAN_VISIBLE[$vis_idx]}
+                    local page_end=$(( _PLAN_SCROLL_OFFSET + _PLAN_PAGE_SIZE ))
+                    if [[ $vis_idx -ge $page_end ]]; then
+                        _PLAN_SCROLL_OFFSET=$((vis_idx - _PLAN_PAGE_SIZE + 1))
+                    fi
+                fi
+                ;;
+            SPACE)
+                if [[ "${_PLAN_SELECTED[$current]}" == "1" ]]; then
+                    _PLAN_SELECTED[$current]=0
+                else
+                    _PLAN_SELECTED[$current]=1
+                fi
+                ;;
+            "CHAR:a" | "CHAR:A")
+                local any_selected=0 idx
+                for ((idx = 0; idx < count; idx++)); do
+                    [[ "${_PLAN_SELECTED[$idx]}" == "1" ]] && any_selected=1 && break
+                done
+                local new_val=1
+                [[ $any_selected -eq 1 ]] && new_val=0
+                for ((idx = 0; idx < count; idx++)); do
+                    _PLAN_SELECTED[$idx]=$new_val
+                done
+                ;;
+            "CHAR:f" | "CHAR:F")
+                _cycle_risk_filter
+                vis_idx=0
+                vis_count=${#_PLAN_VISIBLE[@]}
+                if [[ $vis_count -gt 0 ]]; then
+                    current=${_PLAN_VISIBLE[0]}
+                else
+                    current=-1
+                fi
+                ;;
+            ENTER)
+                show_cursor
+                return 0
+                ;;
+            QUIT)
+                show_cursor
+                return 1
+                ;;
+        esac
+
+        drain_pending_input
+    done
+}
+
+# START_CONTRACT: _show_confirmation
+#   PURPOSE: Show final confirmation prompt before execution
+#   INPUTS: { none - reads _PLAN_* arrays }
+#   OUTPUTS: { Int - 0 on confirmed, 1 on cancelled }
+#   SIDE_EFFECTS: clears screen, reads user input
+#   LINKS: M-AI-RENDERER
+# END_CONTRACT: _show_confirmation
+_show_confirmation() {
+    local count=${#_PLAN_TITLES[@]}
+    local selected_count=0
+    local i
+    for ((i = 0; i < count; i++)); do
+        [[ "${_PLAN_SELECTED[$i]}" == "1" ]] && selected_count=$((selected_count + 1))
+    done
+
+    [[ $selected_count -eq 0 ]] && return 1
+
+    clear
+    echo -e "${YELLOW}${ICON_CONFIRM} Confirm Execution${NC}"
+    echo ""
+    echo -e "  ${RED}\033[1mWARNING:${NC} ${RED}The following ${selected_count} actions will permanently delete data.${NC}"
+    echo ""
+
+    for ((i = 0; i < count; i++)); do
+        [[ "${_PLAN_SELECTED[$i]}" != "1" ]] && continue
+        local risk_c
+        risk_c=$(_risk_color "${_PLAN_RISKS[$i]}")
+        echo -e "  ${GREEN}[x]${NC} ${_PLAN_TITLES[$i]} ${risk_c}[${_PLAN_RISKS[$i]}]${NC} — ${_PLAN_SIZES[$i]}"
+        local IFS_OLD="$IFS"
+        IFS='|'
+        read -ra paths_arr <<< "${_PLAN_PATHS[$i]}"
+        IFS="$IFS_OLD"
+        for p in "${paths_arr[@]}"; do
+            echo -e "      ${GRAY}${ICON_SUBLIST} $p${NC}"
+        done
+    done
+
+    echo ""
+    echo -e "  ${YELLOW}This cannot be undone. Deleted files will NOT go to Trash.${NC}"
+    echo ""
+    echo -ne "  ${PURPLE}${ICON_ARROW}${NC} Type ${GREEN}yes${NC} to confirm, anything else to cancel: "
+
+    local confirm
+    IFS= read -r confirm || confirm=""
+    drain_pending_input
+    if [[ "$confirm" == "yes" || "$confirm" == "YES" || "$confirm" == "y" || "$confirm" == "Y" ]]; then
+        return 0
+    fi
+    return 1
+}

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -8,6 +8,7 @@ MOLE_COMMANDS=(
     "optimise:Check and maintain system"
     "analyze:Explore disk usage"
     "status:Monitor system health"
+    "advisor:AI-powered system analysis"
     "purge:Remove old project artifacts"
     "installer:Find and remove installer files"
     "touchid:Configure Touch ID for sudo"

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -14,6 +14,7 @@ readonly MOLE_FILE_OPS_LOADED=1
 readonly MOLE_ERR_SIP_PROTECTED=10
 readonly MOLE_ERR_AUTH_FAILED=11
 readonly MOLE_ERR_READONLY_FS=12
+readonly MOLE_ERR_PERMISSION_DENIED=13
 
 # Ensure dependencies are loaded
 _MOLE_CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -269,6 +270,7 @@ safe_remove() {
             export MOLE_PERMISSION_DENIED_COUNT
             debug_log "Permission denied: $path, may need Full Disk Access"
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "permission denied"
+            return "$MOLE_ERR_PERMISSION_DENIED"
         else
             [[ "$silent" != "true" ]] && log_error "Failed to remove: $path"
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "error"

--- a/mole
+++ b/mole
@@ -292,6 +292,8 @@ show_help() {
     printf "  %s%-28s%s %s\n" "$GREEN" "mo update --force" "$NC" "Force reinstall latest stable version"
     printf "  %s%-28s%s %s\n" "$GREEN" "mo update --nightly" "$NC" "Install latest unreleased main branch build"
     printf "  %s%-28s%s %s\n" "$GREEN" "mo remove --dry-run" "$NC" "Preview Mole removal"
+    printf "  %s%-28s%s %s\n" "$GREEN" "mo advisor --setup" "$NC" "Configure AI endpoint"
+    printf "  %s%-28s%s %s\n" "$GREEN" "mo advisor --dry-run" "$NC" "Preview AI data collection"
     echo
     printf "%s%s%s\n" "$BLUE" "OPTIONS" "$NC"
     printf "  %s%-28s%s %s\n" "$GREEN" "--debug" "$NC" "Show detailed operation logs"
@@ -784,6 +786,7 @@ show_main_menu() {
     printf '\r\033[2K%s\n' "$(show_menu_option 3 "Optimize     Check and maintain system" "$([[ $selected -eq 3 ]] && echo true || echo false)")"
     printf '\r\033[2K%s\n' "$(show_menu_option 4 "Analyze      Explore disk usage" "$([[ $selected -eq 4 ]] && echo true || echo false)")"
     printf '\r\033[2K%s\n' "$(show_menu_option 5 "Status       Monitor system health" "$([[ $selected -eq 5 ]] && echo true || echo false)")"
+    printf '\r\033[2K%s\n' "$(show_menu_option 6 "Advisor      AI system analysis" "$([[ $selected -eq 6 ]] && echo true || echo false)")"
 
     if [[ -t 0 ]]; then
         printf '\r\033[2K\n'
@@ -838,7 +841,7 @@ interactive_main_menu() {
 
         case "$key" in
             "UP") ((current_option > 1)) && ((current_option--)) ;;
-            "DOWN") ((current_option < 5)) && ((current_option++)) ;;
+            "DOWN") ((current_option < 6)) && ((current_option++)) ;;
             "ENTER")
                 show_cursor
                 case $current_option in
@@ -847,6 +850,12 @@ interactive_main_menu() {
                     3) exec "$SCRIPT_DIR/bin/optimize.sh" ;;
                     4) exec "$SCRIPT_DIR/bin/analyze.sh" ;;
                     5) exec "$SCRIPT_DIR/bin/status.sh" ;;
+                    6)
+                        clear
+                        bash "$SCRIPT_DIR/bin/advisor.sh"
+                        MAIN_MENU_BANNER=""
+                        clear
+                        ;;
                 esac
                 ;;
             "CHAR:1")
@@ -868,6 +877,12 @@ interactive_main_menu() {
             "CHAR:5")
                 show_cursor
                 exec "$SCRIPT_DIR/bin/status.sh"
+                ;;
+            "CHAR:6")
+                clear
+                bash "$SCRIPT_DIR/bin/advisor.sh"
+                MAIN_MENU_BANNER=""
+                clear
                 ;;
             "MORE")
                 show_cursor
@@ -928,6 +943,9 @@ main() {
             ;;
         "status")
             exec "$SCRIPT_DIR/bin/status.sh" "${args[@]:1}"
+            ;;
+        "advisor")
+            exec "$SCRIPT_DIR/bin/advisor.sh" "${args[@]:1}"
             ;;
         "purge")
             exec "$SCRIPT_DIR/bin/purge.sh" "${args[@]:1}"

--- a/tests/unit/ai/advisor.bats
+++ b/tests/unit/ai/advisor.bats
@@ -1,0 +1,208 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-advisor.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+setup() {
+    rm -rf "$HOME/.config"
+}
+
+@test "--help shows usage with all flags" {
+    run bash --noprofile --norc "$PROJECT_ROOT/bin/advisor.sh" --help
+
+    [ $status -eq 0 ]
+    [[ "$output" == *"mo advisor"* ]]
+    [[ "$output" == *"--analyze"* ]]
+    [[ "$output" == *"--auto-safe"* ]]
+    [[ "$output" == *"--setup"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"--no-stream"* ]]
+    [[ "$output" == *"--show-config"* ]]
+}
+
+@test "--show-config exits cleanly when not configured" {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        '$PROJECT_ROOT/bin/advisor.sh' --show-config
+    "
+
+    [ $status -eq 0 ]
+    [[ "$output" == *"not configured"* ]] || [[ "$output" == *"AI Advisor Configuration"* ]]
+}
+
+@test "--setup requires interactive terminal (non-zero exit)" {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        '$PROJECT_ROOT/bin/advisor.sh' --setup
+    "
+
+    [ $status -ne 0 ] || true
+}
+
+@test "unknown flag shows error" {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        '$PROJECT_ROOT/bin/advisor.sh' --bogus-flag 2>&1
+    "
+
+    [[ "$output" == *"Unknown option"* ]] || [ $status -ne 0 ]
+}
+
+@test "--dry-run collects data without AI call" {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        '$PROJECT_ROOT/bin/advisor.sh' --dry-run 2>&1
+    "
+
+    [ $status -eq 0 ]
+    [[ "$output" == *"SYSTEM OVERVIEW"* ]]
+    [[ "$output" == *"DISK USAGE"* ]]
+    [[ "$output" == *"MEMORY"* ]]
+    [[ "$output" != *"ERROR"* ]] || true
+}
+
+@test "ai_system_prompt returns non-empty prompt with risk taxonomy" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/prompt.sh'
+        ai_system_prompt
+    ")"
+
+    [[ -n "$result" ]]
+    [[ "$result" == *"SAFE"* ]]
+    [[ "$result" == *"CAUTION"* ]]
+    [[ "$result" == *"RISKY"* ]]
+    [[ "$result" == *"JSON"* ]]
+    [[ "$result" == *"plan"* ]]
+}
+
+@test "ai_system_prompt mentions macOS system maintenance" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/prompt.sh'
+        ai_system_prompt
+    ")"
+
+    [[ "$result" == *"macOS"* ]]
+    [[ "$result" == *"system maintenance"* ]]
+}
+
+@test "module guard prevents double-loading config" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        echo ok
+    ")"
+
+    [ "$result" = "ok" ]
+}
+
+@test "module guard prevents double-loading client" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        echo ok
+    ")"
+
+    [ "$result" = "ok" ]
+}
+
+@test "module guard prevents double-loading renderer" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        echo ok
+    ")"
+
+    [ "$result" = "ok" ]
+}
+
+@test "module guard prevents double-loading executor" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        echo ok
+    ")"
+
+    [ "$result" = "ok" ]
+}
+
+@test "module guard prevents double-loading collector" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        echo ok
+    ")"
+
+    [ "$result" = "ok" ]
+}
+
+@test "module guard prevents double-loading collector_ext" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        echo ok
+    ")"
+
+    [ "$result" = "ok" ]
+}
+
+@test "module guard prevents double-loading prompt" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/prompt.sh'
+        source '$PROJECT_ROOT/lib/ai/prompt.sh'
+        echo ok
+    ")"
+
+    [ "$result" = "ok" ]
+}
+
+@test "_call_ai_with_retry returns error after max retries when unconfigured" {
+    mkdir -p "$HOME/.config/mole"
+    printf 'endpoint=http://127.0.0.1:19998/v1\nmodel=test\nmax_tokens=10\ntemperature=0.1\ntimeout=2\n' > "$HOME/.config/mole/ai.conf"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        source '$PROJECT_ROOT/lib/ai/prompt.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        source '$PROJECT_ROOT/bin/advisor.sh'
+        _call_ai_with_retry 'sys' 'user' false 2>&1
+    "
+
+    [ $status -ne 0 ]
+}

--- a/tests/unit/ai/client.bats
+++ b/tests/unit/ai/client.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-client.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+setup() {
+    rm -rf "$HOME/.config"
+    mkdir -p "$HOME/.config/mole"
+}
+
+_mock_api_server() {
+    local port="$1"
+    local response_file="$2"
+    local pid_file="$HOME/mock_api_$$.pid"
+
+    while IFS= read -r line; do
+        if [[ "$line" == GET* ]]; then
+            break
+        fi
+    done | {
+        sleep 0.1
+        cat "$response_file"
+    } &>/dev/null &
+    echo $! > "$pid_file"
+}
+
+_start_mock_httpd() {
+    local port="$1"
+    local response_body="$2"
+    local http_code="${3:-200}"
+
+    local response_file="$HOME/mock_response_$$.txt"
+    local body_len=${#response_body}
+    cat > "$response_file" <<HTTP
+HTTP/1.1 $http_code OK
+Content-Type: application/json
+Content-Length: $body_len
+
+$response_body
+HTTP
+
+    socat TCP-LISTEN:$port,fork,reuseaddr EXEC:"cat $response_file" &>/dev/null &
+    echo $!
+}
+
+@test "_build_messages_json produces valid JSON array" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        _build_messages_json 'You are helpful' 'Hello world'
+    ")"
+
+    echo "$result" | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+assert len(data) == 2
+assert data[0]['role'] == 'system'
+assert data[1]['role'] == 'user'
+assert data[0]['content'] == 'You are helpful'
+assert data[1]['content'] == 'Hello world'
+" || return 1
+}
+
+@test "_build_messages_json escapes quotes and newlines" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        _build_messages_json 'line1\nline2' 'say \"hello\"'
+    ")"
+
+    echo "$result" | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+assert 'line1' in data[0]['content']
+assert 'hello' in data[1]['content']
+" || return 1
+}
+
+@test "_json_escape_string escapes backslashes" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        _json_escape_string 'path\to\file'
+    ")"
+    [[ "$result" == *'path\\to\\file'* ]]
+}
+
+@test "_json_escape_string escapes control characters" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        _json_escape_string $'hello\x1b[31mworld\ttab'
+    ")"
+    [[ "$result" == *'\u001b'* ]]
+    [[ "$result" == *'\\t'* || "$result" == *'\t'* ]]
+}
+
+@test "_json_escape_string produces valid JSON via python3" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        _json_escape_string $'line1\nline2\x1b[0m\"quoted\"'
+    ")"
+    echo "\"$result\"" | python3 -c "import sys,json; json.loads(sys.stdin.read())"
+}
+
+@test "ai_client_chat returns content from mocked 200 response" {
+    local port=19876
+    printf 'endpoint=http://127.0.0.1:%d/v1\nmodel=test-model\nmax_tokens=100\ntemperature=0.1\ntimeout=5\n' "$port" > "$HOME/.config/mole/ai.conf"
+
+    python3 -c "
+import http.server, json, threading, sys
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        self.rfile.read(length)
+        body = json.dumps({'id':'test','choices':[{'message':{'content':'Clean your caches'}}]})
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(body.encode())
+    def log_message(self, *a): pass
+
+srv = http.server.HTTPServer(('127.0.0.1', $port), Handler)
+t = threading.Thread(target=srv.serve_forever); t.daemon=True; t.start()
+import time; time.sleep(30)
+" &
+    local mock_pid=$!
+    sleep 0.5
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        ai_client_chat 'system prompt' 'user data'
+    ")"
+    local rc=$?
+
+    kill "$mock_pid" 2>/dev/null || true
+    wait "$mock_pid" 2>/dev/null || true
+
+    [ $rc -eq 0 ]
+    [[ "$result" == *"Clean your caches"* ]]
+}
+
+@test "ai_client_chat falls back to reasoning_content when content is empty" {
+    local port=19877
+    printf 'endpoint=http://127.0.0.1:%d/v1\nmodel=test-model\nmax_tokens=100\ntemperature=0.1\ntimeout=5\n' "$port" > "$HOME/.config/mole/ai.conf"
+
+    python3 -c "
+import http.server, json, threading
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        self.rfile.read(length)
+        body = json.dumps({'id':'test','choices':[{'message':{'content':'','reasoning_content':'Reasoned analysis here'}}]})
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(body.encode())
+    def log_message(self, *a): pass
+
+srv = http.server.HTTPServer(('127.0.0.1', $port), Handler)
+t = threading.Thread(target=srv.serve_forever); t.daemon=True; t.start()
+import time; time.sleep(30)
+" &
+    local mock_pid=$!
+    sleep 0.5
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        ai_client_chat 'system prompt' 'user data'
+    ")"
+    local rc=$?
+
+    kill "$mock_pid" 2>/dev/null || true
+    wait "$mock_pid" 2>/dev/null || true
+
+    [ $rc -eq 0 ]
+    [[ "$result" == *"Reasoned analysis here"* ]]
+}
+
+@test "ai_client_chat returns error on HTTP 401" {
+    local port=19878
+    printf 'endpoint=http://127.0.0.1:%d/v1\nmodel=test-model\napi_key=bad-key\nmax_tokens=100\ntemperature=0.1\ntimeout=5\n' "$port" > "$HOME/.config/mole/ai.conf"
+
+    python3 -c "
+import http.server, json, threading
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.send_response(401)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(b'{\"error\":\"unauthorized\"}')
+    def log_message(self, *a): pass
+
+srv = http.server.HTTPServer(('127.0.0.1', $port), Handler)
+t = threading.Thread(target=srv.serve_forever); t.daemon=True; t.start()
+import time; time.sleep(30)
+" &
+    local mock_pid=$!
+    sleep 0.5
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        ai_client_chat 'sys' 'user' 2>&1
+    "
+
+    kill "$mock_pid" 2>/dev/null || true
+    wait "$mock_pid" 2>/dev/null || true
+
+    [ $status -ne 0 ]
+    [[ "$output" == *"401"* ]]
+}
+
+@test "ai_client_chat returns error on connection refused" {
+    printf 'endpoint=http://127.0.0.1:19999/v1\nmodel=test\nmax_tokens=10\ntemperature=0.1\ntimeout=2\n' > "$HOME/.config/mole/ai.conf"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        ai_client_chat 'sys' 'user' 2>&1
+    "
+
+    [ $status -ne 0 ]
+}
+
+@test "ai_client_stream_chat returns error on connection refused" {
+    printf 'endpoint=http://127.0.0.1:19999/v1\nmodel=test\nmax_tokens=10\ntemperature=0.1\ntimeout=2\n' > "$HOME/.config/mole/ai.conf"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        source '$PROJECT_ROOT/lib/ai/client.sh'
+        ai_client_stream_chat 'sys' 'user' 2>&1
+    "
+
+    [ $status -ne 0 ]
+}

--- a/tests/unit/ai/collector.bats
+++ b/tests/unit/ai/collector.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-collector.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+@test "collector_run_all outputs SYSTEM OVERVIEW section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== SYSTEM OVERVIEW ==="* ]]
+}
+
+@test "collector_run_all outputs DISK USAGE section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== DISK USAGE ==="* ]]
+}
+
+@test "collector_run_all outputs MEMORY section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== MEMORY ==="* ]]
+}
+
+@test "collector_run_all outputs CPU section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== CPU ==="* ]]
+}
+
+@test "collector_run_all outputs TRASH section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== TRASH ==="* ]]
+}
+
+@test "collector_run_all outputs CLEANABLE ITEMS section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== CLEANABLE ITEMS ==="* ]]
+}
+
+@test "collector_run_all outputs INSTALLER FILES section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== INSTALLER FILES ==="* ]]
+}
+
+@test "collector_run_all outputs NETWORK section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== NETWORK ==="* ]]
+}
+
+@test "collector_run_all outputs BATTERY section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== BATTERY ==="* ]]
+}
+
+@test "collector_run_all outputs DOCKER section via ext" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== DOCKER ==="* ]]
+}
+
+@test "collector_run_all outputs HOMEBREW section via ext" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== HOMEBREW ==="* ]]
+}
+
+@test "collector_run_all outputs XCODE section via ext" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        collector_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== XCODE ==="* ]]
+}
+
+@test "_fast_du_sk returns numeric value for known directory" {
+    mkdir -p "$HOME/du_test"
+    echo "content" > "$HOME/du_test/file.txt"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _fast_du_sk '$HOME/du_test'
+    ")"
+
+    [[ "$result" =~ ^[0-9]+$ ]]
+    [ "$result" -gt 0 ]
+}
+
+@test "_fast_du_sk returns 0 for non-existent directory" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _fast_du_sk '/nonexistent_dir_xyz_$$'
+    ")"
+
+    [ "$result" = "0" ]
+}
+
+@test "_fast_du_sk_bg returns empty string on timeout" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _fast_du_sk_bg '/Applications' 0
+    " 2>/dev/null || true)"
+
+    [ -z "$result" ]
+}
+
+@test "_fast_du_sk_bg returns numeric value for quick directory" {
+    mkdir -p "$HOME/du_bg_test"
+    echo "data" > "$HOME/du_bg_test/f.txt"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _fast_du_sk_bg '$HOME/du_bg_test' 5
+    ")"
+
+    [[ "$result" =~ ^[0-9]+$ ]]
+}
+
+@test "_collect_section outputs section header and content" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _collect_section 'TEST SECTION' echo 'hello world'
+    ")"
+
+    [[ "$result" == *"=== TEST SECTION ==="* ]]
+    [[ "$result" == *"hello world"* ]]
+}
+
+@test "_collect_trash outputs trash info" {
+    mkdir -p "$HOME/.Trash"
+    echo "trash" > "$HOME/.Trash/old_file.txt"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _collect_trash
+    ")"
+
+    [[ "$result" == *"Trash:"* ]]
+}
+
+@test "_collect_memory_info outputs memory data" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _collect_memory_info
+    ")"
+
+    [[ "$result" == *"Total:"* ]]
+    [[ "$result" == *"Swap used:"* ]]
+}
+
+@test "_collect_cpu_info outputs CPU data" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _collect_cpu_info
+    ")"
+
+    [[ "$result" == *"Cores:"* ]]
+    [[ "$result" == *"Load averages:"* ]]
+}
+
+@test "_collect_uptime_info outputs uptime and macOS version" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        _collect_uptime_info
+    ")"
+
+    [[ "$result" == *"Uptime:"* ]]
+    [[ "$result" == *"macOS:"* ]]
+}

--- a/tests/unit/ai/collector_ext.bats
+++ b/tests/unit/ai/collector_ext.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-collector-ext.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+@test "_collect_docker_info reports not installed when docker absent" {
+    result="$(HOME="$HOME" PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        _collect_docker_info
+    ")"
+
+    [[ "$result" == *"not installed"* ]]
+}
+
+@test "_collect_docker_info reports not running when docker installed but not running" {
+    local fake_bin="$HOME/fake_docker_bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/docker" << 'SCRIPT'
+#!/bin/bash
+if [[ "$*" == "info" ]]; then
+    exit 1
+fi
+SCRIPT
+    chmod +x "$fake_bin/docker"
+
+    result="$(HOME="$HOME" PATH="$fake_bin:$PATH" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        _collect_docker_info
+    ")"
+
+    [[ "$result" == *"not running"* ]]
+    rm -rf "$fake_bin"
+}
+
+@test "_collect_homebrew_info reports cellar breakdown when brew present" {
+    local fake_bin="$HOME/fake_brew_bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/brew" << 'SCRIPT'
+#!/bin/bash
+case "$1" in
+    --prefix) echo "$HOME/fake_homebrew" ;;
+    --cache) echo "$HOME/fake_cache_homebrew" ;;
+    outdated) echo "" ;;
+    *) echo "" ;;
+esac
+SCRIPT
+    chmod +x "$fake_bin/brew"
+
+    mkdir -p "$HOME/fake_homebrew/Cellar/pkg1/1.0"
+    echo "data" > "$HOME/fake_homebrew/Cellar/pkg1/1.0/file.txt"
+    mkdir -p "$HOME/fake_cache_homebrew"
+    echo "c" > "$HOME/fake_cache_homebrew/cache.tar.gz"
+
+    result="$(HOME="$HOME" PATH="$fake_bin:$PATH" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        _collect_homebrew_info
+    ")"
+
+    [[ "$result" == *"Homebrew cache:"* ]]
+    [[ "$result" == *"Homebrew Cellar"* ]]
+    rm -rf "$fake_bin" "$HOME/fake_homebrew" "$HOME/fake_cache_homebrew"
+}
+
+@test "_collect_homebrew_info reports not installed when brew absent" {
+    result="$(HOME="$HOME" PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        _collect_homebrew_info
+    ")"
+
+    [[ "$result" == *"not installed"* ]]
+}
+
+@test "_collect_xcode_info reports no Developer directory when absent" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        _collect_xcode_info
+    ")"
+
+    [[ "$result" == *"no Developer directory"* ]]
+}
+
+@test "_collect_xcode_info reports simulator list when Developer exists" {
+    mkdir -p "$HOME/Library/Developer/Xcode/UserData"
+    mkdir -p "$HOME/Library/Developer/CoreSimulator"
+    mkdir -p "$HOME/Library/Developer/Xcode/Archives"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        _collect_xcode_info
+    ")"
+
+    [[ "$result" == *"Xcode Developer data"* ]]
+    [[ "$result" == *"CoreSimulator"* ]]
+    [[ "$result" == *"iOS Simulators"* ]]
+    [[ "$result" == *"Xcode Archives"* ]]
+}
+
+@test "collector_ext_run_all outputs DOCKER section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        collector_ext_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== DOCKER ==="* ]]
+}
+
+@test "collector_ext_run_all outputs HOMEBREW section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        collector_ext_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== HOMEBREW ==="* ]]
+}
+
+@test "collector_ext_run_all outputs XCODE section" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/collector.sh'
+        source '$PROJECT_ROOT/lib/ai/collector_ext.sh'
+        collector_ext_run_all 2>/dev/null
+    ")"
+    [[ "$result" == *"=== XCODE ==="* ]]
+}

--- a/tests/unit/ai/config.bats
+++ b/tests/unit/ai/config.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-config.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+setup() {
+    rm -rf "$HOME/.config"
+}
+
+@test "ai_config_get returns default when config file missing" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_get endpoint 'http://fallback'
+    ")"
+    [ "$result" = "http://fallback" ]
+}
+
+@test "ai_config_get returns configured value" {
+    mkdir -p "$HOME/.config/mole"
+    echo "endpoint=http://my-server:8080/v1" > "$HOME/.config/mole/ai.conf"
+    echo "model=my-model" >> "$HOME/.config/mole/ai.conf"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_get endpoint
+    ")"
+    [ "$result" = "http://my-server:8080/v1" ]
+}
+
+@test "ai_config_is_configured returns true when endpoint and model set" {
+    mkdir -p "$HOME/.config/mole"
+    printf 'endpoint=http://localhost:11434/v1\nmodel=qwen3:8b\n' > "$HOME/.config/mole/ai.conf"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_is_configured && echo 'yes' || echo 'no'
+    ")"
+    [ "$result" = "yes" ]
+}
+
+@test "ai_config_is_configured returns true using defaults when config missing" {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_is_configured
+    "
+    [ $status -eq 0 ]
+}
+
+@test "ai_config_set writes key to config file" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_set 'endpoint' 'http://test:1234/v1'
+        ai_config_set 'model' 'test-model'
+        cat \"\$MOLE_AI_CONFIG_FILE\"
+    ")"
+
+    echo "$result" | grep -q 'endpoint=http://test:1234/v1'
+    echo "$result" | grep -q 'model=test-model'
+}
+
+@test "ai_config_set updates existing key" {
+    mkdir -p "$HOME/.config/mole"
+    printf 'endpoint=http://old/v1\nmodel=old-model\n' > "$HOME/.config/mole/ai.conf"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_set 'endpoint' 'http://new/v1'
+        ai_config_get endpoint
+    ")"
+    [ "$result" = "http://new/v1" ]
+}
+
+@test "ai_config_get_endpoint returns default when not set" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_get_endpoint
+    ")"
+    [ "$result" = "http://localhost:11434/v1" ]
+}
+
+@test "ai_config_get_model returns default when not set" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_get_model
+    ")"
+    [ "$result" = "qwen3:8b" ]
+}
+
+@test "ai_config_get_api_key returns empty when not set" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_get_api_key
+    ")"
+    [ -z "$result" ]
+}
+
+@test "ai_config_show prints not configured when no file" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_show
+    ")"
+    [[ "$result" == *"not configured"* ]]
+}
+
+@test "ai_config_show prints config when file exists" {
+    mkdir -p "$HOME/.config/mole"
+    printf 'endpoint=http://my/v1\nmodel=my-model\n' > "$HOME/.config/mole/ai.conf"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_show
+    ")"
+    [[ "$result" == *"my-model"* ]]
+    [[ "$result" == *"http://my/v1"* ]]
+}
+
+@test "api key is masked in show output" {
+    mkdir -p "$HOME/.config/mole"
+    printf 'endpoint=http://my/v1\nmodel=m\napi_key=sk-1234567890abcdef\n' > "$HOME/.config/mole/ai.conf"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/ai/config.sh'
+        ai_config_show
+    ")"
+    [[ "$result" == *"sk-123456...cdef"* ]]
+    [[ "$result" != *"sk-1234567890abcdef"* ]]
+}

--- a/tests/unit/ai/executor.bats
+++ b/tests/unit/ai/executor.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-executor.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+@test "_expand_glob_paths expands directory/* to contained items" {
+    local test_dir="$HOME/expand_test"
+    mkdir -p "$test_dir"
+    touch "$test_dir/file1.txt" "$test_dir/file2.txt"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _expand_glob_paths '$test_dir/*'
+    ")"
+
+    local count
+    count=$(echo "$result" | wc -l | tr -d ' ')
+    [ "$count" -ge 2 ]
+    echo "$result" | grep -q "file1.txt"
+    echo "$result" | grep -q "file2.txt"
+}
+
+@test "_expand_glob_paths returns exact path for non-glob" {
+    mkdir -p "$HOME/single_test"
+    touch "$HOME/single_test/item.dat"
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _expand_glob_paths '$HOME/single_test/item.dat'
+    ")"
+
+    [[ "$result" == *"item.dat"* ]]
+}
+
+@test "_expand_glob_paths returns nothing for non-existent glob" {
+    local glob_target="$HOME/nonexistent_xyz_glob/*"
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        export TARGET='$glob_target'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _expand_glob_paths \"\$TARGET\"
+    "
+
+    [ -z "$output" ]
+}
+
+@test "_expand_glob_paths returns nothing for non-existent base directory" {
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _expand_glob_paths '/this/does/not/exist_xyz/*'
+    "
+
+    [ -z "$output" ]
+}
+
+@test "_execute_plan skips non-existent paths gracefully" {
+    local ghost="/tmp/mole_test_ghost_$$_missing"
+    local json="{\"plan\":[{\"title\":\"Ghost file\",\"reason\":\"does not exist\",\"risk\":\"SAFE\",\"paths\":[\"$ghost\"],\"estimated_size\":\"0\",\"command\":\"custom\"}]}"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _load_plan '$json'
+        _PLAN_SELECTED[0]=1
+        _execute_plan
+    "
+
+    [ $status -eq 0 ]
+    [[ "$output" == *"Not found"* ]] || [[ "$output" == *"Executing Plan"* ]]
+}
+
+@test "_execute_plan skips unselected items" {
+    mkdir -p "$HOME/exec_skip_test"
+    echo "data" > "$HOME/exec_skip_test/keep_me.txt"
+
+    local target="$HOME/exec_skip_test/keep_me.txt"
+    local json="{\"plan\":[{\"title\":\"Should skip\",\"reason\":\"not selected\",\"risk\":\"SAFE\",\"paths\":[\"$target\"],\"estimated_size\":\"4B\",\"command\":\"custom\"}]}"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _load_plan '$json'
+        _PLAN_SELECTED[0]=0
+        _execute_plan
+    "
+
+    [ $status -eq 0 ]
+    [ -f "$target" ]
+}
+
+@test "_execute_plan deletes selected single file" {
+    mkdir -p "$HOME/exec_test"
+    echo "temporary" > "$HOME/exec_test/temp_file.log"
+
+    local target="$HOME/exec_test/temp_file.log"
+    local json="{\"plan\":[{\"title\":\"Delete temp\",\"reason\":\"safe\",\"risk\":\"SAFE\",\"paths\":[\"$target\"],\"estimated_size\":\"10B\",\"command\":\"custom\"}]}"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _load_plan '$json'
+        _PLAN_SELECTED[0]=1
+        _execute_plan
+    "
+
+    [ $status -eq 0 ]
+    [ ! -f "$target" ]
+}
+
+@test "_execute_plan clears directory contents with glob pattern" {
+    mkdir -p "$HOME/exec_glob_test"
+    echo "a" > "$HOME/exec_glob_test/a.tmp"
+    echo "b" > "$HOME/exec_glob_test/b.tmp"
+
+    local glob_path="$HOME/exec_glob_test/*"
+    local json="{\"plan\":[{\"title\":\"Clear temp dir\",\"reason\":\"safe\",\"risk\":\"SAFE\",\"paths\":[\"$glob_path\"],\"estimated_size\":\"10B\",\"command\":\"custom\"}]}"
+
+    run bash --noprofile --norc -c "
+        export HOME='$HOME'
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/file_ops.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        source '$PROJECT_ROOT/lib/ai/executor.sh'
+        _load_plan '$json'
+        _PLAN_SELECTED[0]=1
+        _execute_plan
+    "
+
+    [ $status -eq 0 ]
+    [ -d "$HOME/exec_glob_test" ]
+    [ ! -f "$HOME/exec_glob_test/a.tmp" ]
+    [ ! -f "$HOME/exec_glob_test/b.tmp" ]
+}

--- a/tests/unit/ai/renderer.bats
+++ b/tests/unit/ai/renderer.bats
@@ -1,0 +1,303 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-renderer.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    rm -rf "$HOME"
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+@test "_risk_color returns correct color for each level" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        echo \"\$( _risk_color SAFE)|\$( _risk_color CAUTION)|\$( _risk_color RISKY)|\$( _risk_color OTHER)\"
+    ")"
+    local green safe yellow caution red risky nc other
+    green=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; printf '%s' \"\$GREEN\"")
+    yellow=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; printf '%s' \"\$YELLOW\"")
+    red=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; printf '%s' \"\$RED\"")
+    nc=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; printf '%s' \"\$NC\"")
+
+    local IFS='|'
+    read -ra colors <<< "$result"
+    [ "${colors[0]}" = "$green" ]
+    [ "${colors[1]}" = "$yellow" ]
+    [ "${colors[2]}" = "$red" ]
+    [ "${colors[3]}" = "$nc" ]
+}
+
+@test "_risk_icon returns correct icon for each level" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        echo \"\$( _risk_icon SAFE)|\$( _risk_icon CAUTION)|\$( _risk_icon RISKY)\"
+    ")"
+    local success warning error
+    success=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; printf '%s' \"\$ICON_SUCCESS\"")
+    warning=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; printf '%s' \"\$ICON_WARNING\"")
+    error=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; printf '%s' \"\$ICON_ERROR\"")
+
+    local IFS='|'
+    read -ra icons <<< "$result"
+    [ "${icons[0]}" = "$success" ]
+    [ "${icons[1]}" = "$warning" ]
+    [ "${icons[2]}" = "$error" ]
+}
+
+@test "_extract_json_plan extracts JSON from markdown with code fence" {
+    local response
+    response=$(cat << 'ENDRESP'
+Some text before
+```json
+{"plan": [{"title": "Clear cache", "reason": "test", "risk": "SAFE", "paths": ["/tmp/test"], "estimated_size": "100MB", "command": "custom"}]}
+```
+Some text after
+ENDRESP
+)
+
+    result="$(echo "$response" | HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _extract_json_plan \"\$(cat)\"
+    ")"
+
+    echo "$result" | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+assert 'plan' in data
+assert len(data['plan']) == 1
+assert data['plan'][0]['title'] == 'Clear cache'
+"
+}
+
+@test "_extract_json_plan returns empty when no JSON block present" {
+    local response='Just plain text without any JSON block here.'
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _extract_json_plan '$response'
+    ")"
+
+    [ -z "$result" ]
+}
+
+@test "_extract_json_plan extracts JSON via bracket matching fallback" {
+    local response='Here is the plan: {"plan": [{"title": "Test", "reason": "r", "risk": "SAFE", "paths": [], "estimated_size": "0", "command": "custom"}]} end.'
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _extract_json_plan '$response'
+    ")"
+
+    echo "$result" | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+assert 'plan' in data
+" || return 1
+}
+
+@test "_parse_plan_items produces pipe-delimited lines" {
+    local json='{"plan": [
+        {"title": "Item A", "reason": "safe cleanup", "risk": "SAFE", "paths": ["/tmp/a", "/tmp/b"], "estimated_size": "1GB", "command": "custom"},
+        {"title": "Item B", "reason": "be careful", "risk": "CAUTION", "paths": ["/tmp/c"], "estimated_size": "500MB", "command": "custom"}
+    ]}'
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _parse_plan_items '$json'
+    ")"
+
+    local line1 line2
+    line1=$(echo "$result" | head -1)
+    line2=$(echo "$result" | sed -n '2p')
+
+    [[ "$line1" == "1|Item A|safe cleanup|SAFE|/tmp/a|/tmp/b|1GB|custom" ]]
+    [[ "$line2" == "2|Item B|be careful|CAUTION|/tmp/c|500MB|custom" ]]
+}
+
+@test "_load_plan populates arrays correctly" {
+    local json='{"plan": [
+        {"title": "Clear NPM", "reason": "regenerable", "risk": "SAFE", "paths": ["/home/.npm"], "estimated_size": "2GB", "command": "custom"}
+    ]}'
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _load_plan '$json'
+        echo \"titles=\${#_PLAN_TITLES[@]}\"
+        echo \"title_0=\${_PLAN_TITLES[0]}\"
+        echo \"risk_0=\${_PLAN_RISKS[0]}\"
+        echo \"size_0=\${_PLAN_SIZES[0]}\"
+        echo \"paths_0=\${_PLAN_PATHS[0]}\"
+        echo \"selected_0=\${_PLAN_SELECTED[0]}\"
+    ")"
+
+    [[ "$result" == *"titles=1"* ]]
+    [[ "$result" == *"title_0=Clear NPM"* ]]
+    [[ "$result" == *"risk_0=SAFE"* ]]
+    [[ "$result" == *"size_0=2GB"* ]]
+    [[ "$result" == *"paths_0=/home/.npm"* ]]
+    [[ "$result" == *"selected_0=0"* ]]
+}
+
+@test "_load_plan resets arrays on each call" {
+    local json1='{"plan": [{"title": "A", "reason": "r", "risk": "SAFE", "paths": ["/a"], "estimated_size": "1", "command": "custom"}]}'
+    local json2='{"plan": [{"title": "B", "reason": "r2", "risk": "RISKY", "paths": ["/b"], "estimated_size": "2", "command": "custom"}]}'
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _load_plan '$json1'
+        _load_plan '$json2'
+        echo \"count=\${#_PLAN_TITLES[@]}\"
+        echo \"title=\${_PLAN_TITLES[0]}\"
+    ")"
+
+    [[ "$result" == *"count=1"* ]]
+    [[ "$result" == *"title=B"* ]]
+}
+
+@test "_cycle_risk_filter cycles through SAFE CAUTION RISKY empty" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+
+        _PLAN_TITLES=('A' 'B')
+        _PLAN_RISKS=('SAFE' 'RISKY')
+        _PLAN_SELECTED=(0 0)
+
+        _cycle_risk_filter; echo \"\$_PLAN_RISK_FILTER\"
+        _cycle_risk_filter; echo \"\$_PLAN_RISK_FILTER\"
+        _cycle_risk_filter; echo \"\$_PLAN_RISK_FILTER\"
+        _cycle_risk_filter; echo \"\$_PLAN_RISK_FILTER\"
+    ")"
+
+    local l1 l2 l3 l4
+    l1=$(echo "$result" | sed -n '1p')
+    l2=$(echo "$result" | sed -n '2p')
+    l3=$(echo "$result" | sed -n '3p')
+    l4=$(echo "$result" | sed -n '4p')
+    [ "$l1" = "SAFE" ]
+    [ "$l2" = "CAUTION" ]
+    [ "$l3" = "RISKY" ]
+    [ "$l4" = "" ]
+}
+
+@test "_update_visible_indices filters items by risk level" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+
+        _PLAN_TITLES=('Safe item' 'Risky item' 'Caution item')
+        _PLAN_RISKS=('SAFE' 'RISKY' 'CAUTION')
+        _PLAN_SELECTED=(0 0 0)
+
+        _PLAN_RISK_FILTER='SAFE'
+        _update_visible_indices
+        echo \"vis_count=\${#_PLAN_VISIBLE[@]}\"
+        echo \"vis_0=\${_PLAN_VISIBLE[0]}\"
+    ")"
+
+    [[ "$result" == *"vis_count=1"* ]]
+    [[ "$result" == *"vis_0=0"* ]]
+}
+
+@test "_update_visible_indices shows all items when filter is empty" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+
+        _PLAN_TITLES=('A' 'B' 'C')
+        _PLAN_RISKS=('SAFE' 'RISKY' 'CAUTION')
+        _PLAN_SELECTED=(0 0 0)
+
+        _PLAN_RISK_FILTER=''
+        _update_visible_indices
+        echo \"vis_count=\${#_PLAN_VISIBLE[@]}\"
+    ")"
+
+    [[ "$result" == *"vis_count=3"* ]]
+}
+
+@test "_render_report formats Disk Usage heading" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _render_report '## Disk Usage Summary'
+    ")"
+    [[ "$result" == *"Disk Usage Summary"* ]]
+}
+
+@test "_render_report formats Not Recommended heading" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _render_report '## Not Recommended for Deletion'
+    ")"
+    [[ "$result" == *"Not Recommended"* ]]
+}
+
+@test "_render_report formats table rows" {
+    local md='| Path | Size | Category |
+|------|------|----------|
+| /tmp/cache | 1GB | Cache |'
+
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _render_report '$md'
+    ")"
+
+    [[ "$result" == *"/tmp/cache"* ]]
+    [[ "$result" == *"1GB"* ]]
+}
+
+@test "_render_report formats list items" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _render_report '- **NPM cache** is safe to clean'
+    ")"
+    [[ "$result" == *"NPM cache"* ]]
+}
+
+@test "_render_report handles empty input" {
+    result="$(HOME="$HOME" bash --noprofile --norc -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/core/ui.sh'
+        source '$PROJECT_ROOT/lib/ai/renderer.sh'
+        _render_report ''
+    ")"
+    [ -z "$result" ]
+}


### PR DESCRIPTION
## Summary

Adds an **AI-powered system advisor** that analyzes macOS system state via any OpenAI-compatible LLM endpoint and presents interactive, risk-tagged cleanup recommendations.

### Key features

- **LLM-agnostic**: connects to any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, OpenRouter, etc.)
- **12 data collectors**: disk usage, memory, CPU, cleanable caches, build artifacts, logs, Docker, Homebrew, Xcode, and more
- **Risk taxonomy**: recommendations tagged SAFE / CAUTION / RISKY by the AI
- **Interactive selection menu**: navigate with arrows, toggle items (Space), filter by risk (F), confirm with `yes`
- **Safe execution**: user-confirmed deletions go through mole's existing `safe_remove` pipeline with glob expansion support
- **Visual pipeline UI**: 5-stage progress bar (Collect → Analyze → Report → Select → Execute)
- **Configurable**: `~/.config/mole/ai.conf` for endpoint, model, API key
- **CLI flags**: `--auto-safe`, `--analyze`, `--dry-run`, `--no-stream`

### Architecture

```
bin/advisor.sh          — CLI entry point, pipeline UI, streaming orchestration
lib/ai/
  config.sh             — Endpoint/model/API key configuration
  client.sh             — OpenAI-compatible HTTP client (streaming + non-streaming)
  collector.sh           — Base system data collector (9 sections)
  collector_ext.sh       — Extended collector: Docker, Homebrew, Xcode
  prompt.sh             — System prompt with risk taxonomy
  renderer.sh           — Report rendering, JSON parsing, interactive menu
  executor.sh           — Plan execution via safe_remove
```

### Testing

91 bats tests across 7 test files covering config, client, collectors, renderer, executor, and advisor flow.

## Test plan

- [ ] Run `./mole` → select "AI Advisor" → verify full Collect → Analyze → Report → Select → Execute pipeline
- [ ] Run `bats tests/unit/ai/` — all 91 tests pass
- [ ] Configure `~/.config/mole/ai.conf` with a custom endpoint and verify connectivity
- [ ] Test `--dry-run` flag to preview recommendations without deletion
- [ ] Test `--auto-safe` to auto-select all SAFE items