### PR TITLE
fix: portable sed -i for GNU/Linux compatibility

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -679,7 +679,11 @@ install_files() {
     fi
 
     if [[ "$source_dir_abs" != "$install_dir_abs" ]]; then
-        maybe_sudo sed -i '' "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"$CONFIG_DIR\"|" "$INSTALL_DIR/mole"
+        local sed_inplace=(-i '')
+        if sed --version 2>/dev/null | grep -q GNU; then
+            sed_inplace=(-i)
+        fi
+        maybe_sudo sed "${sed_inplace[@]}" "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"$CONFIG_DIR\"|" "$INSTALL_DIR/mole"
     fi
 
     if ! download_binary "analyze"; then


### PR DESCRIPTION
## Summary

Fixes #796

`sed -i ''` is BSD/macOS syntax. GNU sed (common on Linux) interprets `''` as the backup extension argument, then treats the substitution pattern as a filename, producing:

```
sed: can't read s|SCRIPT_DIR=.*|SCRIPT_DIR="/Users/<user>/.config/mole"|: No such file or directory
```

This causes `curl | bash` installation to fail on Linux.

## Changes

- Detect GNU vs BSD sed at runtime via `sed --version`
- Use `sed -i` on GNU sed, `sed -i ''` on BSD sed
- Only one call site affected: `install.sh:682` (SCRIPT_DIR rewrite)

## Test plan

- [x] `bash -n install.sh` passes (syntax)
- [ ] Manual: run install script on macOS — SCRIPT_DIR rewritten correctly
- [ ] Manual: run install script on Linux (GNU sed) — no error