### PR TITLE
Protect active Codex Desktop runtime caches

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -332,7 +332,7 @@ clean_dev_mise() {
     mise_cache_path=$(get_mise_cache_path)
 
     if command -v mise > /dev/null 2>&1; then
-        if [[ "$DRY_RUN" != "true" ]]; then
+        if [[ "${DRY_RUN:-false}" != "true" ]]; then
             clean_tool_cache "mise cache" "$mise_cache_path" bash -c 'mise cache clear > /dev/null 2>&1 || true'
             note_activity
         elif is_path_whitelisted "$mise_cache_path"; then
@@ -1280,6 +1280,107 @@ clean_dev_api_tools() {
     safe_clean ~/Library/Caches/com.charlesproxy.charles/* "Charles Proxy cache"
     safe_clean ~/Library/Caches/com.proxyman.NSProxy/* "Proxyman cache"
 }
+
+codex_desktop_running() {
+    command -v pgrep > /dev/null 2>&1 || return 1
+
+    pgrep -x "Codex" > /dev/null 2>&1 && return 0
+    pgrep -f "/Codex.app/" > /dev/null 2>&1 && return 0
+    return 1
+}
+
+is_codex_runtime_active() {
+    local runtime_dir="$1"
+    [[ -d "$runtime_dir" ]] || return 1
+    [[ -f "$runtime_dir/runtime.json" ]] || return 1
+    [[ -d "$runtime_dir/dependencies/node" || -d "$runtime_dir/dependencies/python" ]] || return 1
+    return 0
+}
+
+is_codex_runtime_stale() {
+    local runtime_dir="$1"
+    [[ -d "$runtime_dir" ]] || return 1
+
+    local runtime_name
+    runtime_name="$(basename "$runtime_dir")"
+    case "$runtime_name" in
+        tmp* | temp* | *.tmp | incomplete* | *.incomplete | *-incomplete | partial* | *.partial)
+            return 0
+            ;;
+    esac
+
+    if [[ ! -e "$runtime_dir/runtime.json" && ! -e "$runtime_dir/dependencies" ]]; then
+        return 0
+    fi
+
+    return 1
+}
+
+_codex_runtime_size_human() {
+    local target="$1"
+    local size_kb=0
+
+    if declare -f get_path_size_kb > /dev/null 2>&1; then
+        size_kb=$(get_path_size_kb "$target" 2> /dev/null || echo 0)
+    fi
+
+    if declare -f bytes_to_human > /dev/null 2>&1; then
+        bytes_to_human "$((size_kb * 1024))"
+    else
+        printf '%s KB' "$size_kb"
+    fi
+}
+
+clean_codex_runtimes() {
+    local runtime_root="$HOME/.cache/codex-runtimes"
+    [[ -d "$runtime_root" ]] || return 0
+
+    if declare -f is_path_whitelisted > /dev/null 2>&1 && is_path_whitelisted "$runtime_root"; then
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Codex runtimes · would skip (whitelist)"
+        else
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Codex runtimes · skipped (whitelist)"
+        fi
+        note_activity
+        return 0
+    fi
+
+    if codex_desktop_running; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Codex runtimes · skipped (Codex running)"
+        note_activity
+        return 0
+    fi
+
+    local size_human
+    size_human=$(_codex_runtime_size_human "$runtime_root")
+    echo -e "  ${GRAY}${ICON_WARNING}${NC} Codex runtimes · manual review (${size_human})"
+    note_activity
+
+    local runtime_dir
+    while IFS= read -r -d '' runtime_dir; do
+        if declare -f is_path_whitelisted > /dev/null 2>&1 && is_path_whitelisted "$runtime_dir"; then
+            if [[ "${DRY_RUN:-false}" == "true" ]]; then
+                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Codex runtimes · would skip (whitelist)"
+            else
+                echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Codex runtimes · skipped (whitelist)"
+            fi
+            note_activity
+            continue
+        fi
+
+        if is_codex_runtime_active "$runtime_dir"; then
+            debug_log "Codex runtime left for manual review: $runtime_dir"
+            continue
+        fi
+
+        if is_codex_runtime_stale "$runtime_dir"; then
+            safe_clean "$runtime_dir" "Codex CLI runtimes"
+        else
+            debug_log "Codex runtime left for manual review: $runtime_dir"
+        fi
+    done < <(command find "$runtime_root" -mindepth 1 -maxdepth 1 -type d -print0 2> /dev/null)
+}
+
 # Misc dev tool caches.
 clean_dev_misc() {
     safe_clean ~/Library/Caches/com.unity3d.*/* "Unity cache"
@@ -1334,8 +1435,8 @@ clean_dev_misc() {
         safe_clean ~/.local/share/opencode/snapshot/* "OpenCode snapshots"
         safe_clean ~/.local/share/opencode/log/* "OpenCode logs"
     fi
-    # Codex CLI sandbox runtimes
-    safe_clean ~/.cache/codex-runtimes/* "Codex CLI runtimes"
+    # Codex Desktop runtimes contain active Node/Python dependencies.
+    clean_codex_runtimes
     # Cursor Agent session logs (versions cleaned separately in clean_dev_ai_agents)
     [[ -d "$HOME/.local/share/cursor-agent" ]] && safe_find_delete "$HOME/.local/share/cursor-agent" "*.log" "$MOLE_LOG_AGE_DAYS" "f"
     # Playwright cached browser binaries

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -246,6 +246,9 @@ readonly DATA_PROTECTED_BUNDLES=(
     "Claude"
     "com.openai.chat*"
     "ChatGPT"
+    "com.openai.codex"
+    "Codex"
+    "codex-runtimes"
     "com.ollama.ollama"
     "Ollama"
     "com.lmstudio.lmstudio"
@@ -720,7 +723,7 @@ should_protect_data() {
         com.jetbrains.* | JetBrains* | com.microsoft.* | com.visualstudio.*)
             return 0
             ;;
-        com.sublimetext.* | com.sublimehq.* | Cursor | Claude | ChatGPT | Ollama)
+        com.sublimetext.* | com.sublimehq.* | Cursor | Claude | ChatGPT | com.openai.codex | Codex | codex-runtimes | Ollama)
             return 0
             ;;
         # Specific match to avoid ShellCheck redundancy warning with com.clash.*

--- a/lib/core/ui.sh
+++ b/lib/core/ui.sh
@@ -281,6 +281,7 @@ drain_pending_input() {
         drained=$((drained + 1))
         [[ $drained -gt 100 ]] && break
     done
+    return 0
 }
 
 # Format menu option display

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -411,6 +411,120 @@ EOF
     [[ "$output" == *"Prune:  docker system prune"* ]]
 }
 
+@test "clean_codex_runtimes reports active runtime for manual review" {
+    mkdir -p "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin"
+    touch "$HOME/.cache/codex-runtimes/codex-primary-runtime/runtime.json"
+    touch "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+pgrep() { return 1; }
+is_path_whitelisted() { return 1; }
+get_path_size_kb() { echo "1024"; }
+bytes_to_human() { echo "1M"; }
+note_activity() { :; }
+clean_codex_runtimes
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Codex runtimes · manual review"* ]]
+    [[ "$output" != *"SAFE_CLEAN:Codex CLI runtimes|$HOME/.cache/codex-runtimes/codex-primary-runtime"* ]]
+}
+
+@test "clean_codex_runtimes cleans only stale incomplete runtime dirs" {
+    mkdir -p "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin"
+    mkdir -p "$HOME/.cache/codex-runtimes/incomplete-old"
+    touch "$HOME/.cache/codex-runtimes/codex-primary-runtime/runtime.json"
+    touch "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+pgrep() { return 1; }
+is_path_whitelisted() { return 1; }
+get_path_size_kb() { echo "1024"; }
+bytes_to_human() { echo "1M"; }
+note_activity() { :; }
+clean_codex_runtimes
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SAFE_CLEAN:Codex CLI runtimes|$HOME/.cache/codex-runtimes/incomplete-old"* ]]
+    [[ "$output" != *"SAFE_CLEAN:Codex CLI runtimes|$HOME/.cache/codex-runtimes/codex-primary-runtime"* ]]
+}
+
+@test "clean_codex_runtimes skips all runtimes while Codex is running" {
+    mkdir -p "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin"
+    mkdir -p "$HOME/.cache/codex-runtimes/incomplete-old"
+    touch "$HOME/.cache/codex-runtimes/codex-primary-runtime/runtime.json"
+    touch "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+pgrep() { return 0; }
+is_path_whitelisted() { return 1; }
+get_path_size_kb() { echo "1024"; }
+bytes_to_human() { echo "1M"; }
+note_activity() { :; }
+clean_codex_runtimes
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Codex runtimes · skipped (Codex running)"* ]]
+    [[ "$output" != *"SAFE_CLEAN:"* ]]
+}
+
+@test "clean_codex_runtimes respects whitelist" {
+    mkdir -p "$HOME/.cache/codex-runtimes/incomplete-old"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+pgrep() { return 1; }
+is_path_whitelisted() { [[ "$1" == "$HOME/.cache/codex-runtimes"* || "$1" == "$HOME/.cache/codex-runtimes/incomplete-old" ]]; }
+get_path_size_kb() { echo "1024"; }
+bytes_to_human() { echo "1M"; }
+note_activity() { :; }
+clean_codex_runtimes
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Codex runtimes · skipped (whitelist)"* ]]
+    [[ "$output" != *"SAFE_CLEAN:"* ]]
+}
+
+@test "clean_codex_runtimes respects child runtime whitelist" {
+    mkdir -p "$HOME/.cache/codex-runtimes/incomplete-old"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+pgrep() { return 1; }
+is_path_whitelisted() { [[ "$1" == "$HOME/.cache/codex-runtimes/incomplete-old" ]]; }
+get_path_size_kb() { echo "1024"; }
+bytes_to_human() { echo "1M"; }
+note_activity() { :; }
+clean_codex_runtimes
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Codex runtimes · manual review"* ]]
+    [[ "$output" == *"Codex runtimes · skipped (whitelist)"* ]]
+    [[ "$output" != *"SAFE_CLEAN:"* ]]
+}
+
 @test "clean_dev_mise respects MISE_CACHE_DIR and only targets cache" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MISE_CACHE_DIR="/tmp/mise-cache" bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -206,6 +206,21 @@ EOF
     [ "$result" = "protected" ]
 }
 
+@test "should_protect_data protects Codex runtime identifiers" {
+    result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data 'Codex' && echo 'protected' || echo 'not-protected'")
+    [ "$result" = "protected" ]
+
+    result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data 'com.openai.codex' && echo 'protected' || echo 'not-protected'")
+    [ "$result" = "protected" ]
+
+    result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data 'codex-runtimes' && echo 'protected' || echo 'not-protected'")
+    [ "$result" = "protected" ]
+
+    local codex_runtimes_path="$HOME/.cache/codex-runtimes"
+    result=$(HOME="$HOME" TARGET_PATH="$codex_runtimes_path" bash --noprofile --norc -c 'source "$PROJECT_ROOT/lib/core/common.sh"; should_protect_path "$TARGET_PATH" && echo "protected" || echo "not-protected"')
+    [ "$result" = "protected" ]
+}
+
 @test "should_protect_path protects NetworkExtension VPN preferences" {
     result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_path '/Volumes/Data/Library/Preferences/com.apple.networkextension.plist' && echo 'protected' || echo 'not-protected'")
     [ "$result" = "protected" ]


### PR DESCRIPTION
# Protect active Codex Desktop runtime caches

## Summary

- Stop deleting active Codex Desktop runtime dependencies under `~/.cache/codex-runtimes`.
- Replace broad `~/.cache/codex-runtimes/*` cleanup with conservative runtime classification:
  - skip all runtime cleanup while Codex Desktop is running
  - report active runtime layouts for manual review
  - only pass clearly stale/incomplete runtime dirs to `safe_clean`
- Add Codex data-protection patterns for `Codex`, `com.openai.codex`, and `codex-runtimes`.
- Add focused Bats coverage for active runtime skip, stale runtime cleanup, running-app hard skip, whitelist behavior, and Codex protection matching.

## Safety Review

- Yes, this changes cleanup behavior.
- New boundary: `~/.cache/codex-runtimes` is no longer cleaned with a wildcard. A runtime child dir is treated as active and skipped when it has `runtime.json` plus `dependencies/node` or `dependencies/python`.
- If Codex Desktop is running, runtime cleanup hard-skips and prints `Codex runtimes · skipped (Codex running)`.
- Active runtime dirs are reported as `Codex runtimes · manual review` and are not deleted.
- Stale cleanup remains routed through existing `safe_clean`, preserving dry-run, whitelist, and protected-path behavior.
- Codex Electron cache cleanup in `lib/clean/app_caches.sh` is unchanged; this PR only protects runtime dependency dirs.

Why the running-app guard matters:

- Public Codex docs and the `openai/codex` repo do not appear to publish a cleanup contract for `~/.cache/codex-runtimes`, `runtime.json`, `dependencies/node`, or `dependencies/python`.
- The installed Codex Desktop Electron bundle does include primary-runtime update logic for this directory. In `/Applications/Codex.app/Contents/Resources/app.asar`, the runtime updater checks for `missing`, `current`, and `outdated` runtime states, installs into `~/.cache/codex-runtimes`, creates `codex-runtime-install-*` temp dirs, extracts into a `payload` dir, validates `runtime.json`, swaps `codex-primary-runtime` through `codex-primary-runtime.previous`, restores the previous runtime on failure, and removes temp dirs in cleanup.
- That means stale-looking runtime install dirs can exist while Codex Desktop is actively downloading, extracting, validating, swapping, or rolling back a runtime. The hard running-app skip avoids deleting those transient paths mid-update.

Sources checked:

- https://github.com/openai/codex
- https://developers.openai.com/codex/app
- https://developers.openai.com/codex/cli
- Local installed Codex Desktop bundle: `/Applications/Codex.app/Contents/Resources/app.asar`

## Tests

- Passed: `./scripts/check.sh`
- Passed: `golangci-lint run ./cmd/...`
- Passed: `MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/core_common.bats`
- Passed during commit: `.githooks/pre-commit` syntax, `shfmt`, and `shellcheck`
- Not passing locally: `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh`
  - Bats phase: `743 tests, 46 failures, 1 skipped`
  - Performance phase: `2` failures
  - Observed failures were outside the Codex runtime cleanup path, while the new Codex runtime tests passed in the full run.

## Safety-related changes

- Replaces broad runtime deletion with conservative active-runtime detection and manual-review reporting.
- Adds Codex identifiers to data-protection matching as defense in depth.
