### PR TITLE
list doom (emacs) dotfiles as safe

### DIFF
--- a/lib/clean/hints.sh
+++ b/lib/clean/hints.sh
@@ -506,7 +506,7 @@ readonly ORPHAN_DOTDIR_KNOWN_SAFE=(
     ".docker" ".kube" ".minikube" ".helm"
     ".aws" ".azure" ".terraform" ".vagrant"
     # Editors / IDEs
-    ".vim" ".vimrc" ".viminfo" ".emacs" ".emacs.d" ".nano" ".nanorc"
+    ".vim" ".vimrc" ".viminfo" ".emacs" ".emacs.d" ".doom.d" ".nano" ".nanorc"
     ".vscode" ".cursor" ".atom"
     # AI tools
     ".claude" ".copilot" ".ollama"


### PR DESCRIPTION
## Summary
- Add `.doom.d` to `ORPHAN_DOTDIR_KNOWN_SAFE` in `lib/clean/hints.sh` so Doom Emacs configuration directory is not flagged as an orphaned dotdir.

## Safety Review
- This change affects cleanup behavior: it expands the safe-list, meaning `.doom.d` will be excluded from orphan warnings.
- No directories are deleted; this is a false-positive suppression only. No change to path validation, protected directories, symlink handling, sudo boundaries, or install integrity.

## Tests
- None — safe-list additions are low-risk and have no destructive code path.

## Safety-related changes
- None.