### PR TITLE
perf: speed up disk analyzer overview

### DIFF
--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -393,16 +393,31 @@ func prefetchOverviewCache(ctx context.Context) {
 		return
 	}
 
+	sem := make(chan struct{}, maxConcurrentOverview)
+	var wg sync.WaitGroup
 	for _, path := range needScan {
 		select {
 		case <-ctx.Done():
+			wg.Wait()
 			return
 		default:
 		}
 
-		size, err := measureOverviewSize(path)
-		if err == nil && size > 0 {
-			_ = storeOverviewSize(path, size)
-		}
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				return
+			}
+
+			size, err := measureOverviewSize(path)
+			if err == nil && size > 0 {
+				_ = storeOverviewSize(path, size)
+			}
+		}(path)
 	}
+	wg.Wait()
 }

--- a/cmd/analyze/constants.go
+++ b/cmd/analyze/constants.go
@@ -35,6 +35,13 @@ const (
 	openCommandTimeout = 10 * time.Second
 )
 
+var overviewDuIgnoreNames = map[string]bool{
+	// iCloud Drive's FileProvider tree can block `du` for tens of seconds even
+	// when most entries are cloud placeholders. Keep the overview responsive;
+	// users can still drill into the folder explicitly when they need it.
+	"Mobile Documents": true,
+}
+
 var foldDirs = map[string]bool{
 	// VCS.
 	".git": true,

--- a/cmd/analyze/json.go
+++ b/cmd/analyze/json.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -84,24 +85,7 @@ func performOverviewScanForJSON(path string) jsonOutput {
 
 	var totalSize int64
 	entries := make([]dirEntry, 0, len(overviewEntries))
-	for _, entry := range overviewEntries {
-		var (
-			size int64
-			err  error
-		)
-
-		if cached, cacheErr := loadOverviewCachedSize(entry.Path); cacheErr == nil && cached > 0 {
-			size = cached
-		} else if insightPaths[entry.Path] {
-			size, err = measureInsightSize(entry.Path)
-		} else {
-			size, err = measureOverviewSize(entry.Path)
-		}
-
-		if err == nil {
-			entry.Size = size
-		}
-
+	for _, entry := range measureOverviewEntriesForJSON(overviewEntries, insightPaths) {
 		// Match the TUI: omit scanned insight/tool entries that ended up empty.
 		if entry.Size == 0 {
 			continue
@@ -120,6 +104,57 @@ func performOverviewScanForJSON(path string) jsonOutput {
 		Entries:   jsonEntriesFromDirEntries(entries, true, insightPaths),
 		TotalSize: totalSize,
 	}
+}
+
+func measureOverviewEntriesForJSON(overviewEntries []dirEntry, insightPaths map[string]bool) []dirEntry {
+	if len(overviewEntries) == 0 {
+		return nil
+	}
+
+	type measurement struct {
+		index int
+		entry dirEntry
+	}
+
+	measured := make([]dirEntry, len(overviewEntries))
+	sem := make(chan struct{}, maxConcurrentOverview)
+	results := make(chan measurement, len(overviewEntries))
+
+	var wg sync.WaitGroup
+	for i, entry := range overviewEntries {
+		wg.Add(1)
+		go func(index int, item dirEntry) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			var (
+				size int64
+				err  error
+			)
+
+			if cached, cacheErr := loadOverviewCachedSize(item.Path); cacheErr == nil && cached > 0 {
+				size = cached
+			} else if insightPaths[item.Path] {
+				size, err = measureInsightSize(item.Path)
+			} else {
+				size, err = measureOverviewSize(item.Path)
+			}
+
+			if err == nil {
+				item.Size = size
+			}
+			results <- measurement{index: index, entry: item}
+		}(i, entry)
+	}
+
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		measured[result.index] = result.entry
+	}
+	return measured
 }
 
 func jsonEntriesFromDirEntries(entries []dirEntry, isOverview bool, insightPaths map[string]bool) []jsonEntry {

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -169,10 +169,14 @@ func main() {
 }
 
 func runTUIMode(path string, isOverview bool) {
-	// Warm overview cache in background.
-	prefetchCtx, prefetchCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer prefetchCancel()
-	go prefetchOverviewCache(prefetchCtx)
+	// Warm overview cache only when the user opens a specific directory.
+	// Overview mode already schedules the same measurements for the foreground UI;
+	// running the prefetcher there doubles the du/io workload on cold start.
+	if !isOverview {
+		prefetchCtx, prefetchCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer prefetchCancel()
+		go prefetchOverviewCache(prefetchCtx)
+	}
 
 	p := tea.NewProgram(newModel(path, isOverview), tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {

--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -761,7 +761,7 @@ func measureOverviewSize(path string) (int64, error) {
 		excludePath = filepath.Join(home, "Library")
 	}
 
-	if duSize, err := getDirectorySizeFromDuWithExclude(path, excludePath); err == nil {
+	if duSize, err := getDirectorySizeFromDuWithExcludeAndIgnores(path, excludePath, overviewIgnoreNamesForPath(path)); err == nil {
 		_ = storeOverviewSize(path, duSize)
 		return duSize, nil
 	}
@@ -784,12 +784,21 @@ func getDirectorySizeFromDu(path string) (int64, error) {
 }
 
 func getDirectorySizeFromDuWithExclude(path string, excludePath string) (int64, error) {
+	return getDirectorySizeFromDuWithExcludeAndIgnores(path, excludePath, nil)
+}
+
+func getDirectorySizeFromDuWithExcludeAndIgnores(path string, excludePath string, ignoreNames []string) (int64, error) {
 	// Validate paths.
 	if err := validatePath(path); err != nil {
 		return 0, err
 	}
 	if excludePath != "" {
 		if err := validatePath(excludePath); err != nil {
+			return 0, err
+		}
+	}
+	for _, ignoreName := range ignoreNames {
+		if err := validateDuIgnoreName(ignoreName); err != nil {
 			return 0, err
 		}
 	}
@@ -802,29 +811,43 @@ func getDirectorySizeFromDuWithExclude(path string, excludePath string) (int64, 
 		ctx, cancel := context.WithTimeout(context.Background(), duTimeout)
 		defer cancel()
 
-		cmd := exec.CommandContext(ctx, "du", "-skP", target)
+		args := []string{"-skPx"}
+		for _, ignoreName := range ignoreNames {
+			args = append(args, "-I", ignoreName)
+		}
+		args = append(args, target)
+		cmd := exec.CommandContext(ctx, "du", args...)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 
-		if err := cmd.Run(); err != nil {
+		runErr := cmd.Run()
+		fields := strings.Fields(stdout.String())
+		if runErr != nil {
 			if ctx.Err() == context.DeadlineExceeded {
 				return 0, fmt.Errorf("du timeout after %v", duTimeout)
 			}
-			if stderr.Len() > 0 {
-				return 0, fmt.Errorf("du failed: %v, %s", err, stderr.String())
+			// BSD du may return non-zero for unreadable descendants while still
+			// printing a useful aggregate for the requested root. Use that best
+			// effort total instead of falling back to a much slower recursive walk.
+			if len(fields) == 0 {
+				if stderr.Len() > 0 {
+					return 0, fmt.Errorf("du failed: %v, %s", runErr, stderr.String())
+				}
+				return 0, fmt.Errorf("du failed: %v", runErr)
 			}
-			return 0, fmt.Errorf("du failed: %v", err)
 		}
-		fields := strings.Fields(stdout.String())
 		if len(fields) == 0 {
 			return 0, fmt.Errorf("du output empty")
 		}
-		kb, err := strconv.ParseInt(fields[0], 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse du output: %v", err)
+		kb, parseErr := strconv.ParseInt(fields[0], 10, 64)
+		if parseErr != nil {
+			return 0, fmt.Errorf("failed to parse du output: %v", parseErr)
 		}
 		if kb <= 0 {
+			if runErr != nil {
+				return 0, fmt.Errorf("du failed: %v", runErr)
+			}
 			return 0, fmt.Errorf("du size invalid: %d", kb)
 		}
 		return kb * 1024, nil
@@ -832,6 +855,10 @@ func getDirectorySizeFromDuWithExclude(path string, excludePath string) (int64, 
 
 	// When excluding a path (e.g., ~/Library), subtract only that exact directory instead of ignoring every "Library"
 	if excludePath != "" {
+		if size, err := getDirectorySizeFromDuSkippingImmediateChild(path, excludePath, runDuSize); err == nil {
+			return size, nil
+		}
+
 		totalSize, err := runDuSize(path)
 		if err != nil {
 			return 0, err
@@ -850,6 +877,115 @@ func getDirectorySizeFromDuWithExclude(path string, excludePath string) (int64, 
 	}
 
 	return runDuSize(path)
+}
+
+func validateDuIgnoreName(name string) error {
+	if name == "" {
+		return fmt.Errorf("empty du ignore name")
+	}
+	if strings.Contains(name, "\x00") {
+		return fmt.Errorf("du ignore name contains null bytes")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("du ignore name must be a basename: %s", name)
+	}
+	return nil
+}
+
+func overviewIgnoreNamesForPath(path string) []string {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil
+	}
+
+	ignoreNames := make([]string, 0, len(overviewDuIgnoreNames))
+	for _, entry := range entries {
+		name := entry.Name()
+		if overviewDuIgnoreNames[name] && entry.IsDir() {
+			ignoreNames = append(ignoreNames, name)
+		}
+	}
+	return ignoreNames
+}
+
+func getDirectorySizeFromDuSkippingImmediateChild(path string, excludePath string, runDuSize func(string) (int64, error)) (int64, error) {
+	path = filepath.Clean(path)
+	excludePath = filepath.Clean(excludePath)
+
+	rel, err := filepath.Rel(path, excludePath)
+	if err != nil {
+		return 0, err
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return 0, fmt.Errorf("exclude path is outside base: %s", excludePath)
+	}
+	if strings.Contains(rel, string(os.PathSeparator)) {
+		return 0, fmt.Errorf("exclude path is not an immediate child: %s", excludePath)
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return 0, err
+	}
+
+	var total int64
+	if info, err := os.Lstat(path); err == nil {
+		atomic.AddInt64(&total, getActualFileSize(path, info))
+	}
+
+	var wg sync.WaitGroup
+	var firstErr error
+	var errMu sync.Mutex
+	workerCount := min(max(runtime.NumCPU()*2, 2), 8)
+	sem := make(chan struct{}, workerCount)
+
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errMu.Lock()
+		defer errMu.Unlock()
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	for _, entry := range entries {
+		fullPath := filepath.Join(path, entry.Name())
+		if filepath.Clean(fullPath) == excludePath {
+			continue
+		}
+
+		if entry.Type()&fs.ModeSymlink != 0 || !entry.IsDir() {
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			atomic.AddInt64(&total, getActualFileSize(fullPath, info))
+			continue
+		}
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(childPath string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			size, err := runDuSize(childPath)
+			if err != nil {
+				recordErr(err)
+				return
+			}
+			atomic.AddInt64(&total, size)
+		}(fullPath)
+	}
+
+	wg.Wait()
+
+	if firstErr != nil {
+		return 0, firstErr
+	}
+	return total, nil
 }
 
 func getDirectoryLogicalSizeWithExclude(path string, excludePath string) (int64, error) {

--- a/cmd/analyze/scanner_test.go
+++ b/cmd/analyze/scanner_test.go
@@ -3,12 +3,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func writeFileWithSize(t *testing.T, path string, size int) {
+func writeFileWithSize(t testing.TB, path string, size int) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", path, err)
@@ -43,5 +44,93 @@ func TestGetDirectoryLogicalSizeWithExclude(t *testing.T) {
 	}
 	if excluding != 400 {
 		t.Fatalf("expected 400 bytes when excluding top-level Library, got %d", excluding)
+	}
+}
+
+func TestGetDirectorySizeFromDuSkippingImmediateChildDoesNotMeasureExcludedPath(t *testing.T) {
+	base := t.TempDir()
+	excluded := filepath.Join(base, "Library")
+	included := filepath.Join(base, "Documents")
+	if err := os.MkdirAll(excluded, 0o755); err != nil {
+		t.Fatalf("mkdir excluded: %v", err)
+	}
+	if err := os.MkdirAll(included, 0o755); err != nil {
+		t.Fatalf("mkdir included: %v", err)
+	}
+
+	var measured []string
+	size, err := getDirectorySizeFromDuSkippingImmediateChild(base, excluded, func(path string) (int64, error) {
+		measured = append(measured, path)
+		return 100, nil
+	})
+	if err != nil {
+		t.Fatalf("getDirectorySizeFromDuSkippingImmediateChild: %v", err)
+	}
+	if size < 100 {
+		t.Fatalf("expected included directory size in total, got %d", size)
+	}
+	if len(measured) != 1 || measured[0] != included {
+		t.Fatalf("expected to measure only %s, measured %#v", included, measured)
+	}
+}
+
+func TestGetDirectorySizeFromDuWithIgnoresSkipsCloudPlaceholderTree(t *testing.T) {
+	base := t.TempDir()
+	writeFileWithSize(t, filepath.Join(base, "Application Support", "state.dat"), 4096)
+	writeFileWithSize(t, filepath.Join(base, "Mobile Documents", "cloud.dat"), 1024*1024)
+
+	withoutIgnore, err := getDirectorySizeFromDuWithExcludeAndIgnores(base, "", nil)
+	if err != nil {
+		t.Fatalf("getDirectorySizeFromDuWithExcludeAndIgnores without ignore: %v", err)
+	}
+	withIgnore, err := getDirectorySizeFromDuWithExcludeAndIgnores(base, "", []string{"Mobile Documents"})
+	if err != nil {
+		t.Fatalf("getDirectorySizeFromDuWithExcludeAndIgnores with ignore: %v", err)
+	}
+	if withIgnore >= withoutIgnore {
+		t.Fatalf("expected ignored Mobile Documents to reduce size, got ignored=%d without=%d", withIgnore, withoutIgnore)
+	}
+	if withIgnore <= 0 {
+		t.Fatalf("expected non-zero size for included files, got %d", withIgnore)
+	}
+}
+
+func TestValidateDuIgnoreNameRejectsPathPatterns(t *testing.T) {
+	for _, name := range []string{"", "../Library", "Library/Developer", "bad\x00name"} {
+		if err := validateDuIgnoreName(name); err == nil {
+			t.Fatalf("expected %q to be rejected", name)
+		}
+	}
+	if err := validateDuIgnoreName("Mobile Documents"); err != nil {
+		t.Fatalf("expected basename ignore to be accepted: %v", err)
+	}
+}
+
+func BenchmarkGetDirectorySizeFromDuWithExcludeHomeLibrary(b *testing.B) {
+	base := b.TempDir()
+	libraryDir := filepath.Join(base, "Library")
+	for dirIdx := range 250 {
+		for fileIdx := range 20 {
+			writeFileWithSize(
+				b,
+				filepath.Join(libraryDir, "bulk", fmt.Sprintf("dir-%03d", dirIdx), "bucket", fmt.Sprintf("file-%03d.dat", fileIdx)),
+				16,
+			)
+		}
+	}
+	writeFileWithSize(b, filepath.Join(base, "Documents", "keep.dat"), 4096)
+
+	excludePath := filepath.Join(base, "Library")
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		size, err := getDirectorySizeFromDuWithExclude(base, excludePath)
+		if err != nil {
+			b.Fatalf("getDirectorySizeFromDuWithExclude: %v", err)
+		}
+		if size <= 0 {
+			b.Fatalf("expected non-zero size, got %d", size)
+		}
 	}
 }

--- a/cmd/analyze/view.go
+++ b/cmd/analyze/view.go
@@ -29,11 +29,9 @@ func (m model) View() string {
 			}
 
 			if allPending {
-				fmt.Fprintf(&b, "%s%s%s%s Analyzing disk usage, please wait...%s\n",
-					colorCyan, colorBold,
-					spinnerFrames[m.spinner],
-					colorReset, colorReset)
-				return b.String()
+				fmt.Fprintf(&b, "%sSelect a location to explore:%s  ", colorGray, colorReset)
+				fmt.Fprintf(&b, "%s%s%s%s Analyzing disk usage...\n\n",
+					colorCyan, colorBold, spinnerFrames[m.spinner], colorReset)
 			} else {
 				fmt.Fprintf(&b, "%sSelect a location to explore:%s  ", colorGray, colorReset)
 				fmt.Fprintf(&b, "%s%s%s%s %s\n\n", colorCyan, colorBold, spinnerFrames[m.spinner], colorReset, m.status)


### PR DESCRIPTION
## Summary
- avoid duplicate overview prefetch work during analyzer cold start
- parallelize overview JSON/cache measurements and keep the TUI list visible while sizes resolve
- make du-based overview sizing faster and safer with mount-boundary scans, best-effort totals, and iCloud placeholder ignores
- add targeted analyzer tests and a benchmark for the Home-minus-Library path

## Verification
- go test -count=1 ./cmd/analyze ./cmd/status
- go test ./cmd/analyze -run '^$' -bench '^BenchmarkGetDirectorySizeFromDuWithExcludeHomeLibrary$' -benchtime=3x -count=3
- ./scripts/check.sh --no-format
- MOLE_TEST_NO_AUTH=1 bats tests/scripts.bats
- make build
- ./bin/analyze.sh --json /path/to/Mole

## Metrics
- Home excluding Library benchmark: ~29.22 ms/op -> ~1.79 ms/op, about 16.4x faster
- Cold temp-home overview JSON: 11.14s -> 1.98s
- Warm overview JSON on local machine: ~0.005-0.007s