### PR TITLE
fix(uninstall): clean VS Code Application Support folder on uninstall (#850)

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1360,10 +1360,22 @@ find_app_files() {
     [[ "$app_name" =~ Godot|godot ]] && [[ -d ~/Library/Application\ Support/Godot ]] && files_to_clean+=("$HOME/Library/Application Support/Godot")
 
     # 6. Tools
+    # VS Code stores user data under folder names that don't match the app name
+    # ("Visual Studio Code") or bundle id ("com.microsoft.VSCode"). The folder is
+    # named "Code" (stable) or "Code - Insiders". Cover both channels explicitly
+    # so uninstall removes them. Issue #850.
     if [[ "$bundle_id" =~ microsoft.*[vV][sS][cC]ode ]]; then
-        [[ -d "$HOME/.vscode" ]] && files_to_clean+=("$HOME/.vscode")
         [[ -d "$HOME/Library/Caches/com.microsoft.VSCode.ShipIt" ]] && files_to_clean+=("$HOME/Library/Caches/com.microsoft.VSCode.ShipIt")
         [[ -d "$HOME/Library/Caches/com.microsoft.VSCodeInsiders.ShipIt" ]] && files_to_clean+=("$HOME/Library/Caches/com.microsoft.VSCodeInsiders.ShipIt")
+        if [[ "$bundle_id" =~ [iI]nsiders ]]; then
+            [[ -d "$HOME/.vscode-insiders" ]] && files_to_clean+=("$HOME/.vscode-insiders")
+            [[ -d "$HOME/Library/Application Support/Code - Insiders" ]] && files_to_clean+=("$HOME/Library/Application Support/Code - Insiders")
+            [[ -d "$HOME/Library/Caches/com.microsoft.VSCodeInsiders" ]] && files_to_clean+=("$HOME/Library/Caches/com.microsoft.VSCodeInsiders")
+        else
+            [[ -d "$HOME/.vscode" ]] && files_to_clean+=("$HOME/.vscode")
+            [[ -d "$HOME/Library/Application Support/Code" ]] && files_to_clean+=("$HOME/Library/Application Support/Code")
+            [[ -d "$HOME/Library/Caches/com.microsoft.VSCode" ]] && files_to_clean+=("$HOME/Library/Caches/com.microsoft.VSCode")
+        fi
     fi
     [[ "$app_name" =~ Docker ]] && [[ -d ~/.docker ]] && files_to_clean+=("$HOME/.docker")
 

--- a/tests/uninstall_naming_variants.bats
+++ b/tests/uninstall_naming_variants.bats
@@ -146,3 +146,27 @@ setup() {
 
     [[ ! "$result" =~ "Library/Application Support"$ ]]
 }
+
+@test "find_app_files detects VS Code stable Application Support folder (#850)" {
+    mkdir -p "$HOME/Library/Application Support/Code"
+    mkdir -p "$HOME/Library/Application Support/Code - Insiders"
+    mkdir -p "$HOME/.vscode"
+
+    result=$(find_app_files "com.microsoft.VSCode" "Visual Studio Code")
+
+    [[ "$result" =~ Library/Application\ Support/Code$'\n' ]] || [[ "$result" == *"Library/Application Support/Code"* ]]
+    [[ "$result" == *"/.vscode"* ]]
+    [[ "$result" != *"Code - Insiders"* ]]
+}
+
+@test "find_app_files detects VS Code Insiders Application Support folder (#850)" {
+    mkdir -p "$HOME/Library/Application Support/Code"
+    mkdir -p "$HOME/Library/Application Support/Code - Insiders"
+    mkdir -p "$HOME/.vscode-insiders"
+
+    result=$(find_app_files "com.microsoft.VSCodeInsiders" "Visual Studio Code - Insiders")
+
+    [[ "$result" == *"Library/Application Support/Code - Insiders"* ]]
+    [[ "$result" == *"/.vscode-insiders"* ]]
+    [[ ! "$result" =~ Library/Application\ Support/Code$'\n' ]]
+}


### PR DESCRIPTION
## Summary

Fixes #850. `mo uninstall` left `~/Library/Application Support/Code` behind because the folder name (`Code` / `Code - Insiders`) doesn't match `app_name` (`Visual Studio Code`) or `bundle_id` (`com.microsoft.VSCode`), so the standard pattern matching in `find_app_files()` skipped it.

Extended the existing VS Code special-case in `lib/core/app_protection.sh` to branch on stable vs Insiders and explicitly queue the channel-specific folders:

- `~/Library/Application Support/Code` (stable) or `Code - Insiders`
- `~/Library/Caches/com.microsoft.VSCode` (stable) or `com.microsoft.VSCodeInsiders`
- `~/.vscode` (stable) or `.vscode-insiders`

Same shape as the surrounding Raycast / JetBrains / Xcode / Maestro blocks — no new generic mechanism, no fork support (VSCodium / Cursor are out of scope, separate issue territory).

## Test plan

- [x] `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_naming_variants.bats` — 12/12 pass (2 new cases for #850)
- [x] `MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats` — 39/39 pass
- [x] `bash -n lib/core/app_protection.sh` — clean
- [x] Smoke test with fake `$HOME`: stable bundle id queues `Code/` + cache + `.vscode`; Insiders bundle id queues `Code - Insiders/` + `.vscode-insiders` and does NOT queue stable `Code/`