### PR TITLE
fix(whitelist): detect menu cancel, surface "no changes saved" feedback (closes #807)

### DIFF
--- a/lib/manage/whitelist.sh
+++ b/lib/manage/whitelist.sh
@@ -372,13 +372,13 @@ ${GRAY}Edit: ${display_config}${NC}"
     fi
 
     MOLE_SELECTION_RESULT=""
-    paginated_multi_select "$menu_title" "${menu_options[@]}"
+    local exit_code=0
+    paginated_multi_select "$menu_title" "${menu_options[@]}" || exit_code=$?
     unset MOLE_PRESELECTED_INDICES
-    local exit_code=$?
 
-    # Normal exit or cancel
     if [[ $exit_code -ne 0 ]]; then
-        return 1
+        echo -e "${GRAY}Cancelled, no changes saved${NC}"
+        return 0
     fi
 
     # Convert selected indices to patterns

--- a/lib/ui/menu_paginated.sh
+++ b/lib/ui/menu_paginated.sh
@@ -444,7 +444,7 @@ paginated_multi_select() {
             for ((i = 0; i < items_per_page; i++)); do
                 printf "${clear_line}\n" >&2
             done
-            printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}  |  Space  |  Enter  |  Q Exit${NC}\n" >&2
+            printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}  |  Space  |  Enter  |  Q Cancel${NC}\n" >&2
             printf "${clear_line}" >&2
             return
         fi
@@ -504,7 +504,7 @@ paginated_multi_select() {
         local nav="${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}${NC}"
         local space_select="${GRAY}Space Select${NC}"
         local enter="${GRAY}Enter${NC}"
-        local exit="${GRAY}Q Exit${NC}"
+        local cancel_label="${GRAY}Q Cancel${NC}"
 
         local reverse_arrow="↑"
         [[ "$sort_reverse" == "true" ]] && reverse_arrow="↓"
@@ -523,7 +523,7 @@ paginated_multi_select() {
             [[ "$term_width" =~ ^[0-9]+$ ]] || term_width=80
 
             # Full controls
-            local -a _segs=("$nav" "$space_select" "$enter" "$sort_ctrl" "$order_ctrl" "$filter_ctrl" "$exit")
+            local -a _segs=("$nav" "$space_select" "$enter" "$sort_ctrl" "$order_ctrl" "$filter_ctrl" "$cancel_label")
 
             # Calculate width
             local total_len=0 seg_count=${#_segs[@]}
@@ -534,7 +534,7 @@ paginated_multi_select() {
 
             # Level 1: Remove "Space Select" if too wide
             if [[ $total_len -gt $term_width ]]; then
-                _segs=("$nav" "$enter" "$sort_ctrl" "$order_ctrl" "$filter_ctrl" "$exit")
+                _segs=("$nav" "$enter" "$sort_ctrl" "$order_ctrl" "$filter_ctrl" "$cancel_label")
 
                 total_len=0
                 seg_count=${#_segs[@]}
@@ -545,14 +545,14 @@ paginated_multi_select() {
 
                 # Level 2: Remove sort label if still too wide
                 if [[ $total_len -gt $term_width ]]; then
-                    _segs=("$nav" "$enter" "$order_ctrl" "$filter_ctrl" "$exit")
+                    _segs=("$nav" "$enter" "$order_ctrl" "$filter_ctrl" "$cancel_label")
                 fi
             fi
 
             _print_wrapped_controls "$sep" "${_segs[@]}"
         else
             # Without metadata: basic controls
-            local -a _segs_simple=("$nav" "$space_select" "$enter" "$filter_ctrl" "$exit")
+            local -a _segs_simple=("$nav" "$space_select" "$enter" "$filter_ctrl" "$cancel_label")
             _print_wrapped_controls "$sep" "${_segs_simple[@]}"
         fi
         printf "${clear_line}" >&2

--- a/lib/ui/menu_simple.sh
+++ b/lib/ui/menu_simple.sh
@@ -212,7 +212,7 @@ paginated_multi_select() {
 
         # Clear any remaining lines at bottom
         printf "${clear_line}\n" >&2
-        printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN} | Space | Enter | Q Exit${NC}\n" >&2
+        printf "${clear_line}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN} | Space | Enter | Q Cancel${NC}\n" >&2
 
         # Clear one more line to ensure no artifacts
         printf "${clear_line}" >&2

--- a/tests/manage_whitelist.bats
+++ b/tests/manage_whitelist.bats
@@ -116,6 +116,22 @@ setup() {
     [ "$status" -eq 1 ]
 }
 
+@test "mo clean --whitelist cancel preserves existing file (#807)" {
+    whitelist_file="$HOME/.config/mole/whitelist"
+    mkdir -p "$(dirname "$whitelist_file")"
+
+    run bash --noprofile --norc -c "cd '$PROJECT_ROOT'; printf \$'\\n' | HOME='$HOME' ./mo clean --whitelist"
+    [ "$status" -eq 0 ]
+    [[ -f "$whitelist_file" ]]
+    before_hash=$(shasum "$whitelist_file" | awk '{print $1}')
+
+    run bash --noprofile --norc -c "cd '$PROJECT_ROOT'; printf 'q' | HOME='$HOME' ./mo clean --whitelist"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cancelled"* ]]
+    after_hash=$(shasum "$whitelist_file" | awk '{print $1}')
+    [ "$before_hash" = "$after_hash" ]
+}
+
 @test "whitelist validation accepts special and non-ASCII characters (#749)" {
     # Verify the [[:cntrl:]] guard accepts valid macOS path chars and rejects control chars.
     run bash --noprofile --norc -c "


### PR DESCRIPTION
## Problem

`mo clean --whitelist` opens a multi-select menu. Pressing **Q** to quit silently aborted with no feedback. Reopening showed defaults re-preselected, leading users to think their deselects had not saved (#807).

## Root cause

Two layered issues:

1. The function ran under `set -euo pipefail`, which aborted at `paginated_multi_select` returning rc=1 **before** the next line could capture `$?`. The cancel-detection branch was effectively dead code.
2. Footer label `Q Exit` reads as "quit & save" — there was no signal that Q discarded the in-progress selection.

## Fix

- Capture the menu's exit code with the `|| exit_code=$?` idiom so `set -e` does not trip.
- Treat cancel as success: print `Cancelled, no changes saved` and `return 0`. Real failures (file write, etc.) still propagate.
- Rename `Q Exit` → `Q Cancel` in both menu variants (`menu_simple.sh`, `menu_paginated.sh`).
- Drop incidental shadowing of the `exit` builtin (`local exit=` → `local cancel_label=`).

Mirrors the existing cancel-message pattern in `lib/clean/project.sh:1615` (`echo -e "\${GRAY}Purge cancelled\${NC}"`). No new flags, no config knobs.

## Test

New BATS regression in `tests/manage_whitelist.bats`: pipes `q` to `mo clean --whitelist` and asserts (a) the whitelist file's sha is unchanged from before the cancel and (b) the `Cancelled` substring is present in stdout.

- 14/14 BATS whitelist suite pass (test #7 is the new regression test).
- 688/688 full BATS suite pass.

## Manual repro

| Input | rc | File state | Output |
|---|---|---|---|
| `printf '\n'` (Enter) | 0 | written | `Whitelist Updated` |
| `printf 'q'` (Cancel) | 0 | unchanged | `Cancelled, no changes saved` |

Closes #807.