### PR TITLE
Improve status power metrics

### DIFF
--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -262,13 +262,6 @@ func animTickWithSpeed(cpuUsage float64) tea.Cmd {
 func runJSONMode() {
 	collector := NewCollector(processWatchOptionsFromFlags())
 
-	// First collection initializes network state (returns nil for network)
-	_, _ = collector.Collect()
-
-	// Wait 1 second for network rate calculation
-	time.Sleep(1 * time.Second)
-
-	// Second collection has actual network data
 	data, err := collector.Collect()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error collecting metrics: %v\n", err)

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -190,6 +190,8 @@ type ThermalStatus struct {
 	SystemPower  float64 `json:"system_power"`  // System power consumption in Watts
 	AdapterPower float64 `json:"adapter_power"` // AC adapter max power in Watts
 	BatteryPower float64 `json:"battery_power"` // Battery charge/discharge power in Watts (positive = discharging)
+	CurrentPower float64 `json:"current_power"` // Best available real-time power flow in Watts
+	PowerSource  string  `json:"power_source"`  // system, battery, or charging
 }
 
 type SensorReading struct {
@@ -220,6 +222,8 @@ type Collector struct {
 	lastNetAt    time.Time
 	rxHistoryBuf *RingBuffer
 	txHistoryBuf *RingBuffer
+	lastNetIPAt  time.Time
+	cachedNetIPs map[string]string
 	lastGPUAt    time.Time
 	cachedGPU    []GPUStatus
 	prevDiskIO   disk.IOCountersStat
@@ -231,13 +235,16 @@ type Collector struct {
 }
 
 func NewCollector(options ProcessWatchOptions) *Collector {
-	return &Collector{
+	c := &Collector{
 		prevNet:        make(map[string]net.IOCountersStat),
 		rxHistoryBuf:   NewRingBuffer(NetworkHistorySize),
 		txHistoryBuf:   NewRingBuffer(NetworkHistorySize),
+		cachedNetIPs:   make(map[string]string),
 		processWatch:   options.SnapshotConfig(),
 		processWatcher: NewProcessWatcher(options),
 	}
+	c.primeNetworkCounters(time.Now())
+	return c
 }
 
 func (c *Collector) Collect() (MetricsSnapshot, error) {

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -190,8 +190,6 @@ type ThermalStatus struct {
 	SystemPower  float64 `json:"system_power"`  // System power consumption in Watts
 	AdapterPower float64 `json:"adapter_power"` // AC adapter max power in Watts
 	BatteryPower float64 `json:"battery_power"` // Battery charge/discharge power in Watts (positive = discharging)
-	CurrentPower float64 `json:"current_power"` // Best available real-time power flow in Watts
-	PowerSource  string  `json:"power_source"`  // system, battery, or charging
 }
 
 type SensorReading struct {

--- a/cmd/status/metrics_battery.go
+++ b/cmd/status/metrics_battery.go
@@ -228,9 +228,14 @@ func parseAppleSmartBatteryThermal(out string) ThermalStatus {
 			}
 		}
 
-		// Adapter power (Watts) from current adapter.
-		if watts, found := parseIORegFloatValue(line, "Watts"); found && watts > 0 && thermal.AdapterPower == 0 {
-			thermal.AdapterPower = watts
+		// Adapter power (Watts) from current adapter. Ignore AppleRawAdapterDetails:
+		// raw entries can appear before the normalized adapter details and should
+		// not win the display value.
+		if strings.Contains(line, `"AdapterDetails"`) && !strings.Contains(line, "AppleRaw") && thermal.AdapterPower == 0 {
+			watts, found := parseIORegFloatValue(line, "Watts")
+			if found && watts > 0 {
+				thermal.AdapterPower = watts
+			}
 		}
 
 		// System power consumption (mW -> W).
@@ -332,11 +337,11 @@ func parseIORegSignedInteger(raw string) (int64, bool) {
 
 func ioRegValueForKey(line string, key string) (string, bool) {
 	marker := `"` + key + `"`
-	idx := strings.Index(line, marker)
-	if idx == -1 {
+	_, rest, found := strings.Cut(line, marker)
+	if !found {
 		return "", false
 	}
-	rest := strings.TrimLeft(line[idx+len(marker):], " \t")
+	rest = strings.TrimLeft(rest, " \t")
 	if !strings.HasPrefix(rest, "=") {
 		return "", false
 	}

--- a/cmd/status/metrics_battery.go
+++ b/cmd/status/metrics_battery.go
@@ -18,15 +18,6 @@ var (
 	lastPowerAt   time.Time
 	cachedPower   string
 	powerCacheTTL = 30 * time.Second
-
-	// Cache for optional powermetrics output. powermetrics is the only Apple
-	// built-in source that can expose AC-side SoC power draw, but it requires
-	// root. Use non-interactive sudo only and cache failures to keep status fast.
-	lastPowerDrawAt       time.Time
-	lastPowerDrawFailedAt time.Time
-	cachedPowerDraw       ThermalStatus
-	powerDrawCacheTTL     = 3 * time.Second
-	powerDrawFailureTTL   = 30 * time.Second
 )
 
 func collectBatteries() (batts []BatteryStatus, err error) {
@@ -210,65 +201,11 @@ func collectThermal() ThermalStatus {
 		thermal.SystemPower = powerThermal.SystemPower
 		thermal.AdapterPower = powerThermal.AdapterPower
 		thermal.BatteryPower = powerThermal.BatteryPower
-		thermal.CurrentPower = powerThermal.CurrentPower
-		thermal.PowerSource = powerThermal.PowerSource
-	}
-
-	if thermal.CurrentPower == 0 {
-		powerThermal := getCachedPowermetricsPower()
-		if powerThermal.CurrentPower > 0 {
-			thermal.SystemPower = powerThermal.SystemPower
-			thermal.CurrentPower = powerThermal.CurrentPower
-			thermal.PowerSource = powerThermal.PowerSource
-		}
 	}
 
 	// Do not synthesize CPU temperature from battery sensors or cpu_thermal_level.
 	// Those values are not CPU-package temperatures and produce false overheating data.
 	return thermal
-}
-
-func getCachedPowermetricsPower() ThermalStatus {
-	if runtime.GOOS != "darwin" || !commandExists("powermetrics") {
-		return ThermalStatus{}
-	}
-
-	now := time.Now()
-	if cachedPowerDraw.CurrentPower > 0 && now.Sub(lastPowerDrawAt) < powerDrawCacheTTL {
-		return cachedPowerDraw
-	}
-	if now.Sub(lastPowerDrawFailedAt) < powerDrawFailureTTL {
-		return ThermalStatus{}
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
-	defer cancel()
-
-	args := []string{"-n", "1", "-i", "100", "-s", "cpu_power,gpu_power,ane_power,battery", "-a", "0"}
-	name := "powermetrics"
-	if os.Geteuid() != 0 {
-		if !commandExists("sudo") {
-			lastPowerDrawFailedAt = now
-			return ThermalStatus{}
-		}
-		// -n is critical: never block the TUI on a password prompt.
-		args = append([]string{"-n", "powermetrics"}, args...)
-		name = "sudo"
-	}
-
-	out, err := runCmd(ctx, name, args...)
-	if err != nil {
-		lastPowerDrawFailedAt = now
-		return ThermalStatus{}
-	}
-	thermal := parsePowermetricsPower(out)
-	if thermal.CurrentPower <= 0 {
-		lastPowerDrawFailedAt = now
-		return ThermalStatus{}
-	}
-	cachedPowerDraw = thermal
-	lastPowerDrawAt = now
-	return cachedPowerDraw
 }
 
 func parseAppleSmartBatteryThermal(out string) ThermalStatus {
@@ -333,73 +270,7 @@ func parseAppleSmartBatteryThermal(out string) ThermalStatus {
 			thermal.BatteryPower = batteryPowerW
 		}
 	}
-	finalizeCurrentPower(&thermal)
 	return thermal
-}
-
-func parsePowermetricsPower(out string) ThermalStatus {
-	var (
-		combinedPower float64
-		packagePower  float64
-		componentSum  float64
-	)
-
-	for line := range strings.Lines(out) {
-		lower := strings.ToLower(strings.TrimSpace(line))
-		if lower == "" || !strings.Contains(lower, "power") {
-			continue
-		}
-		watts, ok := parsePowerLineWatts(line)
-		if !ok || watts <= 0 || watts > 1000 {
-			continue
-		}
-
-		switch {
-		case strings.Contains(lower, "combined power"):
-			combinedPower = watts
-		case strings.Contains(lower, "package power"):
-			packagePower = watts
-		case strings.Contains(lower, "cpu power") ||
-			strings.Contains(lower, "gpu power") ||
-			strings.Contains(lower, "ane power"):
-			componentSum += watts
-		}
-	}
-
-	draw := combinedPower
-	if draw == 0 {
-		draw = packagePower
-	}
-	if draw == 0 {
-		draw = componentSum
-	}
-	if draw == 0 {
-		return ThermalStatus{}
-	}
-
-	return ThermalStatus{
-		SystemPower:  draw,
-		CurrentPower: draw,
-		PowerSource:  "powermetrics",
-	}
-}
-
-func parsePowerLineWatts(line string) (float64, bool) {
-	fields := strings.Fields(strings.ReplaceAll(line, ":", " "))
-	for i := 0; i < len(fields)-1; i++ {
-		value, err := strconv.ParseFloat(strings.Trim(fields[i], ","), 64)
-		if err != nil {
-			continue
-		}
-		unit := strings.ToLower(strings.Trim(fields[i+1], ",.;)"))
-		switch unit {
-		case "mw", "milliwatts", "milliwatt":
-			return value / 1000.0, true
-		case "w", "watts", "watt":
-			return value, true
-		}
-	}
-	return 0, false
 }
 
 func setSystemPowerMW(thermal *ThermalStatus, powerMW float64) {
@@ -413,20 +284,6 @@ func setBatteryPowerMW(thermal *ThermalStatus, powerMW float64) {
 	// Validate reasonable battery power range: -200W to 200W.
 	if powerMW > -200000 && powerMW < 200000 {
 		thermal.BatteryPower = powerMW / 1000.0
-	}
-}
-
-func finalizeCurrentPower(thermal *ThermalStatus) {
-	switch {
-	case thermal.SystemPower > 0:
-		thermal.CurrentPower = thermal.SystemPower
-		thermal.PowerSource = "system"
-	case thermal.BatteryPower > 0:
-		thermal.CurrentPower = thermal.BatteryPower
-		thermal.PowerSource = "battery"
-	case thermal.BatteryPower < 0:
-		thermal.CurrentPower = -thermal.BatteryPower
-		thermal.PowerSource = "charging"
 	}
 }
 

--- a/cmd/status/metrics_battery.go
+++ b/cmd/status/metrics_battery.go
@@ -18,6 +18,15 @@ var (
 	lastPowerAt   time.Time
 	cachedPower   string
 	powerCacheTTL = 30 * time.Second
+
+	// Cache for optional powermetrics output. powermetrics is the only Apple
+	// built-in source that can expose AC-side SoC power draw, but it requires
+	// root. Use non-interactive sudo only and cache failures to keep status fast.
+	lastPowerDrawAt       time.Time
+	lastPowerDrawFailedAt time.Time
+	cachedPowerDraw       ThermalStatus
+	powerDrawCacheTTL     = 3 * time.Second
+	powerDrawFailureTTL   = 30 * time.Second
 )
 
 func collectBatteries() (batts []BatteryStatus, err error) {
@@ -201,6 +210,17 @@ func collectThermal() ThermalStatus {
 		thermal.SystemPower = powerThermal.SystemPower
 		thermal.AdapterPower = powerThermal.AdapterPower
 		thermal.BatteryPower = powerThermal.BatteryPower
+		thermal.CurrentPower = powerThermal.CurrentPower
+		thermal.PowerSource = powerThermal.PowerSource
+	}
+
+	if thermal.CurrentPower == 0 {
+		powerThermal := getCachedPowermetricsPower()
+		if powerThermal.CurrentPower > 0 {
+			thermal.SystemPower = powerThermal.SystemPower
+			thermal.CurrentPower = powerThermal.CurrentPower
+			thermal.PowerSource = powerThermal.PowerSource
+		}
 	}
 
 	// Do not synthesize CPU temperature from battery sensors or cpu_thermal_level.
@@ -208,96 +228,277 @@ func collectThermal() ThermalStatus {
 	return thermal
 }
 
+func getCachedPowermetricsPower() ThermalStatus {
+	if runtime.GOOS != "darwin" || !commandExists("powermetrics") {
+		return ThermalStatus{}
+	}
+
+	now := time.Now()
+	if cachedPowerDraw.CurrentPower > 0 && now.Sub(lastPowerDrawAt) < powerDrawCacheTTL {
+		return cachedPowerDraw
+	}
+	if now.Sub(lastPowerDrawFailedAt) < powerDrawFailureTTL {
+		return ThermalStatus{}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
+	defer cancel()
+
+	args := []string{"-n", "1", "-i", "100", "-s", "cpu_power,gpu_power,ane_power,battery", "-a", "0"}
+	name := "powermetrics"
+	if os.Geteuid() != 0 {
+		if !commandExists("sudo") {
+			lastPowerDrawFailedAt = now
+			return ThermalStatus{}
+		}
+		// -n is critical: never block the TUI on a password prompt.
+		args = append([]string{"-n", "powermetrics"}, args...)
+		name = "sudo"
+	}
+
+	out, err := runCmd(ctx, name, args...)
+	if err != nil {
+		lastPowerDrawFailedAt = now
+		return ThermalStatus{}
+	}
+	thermal := parsePowermetricsPower(out)
+	if thermal.CurrentPower <= 0 {
+		lastPowerDrawFailedAt = now
+		return ThermalStatus{}
+	}
+	cachedPowerDraw = thermal
+	lastPowerDrawAt = now
+	return cachedPowerDraw
+}
+
 func parseAppleSmartBatteryThermal(out string) ThermalStatus {
 	var thermal ThermalStatus
+	var (
+		voltageMV  float64
+		amperageMA float64
+	)
 
 	for line := range strings.Lines(out) {
 		line = strings.TrimSpace(line)
 
 		// AppleSmartBattery reports battery temperature in centi-degrees Celsius.
-		if _, after, found := strings.Cut(line, "\"Temperature\" = "); found {
-			valStr := strings.TrimSpace(after)
-			if tempRaw, err := strconv.Atoi(valStr); err == nil && tempRaw > 0 {
+		if tempRaw, found := parseIORegFloatValue(line, "Temperature"); found && tempRaw > 0 {
+			if tempRaw < 1000 {
+				// Some fixtures and non-Apple platforms report Celsius directly.
+				thermal.BatteryTemp = tempRaw
+			} else {
 				thermal.BatteryTemp = float64(tempRaw) / 100.0
 			}
 		}
 
 		// Adapter power (Watts) from current adapter.
-		if strings.Contains(line, "\"AdapterDetails\" = {") && !strings.Contains(line, "AppleRaw") {
-			if _, after, found := strings.Cut(line, "\"Watts\"="); found {
-				valStr := strings.TrimSpace(after)
-				valStr, _, _ = strings.Cut(valStr, ",")
-				valStr, _, _ = strings.Cut(valStr, "}")
-				valStr = strings.TrimSpace(valStr)
-				if watts, err := strconv.ParseFloat(valStr, 64); err == nil && watts > 0 {
-					thermal.AdapterPower = watts
-				}
-			}
+		if watts, found := parseIORegFloatValue(line, "Watts"); found && watts > 0 && thermal.AdapterPower == 0 {
+			thermal.AdapterPower = watts
 		}
 
 		// System power consumption (mW -> W).
-		if _, after, found := strings.Cut(line, "\"SystemPowerIn\"="); found {
-			valStr := strings.TrimSpace(after)
-			valStr, _, _ = strings.Cut(valStr, ",")
-			valStr, _, _ = strings.Cut(valStr, "}")
-			valStr = strings.TrimSpace(valStr)
-			if powerMW, err := strconv.ParseFloat(valStr, 64); err == nil {
-				// SystemPower should always be positive, reject invalid values
-				if powerMW >= 0 && powerMW < 1000000 { // 0 to 1000W
-					thermal.SystemPower = powerMW / 1000.0
-				}
+		if powerMW, found := parseIORegFloatValue(line, "SystemPowerIn"); found {
+			setSystemPowerMW(&thermal, powerMW)
+		}
+		if thermal.SystemPower == 0 {
+			if powerMW, found := parseIORegFloatValue(line, "SystemPower"); found {
+				setSystemPowerMW(&thermal, powerMW)
 			}
 		}
 
 		// Battery power (mW -> W, positive = discharging, negative = charging).
-		if _, after, found := strings.Cut(line, "\"BatteryPower\"="); found {
-			valStr := strings.TrimSpace(after)
-			valStr, _, _ = strings.Cut(valStr, ",")
-			valStr, _, _ = strings.Cut(valStr, "}")
-			valStr = strings.TrimSpace(valStr)
+		if powerMW, found := parseIORegSignedNumber(line, "BatteryPower"); found {
+			setBatteryPowerMW(&thermal, powerMW)
+		}
 
-			var powerMW float64
-			var parsed bool
-
-			// Strategy 1: Try parsing as a signed integer first.
-			// This handles standard positive values and explicit negative strings like "-12345".
-			if valInt, err := strconv.ParseInt(valStr, 10, 64); err == nil {
-				powerMW = float64(valInt)
-				parsed = true
-			} else if valUint, err := strconv.ParseUint(valStr, 10, 64); err == nil {
-				// Strategy 2: Try parsing as an unsigned integer (Two's Complement).
-				// ioreg often returns negative values as huge uint64 numbers (e.g. 2^64 - 100).
-				// Explicitly handle two's complement rather than relying on an unchecked cast.
-				var signed int64
-				if valUint <= math.MaxInt64 {
-					// Fits in positive int64 range directly.
-					signed = int64(valUint)
-				} else {
-					// Interpret as negative two's complement value.
-					// For a uint64 v > MaxInt64, the corresponding negative int64 is:
-					// -(^v + 1) where ^ is bitwise NOT in 64 bits.
-					negMag := ^valUint + 1
-					// negMag now holds the magnitude of the negative value as uint64.
-					if negMag <= math.MaxInt64 {
-						signed = -int64(negMag)
-					} else {
-						// Magnitude too large to represent; skip this parsing strategy.
-						goto skipUintParse
-					}
-				}
-				powerMW = float64(signed)
-				parsed = true
-			skipUintParse:
-			}
-
-			if parsed {
-				// Validate reasonable battery power range: -200W to 200W
-				if powerMW > -200000 && powerMW < 200000 {
-					thermal.BatteryPower = powerMW / 1000.0
-				}
-			}
+		if voltage, found := parseIORegFloatValue(line, "Voltage"); found && voltage > 0 {
+			voltageMV = voltage
+		}
+		if voltage, found := parseIORegFloatValue(line, "AppleRawBatteryVoltage"); found && voltage > 0 {
+			voltageMV = voltage
+		}
+		if amperage, found := parseIORegSignedNumber(line, "InstantAmperage"); found && amperage != 0 {
+			amperageMA = amperage
+		}
+		if amperage, found := parseIORegSignedNumber(line, "Amperage"); found && amperage != 0 && amperageMA == 0 {
+			amperageMA = amperage
 		}
 	}
 
+	if thermal.BatteryPower == 0 && voltageMV > 0 && amperageMA != 0 {
+		// AppleSmartBattery amperage is signed mA. Negative current means the
+		// battery is discharging, so keep BatteryPower positive for discharge.
+		batteryPowerW := -(voltageMV * amperageMA) / 1000000.0
+		if batteryPowerW > -200 && batteryPowerW < 200 {
+			thermal.BatteryPower = batteryPowerW
+		}
+	}
+	finalizeCurrentPower(&thermal)
 	return thermal
+}
+
+func parsePowermetricsPower(out string) ThermalStatus {
+	var (
+		combinedPower float64
+		packagePower  float64
+		componentSum  float64
+	)
+
+	for line := range strings.Lines(out) {
+		lower := strings.ToLower(strings.TrimSpace(line))
+		if lower == "" || !strings.Contains(lower, "power") {
+			continue
+		}
+		watts, ok := parsePowerLineWatts(line)
+		if !ok || watts <= 0 || watts > 1000 {
+			continue
+		}
+
+		switch {
+		case strings.Contains(lower, "combined power"):
+			combinedPower = watts
+		case strings.Contains(lower, "package power"):
+			packagePower = watts
+		case strings.Contains(lower, "cpu power") ||
+			strings.Contains(lower, "gpu power") ||
+			strings.Contains(lower, "ane power"):
+			componentSum += watts
+		}
+	}
+
+	draw := combinedPower
+	if draw == 0 {
+		draw = packagePower
+	}
+	if draw == 0 {
+		draw = componentSum
+	}
+	if draw == 0 {
+		return ThermalStatus{}
+	}
+
+	return ThermalStatus{
+		SystemPower:  draw,
+		CurrentPower: draw,
+		PowerSource:  "powermetrics",
+	}
+}
+
+func parsePowerLineWatts(line string) (float64, bool) {
+	fields := strings.Fields(strings.ReplaceAll(line, ":", " "))
+	for i := 0; i < len(fields)-1; i++ {
+		value, err := strconv.ParseFloat(strings.Trim(fields[i], ","), 64)
+		if err != nil {
+			continue
+		}
+		unit := strings.ToLower(strings.Trim(fields[i+1], ",.;)"))
+		switch unit {
+		case "mw", "milliwatts", "milliwatt":
+			return value / 1000.0, true
+		case "w", "watts", "watt":
+			return value, true
+		}
+	}
+	return 0, false
+}
+
+func setSystemPowerMW(thermal *ThermalStatus, powerMW float64) {
+	// SystemPower should always be positive; reject invalid values.
+	if powerMW >= 0 && powerMW < 1000000 { // 0 to 1000W
+		thermal.SystemPower = powerMW / 1000.0
+	}
+}
+
+func setBatteryPowerMW(thermal *ThermalStatus, powerMW float64) {
+	// Validate reasonable battery power range: -200W to 200W.
+	if powerMW > -200000 && powerMW < 200000 {
+		thermal.BatteryPower = powerMW / 1000.0
+	}
+}
+
+func finalizeCurrentPower(thermal *ThermalStatus) {
+	switch {
+	case thermal.SystemPower > 0:
+		thermal.CurrentPower = thermal.SystemPower
+		thermal.PowerSource = "system"
+	case thermal.BatteryPower > 0:
+		thermal.CurrentPower = thermal.BatteryPower
+		thermal.PowerSource = "battery"
+	case thermal.BatteryPower < 0:
+		thermal.CurrentPower = -thermal.BatteryPower
+		thermal.PowerSource = "charging"
+	}
+}
+
+func parseIORegFloatValue(line string, key string) (float64, bool) {
+	raw, found := ioRegValueForKey(line, key)
+	if !found {
+		return 0, false
+	}
+	val, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, false
+	}
+	return val, true
+}
+
+func parseIORegSignedNumber(line string, key string) (float64, bool) {
+	raw, found := ioRegValueForKey(line, key)
+	if !found {
+		return 0, false
+	}
+	val, ok := parseIORegSignedInteger(raw)
+	if !ok {
+		return 0, false
+	}
+	return float64(val), true
+}
+
+func parseIORegSignedInteger(raw string) (int64, bool) {
+	if valInt, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return valInt, true
+	}
+	valUint, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	if valUint <= math.MaxInt64 {
+		return int64(valUint), true
+	}
+	// ioreg sometimes prints negative int64 values as uint64 two's complement.
+	negMag := ^valUint + 1
+	if negMag > math.MaxInt64 {
+		return 0, false
+	}
+	return -int64(negMag), true
+}
+
+func ioRegValueForKey(line string, key string) (string, bool) {
+	marker := `"` + key + `"`
+	idx := strings.Index(line, marker)
+	if idx == -1 {
+		return "", false
+	}
+	rest := strings.TrimLeft(line[idx+len(marker):], " \t")
+	if !strings.HasPrefix(rest, "=") {
+		return "", false
+	}
+	rest = strings.TrimLeft(rest[1:], " \t")
+	if rest == "" || strings.HasPrefix(rest, ",") {
+		return "", false
+	}
+	end := len(rest)
+scan:
+	for i, r := range rest {
+		switch r {
+		case ',', '}', ')', ' ', '\t', '\n', '\r':
+			end = i
+			break scan
+		}
+	}
+	value := strings.Trim(rest[:end], `"`)
+	if value == "" {
+		return "", false
+	}
+	return value, true
 }

--- a/cmd/status/metrics_battery_test.go
+++ b/cmd/status/metrics_battery_test.go
@@ -8,9 +8,9 @@ import (
 func TestParseAppleSmartBatteryThermalKeepsBatteryTemperatureOutOfCPUTemp(t *testing.T) {
 	out := `
   | |   "Temperature" = 3055
-  | |   "SystemPowerIn"=19967
-  | |   "BatteryPower"=13654
-  | |   "AdapterDetails" = {"Watts"=96}
+  | |   "SystemPowerIn" = 19967
+  | |   "BatteryPower" = 13654
+  | |   "AdapterDetails" = {"Watts" = 96}
 `
 
 	thermal := parseAppleSmartBatteryThermal(out)
@@ -30,6 +30,12 @@ func TestParseAppleSmartBatteryThermalKeepsBatteryTemperatureOutOfCPUTemp(t *tes
 	if math.Abs(thermal.BatteryPower-13.654) > 0.001 {
 		t.Fatalf("expected battery power 13.654W, got %v", thermal.BatteryPower)
 	}
+	if math.Abs(thermal.CurrentPower-19.967) > 0.001 {
+		t.Fatalf("expected current power 19.967W, got %v", thermal.CurrentPower)
+	}
+	if thermal.PowerSource != "system" {
+		t.Fatalf("expected system power source, got %q", thermal.PowerSource)
+	}
 }
 
 func TestParseAppleSmartBatteryThermalParsesTwosComplementBatteryPower(t *testing.T) {
@@ -41,5 +47,65 @@ func TestParseAppleSmartBatteryThermalParsesTwosComplementBatteryPower(t *testin
 
 	if math.Abs(thermal.BatteryPower-(-12.345)) > 0.001 {
 		t.Fatalf("expected battery power -12.345W, got %v", thermal.BatteryPower)
+	}
+	if math.Abs(thermal.CurrentPower-12.345) > 0.001 {
+		t.Fatalf("expected current charging power 12.345W, got %v", thermal.CurrentPower)
+	}
+	if thermal.PowerSource != "charging" {
+		t.Fatalf("expected charging power source, got %q", thermal.PowerSource)
+	}
+}
+
+func TestParseAppleSmartBatteryThermalDerivesBatteryWattsFromVoltageAndAmperage(t *testing.T) {
+	out := `
+  | |   "Voltage" = 12000
+  | |   "InstantAmperage" = -1500
+`
+
+	thermal := parseAppleSmartBatteryThermal(out)
+
+	if math.Abs(thermal.BatteryPower-18.0) > 0.001 {
+		t.Fatalf("expected derived battery power 18W, got %v", thermal.BatteryPower)
+	}
+	if math.Abs(thermal.CurrentPower-18.0) > 0.001 {
+		t.Fatalf("expected current power 18W, got %v", thermal.CurrentPower)
+	}
+	if thermal.PowerSource != "battery" {
+		t.Fatalf("expected battery power source, got %q", thermal.PowerSource)
+	}
+}
+
+func TestParsePowermetricsPowerPrefersCombinedPower(t *testing.T) {
+	out := `
+CPU Power: 1200 mW
+GPU Power: 300 mW
+ANE Power: 100 mW
+Combined Power (CPU + GPU + ANE): 1900 mW
+`
+
+	thermal := parsePowermetricsPower(out)
+
+	if math.Abs(thermal.CurrentPower-1.9) > 0.001 {
+		t.Fatalf("expected combined current power 1.9W, got %v", thermal.CurrentPower)
+	}
+	if math.Abs(thermal.SystemPower-1.9) > 0.001 {
+		t.Fatalf("expected system power 1.9W, got %v", thermal.SystemPower)
+	}
+	if thermal.PowerSource != "powermetrics" {
+		t.Fatalf("expected powermetrics source, got %q", thermal.PowerSource)
+	}
+}
+
+func TestParsePowermetricsPowerSumsComponentsWhenCombinedMissing(t *testing.T) {
+	out := `
+CPU Power: 1.5 W
+GPU Power: 500 mW
+ANE Power: 250 mW
+`
+
+	thermal := parsePowermetricsPower(out)
+
+	if math.Abs(thermal.CurrentPower-2.25) > 0.001 {
+		t.Fatalf("expected summed current power 2.25W, got %v", thermal.CurrentPower)
 	}
 }

--- a/cmd/status/metrics_battery_test.go
+++ b/cmd/status/metrics_battery_test.go
@@ -30,12 +30,6 @@ func TestParseAppleSmartBatteryThermalKeepsBatteryTemperatureOutOfCPUTemp(t *tes
 	if math.Abs(thermal.BatteryPower-13.654) > 0.001 {
 		t.Fatalf("expected battery power 13.654W, got %v", thermal.BatteryPower)
 	}
-	if math.Abs(thermal.CurrentPower-19.967) > 0.001 {
-		t.Fatalf("expected current power 19.967W, got %v", thermal.CurrentPower)
-	}
-	if thermal.PowerSource != "system" {
-		t.Fatalf("expected system power source, got %q", thermal.PowerSource)
-	}
 }
 
 func TestParseAppleSmartBatteryThermalParsesTwosComplementBatteryPower(t *testing.T) {
@@ -47,12 +41,6 @@ func TestParseAppleSmartBatteryThermalParsesTwosComplementBatteryPower(t *testin
 
 	if math.Abs(thermal.BatteryPower-(-12.345)) > 0.001 {
 		t.Fatalf("expected battery power -12.345W, got %v", thermal.BatteryPower)
-	}
-	if math.Abs(thermal.CurrentPower-12.345) > 0.001 {
-		t.Fatalf("expected current charging power 12.345W, got %v", thermal.CurrentPower)
-	}
-	if thermal.PowerSource != "charging" {
-		t.Fatalf("expected charging power source, got %q", thermal.PowerSource)
 	}
 }
 
@@ -66,46 +54,5 @@ func TestParseAppleSmartBatteryThermalDerivesBatteryWattsFromVoltageAndAmperage(
 
 	if math.Abs(thermal.BatteryPower-18.0) > 0.001 {
 		t.Fatalf("expected derived battery power 18W, got %v", thermal.BatteryPower)
-	}
-	if math.Abs(thermal.CurrentPower-18.0) > 0.001 {
-		t.Fatalf("expected current power 18W, got %v", thermal.CurrentPower)
-	}
-	if thermal.PowerSource != "battery" {
-		t.Fatalf("expected battery power source, got %q", thermal.PowerSource)
-	}
-}
-
-func TestParsePowermetricsPowerPrefersCombinedPower(t *testing.T) {
-	out := `
-CPU Power: 1200 mW
-GPU Power: 300 mW
-ANE Power: 100 mW
-Combined Power (CPU + GPU + ANE): 1900 mW
-`
-
-	thermal := parsePowermetricsPower(out)
-
-	if math.Abs(thermal.CurrentPower-1.9) > 0.001 {
-		t.Fatalf("expected combined current power 1.9W, got %v", thermal.CurrentPower)
-	}
-	if math.Abs(thermal.SystemPower-1.9) > 0.001 {
-		t.Fatalf("expected system power 1.9W, got %v", thermal.SystemPower)
-	}
-	if thermal.PowerSource != "powermetrics" {
-		t.Fatalf("expected powermetrics source, got %q", thermal.PowerSource)
-	}
-}
-
-func TestParsePowermetricsPowerSumsComponentsWhenCombinedMissing(t *testing.T) {
-	out := `
-CPU Power: 1.5 W
-GPU Power: 500 mW
-ANE Power: 250 mW
-`
-
-	thermal := parsePowermetricsPower(out)
-
-	if math.Abs(thermal.CurrentPower-2.25) > 0.001 {
-		t.Fatalf("expected summed current power 2.25W, got %v", thermal.CurrentPower)
 	}
 }

--- a/cmd/status/metrics_battery_test.go
+++ b/cmd/status/metrics_battery_test.go
@@ -56,3 +56,16 @@ func TestParseAppleSmartBatteryThermalDerivesBatteryWattsFromVoltageAndAmperage(
 		t.Fatalf("expected derived battery power 18W, got %v", thermal.BatteryPower)
 	}
 }
+
+func TestParseAppleSmartBatteryThermalIgnoresRawAdapterWatts(t *testing.T) {
+	out := `
+  | |   "AppleRawAdapterDetails" = {"Watts" = 140}
+  | |   "AdapterDetails" = {"Watts" = 96}
+`
+
+	thermal := parseAppleSmartBatteryThermal(out)
+
+	if thermal.AdapterPower != 96 {
+		t.Fatalf("expected normalized adapter power 96W, got %v", thermal.AdapterPower)
+	}
+}

--- a/cmd/status/metrics_cpu.go
+++ b/cmd/status/metrics_cpu.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	cpuSampleInterval = 200 * time.Millisecond
+	cpuSampleInterval = 100 * time.Millisecond
 )
 
 func collectCPU() (CPUStatus, error) {

--- a/cmd/status/metrics_network.go
+++ b/cmd/status/metrics_network.go
@@ -16,6 +16,11 @@ import (
 
 var ioCountersFunc = net.IOCounters
 
+const (
+	minNetworkSampleInterval = 100 * time.Millisecond
+	networkIPCacheTTL        = 10 * time.Second
+)
+
 func collectIOCountersSafely(pernic bool) (stats []net.IOCountersStat, err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -25,7 +30,28 @@ func collectIOCountersSafely(pernic bool) (stats []net.IOCountersStat, err error
 	return ioCountersFunc(pernic)
 }
 
+func (c *Collector) primeNetworkCounters(now time.Time) {
+	stats, err := collectIOCountersSafely(true)
+	if err != nil {
+		return
+	}
+	c.lastNetAt = now
+	for _, s := range stats {
+		c.prevNet[s.Name] = s
+	}
+}
+
 func (c *Collector) collectNetwork(now time.Time) ([]NetworkStatus, error) {
+	if c.prevNet == nil {
+		c.prevNet = make(map[string]net.IOCountersStat)
+	}
+	if c.rxHistoryBuf == nil {
+		c.rxHistoryBuf = NewRingBuffer(NetworkHistorySize)
+	}
+	if c.txHistoryBuf == nil {
+		c.txHistoryBuf = NewRingBuffer(NetworkHistorySize)
+	}
+
 	stats, err := collectIOCountersSafely(true)
 	if err != nil {
 		// Some restricted environments can break netstat-backed collectors.
@@ -36,19 +62,18 @@ func (c *Collector) collectNetwork(now time.Time) ([]NetworkStatus, error) {
 	}
 
 	// Map interface IPs.
-	ifAddrs := getInterfaceIPs()
+	ifAddrs := c.getInterfaceIPsCached(now)
 
 	if c.lastNetAt.IsZero() {
 		c.lastNetAt = now
 		for _, s := range stats {
 			c.prevNet[s.Name] = s
 		}
-		return nil, nil
 	}
 
 	elapsed := now.Sub(c.lastNetAt).Seconds()
-	if elapsed <= 0 {
-		elapsed = 1
+	if elapsed < minNetworkSampleInterval.Seconds() {
+		elapsed = minNetworkSampleInterval.Seconds()
 	}
 
 	var result []NetworkStatus
@@ -99,6 +124,15 @@ func (c *Collector) collectNetwork(now time.Time) ([]NetworkStatus, error) {
 	c.txHistoryBuf.Add(totalTx)
 
 	return result, nil
+}
+
+func (c *Collector) getInterfaceIPsCached(now time.Time) map[string]string {
+	if c.cachedNetIPs != nil && now.Sub(c.lastNetIPAt) < networkIPCacheTTL {
+		return c.cachedNetIPs
+	}
+	c.cachedNetIPs = getInterfaceIPs()
+	c.lastNetIPAt = now
+	return c.cachedNetIPs
 }
 
 func getInterfaceIPs() map[string]string {

--- a/cmd/status/metrics_network_test.go
+++ b/cmd/status/metrics_network_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	gopsutilnet "github.com/shirou/gopsutil/v4/net"
 )
@@ -99,5 +100,63 @@ func TestCollectIOCountersSafelyReturnsData(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].Name != "en0" {
 		t.Fatalf("unexpected stats: %+v", got)
+	}
+}
+
+func TestCollectNetworkFirstSampleReturnsZeroRateInterfaces(t *testing.T) {
+	original := ioCountersFunc
+	ioCountersFunc = func(bool) ([]gopsutilnet.IOCountersStat, error) {
+		return []gopsutilnet.IOCountersStat{
+			{Name: "en0", BytesRecv: 1000, BytesSent: 2000},
+		}, nil
+	}
+	t.Cleanup(func() { ioCountersFunc = original })
+
+	c := &Collector{}
+	got, err := c.collectNetwork(time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected first sample to render one interface, got %+v", got)
+	}
+	if got[0].RxRateMBs != 0 || got[0].TxRateMBs != 0 {
+		t.Fatalf("expected first sample zero rates, got %+v", got[0])
+	}
+	if len(c.rxHistoryBuf.Slice()) != 1 || len(c.txHistoryBuf.Slice()) != 1 {
+		t.Fatalf("expected history to be seeded on first sample")
+	}
+}
+
+func TestCollectNetworkUsesPrimedCountersForInitialRates(t *testing.T) {
+	original := ioCountersFunc
+	calls := 0
+	samples := [][]gopsutilnet.IOCountersStat{
+		{{Name: "en0", BytesRecv: 1024 * 1024, BytesSent: 0}},
+		{{Name: "en0", BytesRecv: 2 * 1024 * 1024, BytesSent: 512 * 1024}},
+	}
+	ioCountersFunc = func(bool) ([]gopsutilnet.IOCountersStat, error) {
+		if calls >= len(samples) {
+			return samples[len(samples)-1], nil
+		}
+		got := samples[calls]
+		calls++
+		return got, nil
+	}
+	t.Cleanup(func() { ioCountersFunc = original })
+
+	c := NewCollector(ProcessWatchOptions{})
+	got, err := c.collectNetwork(c.lastNetAt.Add(time.Second))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one interface, got %+v", got)
+	}
+	if got[0].RxRateMBs != 1.0 {
+		t.Fatalf("expected 1 MB/s down, got %v", got[0].RxRateMBs)
+	}
+	if got[0].TxRateMBs != 0.5 {
+		t.Fatalf("expected 0.5 MB/s up, got %v", got[0].TxRateMBs)
 	}
 }

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -628,33 +628,32 @@ func renderBatteryCard(batts []BatteryStatus, thermal ThermalStatus) cardData {
 			lines = append(lines, fmt.Sprintf("Health %s  %s", batteryProgressBar(float64(b.Capacity)), capacityText))
 		}
 
-		statusIcon := ""
+		if thermal.CurrentPower > 0 {
+			label := "Draw"
+			if thermal.PowerSource == "charging" {
+				label = "Charge"
+			}
+			lines = append(lines, fmt.Sprintf("%-6s %s  %6s",
+				label,
+				powerProgressBar(thermal.CurrentPower, thermal.AdapterPower),
+				formatWatts(thermal.CurrentPower),
+			))
+		}
+
 		statusStyle := subtleStyle
-		if statusLower == "charging" || statusLower == "charged" {
-			statusIcon = " ⚡"
+		if isPoweredByAC(statusLower) {
 			statusStyle = okStyle
 		} else if b.Percent < 20 {
 			statusStyle = dangerStyle
 		}
-		statusText := b.Status
-		if len(statusText) > 0 {
-			statusText = strings.ToUpper(statusText[:1]) + strings.ToLower(statusText[1:])
-		}
+		statusText := formatBatteryStatus(b.Status)
 		if b.TimeLeft != "" {
 			statusText += " · " + b.TimeLeft
 		}
-		// Add power info.
-		if statusLower == "charging" || statusLower == "charged" {
-			if thermal.SystemPower > 0 {
-				statusText += fmt.Sprintf(" · %.0fW", thermal.SystemPower)
-			} else if thermal.AdapterPower > 0 {
-				statusText += fmt.Sprintf(" · %.0fW Adapter", thermal.AdapterPower)
-			}
-		} else if thermal.BatteryPower > 0 {
-			// Only show battery power when discharging (positive value)
-			statusText += fmt.Sprintf(" · %.0fW", thermal.BatteryPower)
+		if thermal.AdapterPower > 0 && isPoweredByAC(statusLower) {
+			statusText += fmt.Sprintf(" · %.0fW adapter", thermal.AdapterPower)
 		}
-		lines = append(lines, statusStyle.Render(statusText+statusIcon))
+		lines = append(lines, statusStyle.Render(statusText))
 
 		healthParts := []string{}
 
@@ -700,6 +699,62 @@ func renderBatteryCard(batts []BatteryStatus, thermal ThermalStatus) cardData {
 	return cardData{icon: iconBattery, title: "Power", lines: lines}
 }
 
+func isPoweredByAC(statusLower string) bool {
+	return statusLower == "charging" ||
+		statusLower == "charged" ||
+		statusLower == "ac" ||
+		strings.Contains(statusLower, "ac attached")
+}
+
+func formatBatteryStatus(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return "Unknown"
+	}
+	lower := strings.ToLower(status)
+	switch lower {
+	case "ac":
+		return "AC"
+	case "charged":
+		return "Charged"
+	case "charging":
+		return "Charging"
+	case "discharging":
+		return "Discharging"
+	}
+	return strings.ToUpper(status[:1]) + strings.ToLower(status[1:])
+}
+
+func formatWatts(watts float64) string {
+	if watts >= 100 {
+		return fmt.Sprintf("%.0fW", watts)
+	}
+	return fmt.Sprintf("%.1fW", watts)
+}
+
+func powerProgressBar(watts float64, adapterPower float64) string {
+	scale := 60.0
+	if adapterPower > scale {
+		scale = adapterPower
+	}
+	percent := 0.0
+	if scale > 0 {
+		percent = watts / scale * 100.0
+	}
+	return colorizePower(watts, plainProgressBar(percent))
+}
+
+func colorizePower(watts float64, input string) string {
+	switch {
+	case watts >= 80:
+		return dangerStyle.Render(input)
+	case watts >= 45:
+		return warnStyle.Render(input)
+	default:
+		return okStyle.Render(input)
+	}
+}
+
 func renderCard(data cardData, width int, height int) string {
 	if width <= 0 {
 		width = colWidth
@@ -733,6 +788,10 @@ func wrapToWidth(text string, width int) []string {
 }
 
 func progressBar(percent float64) string {
+	return colorizePercent(percent, plainProgressBar(percent))
+}
+
+func plainProgressBar(percent float64) string {
 	total := 16
 	if percent < 0 {
 		percent = 0
@@ -750,7 +809,7 @@ func progressBar(percent float64) string {
 			builder.WriteString("░")
 		}
 	}
-	return colorizePercent(percent, builder.String())
+	return builder.String()
 }
 
 func batteryProgressBar(percent float64) string {

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -628,15 +628,11 @@ func renderBatteryCard(batts []BatteryStatus, thermal ThermalStatus) cardData {
 			lines = append(lines, fmt.Sprintf("Health %s  %s", batteryProgressBar(float64(b.Capacity)), capacityText))
 		}
 
-		if thermal.CurrentPower > 0 {
-			label := "Draw"
-			if thermal.PowerSource == "charging" {
-				label = "Charge"
-			}
+		if thermal.AdapterPower > 0 && isPoweredByAC(statusLower) {
 			lines = append(lines, fmt.Sprintf("%-6s %s  %6s",
-				label,
-				powerProgressBar(thermal.CurrentPower, thermal.AdapterPower),
-				formatWatts(thermal.CurrentPower),
+				"Input",
+				okStyle.Render(plainProgressBar(100)),
+				fmt.Sprintf("%.0fW max", thermal.AdapterPower),
 			))
 		}
 
@@ -723,36 +719,6 @@ func formatBatteryStatus(status string) string {
 		return "Discharging"
 	}
 	return strings.ToUpper(status[:1]) + strings.ToLower(status[1:])
-}
-
-func formatWatts(watts float64) string {
-	if watts >= 100 {
-		return fmt.Sprintf("%.0fW", watts)
-	}
-	return fmt.Sprintf("%.1fW", watts)
-}
-
-func powerProgressBar(watts float64, adapterPower float64) string {
-	scale := 60.0
-	if adapterPower > scale {
-		scale = adapterPower
-	}
-	percent := 0.0
-	if scale > 0 {
-		percent = watts / scale * 100.0
-	}
-	return colorizePower(watts, plainProgressBar(percent))
-}
-
-func colorizePower(watts float64, input string) string {
-	switch {
-	case watts >= 80:
-		return dangerStyle.Render(input)
-	case watts >= 45:
-		return warnStyle.Render(input)
-	default:
-		return okStyle.Render(input)
-	}
 }
 
 func renderCard(data cardData, width int, height int) string {

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -658,6 +658,81 @@ func TestBatteryProgressBar(t *testing.T) {
 	}
 }
 
+func TestRenderBatteryCardShowsCurrentPowerDraw(t *testing.T) {
+	card := renderBatteryCard([]BatteryStatus{{
+		Percent:    80,
+		Status:     "AC",
+		Capacity:   100,
+		CycleCount: 4,
+	}}, ThermalStatus{
+		BatteryTemp:  30.7,
+		AdapterPower: 94,
+		SystemPower:  19.967,
+		CurrentPower: 19.967,
+		PowerSource:  "system",
+	})
+
+	var joined []string
+	for _, line := range card.lines {
+		joined = append(joined, stripANSI(line))
+	}
+	got := strings.Join(joined, "\n")
+
+	if !strings.Contains(got, "Draw") || !strings.Contains(got, "20.0W") {
+		t.Fatalf("expected draw line with current watts, got:\n%s", got)
+	}
+	if !strings.Contains(got, "AC · 94W adapter") {
+		t.Fatalf("expected AC adapter status, got:\n%s", got)
+	}
+	if strings.Contains(got, "Ac") {
+		t.Fatalf("expected AC to stay uppercase, got:\n%s", got)
+	}
+	if strings.Contains(got, "⚡") {
+		t.Fatalf("expected no charging glyph, got:\n%s", got)
+	}
+}
+
+func TestRenderBatteryCardDoesNotShowAdapterInputAsDraw(t *testing.T) {
+	card := renderBatteryCard([]BatteryStatus{{
+		Percent:  80,
+		Status:   "AC",
+		Capacity: 100,
+	}}, ThermalStatus{
+		AdapterPower: 94,
+	})
+
+	got := ""
+	for _, line := range card.lines {
+		got += stripANSI(line) + "\n"
+	}
+	if strings.Contains(got, "Input") || strings.Contains(got, "Draw") || strings.Contains(got, "94W max") {
+		t.Fatalf("expected adapter capacity not to masquerade as live draw, got:\n%s", got)
+	}
+	if strings.Contains(got, "⚡") {
+		t.Fatalf("expected no charging glyph, got:\n%s", got)
+	}
+}
+
+func TestRenderBatteryCardShowsChargingPowerFlow(t *testing.T) {
+	card := renderBatteryCard([]BatteryStatus{{
+		Percent:  42,
+		Status:   "charging",
+		Capacity: 90,
+	}}, ThermalStatus{
+		BatteryPower: -12.345,
+		CurrentPower: 12.345,
+		PowerSource:  "charging",
+	})
+
+	got := ""
+	for _, line := range card.lines {
+		got += stripANSI(line) + "\n"
+	}
+	if !strings.Contains(got, "Charge") || !strings.Contains(got, "12.3W") {
+		t.Fatalf("expected charging watt line, got:\n%s", got)
+	}
+}
+
 func TestColorizeTemp(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -658,7 +658,7 @@ func TestBatteryProgressBar(t *testing.T) {
 	}
 }
 
-func TestRenderBatteryCardShowsCurrentPowerDraw(t *testing.T) {
+func TestRenderBatteryCardShowsAdapterInputOnly(t *testing.T) {
 	card := renderBatteryCard([]BatteryStatus{{
 		Percent:    80,
 		Status:     "AC",
@@ -667,9 +667,6 @@ func TestRenderBatteryCardShowsCurrentPowerDraw(t *testing.T) {
 	}}, ThermalStatus{
 		BatteryTemp:  30.7,
 		AdapterPower: 94,
-		SystemPower:  19.967,
-		CurrentPower: 19.967,
-		PowerSource:  "system",
 	})
 
 	var joined []string
@@ -678,8 +675,11 @@ func TestRenderBatteryCardShowsCurrentPowerDraw(t *testing.T) {
 	}
 	got := strings.Join(joined, "\n")
 
-	if !strings.Contains(got, "Draw") || !strings.Contains(got, "20.0W") {
-		t.Fatalf("expected draw line with current watts, got:\n%s", got)
+	if !strings.Contains(got, "Input") || !strings.Contains(got, "94W max") {
+		t.Fatalf("expected input line with adapter max watts, got:\n%s", got)
+	}
+	if strings.Contains(got, "Draw") || strings.Contains(got, "Charge") {
+		t.Fatalf("expected no live draw or charge watt row, got:\n%s", got)
 	}
 	if !strings.Contains(got, "AC · 94W adapter") {
 		t.Fatalf("expected AC adapter status, got:\n%s", got)
@@ -689,47 +689,6 @@ func TestRenderBatteryCardShowsCurrentPowerDraw(t *testing.T) {
 	}
 	if strings.Contains(got, "⚡") {
 		t.Fatalf("expected no charging glyph, got:\n%s", got)
-	}
-}
-
-func TestRenderBatteryCardDoesNotShowAdapterInputAsDraw(t *testing.T) {
-	card := renderBatteryCard([]BatteryStatus{{
-		Percent:  80,
-		Status:   "AC",
-		Capacity: 100,
-	}}, ThermalStatus{
-		AdapterPower: 94,
-	})
-
-	got := ""
-	for _, line := range card.lines {
-		got += stripANSI(line) + "\n"
-	}
-	if strings.Contains(got, "Input") || strings.Contains(got, "Draw") || strings.Contains(got, "94W max") {
-		t.Fatalf("expected adapter capacity not to masquerade as live draw, got:\n%s", got)
-	}
-	if strings.Contains(got, "⚡") {
-		t.Fatalf("expected no charging glyph, got:\n%s", got)
-	}
-}
-
-func TestRenderBatteryCardShowsChargingPowerFlow(t *testing.T) {
-	card := renderBatteryCard([]BatteryStatus{{
-		Percent:  42,
-		Status:   "charging",
-		Capacity: 90,
-	}}, ThermalStatus{
-		BatteryPower: -12.345,
-		CurrentPower: 12.345,
-		PowerSource:  "charging",
-	})
-
-	got := ""
-	for _, line := range card.lines {
-		got += stripANSI(line) + "\n"
-	}
-	if !strings.Contains(got, "Charge") || !strings.Contains(got, "12.3W") {
-		t.Fatalf("expected charging watt line, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## What changed
- Add an adapter input row to the Power section, showing charger capacity as `Input <watts> max` with the existing bar style.
- Add AC adapter wattage to the Power status text as `AC · <watts> adapter`.
- Speed up Status startup by reducing the CPU sampling delay.
- Seed network counters during collector initialization so network rows can render on the first Status frame.

## Validation
- `go test ./cmd/status`
- `go vet ./cmd/status`
- `git diff --check`