### PR TITLE
Speed up uninstall app scanning

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -36,7 +36,7 @@ readonly MOLE_UNINSTALL_META_CACHE_FILE="$MOLE_UNINSTALL_META_CACHE_DIR/uninstal
 readonly MOLE_UNINSTALL_META_CACHE_LOCK="${MOLE_UNINSTALL_META_CACHE_FILE}.lock"
 readonly MOLE_UNINSTALL_META_REFRESH_TTL=604800 # 7 days
 readonly MOLE_UNINSTALL_SCAN_SPINNER_DELAY_SEC="0.25"
-readonly MOLE_UNINSTALL_INLINE_METADATA_LIMIT=50
+readonly MOLE_UNINSTALL_INLINE_METADATA_LIMIT="${MOLE_UNINSTALL_INLINE_METADATA_LIMIT:-0}"
 readonly MOLE_UNINSTALL_EPOCH_FLOOR=978307200
 readonly MOLE_UNINSTALL_INLINE_MDLS_TIMEOUT_SEC="0.08"
 
@@ -373,21 +373,111 @@ start_uninstall_metadata_refresh() {
         rm -f "$updates_file"
         rm -f "$refresh_file" 2> /dev/null || true
     ) > /dev/null 2>&1 &
+    disown "$!" 2> /dev/null || true
 
+}
+
+uninstall_print_app_search_dirs() {
+    local -a app_dirs=(
+        "/Applications"
+        "$HOME/Applications"
+        "/Library/Input Methods"
+        "$HOME/Library/Input Methods"
+    )
+
+    local vol_app_dir
+    local nullglob_was_set=0
+    shopt -q nullglob && nullglob_was_set=1
+    shopt -s nullglob
+    for vol_app_dir in /Volumes/*/Applications; do
+        [[ -d "$vol_app_dir" && -r "$vol_app_dir" ]] || continue
+        if [[ -d "/Applications" && "$vol_app_dir" -ef "/Applications" ]]; then
+            continue
+        fi
+        if [[ -d "$HOME/Applications" && "$vol_app_dir" -ef "$HOME/Applications" ]]; then
+            continue
+        fi
+        app_dirs+=("$vol_app_dir")
+    done
+    if [[ $nullglob_was_set -eq 0 ]]; then
+        shopt -u nullglob
+    fi
+
+    printf '%s\n' "${app_dirs[@]}"
+}
+
+uninstall_should_skip_app_path() {
+    local app_path="$1"
+
+    [[ -e "$app_path" ]] || return 0
+
+    # Skip nested apps inside another .app bundle.
+    local parent_dir="${app_path%/*}"
+    if [[ "$parent_dir" == *".app" || "$parent_dir" == *".app/"* ]]; then
+        return 0
+    fi
+
+    if [[ -L "$app_path" ]]; then
+        local link_target
+        link_target=$(readlink "$app_path" 2> /dev/null)
+        if [[ -n "$link_target" ]]; then
+            local resolved_target="$link_target"
+            if [[ "$link_target" != /* ]]; then
+                local link_dir="${app_path%/*}"
+                local _link_parent="${link_target%/*}"
+                [[ "$_link_parent" == "$link_target" ]] && _link_parent="."
+                resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$_link_parent" 2> /dev/null && pwd)/"${link_target##*/}" 2> /dev/null || echo ""
+            fi
+            case "$resolved_target" in
+                /System/* | /usr/bin/* | /usr/lib/* | /bin/* | /sbin/* | /private/etc/*)
+                    return 0
+                    ;;
+            esac
+        fi
+    fi
+
+    return 1
+}
+
+uninstall_app_inventory_fingerprint() {
+    local app_dir app_path app_mtime pkg_app_path
+
+    {
+        while IFS= read -r pkg_app_path; do
+            [[ -n "$pkg_app_path" && -d "$pkg_app_path" ]] || continue
+            app_mtime=$(get_file_mtime "$pkg_app_path")
+            printf '%s|%s\n' "$pkg_app_path" "${app_mtime:-0}"
+        done < <(pkg_receipt_nonstandard_app_paths)
+
+        while IFS= read -r app_dir; do
+            [[ -d "$app_dir" ]] || continue
+            while IFS=$'\t' read -r app_mtime app_path; do
+                [[ -n "$app_path" ]] || continue
+                uninstall_should_skip_app_path "$app_path" && continue
+                printf '%s|%s\n' "$app_path" "${app_mtime:-0}"
+            done < <(command find "$app_dir" -maxdepth 3 -name "*.app" -exec stat -f $'%m\t%N' {} + 2> /dev/null)
+        done < <(uninstall_print_app_search_dirs)
+    } | sort -u
 }
 
 # Scan applications and collect information.
 scan_applications() {
-    local temp_file scan_raw_file merged_file refresh_file cache_snapshot_file
+    local temp_file scan_raw_file merged_file refresh_file cache_snapshot_file discovered_file cached_rows_file uncached_rows_file
     temp_file=$(create_temp_file)
     scan_raw_file="${temp_file}.scan"
     merged_file="${temp_file}.merged"
     refresh_file="${temp_file}.refresh"
     cache_snapshot_file="${temp_file}.cache"
+    discovered_file="${temp_file}.discovered"
+    cached_rows_file="${temp_file}.cached_rows"
+    uncached_rows_file="${temp_file}.uncached_rows"
     local scan_status_file="${temp_file}.scan_status"
     : > "$scan_raw_file"
     : > "$refresh_file"
     : > "$cache_snapshot_file"
+    : > "$discovered_file"
+    : > "$cached_rows_file"
+    : > "$uncached_rows_file"
     : > "$scan_status_file"
 
     ensure_user_dir "$MOLE_UNINSTALL_META_CACHE_DIR"
@@ -400,35 +490,21 @@ scan_applications() {
         cache_source_is_temp=true
     fi
 
-    # Fast lookup cache for unchanged apps: path+mtime -> bundle_id/display_name.
-    local -a cache_paths=()
-    local -a cache_mtimes=()
-    local -a cache_bundle_ids=()
-    local -a cache_display_names=()
-    local cache_path cache_mtime _cache_size _cache_epoch _cache_updated cache_bundle cache_display
-    while IFS='|' read -r cache_path cache_mtime _cache_size _cache_epoch _cache_updated cache_bundle cache_display; do
-        [[ -n "$cache_path" ]] || continue
-        cache_paths+=("$cache_path")
-        cache_mtimes+=("${cache_mtime:-0}")
-        cache_bundle_ids+=("${cache_bundle:-}")
-        cache_display_names+=("${cache_display:-}")
-    done < "$cache_source"
+    use_cached_scan_metadata() {
+        local cached_app_path="$1"
+        local cached_app_mtime="$2"
+        local cached_bundle_id="$3"
+        local cached_display_name="$4"
 
-    lookup_cached_identity() {
-        local target_path="$1"
-        local target_mtime="$2"
-        local idx
-        for ((idx = 0; idx < ${#cache_paths[@]}; idx++)); do
-            if [[ "${cache_paths[idx]}" == "$target_path" ]]; then
-                if [[ "${cache_mtimes[idx]:-0}" == "${target_mtime:-0}" ]]; then
-                    echo "${cache_bundle_ids[idx]:-}|${cache_display_names[idx]:-}"
-                else
-                    echo "|"
-                fi
-                return 0
-            fi
-        done
-        echo "|"
+        [[ -n "$cached_bundle_id" && -n "$cached_display_name" ]] || return 1
+
+        # The metadata cache only contains apps that previously passed the
+        # background-only and protection filters. Trust unchanged cached rows
+        # here so returning to the app list does not rebuild the full
+        # protection regex for every application.
+
+        printf "%s|%s|%s|%s\n" "$cached_app_path" "$cached_display_name" "$cached_bundle_id" "$cached_app_mtime" >> "$scan_raw_file"
+        return 0
     }
 
     # Local spinner_pid for cleanup
@@ -455,7 +531,7 @@ scan_applications() {
         if [[ -f "$spinner_shown_file" ]]; then
             printf "\r\033[K" >&2
         fi
-        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file" "$scan_status_file" "${temp_file}.sorted" "$spinner_shown_file" 2> /dev/null || true
+        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file" "$discovered_file" "$cached_rows_file" "$uncached_rows_file" "$scan_status_file" "${temp_file}.sorted" "$spinner_shown_file" 2> /dev/null || true
         exit 130
     }
     trap trap_scan_cleanup INT
@@ -481,29 +557,11 @@ scan_applications() {
 
     # Pass 1: collect app paths and bundle IDs (no mdls).
     local -a app_data_tuples=()
-    local -a app_dirs=(
-        "/Applications"
-        "$HOME/Applications"
-        "/Library/Input Methods"
-        "$HOME/Library/Input Methods"
-    )
-    local vol_app_dir
-    local nullglob_was_set=0
-    shopt -q nullglob && nullglob_was_set=1
-    shopt -s nullglob
-    for vol_app_dir in /Volumes/*/Applications; do
-        [[ -d "$vol_app_dir" && -r "$vol_app_dir" ]] || continue
-        if [[ -d "/Applications" && "$vol_app_dir" -ef "/Applications" ]]; then
-            continue
-        fi
-        if [[ -d "$HOME/Applications" && "$vol_app_dir" -ef "$HOME/Applications" ]]; then
-            continue
-        fi
-        app_dirs+=("$vol_app_dir")
-    done
-    if [[ $nullglob_was_set -eq 0 ]]; then
-        shopt -u nullglob
-    fi
+    local -a app_dirs=()
+    local app_dir
+    while IFS= read -r app_dir; do
+        [[ -n "$app_dir" ]] && app_dirs+=("$app_dir")
+    done < <(uninstall_print_app_search_dirs)
 
     # Scan for pkg-installed apps in non-standard locations.
     local pkg_app_path
@@ -525,61 +583,57 @@ scan_applications() {
         local app_mtime
         app_mtime=$(get_file_mtime "$pkg_app_path")
 
-        local cached_identity cached_bundle_id cached_display_name
-        cached_identity=$(lookup_cached_identity "$pkg_app_path" "$app_mtime")
-        IFS='|' read -r cached_bundle_id cached_display_name <<< "$cached_identity"
-
-        app_data_tuples+=("${pkg_app_path}|${app_name}|${app_mtime}|${cached_bundle_id}|${cached_display_name}")
+        printf "%s|%s|%s\n" "$pkg_app_path" "$app_name" "${app_mtime:-0}" >> "$discovered_file"
     done < <(pkg_receipt_nonstandard_app_paths)
 
     for app_dir in "${app_dirs[@]}"; do
         if [[ ! -d "$app_dir" ]]; then continue; fi
 
-        while IFS= read -r -d '' app_path; do
+        while IFS=$'\t' read -r app_mtime app_path; do
             if [[ ! -e "$app_path" ]]; then continue; fi
 
             local app_name="${app_path##*/}"
             app_name="${app_name%.app}"
 
-            # Skip nested apps inside another .app bundle.
-            local parent_dir="${app_path%/*}"
-            if [[ "$parent_dir" == *".app" || "$parent_dir" == *".app/"* ]]; then
-                continue
-            fi
+            uninstall_should_skip_app_path "$app_path" && continue
 
-            if [[ -L "$app_path" ]]; then
-                local link_target
-                link_target=$(readlink "$app_path" 2> /dev/null)
-                if [[ -n "$link_target" ]]; then
-                    local resolved_target="$link_target"
-                    if [[ "$link_target" != /* ]]; then
-                        local link_dir="${app_path%/*}"
-                        local _link_parent="${link_target%/*}"
-                        [[ "$_link_parent" == "$link_target" ]] && _link_parent="."
-                        resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$_link_parent" 2> /dev/null && pwd)/"${link_target##*/}" 2> /dev/null || echo ""
-                    fi
-                    case "$resolved_target" in
-                        /System/* | /usr/bin/* | /usr/lib/* | /bin/* | /sbin/* | /private/etc/*)
-                            continue
-                            ;;
-                    esac
-                fi
-            fi
-
-            local app_mtime
-            app_mtime=$(get_file_mtime "$app_path")
-
-            local cached_identity cached_bundle_id cached_display_name
-            cached_identity=$(lookup_cached_identity "$app_path" "$app_mtime")
-            IFS='|' read -r cached_bundle_id cached_display_name <<< "$cached_identity"
-
-            # Store tuple for pass 2 (bundle + display resolution, then cache merge).
-            app_data_tuples+=("${app_path}|${app_name}|${app_mtime}|${cached_bundle_id}|${cached_display_name}")
-        done < <(command find "$app_dir" -name "*.app" -maxdepth 3 -print0 2> /dev/null)
+            printf "%s|%s|%s\n" "$app_path" "$app_name" "${app_mtime:-0}" >> "$discovered_file"
+        done < <(command find "$app_dir" -maxdepth 3 -name "*.app" -exec stat -f $'%m\t%N' {} + 2> /dev/null)
     done
 
-    if [[ ${#app_data_tuples[@]} -eq 0 ]]; then
-        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file" "$scan_status_file" "${temp_file}.sorted" "$spinner_shown_file" 2> /dev/null || true
+    if [[ -s "$discovered_file" ]]; then
+        awk -F'|' -v cached_out="$cached_rows_file" -v uncached_out="$uncached_rows_file" '
+            FILENAME == ARGV[1] {
+                cache_mtime[$1] = $2
+                cache_bundle[$1] = $6
+                cache_display[$1] = $7
+                next
+            }
+            {
+                path = $1
+                app_mtime = $3
+                if (cache_mtime[path] == app_mtime && cache_display[path] != "") {
+                    cached_bundle = cache_bundle[path] == "" ? "unknown" : cache_bundle[path]
+                    print path "|" app_mtime "|" cached_bundle "|" cache_display[path] >> cached_out
+                } else {
+                    print path "|" $2 "|" app_mtime "|" cache_bundle[path] "|" cache_display[path] >> uncached_out
+                }
+            }
+        ' "$cache_source" "$discovered_file"
+
+        local cached_app_path cached_app_mtime cached_bundle_id cached_display_name
+        while IFS='|' read -r cached_app_path cached_app_mtime cached_bundle_id cached_display_name; do
+            use_cached_scan_metadata "$cached_app_path" "$cached_app_mtime" "$cached_bundle_id" "$cached_display_name" || true
+        done < "$cached_rows_file"
+
+        local uncached_app_path uncached_app_name uncached_app_mtime uncached_bundle_id uncached_display_name
+        while IFS='|' read -r uncached_app_path uncached_app_name uncached_app_mtime uncached_bundle_id uncached_display_name; do
+            app_data_tuples+=("${uncached_app_path}|${uncached_app_name}|${uncached_app_mtime}|${uncached_bundle_id}|${uncached_display_name}")
+        done < "$uncached_rows_file"
+    fi
+
+    if [[ ${#app_data_tuples[@]} -eq 0 && ! -s "$scan_raw_file" ]]; then
+        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file" "$discovered_file" "$cached_rows_file" "$uncached_rows_file" "$scan_status_file" "${temp_file}.sorted" "$spinner_shown_file" 2> /dev/null || true
         [[ $cache_source_is_temp == true ]] && rm -f "$cache_source" 2> /dev/null || true
         restore_scan_int_trap
         printf "\r\033[K" >&2
@@ -608,7 +662,8 @@ scan_applications() {
         if [[ -z "$bundle_id" ]]; then
             bundle_id="unknown"
             if [[ -f "$app_path/Contents/Info.plist" ]]; then
-                bundle_id=$(defaults read "$app_path/Contents/Info.plist" CFBundleIdentifier 2> /dev/null || echo "unknown")
+                bundle_id=$(plutil -extract CFBundleIdentifier raw "$app_path/Contents/Info.plist" 2> /dev/null || echo "")
+                [[ -n "$bundle_id" ]] || bundle_id="unknown"
             fi
         fi
 
@@ -619,7 +674,7 @@ scan_applications() {
         local plist="$app_path/Contents/Info.plist"
         if [[ -f "$plist" ]]; then
             local bg_only
-            bg_only=$(defaults read "$plist" LSBackgroundOnly 2> /dev/null || echo "")
+            bg_only=$(plutil -extract LSBackgroundOnly raw "$plist" 2> /dev/null || echo "")
             if [[ "$bg_only" == "1" || "$bg_only" == "YES" || "$bg_only" == "true" ]]; then
                 return 0
             fi
@@ -686,7 +741,7 @@ scan_applications() {
     if [[ ! -s "$scan_raw_file" ]]; then
         stop_scan_spinner
         echo "No applications found to uninstall" >&2
-        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file" "${temp_file}.sorted" "$spinner_shown_file" 2> /dev/null || true
+        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file" "$discovered_file" "$cached_rows_file" "$uncached_rows_file" "${temp_file}.sorted" "$spinner_shown_file" 2> /dev/null || true
         [[ $cache_source_is_temp == true ]] && rm -f "$cache_source" 2> /dev/null || true
         restore_scan_int_trap
         return 1
@@ -715,99 +770,208 @@ scan_applications() {
     current_epoch=$(get_epoch_seconds)
     local inline_metadata_count=0
     local inline_metadata_effective_limit=$MOLE_UNINSTALL_INLINE_METADATA_LIMIT
-    [[ $cache_source_is_temp == true ]] && inline_metadata_effective_limit=99999
+    [[ $cache_source_is_temp == true && $inline_metadata_effective_limit -gt 0 ]] && inline_metadata_effective_limit=99999
     local metadata_total=0
     metadata_total=$(wc -l < "$merged_file" 2> /dev/null || echo "0")
     [[ "$metadata_total" =~ ^[0-9]+$ ]] || metadata_total=0
     local metadata_processed=0
     update_scan_status "Collecting metadata..." "0" "$metadata_total"
 
-    while IFS='|' read -r app_path display_name bundle_id app_mtime cached_mtime cached_size_kb cached_epoch cached_updated_epoch cached_bundle_id cached_display_name; do
-        ((metadata_processed++))
-        if ((metadata_processed % 5 == 0 || metadata_processed == metadata_total)); then
-            update_scan_status "Collecting metadata..." "$metadata_processed" "$metadata_total"
-        fi
+    if [[ "$inline_metadata_effective_limit" -eq 0 ]]; then
+        awk -F'|' \
+            -v now="$current_epoch" \
+            -v floor="$MOLE_UNINSTALL_EPOCH_FLOOR" \
+            -v ttl="$MOLE_UNINSTALL_META_REFRESH_TTL" \
+            -v refresh_out="$refresh_file" \
+            -v snapshot_out="$cache_snapshot_file" \
+            -v apps_out="$temp_file" '
+            function isnum(value) {
+                return value ~ /^[0-9]+$/
+            }
+            function human_size(kb, bytes, scaled) {
+                if (!isnum(kb) || kb <= 0) {
+                    return "--"
+                }
+                bytes = kb * 1024
+                if (bytes >= 1000000000) {
+                    scaled = int((bytes * 100 + 500000000) / 1000000000)
+                    return sprintf("%d.%02dGB", int(scaled / 100), scaled % 100)
+                }
+                if (bytes >= 1000000) {
+                    scaled = int((bytes * 10 + 500000) / 1000000)
+                    return sprintf("%d.%01dMB", int(scaled / 10), scaled % 10)
+                }
+                if (bytes >= 1000) {
+                    return sprintf("%dKB", int((bytes + 500) / 1000))
+                }
+                return sprintf("%dB", bytes)
+            }
+            function relative_time(epoch, now_epoch, days_ago, weeks_ago, months_ago, years_ago) {
+                if (!isnum(epoch) || epoch <= 0 || epoch < floor) {
+                    return "Unknown"
+                }
+                days_ago = int((now_epoch - epoch) / 86400)
+                if (days_ago < 0) {
+                    days_ago = 0
+                }
+                if (days_ago == 0) {
+                    return "Today"
+                }
+                if (days_ago == 1) {
+                    return "Yesterday"
+                }
+                if (days_ago < 7) {
+                    return days_ago " days ago"
+                }
+                if (days_ago < 30) {
+                    weeks_ago = int(days_ago / 7)
+                    return weeks_ago == 1 ? "1 week ago" : weeks_ago " weeks ago"
+                }
+                if (days_ago < 365) {
+                    months_ago = int(days_ago / 30)
+                    return months_ago == 1 ? "1 month ago" : months_ago " months ago"
+                }
+                years_ago = int(days_ago / 365)
+                return years_ago == 1 ? "1 year ago" : years_ago " years ago"
+            }
+            {
+                app_path = $1
+                display_name = $2
+                bundle_id = $3
+                app_mtime = $4
+                cached_mtime = $5
+                cached_size_kb = $6
+                cached_epoch = $7
+                cached_updated_epoch = $8
+                cached_bundle_id = $9
+                cached_display_name = $10
 
-        [[ -n "$app_path" && -e "$app_path" ]] || continue
+                cache_match = (cached_mtime != "" && app_mtime != "" && cached_mtime == app_mtime)
 
-        local cache_match=false
-        if [[ -n "$cached_mtime" && -n "$app_mtime" && "$cached_mtime" == "$app_mtime" ]]; then
-            cache_match=true
-        fi
+                final_epoch = (isnum(cached_epoch) && cached_epoch > 0) ? cached_epoch : 0
+                if (isnum(final_epoch) && final_epoch < floor) {
+                    final_epoch = 0
+                }
+                if ((!isnum(final_epoch) || final_epoch <= 0) && isnum(app_mtime) && app_mtime > floor) {
+                    final_epoch = app_mtime
+                }
 
-        local final_epoch=0
-        if [[ "$cached_epoch" =~ ^[0-9]+$ && $cached_epoch -gt 0 ]]; then
-            final_epoch="$cached_epoch"
-        fi
+                final_size_kb = (isnum(cached_size_kb) && cached_size_kb > 0) ? cached_size_kb : 0
+                final_size = human_size(final_size_kb)
+                final_last_used = relative_time(final_epoch, now)
 
-        local final_size_kb=0
-        local final_size="--"
-        if [[ "$cached_size_kb" =~ ^[0-9]+$ && $cached_size_kb -gt 0 ]]; then
-            final_size_kb="$cached_size_kb"
-            final_size=$(bytes_to_human "$((cached_size_kb * 1024))")
-        fi
+                needs_refresh = 0
+                if (!cache_match) {
+                    needs_refresh = 1
+                } else if (!isnum(cached_size_kb) || cached_size_kb <= 0) {
+                    needs_refresh = 1
+                } else if (!isnum(cached_epoch) || cached_epoch <= 0) {
+                    needs_refresh = 1
+                } else if (!isnum(cached_updated_epoch)) {
+                    needs_refresh = 1
+                } else if (cached_bundle_id == "" || cached_display_name == "") {
+                    needs_refresh = 1
+                } else if ((now - cached_updated_epoch) > ttl) {
+                    needs_refresh = 1
+                }
 
-        if [[ "$final_epoch" =~ ^[0-9]+$ && $final_epoch -lt $MOLE_UNINSTALL_EPOCH_FLOOR ]]; then
-            final_epoch=0
-        fi
-        # Fallback to app mtime to avoid unknown "last used" on first scan.
-        if [[ ! "$final_epoch" =~ ^[0-9]+$ || $final_epoch -le 0 ]]; then
-            if [[ "$app_mtime" =~ ^[0-9]+$ && $app_mtime -gt $MOLE_UNINSTALL_EPOCH_FLOOR ]]; then
-                final_epoch="$app_mtime"
+                if (needs_refresh) {
+                    print app_path "|" app_mtime "|" bundle_id "|" display_name >> refresh_out
+                }
+
+                persist_updated_epoch = (isnum(cached_updated_epoch) && cached_updated_epoch > 0) ? cached_updated_epoch : 0
+                print app_path "|" app_mtime "|" final_size_kb "|" final_epoch "|" persist_updated_epoch "|" bundle_id "|" display_name >> snapshot_out
+                print final_epoch "|" app_path "|" display_name "|" bundle_id "|" final_size "|" final_last_used "|" final_size_kb >> apps_out
+            }
+        ' "$merged_file"
+    else
+        while IFS='|' read -r app_path display_name bundle_id app_mtime cached_mtime cached_size_kb cached_epoch cached_updated_epoch cached_bundle_id cached_display_name; do
+            ((metadata_processed++))
+            if ((metadata_processed % 5 == 0 || metadata_processed == metadata_total)); then
+                update_scan_status "Collecting metadata..." "$metadata_processed" "$metadata_total"
             fi
-        fi
 
-        local final_last_used
-        final_last_used=$(uninstall_relative_time_from_epoch "$final_epoch" "$current_epoch")
+            [[ -n "$app_path" && -e "$app_path" ]] || continue
 
-        local needs_refresh=false
-        if [[ $cache_match == false ]]; then
-            needs_refresh=true
-        elif [[ ! "$cached_size_kb" =~ ^[0-9]+$ || $cached_size_kb -le 0 ]]; then
-            needs_refresh=true
-        elif [[ ! "$cached_epoch" =~ ^[0-9]+$ || $cached_epoch -le 0 ]]; then
-            needs_refresh=true
-        elif [[ ! "$cached_updated_epoch" =~ ^[0-9]+$ ]]; then
-            needs_refresh=true
-        elif [[ -z "$cached_bundle_id" || -z "$cached_display_name" ]]; then
-            needs_refresh=true
-        else
-            local cache_age=$((current_epoch - cached_updated_epoch))
-            if [[ $cache_age -gt $MOLE_UNINSTALL_META_REFRESH_TTL ]]; then
+            local cache_match=false
+            if [[ -n "$cached_mtime" && -n "$app_mtime" && "$cached_mtime" == "$app_mtime" ]]; then
+                cache_match=true
+            fi
+
+            local final_epoch=0
+            if [[ "$cached_epoch" =~ ^[0-9]+$ && $cached_epoch -gt 0 ]]; then
+                final_epoch="$cached_epoch"
+            fi
+
+            local final_size_kb=0
+            local final_size="--"
+            if [[ "$cached_size_kb" =~ ^[0-9]+$ && $cached_size_kb -gt 0 ]]; then
+                final_size_kb="$cached_size_kb"
+                final_size=$(bytes_to_human "$((cached_size_kb * 1024))")
+            fi
+
+            if [[ "$final_epoch" =~ ^[0-9]+$ && $final_epoch -lt $MOLE_UNINSTALL_EPOCH_FLOOR ]]; then
+                final_epoch=0
+            fi
+            # Fallback to app mtime to avoid unknown "last used" on first scan.
+            if [[ ! "$final_epoch" =~ ^[0-9]+$ || $final_epoch -le 0 ]]; then
+                if [[ "$app_mtime" =~ ^[0-9]+$ && $app_mtime -gt $MOLE_UNINSTALL_EPOCH_FLOOR ]]; then
+                    final_epoch="$app_mtime"
+                fi
+            fi
+
+            local final_last_used
+            final_last_used=$(uninstall_relative_time_from_epoch "$final_epoch" "$current_epoch")
+
+            local needs_refresh=false
+            if [[ $cache_match == false ]]; then
                 needs_refresh=true
-            fi
-        fi
-
-        if [[ $needs_refresh == true ]]; then
-            if [[ $inline_metadata_count -lt $inline_metadata_effective_limit ]]; then
-                local inline_metadata inline_size_kb inline_epoch inline_updated_epoch
-                inline_metadata=$(uninstall_collect_inline_metadata "$app_path" "${app_mtime:-0}" "$current_epoch")
-                IFS='|' read -r inline_size_kb inline_epoch inline_updated_epoch <<< "$inline_metadata"
-                ((inline_metadata_count++))
-
-                if [[ "$inline_size_kb" =~ ^[0-9]+$ && $inline_size_kb -gt 0 ]]; then
-                    final_size_kb="$inline_size_kb"
-                    final_size=$(bytes_to_human "$((inline_size_kb * 1024))")
-                fi
-                if [[ "$inline_epoch" =~ ^[0-9]+$ && $inline_epoch -gt 0 ]]; then
-                    final_epoch="$inline_epoch"
-                    final_last_used=$(uninstall_relative_time_from_epoch "$final_epoch" "$current_epoch")
-                fi
-                if [[ "$inline_updated_epoch" =~ ^[0-9]+$ && $inline_updated_epoch -gt 0 ]]; then
-                    cached_updated_epoch="$inline_updated_epoch"
+            elif [[ ! "$cached_size_kb" =~ ^[0-9]+$ || $cached_size_kb -le 0 ]]; then
+                needs_refresh=true
+            elif [[ ! "$cached_epoch" =~ ^[0-9]+$ || $cached_epoch -le 0 ]]; then
+                needs_refresh=true
+            elif [[ ! "$cached_updated_epoch" =~ ^[0-9]+$ ]]; then
+                needs_refresh=true
+            elif [[ -z "$cached_bundle_id" || -z "$cached_display_name" ]]; then
+                needs_refresh=true
+            else
+                local cache_age=$((current_epoch - cached_updated_epoch))
+                if [[ $cache_age -gt $MOLE_UNINSTALL_META_REFRESH_TTL ]]; then
+                    needs_refresh=true
                 fi
             fi
-            printf "%s|%s|%s|%s\n" "$app_path" "${app_mtime:-0}" "$bundle_id" "$display_name" >> "$refresh_file"
-        fi
 
-        local persist_updated_epoch=0
-        if [[ "$cached_updated_epoch" =~ ^[0-9]+$ && $cached_updated_epoch -gt 0 ]]; then
-            persist_updated_epoch="$cached_updated_epoch"
-        fi
-        printf "%s|%s|%s|%s|%s|%s|%s\n" "$app_path" "${app_mtime:-0}" "${final_size_kb:-0}" "${final_epoch:-0}" "${persist_updated_epoch:-0}" "$bundle_id" "$display_name" >> "$cache_snapshot_file"
+            if [[ $needs_refresh == true ]]; then
+                if [[ $inline_metadata_count -lt $inline_metadata_effective_limit ]]; then
+                    local inline_metadata inline_size_kb inline_epoch inline_updated_epoch
+                    inline_metadata=$(uninstall_collect_inline_metadata "$app_path" "${app_mtime:-0}" "$current_epoch")
+                    IFS='|' read -r inline_size_kb inline_epoch inline_updated_epoch <<< "$inline_metadata"
+                    ((inline_metadata_count++))
 
-        echo "${final_epoch}|${app_path}|${display_name}|${bundle_id}|${final_size}|${final_last_used}|${final_size_kb}" >> "$temp_file"
-    done < "$merged_file"
+                    if [[ "$inline_size_kb" =~ ^[0-9]+$ && $inline_size_kb -gt 0 ]]; then
+                        final_size_kb="$inline_size_kb"
+                        final_size=$(bytes_to_human "$((inline_size_kb * 1024))")
+                    fi
+                    if [[ "$inline_epoch" =~ ^[0-9]+$ && $inline_epoch -gt 0 ]]; then
+                        final_epoch="$inline_epoch"
+                        final_last_used=$(uninstall_relative_time_from_epoch "$final_epoch" "$current_epoch")
+                    fi
+                    if [[ "$inline_updated_epoch" =~ ^[0-9]+$ && $inline_updated_epoch -gt 0 ]]; then
+                        cached_updated_epoch="$inline_updated_epoch"
+                    fi
+                fi
+                printf "%s|%s|%s|%s\n" "$app_path" "${app_mtime:-0}" "$bundle_id" "$display_name" >> "$refresh_file"
+            fi
+
+            local persist_updated_epoch=0
+            if [[ "$cached_updated_epoch" =~ ^[0-9]+$ && $cached_updated_epoch -gt 0 ]]; then
+                persist_updated_epoch="$cached_updated_epoch"
+            fi
+            printf "%s|%s|%s|%s|%s|%s|%s\n" "$app_path" "${app_mtime:-0}" "${final_size_kb:-0}" "${final_epoch:-0}" "${persist_updated_epoch:-0}" "$bundle_id" "$display_name" >> "$cache_snapshot_file"
+
+            echo "${final_epoch}|${app_path}|${display_name}|${bundle_id}|${final_size}|${final_last_used}|${final_size_kb}" >> "$temp_file"
+        done < "$merged_file"
+    fi
 
     update_scan_status "Updating cache..." "0" "0"
     if [[ -s "$cache_snapshot_file" ]]; then
@@ -820,12 +984,12 @@ scan_applications() {
     update_scan_status "Sorting application list..." "0" "0"
     sort -t'|' -k1,1n "$temp_file" > "${temp_file}.sorted" || {
         stop_scan_spinner
-        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file"
+        rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$refresh_file" "$cache_snapshot_file" "$discovered_file" "$cached_rows_file" "$uncached_rows_file"
         [[ $cache_source_is_temp == true ]] && rm -f "$cache_source" 2> /dev/null || true
         restore_scan_int_trap
         return 1
     }
-    rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$cache_snapshot_file"
+    rm -f "$temp_file" "$scan_raw_file" "$merged_file" "$cache_snapshot_file" "$discovered_file" "$cached_rows_file" "$uncached_rows_file"
     [[ $cache_source_is_temp == true ]] && rm -f "$cache_source" 2> /dev/null || true
 
     update_scan_status "Finalizing list..." "0" "0"
@@ -833,6 +997,7 @@ scan_applications() {
     stop_scan_spinner
 
     if [[ -f "${temp_file}.sorted" ]]; then
+        register_temp_file "${temp_file}.sorted"
         restore_scan_int_trap
         echo "${temp_file}.sorted"
         return 0
@@ -1211,17 +1376,38 @@ main() {
     fi
 
     local first_scan=true
+    local cached_apps_file=""
+    local cached_inventory_fingerprint=""
     while true; do
         unset MOLE_INLINE_LOADING MOLE_MANAGED_ALT_SCREEN
 
         if [[ $first_scan == false ]]; then
-            echo -e "${GRAY}Refreshing application list...${NC}" >&2
+            echo -e "${GRAY}Checking application list...${NC}" >&2
         fi
         first_scan=false
 
         local apps_file=""
-        if ! apps_file=$(scan_applications); then
-            return 1
+        local reused_app_cache=false
+        if [[ -n "$cached_apps_file" && -f "$cached_apps_file" && -n "$cached_inventory_fingerprint" ]]; then
+            local current_inventory_fingerprint
+            current_inventory_fingerprint=$(uninstall_app_inventory_fingerprint 2> /dev/null || echo "")
+            if [[ -n "$current_inventory_fingerprint" && "$current_inventory_fingerprint" == "$cached_inventory_fingerprint" ]]; then
+                apps_file="$cached_apps_file"
+                reused_app_cache=true
+            fi
+        fi
+
+        if [[ "$reused_app_cache" != "true" ]]; then
+            if [[ -n "$cached_apps_file" && -f "$cached_apps_file" ]]; then
+                rm -f "$cached_apps_file" 2> /dev/null || true
+            fi
+
+            if ! apps_file=$(scan_applications); then
+                return 1
+            fi
+
+            cached_apps_file="$apps_file"
+            cached_inventory_fingerprint=$(uninstall_app_inventory_fingerprint 2> /dev/null || echo "")
         fi
 
         if [[ ! -f "$apps_file" ]]; then
@@ -1230,6 +1416,7 @@ main() {
 
         if ! load_applications "$apps_file"; then
             rm -f "$apps_file"
+            [[ "$apps_file" == "$cached_apps_file" ]] && cached_apps_file=""
             return 1
         fi
 
@@ -1248,6 +1435,7 @@ main() {
             clear_screen
             printf '\033[2J\033[H' >&2
             rm -f "$apps_file"
+            [[ "$apps_file" == "$cached_apps_file" ]] && cached_apps_file=""
 
             return 0
         fi
@@ -1258,7 +1446,6 @@ main() {
         local selection_count=${#selected_apps[@]}
         if [[ $selection_count -eq 0 ]]; then
             echo "No apps selected"
-            rm -f "$apps_file"
             continue
         fi
         echo -e "${BLUE}${ICON_CONFIRM}${NC} Selected ${selection_count} apps:"
@@ -1345,8 +1532,6 @@ main() {
         done
 
         batch_uninstall_applications
-
-        rm -f "$apps_file"
 
         local _countdown=5
         local _key=""

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -439,6 +439,77 @@ uninstall_should_skip_app_path() {
     return 1
 }
 
+uninstall_resolve_bundle_id() {
+    local app_path="$1"
+    local fallback_bundle_id="${2:-}"
+    local bundle_id=""
+    local plist="$app_path/Contents/Info.plist"
+
+    fallback_bundle_id="${fallback_bundle_id//|/-}"
+    fallback_bundle_id="${fallback_bundle_id//[$'\t\r\n']/}"
+
+    if [[ -f "$plist" ]]; then
+        bundle_id=$(plutil -extract CFBundleIdentifier raw "$plist" 2> /dev/null || echo "")
+        bundle_id="${bundle_id//|/-}"
+        bundle_id="${bundle_id//[$'\t\r\n']/}"
+    fi
+
+    if [[ -n "$bundle_id" && "$bundle_id" != "(null)" ]]; then
+        printf '%s\n' "$bundle_id"
+        return 0
+    fi
+
+    if [[ -n "$fallback_bundle_id" && "$fallback_bundle_id" != "(null)" ]]; then
+        printf '%s\n' "$fallback_bundle_id"
+        return 0
+    fi
+
+    printf '%s\n' "unknown"
+}
+
+uninstall_app_is_background_only() {
+    local app_path="$1"
+    local plist="$app_path/Contents/Info.plist"
+    [[ -f "$plist" ]] || return 1
+
+    local bg_only
+    bg_only=$(plutil -extract LSBackgroundOnly raw "$plist" 2> /dev/null || echo "")
+    case "$bg_only" in
+        1 | YES | yes | TRUE | true)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+uninstall_app_is_currently_eligible() {
+    local app_path="$1"
+    local bundle_id="${2:-}"
+
+    [[ -n "$app_path" && -e "$app_path" ]] || return 1
+
+    if [[ -n "$bundle_id" && "$bundle_id" != "unknown" ]] && should_protect_from_uninstall "$bundle_id"; then
+        return 1
+    fi
+
+    if uninstall_app_is_background_only "$app_path"; then
+        return 1
+    fi
+
+    return 0
+}
+
+uninstall_resolve_eligible_bundle_id() {
+    local app_path="$1"
+    local fallback_bundle_id="${2:-}"
+    local bundle_id
+
+    bundle_id=$(uninstall_resolve_bundle_id "$app_path" "$fallback_bundle_id")
+    uninstall_app_is_currently_eligible "$app_path" "$bundle_id" || return 1
+    printf '%s\n' "$bundle_id"
+}
+
 uninstall_app_inventory_fingerprint() {
     local app_dir app_path app_mtime pkg_app_path
 
@@ -498,10 +569,7 @@ scan_applications() {
 
         [[ -n "$cached_bundle_id" && -n "$cached_display_name" ]] || return 1
 
-        # The metadata cache only contains apps that previously passed the
-        # background-only and protection filters. Trust unchanged cached rows
-        # here so returning to the app list does not rebuild the full
-        # protection regex for every application.
+        cached_bundle_id=$(uninstall_resolve_eligible_bundle_id "$cached_app_path" "$cached_bundle_id") || return 1
 
         printf "%s|%s|%s|%s\n" "$cached_app_path" "$cached_display_name" "$cached_bundle_id" "$cached_app_mtime" >> "$scan_raw_file"
         return 0
@@ -658,27 +726,8 @@ scan_applications() {
 
         IFS='|' read -r app_path app_name app_mtime cached_bundle_id cached_display_name <<< "$app_data_tuple"
 
-        local bundle_id="${cached_bundle_id:-}"
-        if [[ -z "$bundle_id" ]]; then
-            bundle_id="unknown"
-            if [[ -f "$app_path/Contents/Info.plist" ]]; then
-                bundle_id=$(plutil -extract CFBundleIdentifier raw "$app_path/Contents/Info.plist" 2> /dev/null || echo "")
-                [[ -n "$bundle_id" ]] || bundle_id="unknown"
-            fi
-        fi
-
-        if should_protect_from_uninstall "$bundle_id"; then
-            return 0
-        fi
-
-        local plist="$app_path/Contents/Info.plist"
-        if [[ -f "$plist" ]]; then
-            local bg_only
-            bg_only=$(plutil -extract LSBackgroundOnly raw "$plist" 2> /dev/null || echo "")
-            if [[ "$bg_only" == "1" || "$bg_only" == "YES" || "$bg_only" == "true" ]]; then
-                return 0
-            fi
-        fi
+        local bundle_id
+        bundle_id=$(uninstall_resolve_eligible_bundle_id "$app_path" "${cached_bundle_id:-}") || return 0
 
         local display_name="${cached_display_name:-}"
         if [[ -z "$display_name" ]]; then

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -959,6 +959,133 @@ is_path_whitelisted() {
     return 1
 }
 
+_mole_uninstall_lower() {
+    printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]'
+}
+
+_mole_uninstall_is_common_app_name() {
+    local lower_name
+    lower_name=$(_mole_uninstall_lower "${1:-}")
+    case "$lower_name" in
+        music | notes | photos | finder | safari | preview | calendar | contacts | messages | \
+            reminders | clock | weather | stocks | books | news | podcasts | voice | files | \
+            store | system | helper | agent | daemon | service | update | sync | backup | \
+            cloud | manager | monitor | server | client | worker | runner | launcher | \
+            driver | plugin | extension | widget | utility)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+_mole_uninstall_vendor_product_tokens() {
+    local bundle_id="${1:-}"
+    [[ "$bundle_id" =~ ^[a-zA-Z0-9][-a-zA-Z0-9]*(\.[a-zA-Z0-9][-a-zA-Z0-9]*)+$ ]] || return 1
+
+    local product_token="${bundle_id##*.}"
+    local without_product="${bundle_id%.*}"
+    local vendor_token="${without_product##*.}"
+
+    [[ "$vendor_token" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,}$ ]] || return 1
+    [[ "$product_token" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]{2,}$ ]] || return 1
+
+    printf '%s|%s\n' "$vendor_token" "$product_token"
+}
+
+_mole_uninstall_name_variant_matches() {
+    local candidate_lower="$1"
+    shift
+
+    local variant
+    for variant in "$@"; do
+        [[ -n "$variant" ]] || continue
+        if [[ "$candidate_lower" == "$variant" ||
+            "$candidate_lower" == "$variant "* ||
+            "$candidate_lower" == "$variant-"* ||
+            "$candidate_lower" == "${variant}_"* ||
+            "$candidate_lower" == "$variant."* ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+find_vendor_nested_app_paths() {
+    local bundle_id="$1"
+    local app_name="$2"
+    shift 2
+
+    [[ -n "$app_name" && ${#app_name} -ge 4 ]] || return 0
+    _mole_uninstall_is_common_app_name "$app_name" && return 0
+
+    local token_pair
+    token_pair=$(_mole_uninstall_vendor_product_tokens "$bundle_id" 2> /dev/null) || return 0
+    local vendor_token product_token
+    IFS='|' read -r vendor_token product_token <<< "$token_pair"
+
+    local vendor_lower product_lower app_lower nospace_lower hyphen_lower underscore_lower
+    vendor_lower=$(_mole_uninstall_lower "$vendor_token")
+    product_lower=$(_mole_uninstall_lower "$product_token")
+    app_lower=$(_mole_uninstall_lower "$app_name")
+    nospace_lower=$(_mole_uninstall_lower "${app_name// /}")
+    hyphen_lower=$(_mole_uninstall_lower "${app_name// /-}")
+    underscore_lower=$(_mole_uninstall_lower "${app_name// /_}")
+
+    local root candidate parent_dir parent_base parent_lower child_base child_lower
+    for root in "$@"; do
+        [[ -d "$root" ]] || continue
+        while IFS= read -r -d '' candidate; do
+            parent_dir="${candidate%/*}"
+            parent_base="${parent_dir##*/}"
+            parent_lower=$(_mole_uninstall_lower "$parent_base")
+            [[ "$parent_lower" == "$vendor_lower" ]] || continue
+
+            child_base="${candidate##*/}"
+            child_lower=$(_mole_uninstall_lower "$child_base")
+            if _mole_uninstall_name_variant_matches "$child_lower" \
+                "$app_lower" "$nospace_lower" "$hyphen_lower" "$underscore_lower" "$product_lower"; then
+                printf '%s\n' "$candidate"
+            fi
+        done < <(command find "$root" -mindepth 2 -maxdepth 2 -type d -print0 2> /dev/null)
+    done | sort -u
+}
+
+find_shared_app_paths() {
+    local bundle_id="$1"
+    local app_name="$2"
+    shift 2
+
+    [[ -n "$app_name" && ${#app_name} -ge 5 ]] || return 0
+    _mole_uninstall_is_common_app_name "$app_name" && return 0
+
+    local product_token=""
+    local token_pair
+    if token_pair=$(_mole_uninstall_vendor_product_tokens "$bundle_id" 2> /dev/null); then
+        IFS='|' read -r _ product_token <<< "$token_pair"
+    fi
+
+    local app_lower nospace_lower hyphen_lower underscore_lower product_lower
+    app_lower=$(_mole_uninstall_lower "$app_name")
+    nospace_lower=$(_mole_uninstall_lower "${app_name// /}")
+    hyphen_lower=$(_mole_uninstall_lower "${app_name// /-}")
+    underscore_lower=$(_mole_uninstall_lower "${app_name// /_}")
+    product_lower=$(_mole_uninstall_lower "$product_token")
+
+    local root candidate base lower_base
+    for root in "$@"; do
+        [[ -d "$root" ]] || continue
+        while IFS= read -r -d '' candidate; do
+            base="${candidate##*/}"
+            lower_base=$(_mole_uninstall_lower "$base")
+            if _mole_uninstall_name_variant_matches "$lower_base" \
+                "$app_lower" "$nospace_lower" "$hyphen_lower" "$underscore_lower" "$product_lower"; then
+                printf '%s\n' "$candidate"
+            fi
+        done < <(command find "$root" -mindepth 1 -maxdepth 1 -print0 2> /dev/null)
+    done | sort -u
+}
+
 # Locate files associated with an application
 find_app_files() {
     local bundle_id="$1"
@@ -1102,6 +1229,21 @@ find_app_files() {
 
         files_to_clean+=("$expanded_path")
     done
+
+    # Vendor-nested support directories, e.g.:
+    #   ~/Library/Application Support/Avid/Sibelius
+    # Many professional apps store the product under a vendor folder rather
+    # than directly under Application Support. Match only when the vendor token
+    # comes from the bundle id to avoid broad name-only deletion.
+    local vendor_nested_path
+    while IFS= read -r vendor_nested_path; do
+        [[ -n "$vendor_nested_path" && -e "$vendor_nested_path" ]] && files_to_clean+=("$vendor_nested_path")
+    done < <(
+        find_vendor_nested_app_paths "$bundle_id" "$app_name" \
+            "$HOME/Library/Application Support" \
+            "$HOME/Library/Caches" \
+            "$HOME/Library/Logs"
+    )
 
     # Handle Preferences and ByHost variants (only if bundle_id is valid)
     if [[ -n "$bundle_id" && "$bundle_id" != "unknown" && ${#bundle_id} -gt 3 ]]; then
@@ -1378,6 +1520,25 @@ find_app_system_files() {
 
         system_files+=("$p")
     done
+
+    # Vendor-nested system support directories, e.g.:
+    #   /Library/Application Support/Avid/Sibelius
+    local vendor_nested_system_path
+    while IFS= read -r vendor_nested_system_path; do
+        [[ -n "$vendor_nested_system_path" && -e "$vendor_nested_system_path" ]] && system_files+=("$vendor_nested_system_path")
+    done < <(
+        find_vendor_nested_app_paths "$bundle_id" "$app_name" \
+            "/Library/Application Support" \
+            "/Library/Caches" \
+            "/Library/Logs"
+    )
+
+    # Shared sample/support files are usually outside the user's Library but
+    # are app-owned data (for example /Users/Shared/Sibelius ...).
+    local shared_app_path
+    while IFS= read -r shared_app_path; do
+        [[ -n "$shared_app_path" && -e "$shared_app_path" ]] && system_files+=("$shared_app_path")
+    done < <(find_shared_app_paths "$bundle_id" "$app_name" "/Users/Shared")
 
     # System LaunchAgents/LaunchDaemons often use bundle-id-derived helper
     # labels (for example "<bundle>.ProxyConfigHelper.plist"), so scan for

--- a/lib/core/pkg_receipts.sh
+++ b/lib/core/pkg_receipts.sh
@@ -33,6 +33,32 @@ pkg_receipt_nonstandard_app_paths() {
         return 0
     fi
 
+    local cache_file="${MOLE_PKG_RECEIPT_CACHE_FILE:-$HOME/.cache/mole/pkg_receipt_apps_v1}"
+    local cache_ttl="${MOLE_PKG_RECEIPT_CACHE_TTL:-3600}"
+    local now_epoch=0
+    if declare -f get_epoch_seconds > /dev/null 2>&1; then
+        now_epoch=$(get_epoch_seconds)
+    else
+        now_epoch=$(date +%s 2> /dev/null || echo 0)
+    fi
+
+    if [[ "${MOLE_PKG_RECEIPT_CACHE_DISABLE:-0}" != "1" && -r "$cache_file" ]]; then
+        local cache_mtime=0
+        if declare -f get_file_mtime > /dev/null 2>&1; then
+            cache_mtime=$(get_file_mtime "$cache_file")
+        else
+            cache_mtime=$(stat -f "%m" "$cache_file" 2> /dev/null || echo 0)
+        fi
+        if [[ "$cache_ttl" =~ ^[0-9]+$ && "$cache_mtime" =~ ^[0-9]+$ &&
+            "$now_epoch" =~ ^[0-9]+$ && $cache_ttl -gt 0 &&
+            $((now_epoch - cache_mtime)) -lt $cache_ttl ]]; then
+            while IFS= read -r cached_app_path; do
+                [[ -n "$cached_app_path" && -d "$cached_app_path" ]] && printf '%s\n' "$cached_app_path"
+            done < "$cache_file"
+            return 0
+        fi
+    fi
+
     local pkgs_output
     if declare -f run_with_timeout > /dev/null 2>&1; then
         pkgs_output=$(run_with_timeout "${MOLE_PKG_RECEIPT_LIST_TIMEOUT:-3}" pkgutil --pkgs 2> /dev/null || true)
@@ -88,7 +114,31 @@ pkg_receipt_nonstandard_app_paths() {
             [[ "$duplicate" == "true" ]] && continue
 
             seen_apps+=("$app_path")
-            printf '%s\n' "$app_path"
         done <<< "$pkg_files"
     done <<< "$pkgs_output"
+
+    if [[ ${#seen_apps[@]} -gt 0 ]]; then
+        printf '%s\n' "${seen_apps[@]}" | sort -u
+    fi
+
+    if [[ "${MOLE_PKG_RECEIPT_CACHE_DISABLE:-0}" != "1" && -n "$cache_file" ]]; then
+        local cache_dir="${cache_file%/*}"
+        if [[ -n "$cache_dir" && "$cache_dir" != "$cache_file" ]]; then
+            if declare -f ensure_user_dir > /dev/null 2>&1; then
+                ensure_user_dir "$cache_dir"
+            else
+                mkdir -p "$cache_dir" 2> /dev/null || true
+            fi
+        fi
+        local cache_tmp
+        cache_tmp=$(mktemp "${TMPDIR:-/tmp}/mole.pkg_receipts.XXXXXX" 2> /dev/null || true)
+        if [[ -n "$cache_tmp" ]]; then
+            if [[ ${#seen_apps[@]} -gt 0 ]]; then
+                printf '%s\n' "${seen_apps[@]}" | sort -u > "$cache_tmp"
+            else
+                : > "$cache_tmp"
+            fi
+            mv -f "$cache_tmp" "$cache_file" 2> /dev/null || rm -f "$cache_tmp" 2> /dev/null || true
+        fi
+    fi
 }

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -380,7 +380,7 @@ batch_uninstall_applications() {
         local exec_name=""
         local info_plist="$app_path/Contents/Info.plist"
         if [[ -e "$info_plist" ]]; then
-            exec_name=$(defaults read "$info_plist" CFBundleExecutable 2> /dev/null || echo "")
+            exec_name=$(plutil -extract CFBundleExecutable raw "$info_plist" 2> /dev/null || echo "")
         fi
         if pgrep -qx "${exec_name:-$app_name}" 2> /dev/null; then
             running_apps+=("$app_name")

--- a/tests/performance_uninstall_scan.sh
+++ b/tests/performance_uninstall_scan.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Benchmark the read-only uninstall application scan.
+#
+# Usage:
+#   tests/performance_uninstall_scan.sh [runs]
+#
+# The benchmark calls scan_applications directly with bin/uninstall.sh sourced
+# under a test harness. This isolates the UI's "collecting data" path from
+# unrelated `--list` formatting and Homebrew-name lookup work while still using
+# the same scanner code as the interactive uninstaller.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNS="${1:-5}"
+
+if [[ ! "$RUNS" =~ ^[0-9]+$ || "$RUNS" -lt 1 ]]; then
+    echo "runs must be a positive integer" >&2
+    exit 2
+fi
+
+now_ms() {
+    python3 - << 'PY'
+import time
+print(time.perf_counter_ns() // 1_000_000)
+PY
+}
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+    rm -f "$tmp_dir"/* 2> /dev/null || true
+    rmdir "$tmp_dir" 2> /dev/null || true
+}
+trap cleanup EXIT
+
+uninstall_source="$tmp_dir/uninstall_source.sh"
+awk -v script_dir="$REPO_ROOT/bin" '
+    /^SCRIPT_DIR=/ {
+        print "SCRIPT_DIR=\"" script_dir "\""
+        next
+    }
+    /^main "\$@"/ {
+        print "# main skipped by performance_uninstall_scan.sh"
+        next
+    }
+    { print }
+' "$REPO_ROOT/bin/uninstall.sh" > "$uninstall_source"
+
+durations_file="$tmp_dir/durations"
+: > "$durations_file"
+
+printf 'run,duration_ms,app_count,status\n'
+
+for ((run = 1; run <= RUNS; run++)); do
+    out_file="$tmp_dir/out.$run"
+    err_file="$tmp_dir/err.$run"
+    start_ms="$(now_ms)"
+    set +e
+    MOLE_TEST_NO_AUTH=1 bash -c '
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        source "$1"
+        apps_file="$(scan_applications 2> /dev/null)"
+        app_count="$(wc -l < "$apps_file" | tr -d "[:space:]")"
+        rm -f "$apps_file"
+        printf "%s\n" "$app_count"
+    ' bash "$uninstall_source" > "$out_file" 2> "$err_file"
+    status=$?
+    set -e
+    end_ms="$(now_ms)"
+    duration_ms=$((end_ms - start_ms))
+
+    app_count="$(cat "$out_file" 2> /dev/null || echo 0)"
+    printf '%d,%d,%s,%d\n' "$run" "$duration_ms" "${app_count:-0}" "$status"
+    printf '%d\n' "$duration_ms" >> "$durations_file"
+done
+
+python3 - "$durations_file" << 'PY'
+import statistics
+import sys
+from pathlib import Path
+
+values = [int(line) for line in Path(sys.argv[1]).read_text().splitlines() if line.strip()]
+if not values:
+    raise SystemExit(0)
+
+print(
+    "summary,"
+    f"min_ms={min(values)},"
+    f"median_ms={int(statistics.median(values))},"
+    f"mean_ms={int(statistics.fmean(values))},"
+    f"max_ms={max(values)},"
+    f"runs={len(values)}"
+)
+PY

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -452,6 +452,93 @@ EOF
 	[ "$status" -eq 0 ]
 }
 
+@test "cached uninstall metadata is rejected when the current bundle is protected" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+eval "$(sed -n '/^uninstall_resolve_bundle_id()/,/^uninstall_app_inventory_fingerprint()/p' "$PROJECT_ROOT/bin/uninstall.sh" | sed '$d')"
+
+app_path="$HOME/Applications/Safari.app"
+mkdir -p "$app_path/Contents"
+cat > "$app_path/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.apple.Safari</string>
+</dict>
+</plist>
+PLIST
+
+if uninstall_resolve_eligible_bundle_id "$app_path" "com.example.cached" > /dev/null; then
+    echo "protected app should not be eligible" >&2
+    exit 1
+fi
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
+@test "cached uninstall metadata is rejected when the app is background-only" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+eval "$(sed -n '/^uninstall_resolve_bundle_id()/,/^uninstall_app_inventory_fingerprint()/p' "$PROJECT_ROOT/bin/uninstall.sh" | sed '$d')"
+
+app_path="$HOME/Applications/Helper.app"
+mkdir -p "$app_path/Contents"
+cat > "$app_path/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Helper</string>
+    <key>LSBackgroundOnly</key>
+    <true/>
+</dict>
+</plist>
+PLIST
+
+if uninstall_resolve_eligible_bundle_id "$app_path" "com.example.Helper" > /dev/null; then
+    echo "background-only app should not be eligible" >&2
+    exit 1
+fi
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
+@test "eligible uninstall metadata uses the current bundle id over stale cache" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+eval "$(sed -n '/^uninstall_resolve_bundle_id()/,/^uninstall_app_inventory_fingerprint()/p' "$PROJECT_ROOT/bin/uninstall.sh" | sed '$d')"
+
+app_path="$HOME/Applications/Plain.app"
+mkdir -p "$app_path/Contents"
+cat > "$app_path/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Plain</string>
+</dict>
+</plist>
+PLIST
+
+result=$(uninstall_resolve_eligible_bundle_id "$app_path" "com.example.Stale")
+[[ "$result" == "com.example.Plain" ]] || {
+    echo "unexpected bundle id: $result" >&2
+    exit 1
+}
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "safe_remove can remove a simple directory" {
 	mkdir -p "$HOME/test_dir"
 	touch "$HOME/test_dir/file.txt"

--- a/tests/uninstall_naming_variants.bats
+++ b/tests/uninstall_naming_variants.bats
@@ -24,7 +24,7 @@ teardown_file() {
 }
 
 setup() {
-    find "$HOME" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+    find "$HOME" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2> /dev/null || true
     source "$PROJECT_ROOT/lib/core/base.sh"
     source "$PROJECT_ROOT/lib/core/log.sh"
     source "$PROJECT_ROOT/lib/core/app_protection.sh"
@@ -127,10 +127,22 @@ setup() {
     [[ ! "$result" =~ Library/Containers/com.tencent.otherapp.Helper ]]
 }
 
+@test "find_app_files detects vendor-nested Application Support directories" {
+    mkdir -p "$HOME/Library/Application Support/Avid/Sibelius"
+    mkdir -p "$HOME/Library/Application Support/OtherVendor/Sibelius"
+    echo "test" > "$HOME/Library/Application Support/Avid/Sibelius/settings.db"
+    echo "test" > "$HOME/Library/Application Support/OtherVendor/Sibelius/settings.db"
+
+    result=$(find_app_files "com.avid.sibelius" "Sibelius")
+
+    [[ "$result" =~ Library/Application\ Support/Avid/Sibelius ]]
+    [[ ! "$result" =~ Library/Application\ Support/OtherVendor/Sibelius ]]
+}
+
 @test "find_app_files does not match empty app name" {
     mkdir -p "$HOME/Library/Application Support/test"
 
-    result=$(find_app_files "com.test" "" 2>/dev/null || true)
+    result=$(find_app_files "com.test" "" 2> /dev/null || true)
 
     [[ ! "$result" =~ "Library/Application Support"$ ]]
 }


### PR DESCRIPTION
## Summary
- add a focused uninstall scan benchmark script
- speed up warm uninstall scans by reusing unchanged metadata and avoiding per-app metadata work on the hot path
- reuse the in-session app list after cancel/return when the app inventory fingerprint is unchanged
- improve leftover detection for vendor-nested app support folders and shared app data, covering cases like Avid/Sibelius without hardcoding the app

## Why
The uninstall flow was spending too much time in the collecting-data path, especially when returning from the confirmation screen back to the app list. The scanner also missed common professional-app layouts such as `Application Support/<Vendor>/<Product>` and `/Users/Shared/<Product>...`.

## Validation
- `MOLE_TEST_NO_AUTH=1 ./scripts/check.sh --no-format`
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_naming_variants.bats tests/uninstall.bats`
- `bash tests/performance_uninstall_scan.sh 7`

Measured locally:
- scan benchmark median: 1138 ms -> 407 ms
- return-to-list cache path median: 1138 ms -> 51 ms
