### PR TITLE
perf(uninstall): optimize pkg receipt scan (#798)

### DIFF
--- a/lib/core/pkg_receipts.sh
+++ b/lib/core/pkg_receipts.sh
@@ -54,16 +54,27 @@ pkg_receipt_nonstandard_app_paths() {
         [[ "$pkg_id" =~ ^com\.apple\. ]] && continue
 
         local pkg_files
-        if declare -f run_with_timeout > /dev/null 2>&1; then
-            pkg_files=$(run_with_timeout "${MOLE_PKG_RECEIPT_FILES_TIMEOUT:-1}" pkgutil --files "$pkg_id" 2> /dev/null || true)
-        else
-            pkg_files=$(pkgutil --files "$pkg_id" 2> /dev/null || true)
-        fi
+        pkg_files=$(pkgutil --files "$pkg_id" 2> /dev/null | command grep -E '^(/usr/local/|/opt/).*\.app(/|$)' || true)
         [[ -n "$pkg_files" ]] || continue
 
         local rel_path app_path duplicate
         while IFS= read -r rel_path; do
-            app_path=$(_mole_pkg_receipt_app_root "$rel_path" 2> /dev/null || true)
+            if [[ "$scan_timeout" =~ ^[0-9]+$ && $scan_timeout -gt 0 && $((SECONDS - scan_start)) -ge $scan_timeout ]]; then
+                break 2
+            fi
+
+            local stripped="${rel_path#/}"
+            [[ -n "$stripped" ]] || continue
+            local candidate="/$stripped"
+
+            case "$candidate" in
+                /usr/local/*.app) app_path="$candidate" ;;
+                /opt/*.app) app_path="$candidate" ;;
+                /usr/local/*.app/*) app_path="${candidate%%.app/*}.app" ;;
+                /opt/*.app/*) app_path="${candidate%%.app/*}.app" ;;
+                *) continue ;;
+            esac
+
             [[ -n "$app_path" && -d "$app_path" ]] || continue
 
             duplicate=false


### PR DESCRIPTION
## Summary

- Pre-filter `pkgutil --files` output through `grep` before bash processing — eliminates 50K+ line buffers for large packages like Microsoft Office
- Replace per-file `_mole_pkg_receipt_app_root` subshell fork (`$()`) with inline `case` matching — removes ~50K fork/exec syscalls
- Add inner loop timeout check with `break 2` so the 8s scan deadline is honored even during large file list processing

## Performance

| Metric | Before | After |
|---|---|---|
| `pkg_receipt_nonstandard_app_paths` | ~19s | ~2s |

Measured on macOS arm64 with 39 non-Apple packages installed (including Microsoft Word 50K files, Excel 44K files, Powerpoint 33K files).

## Context

Investigation into #798 (`mo uninstall` appears to hang). This function runs **before** the scan spinner starts, so the user sees no feedback for its entire duration. On systems with many installed packages, this created a perceived hang of 10-20 seconds.

This is a **performance optimization**, not necessarily the complete fix for #798. If the reported hang is an actual infinite stall (not just slow), further investigation is needed into `run_with_timeout` / `set -e` interaction or terminal raw-mode issues.