### PR TITLE
Harden cleanup safety rules for user caches

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -123,11 +123,10 @@ clean_xcode_tools() {
     safe_clean ~/Library/Developer/Xcode/Products/* "Xcode build products"
     if [[ "$xcode_running" == "false" ]]; then
         clean_xcode_derived_data
-        safe_clean ~/Library/Developer/Xcode/Archives/* "Xcode archives"
         safe_clean ~/Library/Developer/Xcode/DocumentationCache/* "Xcode documentation cache"
         safe_clean ~/Library/Developer/Xcode/DocumentationIndex/* "Xcode documentation index"
     else
-        echo -e "  ${GRAY}${ICON_WARNING}${NC} Xcode is running, skipping DerivedData/Archives/Documentation cleanup"
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Xcode is running, skipping DerivedData/Documentation cleanup"
     fi
 }
 # Code editors.

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -347,11 +347,6 @@ clean_orphaned_app_data() {
         "$HOME/Library/Caches|Caches|com.*:org.*:net.*:io.*"
         "$HOME/Library/Logs|Logs|com.*:org.*:net.*:io.*"
         "$HOME/Library/Saved Application State|States|*.savedState"
-        "$HOME/Library/WebKit|WebKit|com.*:org.*:net.*:io.*"
-        "$HOME/Library/HTTPStorages|HTTP|com.*:org.*:net.*:io.*"
-        "$HOME/Library/Cookies|Cookies|*.binarycookies"
-        "$HOME/Library/Application Support|AppSupport|com.*:org.*:net.*:io.*"
-        "$HOME/Library/Preferences|Prefs|com.*:org.*:net.*:io.*"
     )
     for resource_type in "${resource_types[@]}"; do
         IFS='|' read -r base_path label patterns <<< "$resource_type"

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -40,6 +40,86 @@ clean_tool_cache() {
     fi
     return 0
 }
+
+clean_corepack_cache() {
+    local corepack_home="${COREPACK_HOME:-$HOME/.cache/node/corepack}"
+    [[ -n "$corepack_home" && "$corepack_home" == /* ]] || return 0
+    case "$corepack_home" in
+        / | "$HOME" | "$HOME/" | "$HOME/Library" | "$HOME/Library/")
+            debug_log "Skipping unsafe Corepack cache path: $corepack_home"
+            return 0
+            ;;
+    esac
+    if command -v corepack > /dev/null 2>&1 && run_with_timeout 2 corepack --version > /dev/null 2>&1; then
+        clean_tool_cache "Corepack cache" "$corepack_home" run_with_timeout 20 corepack cache clean
+    else
+        safe_clean "$corepack_home"/* "Corepack cache"
+    fi
+}
+
+clean_uv_cache() {
+    local uv_cache_path="$HOME/.cache/uv"
+    if command -v uv > /dev/null 2>&1 && run_with_timeout 2 uv --version > /dev/null 2>&1; then
+        local detected_cache
+        detected_cache=$(run_with_timeout 2 uv cache dir 2> /dev/null || true)
+        if [[ -n "$detected_cache" && "$detected_cache" == /* ]]; then
+            uv_cache_path="$detected_cache"
+        fi
+        clean_tool_cache "uv cache" "$uv_cache_path" run_with_timeout 20 uv cache prune
+    else
+        safe_clean "$uv_cache_path"/* "uv cache"
+    fi
+}
+
+conda_cache_whitelisted() {
+    local root
+    for root in "$@"; do
+        [[ -n "$root" ]] || continue
+        if is_path_whitelisted "$root" 2> /dev/null || is_path_whitelisted "$root/.mole-cache-guard" 2> /dev/null; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+clean_conda_metadata_caches() {
+    local -a conda_pkg_roots=(
+        "$HOME/.conda/pkgs"
+        "$HOME/anaconda3/pkgs"
+        "$HOME/miniconda3/pkgs"
+        "$HOME/miniforge3/pkgs"
+        "$HOME/mambaforge/pkgs"
+    )
+    if conda_cache_whitelisted "${conda_pkg_roots[@]}"; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} conda index/tarball/log caches · would skip (whitelist)"
+        else
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} conda index/tarball/log caches · skipped (whitelist)"
+        fi
+        return 0
+    fi
+
+    local conda_cache_hint="$HOME/.conda/pkgs"
+    if command -v conda > /dev/null 2>&1 && run_with_timeout 2 conda --version > /dev/null 2>&1; then
+        clean_tool_cache "conda index/tarball/log caches" "$conda_cache_hint" \
+            run_with_timeout 30 conda clean --yes --index-cache --tarballs --logfiles
+        note_activity
+        return 0
+    fi
+
+    local root
+    for root in "${conda_pkg_roots[@]}"; do
+        [[ -d "$root" ]] || continue
+        debug_log "Conda package cache present but conda is unavailable, leaving for manual review: $root"
+    done
+}
+
+gradle_daemon_running() {
+    pgrep -f "org.gradle.launcher.daemon" > /dev/null 2>&1 && return 0
+    pgrep -f "GradleDaemon" > /dev/null 2>&1 && return 0
+    return 1
+}
+
 # npm/pnpm/yarn/bun caches.
 clean_dev_npm() {
     local npm_default_cache="$HOME/.npm"
@@ -98,15 +178,11 @@ clean_dev_npm() {
         if [[ -n "$pnpm_store_path" && "$pnpm_store_path" == /* ]]; then
             pnpm_cache_check="$pnpm_store_path"
         fi
-        COREPACK_ENABLE_DOWNLOAD_PROMPT=0 clean_tool_cache "pnpm cache" "$pnpm_cache_check" pnpm store prune
-
-        if [[ -n "$pnpm_store_path" && "$pnpm_store_path" != "$pnpm_default_store" ]]; then
-            safe_clean "$pnpm_default_store"/* "Orphaned pnpm store"
-        fi
+        COREPACK_ENABLE_DOWNLOAD_PROMPT=0 clean_tool_cache "pnpm cache" "$pnpm_cache_check" run_with_timeout 20 pnpm store prune
     else
-        # pnpm not installed or not usable, just clean the default store directory
-        safe_clean "$pnpm_default_store"/* "pnpm store"
+        debug_log "pnpm is unavailable, leaving global pnpm store for manual review: $pnpm_default_store"
     fi
+    clean_corepack_cache
     local bun_default_cache="$HOME/.bun/install/cache"
     local bun_cache_path="$bun_default_cache"
     local bun_cache_cleaned=false
@@ -189,7 +265,7 @@ clean_dev_python() {
     fi
     safe_clean ~/.pyenv/cache/* "pyenv cache"
     safe_clean ~/.cache/poetry/* "Poetry cache"
-    safe_clean ~/.cache/uv/* "uv cache"
+    clean_uv_cache
     safe_clean ~/.cache/ruff/* "Ruff cache"
     safe_clean ~/.cache/mypy/* "MyPy cache"
     safe_clean ~/.pytest_cache/* "Pytest cache"
@@ -197,8 +273,7 @@ clean_dev_python() {
     safe_clean ~/.cache/huggingface/* "Hugging Face cache"
     safe_clean ~/.cache/torch/* "PyTorch cache"
     safe_clean ~/.cache/tensorflow/* "TensorFlow cache"
-    safe_clean ~/.conda/pkgs/* "Conda packages cache"
-    safe_clean ~/anaconda3/pkgs/* "Anaconda packages cache"
+    clean_conda_metadata_caches
     safe_clean ~/.cache/wandb/* "Weights & Biases cache"
 }
 # Go build/module caches.
@@ -951,10 +1026,17 @@ clean_dev_jvm() {
     if declare -f clean_maven_repository > /dev/null 2>&1; then
         clean_maven_repository
     fi
-    safe_clean ~/.sbt/* "SBT cache"
+    safe_clean ~/.sbt/boot/* "SBT boot cache"
+    safe_clean ~/.sbt/launchers/* "SBT launcher cache"
     safe_clean ~/.ivy2/cache/* "Ivy cache"
-    safe_clean ~/.gradle/caches/* "Gradle cache"
-    safe_clean ~/.gradle/daemon/* "Gradle daemon"
+    safe_clean ~/.gradle/caches/build-cache-*/* "Gradle build cache"
+    safe_clean ~/.gradle/notifications/* "Gradle notifications cache"
+    if gradle_daemon_running; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Gradle daemon is running · daemon/workers cleanup skipped"
+    else
+        safe_clean ~/.gradle/daemon/* "Gradle daemon"
+        safe_clean ~/.gradle/workers/* "Gradle workers"
+    fi
 }
 # JetBrains Toolbox old IDE versions (keep current + recent backup).
 clean_dev_jetbrains_toolbox() {

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -8,6 +8,8 @@ clean_user_essentials() {
 
     safe_clean ~/Library/Logs/* "User app logs"
 
+    _clean_darwin_user_runtime_dirs
+
     if ! is_path_whitelisted "$HOME/.Trash"; then
         local trash_count
         local trash_count_status=0
@@ -114,6 +116,12 @@ _clean_mail_downloads() {
     if ! [[ "$mail_age_days" =~ ^[0-9]+$ ]]; then
         mail_age_days=30
     fi
+
+    if pgrep -x "Mail" > /dev/null 2>&1; then
+        debug_log "Mail is running, skipping Mail Downloads cleanup"
+        return 0
+    fi
+
     local -a mail_dirs=(
         "$HOME/Library/Mail Downloads"
         "$HOME/Library/Containers/com.apple.mail/Data/Library/Mail Downloads"
@@ -160,6 +168,142 @@ _clean_mail_downloads() {
         echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Cleaned $count mail attachments older than ${mail_age_days}d, about ${cleaned_mb}MB"
         note_activity
     fi
+}
+
+_darwin_user_runtime_realpath() {
+    local runtime_dir="$1"
+    [[ -n "$runtime_dir" && -d "$runtime_dir" && ! -L "$runtime_dir" ]] || return 1
+    (cd "$runtime_dir" 2> /dev/null && pwd -P)
+}
+
+_darwin_user_runtime_dir_is_safe() {
+    local runtime_dir="$1"
+    local kind="$2"
+    local resolved=""
+    resolved=$(_darwin_user_runtime_realpath "$runtime_dir") || return 1
+
+    case "$kind:$resolved" in
+        temp:/private/var/folders/*/*/T | cache:/private/var/folders/*/*/C)
+            ;;
+        *)
+            debug_log "Skipping unexpected Darwin user runtime dir: $runtime_dir -> $resolved"
+            return 1
+            ;;
+    esac
+
+    local owner_uid current_uid
+    owner_uid=$(stat -f%u "$resolved" 2> /dev/null || echo "")
+    current_uid=$(id -u 2> /dev/null || echo "")
+    [[ -n "$owner_uid" && "$owner_uid" == "$current_uid" ]]
+}
+
+_clean_darwin_user_runtime_dir() {
+    local runtime_dir="$1"
+    local kind="$2"
+    local label="$3"
+    local age_days="${MOLE_DARWIN_USER_RUNTIME_AGE_DAYS:-7}"
+    local max_items="${MOLE_DARWIN_USER_RUNTIME_MAX_ITEMS:-1500}"
+    local scan_timeout="${MOLE_DARWIN_USER_RUNTIME_SCAN_TIMEOUT:-8}"
+
+    [[ "$age_days" =~ ^[0-9]+$ ]] || age_days=7
+    [[ "$max_items" =~ ^[0-9]+$ ]] || max_items=1500
+    [[ "$scan_timeout" =~ ^[0-9]+$ ]] || scan_timeout=8
+    [[ -d "$runtime_dir" ]] || return 0
+    _darwin_user_runtime_dir_is_safe "$runtime_dir" "$kind" || return 0
+
+    local current_uid
+    current_uid=$(id -u 2> /dev/null || echo "")
+    [[ -n "$current_uid" ]] || return 0
+
+    local count=0
+    local total_size_kb=0
+    local hit_cap=false
+    local found_any=false
+    local item
+
+    while IFS= read -r -d '' item; do
+        [[ -e "$item" && ! -L "$item" ]] || continue
+        case "$item" in
+            *.sqlite | *.sqlite-shm | *.sqlite-wal | *.db | *.plist)
+                continue
+                ;;
+        esac
+        if should_protect_path "$item" 2> /dev/null || is_path_whitelisted "$item" 2> /dev/null; then
+            continue
+        fi
+
+        local item_size_kb=0
+        item_size_kb=$(get_path_size_kb "$item" 2> /dev/null || echo "0")
+        [[ "$item_size_kb" =~ ^[0-9]+$ ]] || item_size_kb=0
+
+        if [[ "${DRY_RUN:-false}" == "true" ]] || safe_remove "$item" true "$item_size_kb" > /dev/null 2>&1; then
+            found_any=true
+            count=$((count + 1))
+            total_size_kb=$((total_size_kb + item_size_kb))
+        fi
+
+        if [[ "$count" -ge "$max_items" ]]; then
+            hit_cap=true
+            break
+        fi
+    done < <(
+        run_with_timeout "$scan_timeout" \
+            find -P "$runtime_dir" -xdev -mindepth 1 -user "$current_uid" -type f -mtime +"$age_days" \
+            ! -name "*.sqlite" ! -name "*.sqlite-shm" ! -name "*.sqlite-wal" ! -name "*.db" ! -name "*.plist" \
+            -print0 2> /dev/null || true
+    )
+
+    if [[ "$count" -lt "$max_items" ]]; then
+        while IFS= read -r -d '' item; do
+            [[ -d "$item" && ! -L "$item" ]] || continue
+            if should_protect_path "$item" 2> /dev/null || is_path_whitelisted "$item" 2> /dev/null; then
+                continue
+            fi
+            if [[ "${DRY_RUN:-false}" == "true" ]] || safe_remove "$item" true "0" > /dev/null 2>&1; then
+                found_any=true
+                count=$((count + 1))
+            fi
+            if [[ "$count" -ge "$max_items" ]]; then
+                hit_cap=true
+                break
+            fi
+        done < <(
+            run_with_timeout "$scan_timeout" \
+                find -P "$runtime_dir" -xdev -mindepth 1 -user "$current_uid" -type d -empty -mtime +"$age_days" -print0 2> /dev/null || true
+        )
+    fi
+
+    if [[ "$found_any" == "true" ]]; then
+        local size_human
+        size_human=$(bytes_to_human "$((total_size_kb * 1024))")
+        local cap_note=""
+        [[ "$hit_cap" == "true" ]] && cap_note=", capped"
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} ${label}${NC}, ${YELLOW}${count} old items, ${size_human} dry${cap_note}${NC}"
+        else
+            local line_color
+            line_color=$(cleanup_result_color_kb "$total_size_kb")
+            echo -e "  ${line_color}${ICON_SUCCESS}${NC} ${label}${NC}, ${line_color}${count} old items, ${size_human}${cap_note}${NC}"
+        fi
+        files_cleaned=$((files_cleaned + count))
+        total_size_cleaned=$((total_size_cleaned + total_size_kb))
+        total_items=$((total_items + 1))
+        note_activity
+    fi
+}
+
+_clean_darwin_user_runtime_dirs() {
+    if [[ "${MOLE_TEST_MODE:-0}" == "1" || "${MOLE_TEST_NO_AUTH:-0}" == "1" ]]; then
+        [[ "${MOLE_ENABLE_DARWIN_RUNTIME_CLEANUP_IN_TESTS:-0}" == "1" ]] || return 0
+    fi
+
+    local temp_dir=""
+    local cache_dir=""
+    temp_dir=$(getconf DARWIN_USER_TEMP_DIR 2> /dev/null || true)
+    cache_dir=$(getconf DARWIN_USER_CACHE_DIR 2> /dev/null || true)
+
+    _clean_darwin_user_runtime_dir "$temp_dir" "temp" "Darwin user temp files"
+    _clean_darwin_user_runtime_dir "$cache_dir" "cache" "Darwin user cache files"
 }
 
 # Remove old Google Chrome versions while keeping Current.
@@ -688,7 +832,8 @@ clean_app_caches() {
     safe_clean ~/Library/Caches/Quick\ Look/* "QuickLook cache" || true
     safe_clean ~/Library/Caches/com.apple.iconservices* "Icon services cache" || true
     _clean_incomplete_downloads
-    safe_clean ~/Library/Autosave\ Information/* "Autosave information" || true
+    # Do not clean ~/Library/Autosave Information by default: it can contain
+    # recoverable user documents, not only disposable cache data.
     safe_clean ~/Library/IdentityCaches/* "Identity caches" || true
     safe_clean ~/Library/Suggestions/* "Siri suggestions cache" || true
     safe_clean ~/Library/Calendars/Calendar\ Cache "Calendar cache" || true
@@ -1076,8 +1221,6 @@ clean_external_volume_target() {
     local -a top_level_targets=(
         "$volume/.TemporaryItems"
         "$volume/.Trashes"
-        "$volume/.Spotlight-V100"
-        "$volume/.fseventsd"
     )
     local cleaned_count=0
     local total_size=0
@@ -1113,6 +1256,8 @@ clean_external_volume_target() {
         clean_ds_store_tree "$volume" "${volume_name} volume, .DS_Store"
     fi
 
+    local metadata_scan_timeout="${MOLE_EXTERNAL_VOLUME_SCAN_TIMEOUT:-15}"
+    [[ "$metadata_scan_timeout" =~ ^[0-9]+$ ]] || metadata_scan_timeout=15
     while IFS= read -r -d '' metadata_file; do
         [[ -e "$metadata_file" ]] || continue
         if should_protect_path "$metadata_file" 2> /dev/null || is_path_whitelisted "$metadata_file" 2> /dev/null; then
@@ -1132,7 +1277,7 @@ clean_external_volume_target() {
             cleaned_count=$((cleaned_count + 1))
             total_size=$((total_size + size_kb))
         fi
-    done < <(command find "$volume" -type f -name "._*" -print0 2> /dev/null || true)
+    done < <(run_with_timeout "$metadata_scan_timeout" find -P "$volume" -xdev -type f -name "._*" -print0 2> /dev/null || true)
 
     stop_section_spinner
 
@@ -1160,18 +1305,27 @@ clean_browsers() {
     safe_clean ~/Library/Caches/com.apple.Safari/* "Safari cache"
     # Chrome/Chromium.
     safe_clean ~/Library/Caches/Google/Chrome/* "Chrome cache"
-    safe_clean ~/Library/Application\ Support/Google/Chrome/*/Application\ Cache/* "Chrome app cache"
-    safe_clean ~/Library/Application\ Support/Google/Chrome/*/GPUCache/* "Chrome GPU cache"
-    safe_clean ~/Library/Application\ Support/Google/Chrome/component_crx_cache/* "Chrome component CRX cache"
-    safe_clean ~/Library/Application\ Support/Google/Chrome/ShaderCache/* "Chrome shader cache"
-    safe_clean ~/Library/Application\ Support/Google/Chrome/GrShaderCache/* "Chrome GR shader cache"
-    safe_clean ~/Library/Application\ Support/Google/Chrome/GraphiteDawnCache/* "Chrome Dawn cache"
-    local _chrome_profile
     # Skip ScriptCache wipe while the browser is running: removing V8 bytecode
     # under a live Chromium process breaks loaded MV3 extension service workers
     # until the user toggles them in chrome://extensions. See #785.
     local _chrome_running=false
     pgrep -x "Google Chrome" > /dev/null 2>&1 && _chrome_running=true
+    if [[ "$_chrome_running" != "true" ]]; then
+        safe_clean ~/Library/Application\ Support/Google/Chrome/*/Application\ Cache/* "Chrome app cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/*/Code\ Cache/* "Chrome code cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/*/GPUCache/* "Chrome GPU cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/*/DawnCache/* "Chrome Dawn cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/*/GrShaderCache/* "Chrome GR shader cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/*/GraphiteDawnCache/* "Chrome Graphite Dawn cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/component_crx_cache/* "Chrome component CRX cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/ShaderCache/* "Chrome shader cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/GrShaderCache/* "Chrome GR shader cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/GraphiteDawnCache/* "Chrome Dawn cache"
+        safe_clean ~/Library/Application\ Support/Google/Chrome/Crashpad/completed/* "Chrome crash reports"
+    else
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Chrome is running · Application Support cache cleanup skipped"
+    fi
+    local _chrome_profile
     for _chrome_profile in "$HOME/Library/Application Support/Google/Chrome"/*/; do
         clean_service_worker_cache "Chrome" "$_chrome_profile/Service Worker/CacheStorage"
         if [[ "$_chrome_running" != "true" ]]; then
@@ -1186,13 +1340,20 @@ clean_browsers() {
     # Arc Browser.
     if [[ -d ~/Library/Application\ Support/Arc ]]; then
         safe_clean ~/Library/Caches/company.thebrowser.Browser/* "Arc cache"
-        safe_clean ~/Library/Application\ Support/Arc/*/GPUCache/* "Arc GPU cache"
-        safe_clean ~/Library/Application\ Support/Arc/ShaderCache/* "Arc shader cache"
-        safe_clean ~/Library/Application\ Support/Arc/GrShaderCache/* "Arc GR shader cache"
-        safe_clean ~/Library/Application\ Support/Arc/GraphiteDawnCache/* "Arc Dawn cache"
         local _arc_profile
         local _arc_running=false
         pgrep -x "Arc" > /dev/null 2>&1 && _arc_running=true
+        if [[ "$_arc_running" != "true" ]]; then
+            safe_clean ~/Library/Application\ Support/Arc/*/Code\ Cache/* "Arc code cache"
+            safe_clean ~/Library/Application\ Support/Arc/*/GPUCache/* "Arc GPU cache"
+            safe_clean ~/Library/Application\ Support/Arc/*/DawnCache/* "Arc Dawn cache"
+            safe_clean ~/Library/Application\ Support/Arc/*/GrShaderCache/* "Arc GR shader cache"
+            safe_clean ~/Library/Application\ Support/Arc/*/GraphiteDawnCache/* "Arc Graphite Dawn cache"
+            safe_clean ~/Library/Application\ Support/Arc/ShaderCache/* "Arc shader cache"
+            safe_clean ~/Library/Application\ Support/Arc/GrShaderCache/* "Arc GR shader cache"
+            safe_clean ~/Library/Application\ Support/Arc/GraphiteDawnCache/* "Arc Dawn cache"
+            safe_clean ~/Library/Application\ Support/Arc/Crashpad/completed/* "Arc crash reports"
+        fi
         for _arc_profile in "$HOME/Library/Application Support/Arc"/*/; do
             clean_service_worker_cache "Arc" "$_arc_profile/Service Worker/CacheStorage"
             if [[ "$_arc_running" != "true" ]]; then
@@ -1203,15 +1364,22 @@ clean_browsers() {
     safe_clean ~/Library/Caches/company.thebrowser.dia/* "Dia cache"
     if [[ -d ~/Library/Application\ Support/BraveSoftware ]]; then
         safe_clean ~/Library/Caches/BraveSoftware/Brave-Browser/* "Brave cache"
-        safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/Application\ Cache/* "Brave app cache"
-        safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/GPUCache/* "Brave GPU cache"
-        safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/component_crx_cache/* "Brave component CRX cache"
-        safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/ShaderCache/* "Brave shader cache"
-        safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/GrShaderCache/* "Brave GR shader cache"
-        safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/GraphiteDawnCache/* "Brave Dawn cache"
         local _brave_profile
         local _brave_running=false
         pgrep -x "Brave Browser" > /dev/null 2>&1 && _brave_running=true
+        if [[ "$_brave_running" != "true" ]]; then
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/Application\ Cache/* "Brave app cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/Code\ Cache/* "Brave code cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/GPUCache/* "Brave GPU cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/DawnCache/* "Brave Dawn cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/GrShaderCache/* "Brave GR shader cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/*/GraphiteDawnCache/* "Brave Graphite Dawn cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/component_crx_cache/* "Brave component CRX cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/ShaderCache/* "Brave shader cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/GrShaderCache/* "Brave GR shader cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/GraphiteDawnCache/* "Brave Dawn cache"
+            safe_clean ~/Library/Application\ Support/BraveSoftware/Brave-Browser/Crashpad/completed/* "Brave crash reports"
+        fi
         for _brave_profile in "$HOME/Library/Application Support/BraveSoftware/Brave-Browser"/*/; do
             clean_service_worker_cache "Brave" "$_brave_profile/Service Worker/CacheStorage"
             if [[ "$_brave_running" != "true" ]]; then
@@ -1251,13 +1419,20 @@ clean_browsers() {
     # Vivaldi Browser.
     if [[ -d ~/Library/Application\ Support/Vivaldi ]]; then
         safe_clean ~/Library/Caches/com.vivaldi.Vivaldi/* "Vivaldi cache"
-        safe_clean ~/Library/Application\ Support/Vivaldi/*/GPUCache/* "Vivaldi GPU cache"
-        safe_clean ~/Library/Application\ Support/Vivaldi/ShaderCache/* "Vivaldi shader cache"
-        safe_clean ~/Library/Application\ Support/Vivaldi/GrShaderCache/* "Vivaldi GR shader cache"
-        safe_clean ~/Library/Application\ Support/Vivaldi/GraphiteDawnCache/* "Vivaldi Dawn cache"
         local _vivaldi_profile
         local _vivaldi_running=false
         pgrep -x "Vivaldi" > /dev/null 2>&1 && _vivaldi_running=true
+        if [[ "$_vivaldi_running" != "true" ]]; then
+            safe_clean ~/Library/Application\ Support/Vivaldi/*/Code\ Cache/* "Vivaldi code cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/*/GPUCache/* "Vivaldi GPU cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/*/DawnCache/* "Vivaldi Dawn cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/*/GrShaderCache/* "Vivaldi GR shader cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/*/GraphiteDawnCache/* "Vivaldi Graphite Dawn cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/ShaderCache/* "Vivaldi shader cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/GrShaderCache/* "Vivaldi GR shader cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/GraphiteDawnCache/* "Vivaldi Dawn cache"
+            safe_clean ~/Library/Application\ Support/Vivaldi/Crashpad/completed/* "Vivaldi crash reports"
+        fi
         for _vivaldi_profile in "$HOME/Library/Application Support/Vivaldi"/*/; do
             clean_service_worker_cache "Vivaldi" "$_vivaldi_profile/Service Worker/CacheStorage"
             if [[ "$_vivaldi_running" != "true" ]]; then
@@ -1284,13 +1459,25 @@ clean_cloud_storage() {
     if [[ "${MO_DEBUG:-0}" == "1" ]]; then
         echo "[DEBUG] Cleaning cloud storage caches..." >&2
     fi
-    safe_clean ~/Library/Caches/com.dropbox.* "Dropbox cache"
-    safe_clean ~/Library/Caches/com.getdropbox.dropbox "Dropbox cache"
-    safe_clean ~/Library/Caches/com.google.GoogleDrive "Google Drive cache"
+    if pgrep -x "Dropbox" > /dev/null 2>&1; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Dropbox is running · cache cleanup skipped"
+    else
+        safe_clean ~/Library/Caches/com.dropbox.* "Dropbox cache"
+        safe_clean ~/Library/Caches/com.getdropbox.dropbox "Dropbox cache"
+    fi
+    if pgrep -x "Google Drive" > /dev/null 2>&1; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Google Drive is running · cache cleanup skipped"
+    else
+        safe_clean ~/Library/Caches/com.google.GoogleDrive "Google Drive cache"
+    fi
     safe_clean ~/Library/Caches/com.baidu.netdisk "Baidu Netdisk cache"
     safe_clean ~/Library/Caches/com.alibaba.teambitiondisk "Alibaba Cloud cache"
     safe_clean ~/Library/Caches/com.box.desktop "Box cache"
-    safe_clean ~/Library/Caches/com.microsoft.OneDrive "OneDrive cache"
+    if pgrep -x "OneDrive" > /dev/null 2>&1; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} OneDrive is running · cache cleanup skipped"
+    else
+        safe_clean ~/Library/Caches/com.microsoft.OneDrive "OneDrive cache"
+    fi
 }
 
 # Office app caches.
@@ -1444,7 +1631,18 @@ clean_application_support_logs() {
         if is_critical_system_component "$app_name"; then
             continue
         fi
-        local -a start_candidates=("$app_dir/log" "$app_dir/logs" "$app_dir/activitylog" "$app_dir/Cache/Cache_Data" "$app_dir/Crashpad/completed")
+        # Application Support can hold licenses, databases, offline assets and
+        # session state. Keep this generic pass to explicit, regenerable cache
+        # subtrees only; app-specific log/cache cleanup belongs in allowlisted
+        # app modules above.
+        local -a start_candidates=(
+            "$app_dir/Code Cache"
+            "$app_dir/GPUCache"
+            "$app_dir/DawnCache"
+            "$app_dir/GrShaderCache"
+            "$app_dir/GraphiteDawnCache"
+            "$app_dir/Crashpad/completed"
+        )
         for candidate in "${start_candidates[@]}"; do
             if [[ -d "$candidate" ]]; then
                 if should_protect_path "$candidate" 2> /dev/null || is_path_whitelisted "$candidate" 2> /dev/null; then
@@ -1730,6 +1928,30 @@ check_large_file_candidates() {
     local threshold_kb=$((1024 * 1024)) # 1GB
     local found_any=false
 
+    _large_candidate_size_kb() {
+        local path="$1"
+        local timeout_seconds="${MOLE_LARGE_CANDIDATE_SIZE_TIMEOUT:-3}"
+        [[ "$timeout_seconds" =~ ^[0-9]+$ ]] || timeout_seconds=3
+        local du_output=""
+        du_output=$(run_with_timeout "$timeout_seconds" du -skP "$path" 2> /dev/null || true)
+        local size_kb="${du_output%%[^0-9]*}"
+        [[ "$size_kb" =~ ^[0-9]+$ ]] || return 1
+        printf '%s\n' "$size_kb"
+    }
+
+    _report_large_review_dir() {
+        local label="$1"
+        local path="$2"
+        [[ -d "$path" ]] || return 0
+        local size_kb=""
+        size_kb=$(_large_candidate_size_kb "$path") || return 0
+        [[ "$size_kb" -ge "$threshold_kb" ]] || return 0
+        local size_human
+        size_human=$(bytes_to_human "$((size_kb * 1024))")
+        echo -e "  ${YELLOW}${ICON_WARNING}${NC} ${label}: ${GREEN}${size_human}${NC}${GRAY}, Path: $path${NC}"
+        found_any=true
+    }
+
     local mail_dir="$HOME/Library/Mail"
     if [[ -d "$mail_dir" ]]; then
         local mail_kb
@@ -1814,9 +2036,21 @@ check_large_file_candidates() {
         fi
     fi
 
+    _report_large_review_dir "Xcode archives (review only)" "$HOME/Library/Developer/Xcode/Archives"
+    _report_large_review_dir "iOS backups (review only)" "$HOME/Library/Application Support/MobileSync/Backup"
+    _report_large_review_dir "LM Studio models (review only)" "$HOME/.lmstudio/models"
+    _report_large_review_dir "OrbStack data (review only)" "$HOME/OrbStack"
+    _report_large_review_dir "Lima data (review only)" "$HOME/.lima"
+    _report_large_review_dir "Maven local repository (review only)" "$HOME/.m2/repository"
+    _report_large_review_dir "pnpm store (review only)" "$HOME/Library/pnpm/store"
+    _report_large_review_dir "Conda packages (review only)" "$HOME/.conda/pkgs"
+    _report_large_review_dir "Anaconda packages (review only)" "$HOME/anaconda3/pkgs"
+
     if [[ "$found_any" == "false" ]]; then
         echo -e "  ${GREEN}${ICON_SUCCESS}${NC} No large items detected in common locations"
     fi
+
+    unset -f _large_candidate_size_kb _report_large_review_dir
 
     note_activity
     return 0

--- a/lib/manage/whitelist.sh
+++ b/lib/manage/whitelist.sh
@@ -78,10 +78,10 @@ get_all_cache_items() {
     # Format: "display_name|pattern|category"
     cat << 'EOF'
 Apple Mail cache|$HOME/Library/Caches/com.apple.mail/*|system_cache
-Gradle build cache (Android Studio, Gradle projects)|$HOME/.gradle/caches/*|ide_cache
+Gradle build cache (Android Studio, Gradle projects)|$HOME/.gradle/caches/build-cache-*/*|ide_cache
 Gradle daemon processes cache|$HOME/.gradle/daemon/*|ide_cache
+Gradle worker cache|$HOME/.gradle/workers/*|ide_cache
 Xcode DerivedData (build outputs, indexes)|$HOME/Library/Developer/Xcode/DerivedData/*|ide_cache
-Xcode archives (built app packages)|$HOME/Library/Developer/Xcode/Archives/*|ide_cache
 Xcode internal cache files|$HOME/Library/Caches/com.apple.dt.Xcode/*|ide_cache
 Xcode iOS device support symbols|$HOME/Library/Developer/Xcode/iOS DeviceSupport/*/Symbols/System/Library/Caches/*|ide_cache
 Maven local repository (Java dependencies)|$HOME/.m2/repository/*|ide_cache
@@ -127,8 +127,8 @@ pnpm package store|$HOME/Library/pnpm/store/*|package_manager
 Composer PHP dependencies cache (legacy)|$HOME/.composer/cache/*|package_manager
 Composer PHP dependencies cache|$HOME/Library/Caches/composer/*|package_manager
 RubyGems cache|$HOME/.gem/cache/*|package_manager
-Conda packages cache|$HOME/.conda/pkgs/*|package_manager
-Anaconda packages cache|$HOME/anaconda3/pkgs/*|package_manager
+Conda package metadata/tarball cache|$HOME/.conda/pkgs|package_manager
+Anaconda package metadata/tarball cache|$HOME/anaconda3/pkgs|package_manager
 PyTorch model cache|$HOME/.cache/torch/*|ai_ml_cache
 TensorFlow model and dataset cache|$HOME/.cache/tensorflow/*|ai_ml_cache
 HuggingFace models and datasets|$HOME/.cache/huggingface/*|ai_ml_cache

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -37,11 +37,10 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Xcode is running"* ]]
     [[ "$output" != *"derived data"* ]]
-    [[ "$output" != *"archives"* ]]
     [[ "$output" != *"documentation cache"* ]]
 }
 
-@test "clean_xcode_tools cleans documentation caches when Xcode is not running" {
+@test "clean_xcode_tools cleans documentation caches but not archives when Xcode is not running" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -53,7 +52,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Xcode derived data"* ]]
-    [[ "$output" == *"Xcode archives"* ]]
+    [[ "$output" != *"Xcode archives"* ]]
     [[ "$output" == *"Xcode documentation cache"* ]]
     [[ "$output" == *"Xcode documentation index"* ]]
 }

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -20,7 +20,7 @@ teardown_file() {
     fi
 }
 
-@test "clean_dev_npm cleans orphaned pnpm store" {
+@test "clean_dev_npm prunes pnpm store without deleting orphaned global store" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -47,7 +47,9 @@ clean_dev_npm
 EOF
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Orphaned pnpm store"* ]]
+    [[ "$output" == *"pnpm cache"* ]]
+    [[ "$output" != *"Orphaned pnpm store"* ]]
+    [[ "$output" != *"pnpm store"* ]]
 }
 
 @test "clean_dev_npm cleans default npm residual directories" {
@@ -76,6 +78,25 @@ EOF
     [[ "$output" == *"npm npx cache|$HOME/.npm/_npx/*"* ]]
     [[ "$output" == *"npm logs|$HOME/.npm/_logs/*"* ]]
     [[ "$output" == *"npm prebuilds|$HOME/.npm/_prebuilds/*"* ]]
+}
+
+@test "clean_conda_metadata_caches honors package cache whitelist before conda clean" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+WHITELIST_PATTERNS=("$HOME/anaconda3/pkgs")
+conda() { echo "conda called"; return 0; }
+export -f conda
+clean_conda_metadata_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"conda index/tarball/log caches · skipped (whitelist)"* ]]
+    [[ "$output" != *"conda called"* ]]
 }
 
 @test "clean_dev_npm cleans custom npm cache path when detected" {

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -135,6 +135,27 @@ EOF
     [[ "$output" == *"Saved application states"* ]] || [[ "$output" == *"App caches"* ]]
 }
 
+@test "clean_app_caches does not clean Autosave Information" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+stop_section_spinner() { :; }
+start_section_spinner() { :; }
+safe_clean() { echo "$2|$1"; }
+bytes_to_human() { echo "0B"; }
+note_activity() { :; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+clean_app_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Autosave information"* ]]
+    [[ "$output" != *"Library/Autosave Information"* ]]
+}
+
 @test "clean_app_caches includes CleanMyMac-observed Apple cache families" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -300,8 +321,8 @@ files_cleaned=0
 total_size_cleaned=0
 total_items=0
 
-mkdir -p "$HOME/Library/Application Support/TestApp/logs/nested"
-dd if=/dev/zero of="$HOME/Library/Application Support/TestApp/logs/nested/data.bin" bs=1024 count=2 2> /dev/null
+mkdir -p "$HOME/Library/Application Support/TestApp/Code Cache/nested"
+dd if=/dev/zero of="$HOME/Library/Application Support/TestApp/Code Cache/nested/data.bin" bs=1024 count=2 2> /dev/null
 
 clean_application_support_logs
 echo "TOTAL_KB=$total_size_cleaned"
@@ -335,9 +356,9 @@ files_cleaned=0
 total_size_cleaned=0
 total_items=0
 
-mkdir -p "$HOME/Library/Application Support/adspower_global/logs"
+mkdir -p "$HOME/Library/Application Support/adspower_global/Crashpad/completed"
 for i in $(seq 1 101); do
-    touch "$HOME/Library/Application Support/adspower_global/logs/file-$i.log"
+    touch "$HOME/Library/Application Support/adspower_global/Crashpad/completed/file-$i.dmp"
 done
 
 clean_application_support_logs
@@ -348,6 +369,36 @@ EOF
     [[ "$output" == *"SPIN:Scanning Application Support... 1/1 [adspower_global, bulk clean]"* ]]
     [[ "$output" == *"Application Support logs/caches"* ]]
     [[ "$output" != *"151250 items"* ]]
+    [[ "$output" != *"REMOVE:"* ]]
+}
+
+@test "clean_application_support_logs does not clean generic Application Support logs" {
+    local support_home="$HOME/support-appsupport-generic-logs"
+    run env HOME="$support_home" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+mkdir -p "$HOME"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+safe_remove() { echo "REMOVE:$1"; }
+update_progress_if_needed() { return 1; }
+should_protect_data() { return 1; }
+is_critical_system_component() { return 1; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+mkdir -p "$HOME/Library/Application Support/TestApp/logs"
+touch "$HOME/Library/Application Support/TestApp/logs/runtime.log"
+
+clean_application_support_logs
+test -f "$HOME/Library/Application Support/TestApp/logs/runtime.log"
+rm -rf "$HOME/Library/Application Support"
+EOF
+
+    [ "$status" -eq 0 ]
     [[ "$output" != *"REMOVE:"* ]]
 }
 
@@ -370,16 +421,46 @@ files_cleaned=0
 total_size_cleaned=0
 total_items=0
 
-mkdir -p "$HOME/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/logs"
-touch "$HOME/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/logs/runtime.log"
+mkdir -p "$HOME/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/Code Cache"
+touch "$HOME/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/Code Cache/runtime.bin"
 
 clean_application_support_logs
-test -f "$HOME/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/logs/runtime.log"
+test -f "$HOME/Library/Application Support/io.github.clash-verge-rev.clash-verge-rev/Code Cache/runtime.bin"
 rm -rf "$HOME/Library/Application Support"
 EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" != *"REMOVE:"* ]]
+}
+
+@test "_clean_darwin_user_runtime_dir removes only old non-state files" {
+    local runtime_home="$HOME/darwin-runtime"
+    run env HOME="$runtime_home" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+mkdir -p "$HOME/runtime/T"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+_darwin_user_runtime_dir_is_safe() { return 0; }
+note_activity() { :; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+echo "old" > "$HOME/runtime/T/old.tmp"
+echo "new" > "$HOME/runtime/T/new.tmp"
+echo "state" > "$HOME/runtime/T/state.sqlite"
+touch -t 202301010000 "$HOME/runtime/T/old.tmp" "$HOME/runtime/T/state.sqlite"
+
+_clean_darwin_user_runtime_dir "$HOME/runtime/T" "temp" "Darwin user temp files"
+
+[[ ! -e "$HOME/runtime/T/old.tmp" ]]
+[[ -e "$HOME/runtime/T/new.tmp" ]]
+[[ -e "$HOME/runtime/T/state.sqlite" ]]
+echo "PASS"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
 }
 
 @test "app_support_entry_count_capped stops at cap without failing under pipefail" {


### PR DESCRIPTION
## Summary
- Add a guarded Darwin user temp/cache cleanup path for old non-state files only, with current-UID, canonical `/private/var/folders/.../{T,C}`, no-symlink, age, item-cap, and timeout guards.
- Narrow risky cleanup surfaces: stop default cleanup for Autosave Information, Xcode Archives, orphaned WebKit/HTTPStorages/Cookies/Application Support/Preferences, and external-volume Spotlight/fseventsd metadata.
- Prefer bounded/tool-native cleanup for pnpm, Corepack, uv, and conda metadata; narrow Gradle/SBT cleanup and skip live app/cache families where needed.
- Add review-only reporting for large persistent stores such as LM Studio models, Xcode archives, iOS backups, VM data, and dependency stores.

## Safety notes
- Deletion remains on the existing cleanup flow (`safe_clean` / `safe_remove`), with dry-run accounting and whitelist/protection checks preserved.
- Large model/backup/archive/VM locations are reported for manual review only, not deleted.

## Testing
- `./scripts/check.sh --format`
- `./scripts/check.sh --no-format`
- `go test ./...`
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/manage_whitelist.bats`
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/manage_whitelist.bats tests/clean_user_core.bats tests/clean_app_caches.bats tests/clean_apps.bats`
- `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh` (750 tests, 0 failures, 7 skipped)
- `MOLE_TEST_NO_AUTH=1 ./mole clean --dry-run`