### PR TITLE
Expand rebuildable cache cleanup coverage

### DIFF
--- a/lib/clean/system.sh
+++ b/lib/clean/system.sh
@@ -1,6 +1,45 @@
 #!/bin/bash
 # System-Level Cleanup Module (requires sudo).
 set -euo pipefail
+
+is_rebuildable_gpu_cache_dir() {
+    local cache_dir="$1"
+
+    # Only match current-user-accessible Darwin cache shards under C/.  Do not
+    # match T/ temp folders, generic /private/var/folders entries, or arbitrary
+    # system paths: these Metal/GPU caches are rebuildable, but deleting active
+    # caches can force live apps to recompile shaders and momentarily stutter.
+    case "$cache_dir" in
+        /private/var/folders/*/*/C/*/com.apple.gpuarchiver | \
+            /private/var/folders/*/*/C/*/com.apple.metal | \
+            /private/var/folders/*/*/C/*/com.apple.metalfe | \
+            /var/folders/*/*/C/*/com.apple.gpuarchiver | \
+            /var/folders/*/*/C/*/com.apple.metal | \
+            /var/folders/*/*/C/*/com.apple.metalfe)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+gpu_cache_dir_is_stale() {
+    local cache_dir="$1"
+    local age_days="${2:-${MOLE_GPU_CACHE_AGE_DAYS:-1}}"
+
+    [[ "$age_days" =~ ^[0-9]+$ ]] || age_days=1
+    [[ -d "$cache_dir" ]] || return 1
+    [[ -L "$cache_dir" ]] && return 1
+
+    # Directory mtime only changes when entries are added/removed/renamed.
+    # Treat a cache as stale only when no contained file was modified inside
+    # the retention window, so live apps that rewrite existing Metal cache
+    # files do not lose their active shader/GPU cache on every cleanup run.
+    local recent_file=""
+    recent_file=$(command find "$cache_dir" -type f -mtime "-$age_days" -print -quit 2> /dev/null) || return 1
+    [[ -z "$recent_file" ]]
+}
+
 # System caches, logs, and temp files.
 clean_deep_system() {
     stop_section_spinner
@@ -174,6 +213,47 @@ clean_deep_system() {
     done < <(run_with_timeout 5 command find /private/var/folders -maxdepth 5 -type d -name "*.code_sign_clone" -path "*/X/*" -print0 2> /dev/null || true)
     stop_section_spinner
     [[ $code_sign_cleaned -gt 0 ]] && log_success "Browser code signature caches, $code_sign_cleaned items"
+
+    start_section_spinner "Cleaning rebuildable system service caches..."
+    local rebuildable_cache_cleaned=0
+    local -a rebuildable_cache_dirs=(
+        "/Library/Caches/com.apple.iconservices.store"
+    )
+    local rebuildable_cache_dir=""
+    for rebuildable_cache_dir in "${rebuildable_cache_dirs[@]}"; do
+        if sudo test -e "$rebuildable_cache_dir" 2> /dev/null; then
+            if safe_sudo_remove "$rebuildable_cache_dir"; then
+                rebuildable_cache_cleaned=$((rebuildable_cache_cleaned + 1))
+            fi
+        fi
+    done
+    stop_section_spinner
+    if [[ $rebuildable_cache_cleaned -gt 0 ]]; then
+        local rebuildable_cache_label="items"
+        [[ $rebuildable_cache_cleaned -eq 1 ]] && rebuildable_cache_label="item"
+        log_success "Rebuildable system caches, $rebuildable_cache_cleaned $rebuildable_cache_label"
+    fi
+
+    start_section_spinner "Scanning accessible rebuildable GPU caches..."
+    local gpu_cache_cleaned=0
+    local gpu_cache_dir=""
+    while IFS= read -r -d '' gpu_cache_dir; do
+        is_rebuildable_gpu_cache_dir "$gpu_cache_dir" || continue
+        gpu_cache_dir_is_stale "$gpu_cache_dir" "$MOLE_GPU_CACHE_AGE_DAYS" || continue
+        if safe_sudo_remove "$gpu_cache_dir"; then
+            gpu_cache_cleaned=$((gpu_cache_cleaned + 1))
+        fi
+    done < <(run_with_timeout 8 command find /private/var/folders -maxdepth 8 -type d \( \
+        -name "com.apple.gpuarchiver" -o \
+        -name "com.apple.metal" -o \
+        -name "com.apple.metalfe" \
+        \) -path "*/C/*" -print0 2> /dev/null || true)
+    stop_section_spinner
+    if [[ $gpu_cache_cleaned -gt 0 ]]; then
+        local gpu_cache_label="items"
+        [[ $gpu_cache_cleaned -eq 1 ]] && gpu_cache_label="item"
+        log_success "Accessible rebuildable GPU caches, $gpu_cache_cleaned $gpu_cache_label"
+    fi
 
     local diag_base="/private/var/db/diagnostics"
     start_section_spinner "Cleaning system diagnostic logs..."

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -705,6 +705,11 @@ clean_app_caches() {
     safe_clean ~/Library/Containers/com.apple.CoreDevice.CoreDeviceService/Data/Library/Caches/* "CoreDevice service cache"
     safe_clean ~/Library/Containers/com.apple.NeptuneOneExtension/Data/Library/Caches/* "Apple Intelligence extension cache"
     safe_clean ~/Library/Containers/com.apple.AppleMediaServicesUI.UtilityExtension/Data/tmp/* "Apple Media Services temp files"
+    safe_clean ~/Library/Caches/com.apple.AppleMediaServices/* "Apple Media Services cache"
+    safe_clean ~/Library/Caches/com.apple.duetexpertd/* "Duet Expert cache"
+    safe_clean ~/Library/Caches/com.apple.parsecd/* "Parsecd cache"
+    safe_clean ~/Library/Caches/com.apple.python/* "Apple Python cache"
+    safe_clean ~/Library/Caches/com.apple.e5rt.e5bundlecache/* "Apple Intelligence runtime cache"
     local containers_dir="$HOME/Library/Containers"
     [[ ! -d "$containers_dir" ]] && return 0
     start_section_spinner "Scanning sandboxed apps..."

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -76,6 +76,7 @@ readonly MOLE_MAIL_AGE_DAYS=30           # Mail attachment retention (days)
 readonly MOLE_LOG_AGE_DAYS=7             # Log retention (days)
 readonly MOLE_CRASH_REPORT_AGE_DAYS=7    # Crash report retention (days)
 readonly MOLE_SAVED_STATE_AGE_DAYS=30    # Saved state retention (days) - increased for safety
+readonly MOLE_GPU_CACHE_AGE_DAYS=1       # Rebuildable GPU cache retention (days)
 readonly MOLE_TM_BACKUP_SAFE_HOURS=48    # TM backup safety window (hours)
 readonly MOLE_MAX_DS_STORE_FILES=500     # Max .DS_Store files to clean per scan
 readonly MOLE_MAX_ORPHAN_ITERATIONS=100  # Max iterations for orphaned app data scan

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -147,7 +147,7 @@ validate_path_for_deletion() {
 
     # Check path isn't critical system directory
     case "$path" in
-        / | /bin | /bin/* | /sbin | /sbin/* | /usr | /usr/bin | /usr/bin/* | /usr/sbin | /usr/sbin/* | /usr/lib | /usr/lib/* | /System | /System/* | /Library/Extensions)
+        / | /bin | /bin/* | /sbin | /sbin/* | /usr | /usr/bin | /usr/bin/* | /usr/sbin | /usr/sbin/* | /usr/lib | /usr/lib/* | /System | /System/* | /Library/Extensions | /Library/Extensions/*)
             log_error "Path validation failed: critical system directory: $path"
             return 1
             ;;

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -1184,6 +1184,143 @@ EOF
     [[ "$output" != *"SUCCESS:Browser code signature caches"* ]]
 }
 
+@test "clean_deep_system cleans CleanMyMac-observed rebuildable system caches" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+CALL_LOG="$HOME/rebuildable_cache_calls.log"
+> "$CALL_LOG"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+sudo() {
+    if [[ "$1" == "test" ]]; then
+        case "$3" in
+            /Library/Caches/com.apple.iconservices.store)
+                return 0
+                ;;
+        esac
+        return 1
+    fi
+    if [[ "$1" == "find" ]]; then
+        return 0
+    fi
+    return 0
+}
+safe_sudo_find_delete() { return 0; }
+safe_sudo_remove() {
+    echo "safe_sudo_remove:$1" >> "$CALL_LOG"
+    return 0
+}
+log_success() { echo "SUCCESS:$1" >> "$CALL_LOG"; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+is_sip_enabled() { return 1; }
+find() { return 0; }
+run_with_timeout() { shift; "$@"; }
+
+clean_deep_system
+cat "$CALL_LOG"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"safe_sudo_remove:/Library/Caches/com.apple.iconservices.store"* ]]
+    [[ "$output" == *"SUCCESS:Rebuildable system caches, 1 item"* ]]
+}
+
+@test "is_rebuildable_gpu_cache_dir only allows C GPU cache shards" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+is_rebuildable_gpu_cache_dir "/private/var/folders/test/a/C/com.example.App/com.apple.metal"
+is_rebuildable_gpu_cache_dir "/private/var/folders/test/a/C/com.example.App/com.apple.metalfe"
+is_rebuildable_gpu_cache_dir "/private/var/folders/test/a/C/com.example.App/com.apple.gpuarchiver"
+! is_rebuildable_gpu_cache_dir "/private/var/folders/test/a/T/com.example.App/com.apple.metal"
+! is_rebuildable_gpu_cache_dir "/private/var/folders/test/a/C/com.example.App/not-a-gpu-cache"
+! is_rebuildable_gpu_cache_dir "/Library/Extensions/com.example.driver/com.apple.metal"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "gpu_cache_dir_is_stale uses contained file mtimes" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+stale_dir="$HOME/gpu-stale"
+active_dir="$HOME/gpu-active"
+mkdir -p "$stale_dir" "$active_dir"
+touch "$stale_dir/functions.data" "$active_dir/functions.data"
+touch -t 202001010000 "$stale_dir/functions.data"
+
+gpu_cache_dir_is_stale "$stale_dir" 1
+! gpu_cache_dir_is_stale "$active_dir" 1
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "clean_deep_system cleans only narrow private var GPU cache shards" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+CALL_LOG="$HOME/gpu_cache_calls.log"
+> "$CALL_LOG"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+sudo() {
+    if [[ "$1" == "test" ]]; then
+        return 1
+    fi
+    if [[ "$1" == "find" ]]; then
+        return 0
+    fi
+    return 0
+}
+safe_sudo_find_delete() { return 0; }
+safe_sudo_remove() {
+    echo "safe_sudo_remove:$1" >> "$CALL_LOG"
+    return 0
+}
+log_success() { echo "SUCCESS:$1" >> "$CALL_LOG"; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+is_sip_enabled() { return 1; }
+find() { return 0; }
+gpu_cache_dir_is_stale() { return 0; }
+run_with_timeout() {
+    local _timeout="$1"
+    shift
+    if [[ "${1:-}" == "command" && "${2:-}" == "find" && "${3:-}" == "/private/var/folders" ]]; then
+        printf 'find_args:%s\n' "$*" >> "$CALL_LOG"
+        printf '%s\0' \
+            "/private/var/folders/test/a/C/com.example.App/com.apple.metal" \
+            "/private/var/folders/test/a/C/com.example.App/com.apple.metalfe" \
+            "/private/var/folders/test/a/C/com.example.App/com.apple.gpuarchiver" \
+            "/private/var/folders/test/a/T/com.example.App/com.apple.metal" \
+            "/private/var/folders/test/a/C/com.example.App/not-a-gpu-cache"
+        return 0
+    fi
+    "$@"
+}
+
+clean_deep_system
+cat "$CALL_LOG"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"safe_sudo_remove:/private/var/folders/test/a/C/com.example.App/com.apple.metal"* ]]
+    [[ "$output" == *"safe_sudo_remove:/private/var/folders/test/a/C/com.example.App/com.apple.metalfe"* ]]
+    [[ "$output" == *"safe_sudo_remove:/private/var/folders/test/a/C/com.example.App/com.apple.gpuarchiver"* ]]
+    [[ "$output" != *"/private/var/folders/test/a/T/com.example.App/com.apple.metal"* ]]
+    [[ "$output" != *"not-a-gpu-cache"* ]]
+    [[ "$output" != *"-mtime +1"* ]]
+    [[ "$output" == *"SUCCESS:Accessible rebuildable GPU caches, 3 items"* ]]
+}
+
 @test "opt_memory_pressure_relief skips when pressure is normal" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -135,6 +135,30 @@ EOF
     [[ "$output" == *"Saved application states"* ]] || [[ "$output" == *"App caches"* ]]
 }
 
+@test "clean_app_caches includes CleanMyMac-observed Apple cache families" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+stop_section_spinner() { :; }
+start_section_spinner() { :; }
+safe_clean() { echo "$2"; }
+bytes_to_human() { echo "0B"; }
+note_activity() { :; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+clean_app_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Apple Media Services cache"* ]]
+    [[ "$output" == *"Duet Expert cache"* ]]
+    [[ "$output" == *"Parsecd cache"* ]]
+    [[ "$output" == *"Apple Python cache"* ]]
+    [[ "$output" == *"Apple Intelligence runtime cache"* ]]
+}
+
 @test "clean_app_caches shows spinner during initial app cache scan" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -84,6 +84,15 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "validate_path_for_deletion allows Darwin C cache shards but rejects protected extension paths" {
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/private/var/folders/test/a/C/com.example.App/com.apple.metal'"
+    [ "$status" -eq 0 ]
+
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/Library/Extensions/com.example.driver/com.apple.metal' 2>&1"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"critical system directory"* ]]
+}
+
 @test "safe_remove validates path before deletion" {
     run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; safe_remove '/System/test' 2>&1"
     [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary

- Add additional rebuildable Apple user cache cleanup targets.
- Add conservative system cache cleanup for the iconservices cache.
- Add narrowly scoped GPU cache cleanup under accessible `/private/var/folders/*/*/C` cache shards.
- Cover the new cleanup paths with targeted Bats tests.

## Safety

- Uses existing `safe_clean` and `safe_sudo_remove` helpers.
- Does not use raw `rm -rf` or `find -delete`.
- Keeps system-level scope limited to rebuildable cache directories.
- Limits GPU cache cleanup to cache shards whose contained files are older than the configured retention window.
- Uses non-sudo discovery for GPU cache shards so the scan only covers paths visible to the current process; deletion still flows through `safe_sudo_remove`.
- Leaves app bundles and protected system areas untouched.

## Verification

- `MOLE_TEST_NO_AUTH=1 bats tests/core_safe_functions.bats tests/clean_system_maintenance.bats tests/clean_user_core.bats`
- `MOLE_TEST_NO_AUTH=1 ./scripts/check.sh --no-format`
- `git diff --check`
