### PR TITLE
feat(clean): add Final Cut Pro cache cleanup

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -198,9 +198,114 @@ clean_design_tools() {
     safe_clean ~/Library/Application\ Support/Adobe/Common/Media\ Cache\ Files/* "Adobe media cache files"
 }
 # Video editing tools.
+final_cut_pro_is_running() {
+    command -v pgrep > /dev/null 2>&1 || return 1
+
+    pgrep -x "Final Cut Pro" > /dev/null 2>&1 && return 0
+    pgrep -f "/Final Cut Pro.app/" > /dev/null 2>&1 && return 0
+    return 1
+}
+
+final_cut_pro_path_has_protected_component() {
+    local path="$1"
+
+    case "$path" in
+        */Original\ Media | */Original\ Media/* | \
+            */CurrentVersion.flexolibrary | */CurrentVersion.plist | */Settings.plist | \
+            */Motion\ Templates | */Motion\ Templates/* | \
+            */Final\ Cut\ Pro\ Backups | */Final\ Cut\ Pro\ Backups/*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+is_final_cut_pro_generated_cache_target() {
+    local library="$1"
+    local target="$2"
+
+    [[ -n "$library" && -n "$target" ]] || return 1
+    [[ "$library" == /* && "$target" == /* ]] || return 1
+    [[ "$library" == "$HOME"/Movies/*.fcpbundle ]] || return 1
+    [[ "$target" == "$library"/* ]] || return 1
+    [[ -d "$library" && ! -L "$library" ]] || return 1
+    [[ -d "$target" && ! -L "$target" ]] || return 1
+
+    final_cut_pro_path_has_protected_component "$target" && return 1
+
+    if declare -f validate_path_for_deletion > /dev/null 2>&1; then
+        validate_path_for_deletion "$target" > /dev/null 2>&1 || return 1
+    fi
+
+    local relative_target="${target#"$library"/}"
+    case "$relative_target" in
+        */Render\ Files/High\ Quality\ Media | */Transcoded\ Media/Proxy\ Media)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+find_final_cut_pro_generated_cache_targets() {
+    local movies_dir="$HOME/Movies"
+    [[ -d "$movies_dir" ]] || return 0
+
+    local library target
+    while IFS= read -r -d '' library; do
+        [[ -d "$library" && ! -L "$library" ]] || continue
+
+        while IFS= read -r -d '' target; do
+            if is_final_cut_pro_generated_cache_target "$library" "$target"; then
+                printf '%s\0' "$target"
+            fi
+        done < <(command find "$library" \
+            \( -type d \( \
+            -name "Original Media" -o \
+            -name "Analysis Files" -o \
+            -name "Motion Templates" -o \
+            -name "Final Cut Pro Backups" \
+            \) -prune \) -o \
+            \( -type d \( \
+            -path "*/Render Files/High Quality Media" -o \
+            -path "*/Transcoded Media/Proxy Media" \
+            \) -print0 \) 2> /dev/null || true)
+    done < <(command find "$movies_dir" -maxdepth 4 -type d -name "*.fcpbundle" -prune -print0 2> /dev/null || true)
+}
+
+clean_final_cut_pro_generated_caches() {
+    if final_cut_pro_is_running; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Final Cut Pro is running, skipping generated cache cleanup"
+        note_activity
+        return 0
+    fi
+
+    local -a fcp_cache_targets=()
+    local target
+    while IFS= read -r -d '' target; do
+        fcp_cache_targets+=("$target")
+    done < <(find_final_cut_pro_generated_cache_targets)
+
+    [[ ${#fcp_cache_targets[@]} -gt 0 ]] || return 0
+
+    # Final Cut Pro generated cache cleanup (issue #843).
+    # Safety scope for the first pass:
+    # - only scan ~/Movies, the default Apple library location;
+    # - only delete exact generated-media directories documented by Apple as
+    #   regenerable: render media and proxy media;
+    # - never touch Original Media, library databases, plist settings, backups,
+    #   Motion templates, Analysis Files, optimized media, or external .fcpcache.
+    # Future expansion can add explicit flags or configurable roots for
+    # optimized media, Analysis Files, and external cache bundles after more
+    # field feedback.
+    safe_clean "${fcp_cache_targets[@]}" "Final Cut Pro generated cache"
+}
+
 clean_video_tools() {
     safe_clean ~/Library/Caches/net.telestream.screenflow10/* "ScreenFlow cache"
     safe_clean ~/Library/Caches/com.apple.FinalCut/* "Final Cut Pro cache"
+    clean_final_cut_pro_generated_caches
     safe_clean ~/Library/Caches/com.blackmagic-design.DaVinciResolve/* "DaVinci Resolve cache"
     safe_clean ~/Movies/CacheClip/* "DaVinci Resolve CacheClip"
     safe_clean ~/Library/Caches/com.adobe.PremierePro.*/* "Premiere Pro cache"

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -113,6 +113,83 @@ EOF
     [[ "$output" == *"ai"* ]]
 }
 
+@test "clean_final_cut_pro_generated_caches targets only safe generated media in Movies libraries" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+mkdir -p "$HOME/Movies/Project.fcpbundle/Event/Render Files/High Quality Media"
+mkdir -p "$HOME/Movies/Project.fcpbundle/Event/Transcoded Media/Proxy Media"
+mkdir -p "$HOME/Movies/Project.fcpbundle/Event/Transcoded Media/High Quality Media"
+mkdir -p "$HOME/Movies/Project.fcpbundle/Event/Analysis Files/Stabilization"
+mkdir -p "$HOME/Movies/Project.fcpbundle/Event/Original Media/Render Files/High Quality Media"
+mkdir -p "$HOME/Documents/Other.fcpbundle/Event/Render Files/High Quality Media"
+
+touch "$HOME/Movies/Project.fcpbundle/Event/Render Files/High Quality Media/render.mov"
+touch "$HOME/Movies/Project.fcpbundle/Event/Transcoded Media/Proxy Media/proxy.mov"
+
+pgrep() { return 1; }
+safe_clean() {
+    local arg
+    for arg in "$@"; do
+        printf 'CLEAN:%s\n' "$arg"
+    done
+}
+
+clean_final_cut_pro_generated_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CLEAN:$HOME/Movies/Project.fcpbundle/Event/Render Files/High Quality Media"* ]]
+    [[ "$output" == *"CLEAN:$HOME/Movies/Project.fcpbundle/Event/Transcoded Media/Proxy Media"* ]]
+    [[ "$output" == *"CLEAN:Final Cut Pro generated cache"* ]]
+    [[ "$output" != *"Transcoded Media/High Quality Media"* ]]
+    [[ "$output" != *"Analysis Files"* ]]
+    [[ "$output" != *"Original Media"* ]]
+    [[ "$output" != *"Documents/Other.fcpbundle"* ]]
+}
+
+@test "clean_final_cut_pro_generated_caches skips while Final Cut Pro is running" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+mkdir -p "$HOME/Movies/Project.fcpbundle/Event/Render Files/High Quality Media"
+pgrep() { return 0; }
+safe_clean() {
+    echo "unexpected safe_clean"
+    return 1
+}
+
+clean_final_cut_pro_generated_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Final Cut Pro is running"* ]]
+    [[ "$output" != *"unexpected safe_clean"* ]]
+}
+
+@test "is_final_cut_pro_generated_cache_target rejects protected sibling paths" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+library="$HOME/Movies/Project.fcpbundle"
+mkdir -p "$library/Event/Render Files/High Quality Media"
+mkdir -p "$library/Event/Original Media/Render Files/High Quality Media"
+mkdir -p "$library/Event/Transcoded Media/High Quality Media"
+
+is_final_cut_pro_generated_cache_target "$library" "$library/Event/Render Files/High Quality Media"
+! is_final_cut_pro_generated_cache_target "$library" "$library/Event/Original Media/Render Files/High Quality Media"
+! is_final_cut_pro_generated_cache_target "$library" "$library/Event/Transcoded Media/High Quality Media"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "clean_ai_apps calls expected caches" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

Adds a conservative Final Cut Pro generated-cache cleanup pass to `mo clean` under the existing video tools cleanup.

The first-pass scope is intentionally narrow:
- scans only Final Cut Pro libraries under `~/Movies`, Apple's default library location
- skips cleanup while Final Cut Pro is running
- deletes only exact generated-media directories that Apple documents as regenerable: render media and proxy media
- explicitly avoids `Original Media`, library database/plist files, backups, Motion templates, Analysis Files, optimized media, external `.fcpcache` bundles, and other broader cleanup categories

## Safety notes

The path matcher validates that each target is inside a `*.fcpbundle` under `~/Movies`, is a real directory, passes Mole deletion validation, and matches only one of these exact relative path shapes:

- `*/Render Files/High Quality Media`
- `*/Transcoded Media/Proxy Media`

The scanner also prunes high-risk/heavy sibling trees such as `Original Media` and `Analysis Files` before matching.

Apple references used for the safety boundary:
- https://support.apple.com/guide/final-cut-pro/set-storage-locations-ver7db6ffe77/mac
- https://support.apple.com/guide/final-cut-pro/manage-render-files-ver68a8c250/mac
- https://support.apple.com/guide/final-cut-pro/create-optimized-and-proxy-files-verb8e5f6fd/mac

## Tests

- `MOLE_TEST_NO_AUTH=1 bats tests/clean_app_caches.bats tests/clean_misc.bats`
- `./scripts/check.sh --no-format`
- `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh`
