### PR TITLE
feat(uninstall): add per-file deselect at confirm prompt (#852)

### DIFF
--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -92,7 +92,11 @@ decode_file_list() {
 }
 # Note: find_app_files() and calculate_total_size() are in lib/core/common.sh.
 
-# Stop Launch Agents/Daemons for an app.
+# Unload Launch Agents/Daemons for an app. **Unload only** -- never remove the
+# plist file. Plist deletion is owned by `remove_file_list` so the review
+# picker's selection is the single source of truth for what survives on disk.
+# Always called before file removal so we don't strand a running daemon when
+# its plist is about to be deleted.
 # Security: bundle_id is validated to be reverse-DNS format before use in find patterns
 stop_launch_services() {
     local bundle_id="$1"
@@ -116,7 +120,6 @@ stop_launch_services() {
     if [[ -d ~/Library/LaunchAgents ]]; then
         while IFS= read -r -d '' plist; do
             launchctl unload "$plist" 2> /dev/null || true
-            safe_remove "$plist" 2> /dev/null || true
         done < <(find ~/Library/LaunchAgents -maxdepth 1 -name "${bundle_id}*.plist" -print0 2> /dev/null)
     fi
 
@@ -124,13 +127,11 @@ stop_launch_services() {
         if [[ -d /Library/LaunchAgents ]]; then
             while IFS= read -r -d '' plist; do
                 sudo launchctl unload "$plist" 2> /dev/null || true
-                safe_sudo_remove "$plist" 2> /dev/null || true
             done < <(find /Library/LaunchAgents -maxdepth 1 -name "${bundle_id}*.plist" -print0 2> /dev/null)
         fi
         if [[ -d /Library/LaunchDaemons ]]; then
             while IFS= read -r -d '' plist; do
                 sudo launchctl unload "$plist" 2> /dev/null || true
-                safe_sudo_remove "$plist" 2> /dev/null || true
             done < <(find /Library/LaunchDaemons -maxdepth 1 -name "${bundle_id}*.plist" -print0 2> /dev/null)
         fi
     fi
@@ -141,20 +142,17 @@ stop_launch_services() {
         if [[ -d ~/Library/LaunchAgents ]]; then
             while IFS= read -r -d '' plist; do
                 launchctl unload "$plist" 2> /dev/null || true
-                safe_remove "$plist" 2> /dev/null || true
             done < <(grep -rlZ "$app_path" ~/Library/LaunchAgents/ 2> /dev/null || true)
         fi
         if [[ "$has_system_files" == "true" ]]; then
             if [[ -d /Library/LaunchAgents ]]; then
                 while IFS= read -r -d '' plist; do
                     sudo launchctl unload "$plist" 2> /dev/null || true
-                    safe_sudo_remove "$plist" 2> /dev/null || true
                 done < <(grep -rlZ "$app_path" /Library/LaunchAgents/ 2> /dev/null || true)
             fi
             if [[ -d /Library/LaunchDaemons ]]; then
                 while IFS= read -r -d '' plist; do
                     sudo launchctl unload "$plist" 2> /dev/null || true
-                    safe_sudo_remove "$plist" 2> /dev/null || true
                 done < <(grep -rlZ "$app_path" /Library/LaunchDaemons/ 2> /dev/null || true)
             fi
         fi
@@ -324,6 +322,309 @@ remove_file_list() {
     echo "$count"
 }
 
+# Interactive review picker.
+#
+# Reads the caller's `app_details` array (12-column rows from
+# `batch_uninstall_applications`), flattens each app's removal candidates
+# (the `.app` bundle plus user/system/diagnostic file buckets) into a flat
+# multi-select catalogue with everything preselected, runs
+# `paginated_multi_select`, then rebuilds `app_details` so that:
+#   - `related_files`, `system_files`, and `diag_system` retain only the
+#     paths the user kept selected (re-base64-encoded in place);
+#   - a 13th column `keep_app` (`true|false`) is appended. `keep_app=true`
+#     means the user explicitly deselected the `.app` row -- callers must
+#     skip the bundle-removal / launch-services / brew-cask steps for that
+#     entry but may still drop the surviving leftover files.
+#
+# Returns 0 on confirm (mutates `app_details` in place via dynamic scope),
+# returns 1 on picker cancel (`app_details` is left untouched).
+interactive_review_files() {
+    [[ ${#app_details[@]} -eq 0 ]] && return 0
+
+    local -a row_app_idx=()
+    local -a row_bucket=()
+    local -a row_path=()
+    local -a menu_options=()
+
+    local app_idx=0
+    local detail
+    for detail in "${app_details[@]}"; do
+        local app_name app_path bundle_id total_kb encoded_files encoded_system_files
+        local has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage
+        local _existing_keep_app="false"
+        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files \
+            has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage \
+            _existing_keep_app <<< "$detail"
+
+        # .app bundle row.
+        row_app_idx+=("$app_idx")
+        row_bucket+=("app")
+        row_path+=("$app_path")
+        menu_options+=("$(_review_format_menu_row "$app_name" "$app_path" "false")")
+
+        # Related user files.
+        local related_files
+        related_files=$(decode_file_list "$encoded_files" "$app_name")
+        local f
+        while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            row_app_idx+=("$app_idx")
+            row_bucket+=("related")
+            row_path+=("$f")
+            menu_options+=("$(_review_format_menu_row "$app_name" "$f" "false")")
+        done <<< "$related_files"
+
+        # System files (sudo-required).
+        local system_files
+        system_files=$(decode_file_list "$encoded_system_files" "$app_name")
+        while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            row_app_idx+=("$app_idx")
+            row_bucket+=("system")
+            row_path+=("$f")
+            menu_options+=("$(_review_format_menu_row "$app_name" "$f" "true")")
+        done <<< "$system_files"
+
+        # System-level diagnostic reports.
+        local diag_system
+        diag_system=$(decode_file_list "$encoded_diag_system" "$app_name")
+        while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            row_app_idx+=("$app_idx")
+            row_bucket+=("diag")
+            row_path+=("$f")
+            menu_options+=("$(_review_format_menu_row "$app_name" "$f" "true")")
+        done <<< "$diag_system"
+
+        app_idx=$((app_idx + 1))
+    done
+
+    local total_rows=${#menu_options[@]}
+    [[ $total_rows -eq 0 ]] && return 0
+
+    # Preselect every row -- the picker's job is to let the user opt OUT of paths.
+    local preselect_csv=""
+    local i
+    for ((i = 0; i < total_rows; i++)); do
+        if [[ -z "$preselect_csv" ]]; then
+            preselect_csv="$i"
+        else
+            preselect_csv+=",$i"
+        fi
+    done
+    export MOLE_PRESELECTED_INDICES="$preselect_csv"
+
+    MOLE_SELECTION_RESULT=""
+    local exit_code=0
+    paginated_multi_select "Review files to remove" "${menu_options[@]}" || exit_code=$?
+    unset MOLE_PRESELECTED_INDICES
+
+    if [[ $exit_code -ne 0 ]]; then
+        return 1
+    fi
+
+    # Map surviving (still-selected) row indices into a per-row boolean.
+    local -a row_kept=()
+    for ((i = 0; i < total_rows; i++)); do
+        row_kept[i]="false"
+    done
+    if [[ -n "$MOLE_SELECTION_RESULT" ]]; then
+        local idx
+        local -a indices_array=()
+        IFS=',' read -r -a indices_array <<< "$MOLE_SELECTION_RESULT"
+        for idx in "${indices_array[@]}"; do
+            if [[ "$idx" =~ ^[0-9]+$ ]] && [[ $idx -ge 0 ]] && [[ $idx -lt $total_rows ]]; then
+                row_kept[idx]="true"
+            fi
+        done
+    fi
+
+    # Rebuild each app_details row from the surviving paths.
+    local -a new_app_details=()
+    local current_app=0
+    while [[ $current_app -lt ${#app_details[@]} ]]; do
+        local detail_in="${app_details[current_app]}"
+        local app_name app_path bundle_id total_kb encoded_files encoded_system_files
+        local has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage
+        local _ignored_keep_app="false"
+        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files \
+            has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage \
+            _ignored_keep_app <<< "$detail_in"
+
+        local keep_app="false"
+        local -a kept_related=()
+        local -a kept_system=()
+        local -a kept_diag=()
+
+        for ((i = 0; i < total_rows; i++)); do
+            [[ "${row_app_idx[i]}" != "$current_app" ]] && continue
+            local bucket="${row_bucket[i]}"
+            local p="${row_path[i]}"
+            local sel="${row_kept[i]}"
+            case "$bucket" in
+                app)
+                    # `.app` row preselected = remove. Deselected = keep the bundle.
+                    [[ "$sel" == "false" ]] && keep_app="true"
+                    ;;
+                related)
+                    [[ "$sel" == "true" ]] && kept_related+=("$p")
+                    ;;
+                system)
+                    [[ "$sel" == "true" ]] && kept_system+=("$p")
+                    ;;
+                diag)
+                    [[ "$sel" == "true" ]] && kept_diag+=("$p")
+                    ;;
+            esac
+        done
+
+        local new_related="" new_system="" new_diag=""
+        [[ ${#kept_related[@]} -gt 0 ]] && new_related=$(printf '%s\n' "${kept_related[@]}")
+        [[ ${#kept_system[@]} -gt 0 ]] && new_system=$(printf '%s\n' "${kept_system[@]}")
+        [[ ${#kept_diag[@]} -gt 0 ]] && new_diag=$(printf '%s\n' "${kept_diag[@]}")
+
+        local enc_related enc_system enc_diag
+        enc_related=$(printf '%s' "$new_related" | base64 | tr -d '\n')
+        enc_system=$(printf '%s' "$new_system" | base64 | tr -d '\n')
+        enc_diag=$(printf '%s' "$new_diag" | base64 | tr -d '\n')
+
+        # Recompute total_kb so the re-rendered confirm prompt reflects the
+        # trimmed selection rather than the pre-review snapshot.
+        local new_total_kb=0
+        if [[ "$keep_app" != "true" ]]; then
+            new_total_kb=$((new_total_kb + $(get_path_size_kb "$app_path" 2> /dev/null || echo 0)))
+        fi
+        [[ -n "$new_related" ]] && new_total_kb=$((new_total_kb + $(calculate_total_size "$new_related" 2> /dev/null || echo 0)))
+        [[ -n "$new_system" ]] && new_total_kb=$((new_total_kb + $(calculate_total_size "$new_system" 2> /dev/null || echo 0)))
+        [[ -n "$new_diag" ]] && new_total_kb=$((new_total_kb + $(calculate_total_size "$new_diag" 2> /dev/null || echo 0)))
+
+        new_app_details+=("$app_name|$app_path|$bundle_id|$new_total_kb|$enc_related|$enc_system|$has_sensitive_data|$needs_sudo|$is_brew_cask|$cask_name|$enc_diag|$has_local_network_usage|$keep_app")
+        current_app=$((current_app + 1))
+    done
+
+    app_details=("${new_app_details[@]}")
+    return 0
+}
+
+# Format one row in the review picker. Adds a `[system]` tag for sudo-required
+# paths so they are visually distinguished when scanning the list.
+_review_format_menu_row() {
+    local app_name="$1" path="$2" is_system="$3"
+    local display="${path/#$HOME/~}"
+    local tag=""
+    if [[ "$is_system" == "true" ]]; then
+        tag="  ${GRAY:-}[system]${NC:-}"
+    fi
+    printf "%s: %s%s" "$app_name" "$display" "$tag"
+}
+
+# Render the "Files to be removed:" preview block for the current
+# `app_details` snapshot. Reads `app_details` and `brew_cask_apps` via
+# dynamic scope so it can be re-rendered after `interactive_review_files`
+# mutates them.
+_print_files_to_remove() {
+    echo -e "\n${PURPLE_BOLD}Files to be removed:${NC}"
+
+    local has_brew_cask=false
+    [[ ${#brew_cask_apps[@]} -gt 0 ]] && has_brew_cask=true
+    if [[ "$has_brew_cask" == "true" ]]; then
+        echo -e "${GRAY}${ICON_WARNING} Homebrew apps will be fully cleaned, --zap removes configs and data${NC}"
+    fi
+    echo ""
+
+    local detail
+    for detail in "${app_details[@]}"; do
+        local app_name app_path bundle_id total_kb encoded_files encoded_system_files
+        local has_sensitive_data needs_sudo_flag is_brew_cask cask_name encoded_diag_system
+        local has_local_network_usage keep_app="false"
+        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files \
+            has_sensitive_data needs_sudo_flag is_brew_cask cask_name encoded_diag_system \
+            has_local_network_usage keep_app <<< "$detail"
+        local app_size_display=$(bytes_to_human "$((total_kb * 1024))")
+
+        local brew_tag=""
+        [[ "$is_brew_cask" == "true" ]] && brew_tag=" ${CYAN}[Brew]${NC}"
+        local kept_tag=""
+        [[ "$keep_app" == "true" ]] && kept_tag=" ${YELLOW}[kept]${NC}"
+        echo -e "${BLUE}${ICON_CONFIRM}${NC} ${app_name}${brew_tag}${kept_tag} ${GRAY}, ${app_size_display}${NC}"
+
+        local related_files=$(decode_file_list "$encoded_files" "$app_name")
+        local system_files=$(decode_file_list "$encoded_system_files" "$app_name")
+        local diag_system_display
+        diag_system_display=$(decode_file_list "$encoded_diag_system" "$app_name")
+        [[ -n "$diag_system_display" ]] && system_files=$(
+            [[ -n "$system_files" ]] && echo "$system_files"
+            echo "$diag_system_display"
+        )
+
+        if [[ "$keep_app" != "true" ]]; then
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} ${app_path/$HOME/~}"
+        fi
+
+        local file
+        while IFS= read -r file; do
+            if [[ -n "$file" && -e "$file" ]]; then
+                echo -e "  ${GREEN}${ICON_SUCCESS}${NC} ${file/$HOME/~}"
+            fi
+        done <<< "$related_files"
+
+        while IFS= read -r file; do
+            if [[ -n "$file" && -e "$file" ]]; then
+                echo -e "  ${BLUE}${ICON_WARNING}${NC} System: $file"
+            fi
+        done <<< "$system_files"
+    done
+}
+
+# Recompute the sudo / brew_cask aggregates after a file review pass so the
+# downstream sudo gate and brew autoremove logic see the current state.
+# `keep_app=true` apps no longer trigger their own sudo or brew uninstall;
+# system file lists may have shrunk to empty.
+_recompute_uninstall_aggregates() {
+    sudo_apps=()
+    brew_cask_apps=()
+    total_estimated_size=0
+
+    local detail
+    for detail in "${app_details[@]}"; do
+        local app_name app_path bundle_id total_kb encoded_files encoded_system_files
+        local has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system
+        local has_local_network_usage keep_app="false"
+        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files \
+            has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system \
+            has_local_network_usage keep_app <<< "$detail"
+
+        local has_system_remaining="false"
+        if [[ -n "$encoded_system_files" || -n "$encoded_diag_system" ]]; then
+            has_system_remaining="true"
+        fi
+
+        local needs_sudo_now="false"
+        if [[ "$has_system_remaining" == "true" ]]; then
+            needs_sudo_now="true"
+        elif [[ "$keep_app" != "true" && "$needs_sudo" == "true" ]]; then
+            # We will still try to delete the .app bundle, which originally
+            # required sudo (parent dir or owner mismatch).
+            needs_sudo_now="true"
+        fi
+
+        if [[ "$needs_sudo_now" == "true" ]]; then
+            sudo_apps+=("$app_name")
+        fi
+        if [[ "$is_brew_cask" == "true" && "$keep_app" != "true" ]]; then
+            brew_cask_apps+=("$app_name")
+        fi
+
+        if [[ "$total_kb" =~ ^[0-9]+$ ]]; then
+            total_estimated_size=$((total_estimated_size + total_kb))
+        fi
+    done
+
+    if declare -p size_display > /dev/null 2>&1; then
+        size_display=$(bytes_to_human "$((total_estimated_size * 1024))")
+    fi
+}
+
 # Batch uninstall with single confirmation.
 batch_uninstall_applications() {
     local total_size_freed=0
@@ -462,92 +763,66 @@ batch_uninstall_applications() {
         encoded_system_files=$(printf '%s' "$system_files" | base64 | tr -d '\n' || echo "")
         local encoded_diag_system
         encoded_diag_system=$(printf '%s' "$diag_system" | base64 | tr -d '\n' || echo "")
-        app_details+=("$app_name|$app_path|$bundle_id|$total_kb|$encoded_files|$encoded_system_files|$has_sensitive_data|$needs_sudo|$is_brew_cask|$cask_name|$encoded_diag_system|$has_local_network_usage")
+        app_details+=("$app_name|$app_path|$bundle_id|$total_kb|$encoded_files|$encoded_system_files|$has_sensitive_data|$needs_sudo|$is_brew_cask|$cask_name|$encoded_diag_system|$has_local_network_usage|false")
     done
     if [[ -t 1 ]]; then stop_inline_spinner; fi
 
     local size_display=$(bytes_to_human "$((total_estimated_size * 1024))")
 
-    echo -e "\n${PURPLE_BOLD}Files to be removed:${NC}"
-
-    # Warn if brew cask apps are present.
-    local has_brew_cask=false
-    [[ ${#brew_cask_apps[@]} -gt 0 ]] && has_brew_cask=true
-
-    if [[ "$has_brew_cask" == "true" ]]; then
-        echo -e "${GRAY}${ICON_WARNING} Homebrew apps will be fully cleaned, --zap removes configs and data${NC}"
-    fi
-
-    echo ""
-
-    for detail in "${app_details[@]}"; do
-        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files has_sensitive_data needs_sudo_flag is_brew_cask cask_name encoded_diag_system has_local_network_usage <<< "$detail"
-        local app_size_display=$(bytes_to_human "$((total_kb * 1024))")
-
-        local brew_tag=""
-        [[ "$is_brew_cask" == "true" ]] && brew_tag=" ${CYAN}[Brew]${NC}"
-        echo -e "${BLUE}${ICON_CONFIRM}${NC} ${app_name}${brew_tag} ${GRAY}, ${app_size_display}${NC}"
-
-        # Show detailed file list for ALL apps (brew casks leave user data behind)
-        local related_files=$(decode_file_list "$encoded_files" "$app_name")
-        local system_files=$(decode_file_list "$encoded_system_files" "$app_name")
-        local diag_system_display
-        diag_system_display=$(decode_file_list "$encoded_diag_system" "$app_name")
-        [[ -n "$diag_system_display" ]] && system_files=$(
-            [[ -n "$system_files" ]] && echo "$system_files"
-            echo "$diag_system_display"
-        )
-
-        echo -e "  ${GREEN}${ICON_SUCCESS}${NC} ${app_path/$HOME/~}"
-
-        # Show all related files so users can fully review before deletion.
-        while IFS= read -r file; do
-            if [[ -n "$file" && -e "$file" ]]; then
-                echo -e "  ${GREEN}${ICON_SUCCESS}${NC} ${file/$HOME/~}"
-            fi
-        done <<< "$related_files"
-
-        # Show all system files so users can fully review before deletion.
-        while IFS= read -r file; do
-            if [[ -n "$file" && -e "$file" ]]; then
-                echo -e "  ${BLUE}${ICON_WARNING}${NC} System: $file"
-            fi
-        done <<< "$system_files"
-    done
+    _print_files_to_remove
 
     # Confirmation before requesting sudo.
     local app_total=${#selected_apps[@]}
     local app_text="app"
     [[ $app_total -gt 1 ]] && app_text="apps"
 
-    echo ""
-    local removal_note="Remove ${app_total} ${app_text}"
-    [[ -n "$size_display" ]] && removal_note+=", ${size_display}"
-    if [[ ${#running_apps[@]} -gt 0 ]]; then
-        removal_note+=" ${YELLOW}[Running]${NC}"
-    fi
-    echo -ne "${PURPLE}${ICON_ARROW}${NC} ${removal_note}  ${GREEN}Enter${NC} confirm, ${GRAY}ESC${NC} cancel: "
+    local removal_note=""
+    _build_removal_note() {
+        removal_note="Remove ${app_total} ${app_text}"
+        [[ -n "$size_display" ]] && removal_note+=", ${size_display}"
+        if [[ ${#running_apps[@]} -gt 0 ]]; then
+            removal_note+=" ${YELLOW}[Running]${NC}"
+        fi
+    }
 
-    drain_pending_input # Clean up any pending input before confirmation
-    IFS= read -r -s -n1 key || key=""
-    drain_pending_input # Clean up any escape sequence remnants
-    case "$key" in
-        $'\e' | q | Q)
-            echo ""
-            echo ""
-            _restore_uninstall_traps
-            return 0
-            ;;
-        "" | $'\n' | $'\r' | y | Y)
-            echo "" # Move to next line
-            ;;
-        *)
-            echo ""
-            echo ""
-            _restore_uninstall_traps
-            return 0
-            ;;
-    esac
+    _build_removal_note
+    echo ""
+    echo -ne "${PURPLE}${ICON_ARROW}${NC} ${removal_note}  ${GREEN}Enter${NC} confirm, ${YELLOW}R${NC} review, ${GRAY}ESC${NC} cancel: "
+
+    while true; do
+        drain_pending_input # Clean up any pending input before confirmation
+        IFS= read -r -s -n1 key || key=""
+        drain_pending_input # Clean up any escape sequence remnants
+        case "$key" in
+            $'\e' | q | Q)
+                echo ""
+                echo ""
+                _restore_uninstall_traps
+                return 0
+                ;;
+            r | R)
+                echo ""
+                if interactive_review_files; then
+                    _recompute_uninstall_aggregates
+                    _print_files_to_remove
+                    _build_removal_note
+                fi
+                echo ""
+                echo -ne "${PURPLE}${ICON_ARROW}${NC} ${removal_note}  ${GREEN}Enter${NC} confirm, ${YELLOW}R${NC} review, ${GRAY}ESC${NC} cancel: "
+                continue
+                ;;
+            "" | $'\n' | $'\r' | y | Y)
+                echo "" # Move to next line
+                break
+                ;;
+            *)
+                echo ""
+                echo ""
+                _restore_uninstall_traps
+                return 0
+                ;;
+        esac
+    done
 
     # Enable uninstall mode - allows deletion of data-protected apps (VPNs, dev tools, etc.)
     # that user explicitly chose to uninstall. System-critical components remain protected.
@@ -574,47 +849,67 @@ batch_uninstall_applications() {
     fi
 
     # Perform uninstallations with per-app progress feedback
-    local success_count=0 failed_count=0
+    local success_count=0 failed_count=0 kept_count=0
     local brew_apps_removed=0 # Track successful brew uninstalls for silent autoremove
     local -a failed_items=()
     local -a success_items=()
+    local -a kept_items=()
     local -a local_network_warning_apps=()
     local -a system_extension_warning_apps=()
     local current_index=0
     for detail in "${app_details[@]}"; do
         current_index=$((current_index + 1))
-        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage <<< "$detail"
+        local keep_app="false"
+        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage keep_app <<< "$detail"
         local related_files=$(decode_file_list "$encoded_files" "$app_name")
         local system_files=$(decode_file_list "$encoded_system_files" "$app_name")
         local diag_system=$(decode_file_list "$encoded_diag_system" "$app_name")
         local reason=""
         local suggestion=""
 
+        # Review picker may have left an app with nothing to do (.app kept and
+        # every leftover bucket emptied). Log + skip without touching counters
+        # or spinner.
+        if [[ "$keep_app" == "true" && -z "$related_files" && -z "$system_files" && -z "$diag_system" ]]; then
+            echo -e "${GRAY}${ICON_INFO:-→} Skipped ${app_name} (all paths deselected)${NC}"
+            continue
+        fi
+
         # Show progress for current app
         local brew_tag=""
         [[ "$is_brew_cask" == "true" ]] && brew_tag=" ${CYAN}[Brew]${NC}"
+        local action_word="Uninstalling"
+        [[ "$keep_app" == "true" ]] && action_word="Cleaning leftovers for"
         if [[ -t 1 ]]; then
             if [[ ${#app_details[@]} -gt 1 ]]; then
-                start_inline_spinner "[$current_index/${#app_details[@]}] Uninstalling ${app_name}${brew_tag}..."
+                start_inline_spinner "[$current_index/${#app_details[@]}] ${action_word} ${app_name}${brew_tag}..."
             else
-                start_inline_spinner "Uninstalling ${app_name}${brew_tag}..."
+                start_inline_spinner "${action_word} ${app_name}${brew_tag}..."
             fi
         fi
 
-        # Stop Launch Agents/Daemons before removal.
+        # Always unload Launch Agents/Daemons before removing any plist on disk
+        # -- otherwise `remove_file_list` would delete a plist whose daemon is
+        # still registered with launchd (zombie until reboot). `stop_launch_services`
+        # is unload-only; plist deletion stays owned by `remove_file_list` so the
+        # review picker's selection is the source of truth for what survives.
         local has_system_files="false"
         [[ -n "$system_files" ]] && has_system_files="true"
-
         stop_launch_services "$bundle_id" "$has_system_files" "$app_path"
-        unregister_app_bundle "$app_path"
 
-        # Remove from Login Items
-        remove_login_item "$app_name" "$bundle_id"
+        if [[ "$keep_app" != "true" ]]; then
+            unregister_app_bundle "$app_path"
 
-        if ! force_kill_app "$app_name" "$app_path"; then
-            reason="still running"
+            # Remove from Login Items
+            remove_login_item "$app_name" "$bundle_id"
+
+            if ! force_kill_app "$app_name" "$app_path"; then
+                reason="still running"
+            fi
         fi
 
+        local used_brew_successfully=false
+        if [[ "$keep_app" != "true" ]]; then
         # Keep the spinner alive through the heavy work. For large apps the
         # main bundle delete alone can take many seconds; for apps with
         # 50-200 leftover files the per-file Trash moves add even more. The
@@ -630,7 +925,6 @@ batch_uninstall_applications() {
             start_inline_spinner "${_phase_prefix}Removing ${app_name} (${_phase_size})..."
         fi
 
-        local used_brew_successfully=false
         if [[ -z "$reason" ]]; then
             if [[ "$is_brew_cask" == "true" && -n "$cask_name" ]]; then
                 # Use brew_uninstall_cask helper (handles env vars, timeout, verification)
@@ -713,6 +1007,7 @@ batch_uninstall_applications() {
                 fi
             fi
         fi
+        fi # end if keep_app != true
 
         # Remove related files if app removal succeeded.
         if [[ -z "$reason" ]]; then
@@ -768,7 +1063,9 @@ batch_uninstall_applications() {
             fi
 
             # Defaults writes are side effects that should never run in dry-run mode.
-            if [[ -n "$bundle_id" && "$bundle_id" != "unknown" ]]; then
+            # Skip when the user kept the .app; they remain in control of its
+            # preference surface and only chose to drop specific files.
+            if [[ "$keep_app" != "true" && -n "$bundle_id" && "$bundle_id" != "unknown" ]]; then
                 if is_uninstall_dry_run; then
                     debug_log "[DRY RUN] Would clear defaults domain: $bundle_id"
                 else
@@ -794,11 +1091,13 @@ batch_uninstall_applications() {
             [[ -t 1 ]] && stop_inline_spinner
 
             # Show success
+            local _kept_suffix=""
+            [[ "$keep_app" == "true" ]] && _kept_suffix=" ${GRAY}(kept .app)${NC}"
             if [[ -t 1 ]]; then
                 if [[ ${#app_details[@]} -gt 1 ]]; then
-                    echo -e "${GREEN}${ICON_SUCCESS}${NC} [$current_index/${#app_details[@]}] ${app_name}"
+                    echo -e "${GREEN}${ICON_SUCCESS}${NC} [$current_index/${#app_details[@]}] ${app_name}${_kept_suffix}"
                 else
-                    echo -e "${GREEN}${ICON_SUCCESS}${NC} ${app_name}"
+                    echo -e "${GREEN}${ICON_SUCCESS}${NC} ${app_name}${_kept_suffix}"
                 fi
             fi
 
@@ -812,19 +1111,24 @@ batch_uninstall_applications() {
             fi
 
             total_size_freed=$((total_size_freed + total_kb))
-            success_count=$((success_count + 1))
             [[ "$used_brew_successfully" == "true" ]] && brew_apps_removed=$((brew_apps_removed + 1))
             files_cleaned=$((files_cleaned + 1))
             total_items=$((total_items + 1))
-            success_items+=("$app_path")
-            if [[ "$has_local_network_usage" == "true" ]]; then
-                local_network_warning_apps+=("$app_name")
-            fi
+            if [[ "$keep_app" == "true" ]]; then
+                kept_count=$((kept_count + 1))
+                kept_items+=("$app_path")
+            else
+                success_count=$((success_count + 1))
+                success_items+=("$app_path")
+                if [[ "$has_local_network_usage" == "true" ]]; then
+                    local_network_warning_apps+=("$app_name")
+                fi
 
-            # Check for orphaned system extensions (camera, network, endpoint security, etc.)
-            if [[ -n "$bundle_id" && "$bundle_id" != "unknown" && "$bundle_id" =~ ^[A-Za-z0-9._-]+$ && -d /Library/SystemExtensions ]]; then
-                if command find /Library/SystemExtensions -maxdepth 3 -name "*.systemextension" -path "*${bundle_id}*" -print -quit 2> /dev/null | grep -q .; then
-                    system_extension_warning_apps+=("$app_name")
+                # Check for orphaned system extensions (camera, network, endpoint security, etc.)
+                if [[ -n "$bundle_id" && "$bundle_id" != "unknown" && "$bundle_id" =~ ^[A-Za-z0-9._-]+$ && -d /Library/SystemExtensions ]]; then
+                    if command find /Library/SystemExtensions -maxdepth 3 -name "*.systemextension" -path "*${bundle_id}*" -print -quit 2> /dev/null | grep -q .; then
+                        system_extension_warning_apps+=("$app_name")
+                    fi
                 fi
             fi
         else
@@ -903,6 +1207,47 @@ batch_uninstall_applications() {
         fi
     fi
 
+    if [[ $kept_count -gt 0 ]]; then
+        local kept_text="app"
+        [[ $kept_count -gt 1 ]] && kept_text="apps"
+        local kept_line="Cleaned leftovers for ${kept_count} ${kept_text} (kept .app)"
+        if is_uninstall_dry_run; then
+            kept_line="Would clean leftovers for ${kept_count} ${kept_text} (kept .app)"
+        fi
+
+        if [[ ${#kept_items[@]} -gt 0 ]]; then
+            local idx=0
+            local is_first_line=true
+            local current_line=""
+
+            for kept_path in "${kept_items[@]}"; do
+                local display_name
+                display_name=$(basename "$kept_path" .app)
+                local display_item="${YELLOW}${display_name}${NC}"
+
+                if ((idx % 3 == 0)); then
+                    if [[ -n "$current_line" ]]; then
+                        summary_details+=("$current_line")
+                    fi
+                    if [[ "$is_first_line" == true ]]; then
+                        current_line="${kept_line}: $display_item"
+                        is_first_line=false
+                    else
+                        current_line="$display_item"
+                    fi
+                else
+                    current_line="$current_line, $display_item"
+                fi
+                idx=$((idx + 1))
+            done
+            if [[ -n "$current_line" ]]; then
+                summary_details+=("$current_line")
+            fi
+        else
+            summary_details+=("$kept_line")
+        fi
+    fi
+
     if [[ $failed_count -gt 0 ]]; then
         summary_status="warn"
 
@@ -942,7 +1287,7 @@ batch_uninstall_applications() {
         fi
     fi
 
-    if [[ $success_count -eq 0 && $failed_count -eq 0 ]]; then
+    if [[ $success_count -eq 0 && $failed_count -eq 0 && $kept_count -eq 0 ]]; then
         summary_status="info"
         summary_details+=("No applications were uninstalled.")
     fi

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -910,104 +910,104 @@ batch_uninstall_applications() {
 
         local used_brew_successfully=false
         if [[ "$keep_app" != "true" ]]; then
-        # Keep the spinner alive through the heavy work. For large apps the
-        # main bundle delete alone can take many seconds; for apps with
-        # 50-200 leftover files the per-file Trash moves add even more. The
-        # message is updated so the user sees which phase is running rather
-        # than a single static spinner.
-        if [[ -t 1 && -z "$reason" ]]; then
-            local _phase_size
-            _phase_size=$(bytes_to_human "$((total_kb * 1024))")
-            local _phase_prefix=""
-            if [[ ${#app_details[@]} -gt 1 ]]; then
-                _phase_prefix="[$current_index/${#app_details[@]}] "
+            # Keep the spinner alive through the heavy work. For large apps the
+            # main bundle delete alone can take many seconds; for apps with
+            # 50-200 leftover files the per-file Trash moves add even more. The
+            # message is updated so the user sees which phase is running rather
+            # than a single static spinner.
+            if [[ -t 1 && -z "$reason" ]]; then
+                local _phase_size
+                _phase_size=$(bytes_to_human "$((total_kb * 1024))")
+                local _phase_prefix=""
+                if [[ ${#app_details[@]} -gt 1 ]]; then
+                    _phase_prefix="[$current_index/${#app_details[@]}] "
+                fi
+                start_inline_spinner "${_phase_prefix}Removing ${app_name} (${_phase_size})..."
             fi
-            start_inline_spinner "${_phase_prefix}Removing ${app_name} (${_phase_size})..."
-        fi
 
-        if [[ -z "$reason" ]]; then
-            if [[ "$is_brew_cask" == "true" && -n "$cask_name" ]]; then
-                # Use brew_uninstall_cask helper (handles env vars, timeout, verification)
-                if brew_uninstall_cask "$cask_name" "$app_path"; then
-                    used_brew_successfully=true
-                else
-                    # Only fall back to manual app removal when Homebrew no longer
-                    # tracks the cask. Otherwise we would recreate the mismatch
-                    # where brew still reports the app as installed after Mole
-                    # removes the bundle manually.
-                    local cask_state=2
-                    if command -v is_brew_cask_installed > /dev/null 2>&1; then
-                        if is_brew_cask_installed "$cask_name"; then
-                            cask_state=0
+            if [[ -z "$reason" ]]; then
+                if [[ "$is_brew_cask" == "true" && -n "$cask_name" ]]; then
+                    # Use brew_uninstall_cask helper (handles env vars, timeout, verification)
+                    if brew_uninstall_cask "$cask_name" "$app_path"; then
+                        used_brew_successfully=true
+                    else
+                        # Only fall back to manual app removal when Homebrew no longer
+                        # tracks the cask. Otherwise we would recreate the mismatch
+                        # where brew still reports the app as installed after Mole
+                        # removes the bundle manually.
+                        local cask_state=2
+                        if command -v is_brew_cask_installed > /dev/null 2>&1; then
+                            if is_brew_cask_installed "$cask_name"; then
+                                cask_state=0
+                            else
+                                cask_state=$?
+                            fi
+                        fi
+
+                        if [[ $cask_state -eq 1 ]]; then
+                            if ! mole_delete "$app_path" "$needs_sudo"; then
+                                reason="brew cleanup incomplete, manual removal failed"
+                            fi
+                        elif [[ $cask_state -eq 0 ]]; then
+                            reason="brew uninstall failed, package still installed"
+                            suggestion="Run brew uninstall --cask --zap $cask_name"
                         else
-                            cask_state=$?
+                            reason="brew uninstall failed, package state unknown"
+                            suggestion="Run brew uninstall --cask --zap $cask_name"
                         fi
                     fi
-
-                    if [[ $cask_state -eq 1 ]]; then
-                        if ! mole_delete "$app_path" "$needs_sudo"; then
-                            reason="brew cleanup incomplete, manual removal failed"
+                elif [[ "$needs_sudo" == true ]]; then
+                    if [[ -L "$app_path" ]]; then
+                        local link_target
+                        link_target=$(readlink "$app_path" 2> /dev/null)
+                        if [[ -n "$link_target" ]]; then
+                            local resolved_target="$link_target"
+                            if [[ "$link_target" != /* ]]; then
+                                local link_dir
+                                link_dir=$(dirname "$app_path")
+                                resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$(dirname "$link_target")" 2> /dev/null && pwd)/$(basename "$link_target") 2> /dev/null || echo ""
+                            fi
+                            case "$resolved_target" in
+                                /System/* | /usr/bin/* | /usr/lib/* | /bin/* | /sbin/* | /private/etc/*)
+                                    reason="protected system symlink, cannot remove"
+                                    ;;
+                                *)
+                                    if ! mole_delete "$app_path" "true"; then
+                                        reason="failed to remove symlink"
+                                    fi
+                                    ;;
+                            esac
+                        else
+                            if ! mole_delete "$app_path" "true"; then
+                                reason="failed to remove symlink"
+                            fi
                         fi
-                    elif [[ $cask_state -eq 0 ]]; then
-                        reason="brew uninstall failed, package still installed"
-                        suggestion="Run brew uninstall --cask --zap $cask_name"
                     else
-                        reason="brew uninstall failed, package state unknown"
-                        suggestion="Run brew uninstall --cask --zap $cask_name"
-                    fi
-                fi
-            elif [[ "$needs_sudo" == true ]]; then
-                if [[ -L "$app_path" ]]; then
-                    local link_target
-                    link_target=$(readlink "$app_path" 2> /dev/null)
-                    if [[ -n "$link_target" ]]; then
-                        local resolved_target="$link_target"
-                        if [[ "$link_target" != /* ]]; then
-                            local link_dir
-                            link_dir=$(dirname "$app_path")
-                            resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$(dirname "$link_target")" 2> /dev/null && pwd)/$(basename "$link_target") 2> /dev/null || echo ""
-                        fi
-                        case "$resolved_target" in
-                            /System/* | /usr/bin/* | /usr/lib/* | /bin/* | /sbin/* | /private/etc/*)
-                                reason="protected system symlink, cannot remove"
-                                ;;
-                            *)
-                                if ! mole_delete "$app_path" "true"; then
-                                    reason="failed to remove symlink"
-                                fi
-                                ;;
-                        esac
-                    else
-                        if ! mole_delete "$app_path" "true"; then
-                            reason="failed to remove symlink"
+                        if is_uninstall_dry_run; then
+                            if ! mole_delete "$app_path" "false"; then
+                                reason="dry-run path validation failed"
+                            fi
+                        else
+                            local ret=0
+                            mole_delete "$app_path" "true" || ret=$?
+                            if [[ $ret -ne 0 ]]; then
+                                local diagnosis
+                                diagnosis=$(diagnose_removal_failure "$ret" "$app_name")
+                                IFS='|' read -r reason suggestion <<< "$diagnosis"
+                            fi
                         fi
                     fi
                 else
-                    if is_uninstall_dry_run; then
-                        if ! mole_delete "$app_path" "false"; then
-                            reason="dry-run path validation failed"
+                    if ! mole_delete "$app_path" "false"; then
+                        if [[ ! -w "$(dirname "$app_path")" ]]; then
+                            reason="parent directory not writable"
+                        else
+                            reason="remove failed, check permissions"
                         fi
-                    else
-                        local ret=0
-                        mole_delete "$app_path" "true" || ret=$?
-                        if [[ $ret -ne 0 ]]; then
-                            local diagnosis
-                            diagnosis=$(diagnose_removal_failure "$ret" "$app_name")
-                            IFS='|' read -r reason suggestion <<< "$diagnosis"
-                        fi
-                    fi
-                fi
-            else
-                if ! mole_delete "$app_path" "false"; then
-                    if [[ ! -w "$(dirname "$app_path")" ]]; then
-                        reason="parent directory not writable"
-                    else
-                        reason="remove failed, check permissions"
                     fi
                 fi
             fi
         fi
-        fi # end if keep_app != true
 
         # Remove related files if app removal succeeded.
         if [[ -z "$reason" ]]; then

--- a/tests/uninstall_review_files.bats
+++ b/tests/uninstall_review_files.bats
@@ -1,0 +1,317 @@
+#!/usr/bin/env bats
+
+# Tests for the per-file deselect review flow added for issue #852:
+# - `interactive_review_files` flattens / re-encodes `app_details`
+# - `_recompute_uninstall_aggregates` derives sudo / brew_cask state
+# - the confirm prompt now exposes the `R review` keystroke
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+setup() {
+    SANDBOX="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-uninstall-review.XXXXXX")"
+    export SANDBOX
+    HOME="$SANDBOX/home"
+    mkdir -p "$HOME"
+    export HOME
+    export MOLE_TEST_NO_AUTH=1
+}
+
+teardown() {
+    rm -rf "$SANDBOX"
+}
+
+# Shared prelude: load batch.sh, neutralize the interactive menu, and provide a
+# tiny helper to encode a newline-joined path list the way `app_details` rows
+# expect.
+prelude() {
+    cat <<EOF
+set -euo pipefail
+export MOLE_TEST_NO_AUTH=1
+export HOME="$HOME"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+paginated_multi_select() {
+    return "\${STUB_PAGINATED_RC:-0}"
+}
+
+enc() {
+    if [[ -z "\$1" ]]; then
+        printf ''
+    else
+        printf '%s' "\$1" | base64 | tr -d '\n'
+    fi
+}
+EOF
+}
+
+@test "interactive_review_files returns 0 with empty app_details and no menu call" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+app_details=()
+called=0
+paginated_multi_select() { called=1; return 0; }
+interactive_review_files
+echo "rc=\$?"
+echo "called=\$called"
+echo "count=\${#app_details[@]}"
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"rc=0"* ]]
+    [[ "$output" == *"called=0"* ]]
+    [[ "$output" == *"count=0"* ]]
+}
+
+@test "interactive_review_files returns 1 and leaves app_details untouched on picker cancel" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+related="\$HOME/Library/Preferences/com.x.plist"
+mkdir -p "\$(dirname "\$related")"
+: > "\$related"
+encoded="\$(enc "\$related")"
+original="App|/Applications/App.app|com.x|100|\$encoded|||false|false|||false|false"
+app_details=("\$original")
+paginated_multi_select() { return 1; }
+rc=0
+interactive_review_files || rc=\$?
+echo "rc=\$rc"
+[[ "\${app_details[0]}" == "\$original" ]] && echo "unchanged=true" || echo "unchanged=false"
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"rc=1"* ]]
+    [[ "$output" == *"unchanged=true"* ]]
+}
+
+@test "interactive_review_files keeps every preselected row when MOLE_SELECTION_RESULT echoes them all back" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+mkdir -p "\$HOME/Library/Preferences"
+f1="\$HOME/Library/Preferences/com.x.plist"
+f2="\$HOME/Library/Preferences/com.x.helper.plist"
+: > "\$f1"; : > "\$f2"
+related_in="\$f1
+\$f2"
+encoded="\$(enc "\$related_in")"
+app_details=("App|/Applications/App.app|com.x|100|\$encoded|||false|false|||false|false")
+paginated_multi_select() {
+    # 3 rows: app(0), related f1(1), related f2(2). Keep all selected.
+    MOLE_SELECTION_RESULT="0,1,2"
+    return 0
+}
+interactive_review_files
+echo "rc=\$?"
+IFS='|' read -r _ _ _ _ enc_related _ _ _ _ _ _ _ keep_app <<< "\${app_details[0]}"
+echo "keep_app=\$keep_app"
+echo "decoded:"
+printf '%s' "\$enc_related" | base64 -d
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"rc=0"* ]]
+    [[ "$output" == *"keep_app=false"* ]]
+    [[ "$output" == *"com.x.plist"* ]]
+    [[ "$output" == *"com.x.helper.plist"* ]]
+}
+
+@test "interactive_review_files drops a deselected related file and re-encodes the survivors" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+mkdir -p "\$HOME/Library/Preferences"
+f1="\$HOME/Library/Preferences/com.x.plist"
+f2="\$HOME/Library/Preferences/com.x.helper.plist"
+: > "\$f1"; : > "\$f2"
+related_in="\$f1
+\$f2"
+encoded="\$(enc "\$related_in")"
+app_details=("App|/Applications/App.app|com.x|100|\$encoded|||false|false|||false|false")
+paginated_multi_select() {
+    # Drop row 1 (the f1 preference). Keep app(0) and helper(2).
+    MOLE_SELECTION_RESULT="0,2"
+    return 0
+}
+interactive_review_files
+IFS='|' read -r _ _ _ _ enc_related _ _ _ _ _ _ _ keep_app <<< "\${app_details[0]}"
+echo "keep_app=\$keep_app"
+decoded="\$(printf '%s' "\$enc_related" | base64 -d)"
+echo "decoded=\$decoded"
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"keep_app=false"* ]]
+    [[ "$output" == *"com.x.helper.plist"* ]]
+    [[ "$output" != *"com.x.plist
+"* ]]  # bare com.x.plist line should be gone
+}
+
+@test "deselecting the .app row flips keep_app=true while leaving related files intact" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+mkdir -p "\$HOME/Library/Preferences"
+f1="\$HOME/Library/Preferences/com.x.plist"
+: > "\$f1"
+encoded="\$(enc "\$f1")"
+app_details=("App|/Applications/App.app|com.x|100|\$encoded|||false|false|||false|false")
+paginated_multi_select() {
+    # Row 0 = .app (deselected). Row 1 = related file (kept).
+    MOLE_SELECTION_RESULT="1"
+    return 0
+}
+interactive_review_files
+IFS='|' read -r _ _ _ _ enc_related _ _ _ _ _ _ _ keep_app <<< "\${app_details[0]}"
+echo "keep_app=\$keep_app"
+decoded="\$(printf '%s' "\$enc_related" | base64 -d)"
+echo "decoded=\$decoded"
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"keep_app=true"* ]]
+    [[ "$output" == *"com.x.plist"* ]]
+}
+
+@test "deselecting every row marks keep_app=true with empty buckets" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+mkdir -p "\$HOME/Library/Preferences"
+f1="\$HOME/Library/Preferences/com.x.plist"
+: > "\$f1"
+encoded="\$(enc "\$f1")"
+app_details=("App|/Applications/App.app|com.x|100|\$encoded|||false|false|||false|false")
+paginated_multi_select() {
+    MOLE_SELECTION_RESULT=""
+    return 0
+}
+interactive_review_files
+IFS='|' read -r _ _ _ _ enc_related enc_system _ _ _ _ enc_diag _ keep_app <<< "\${app_details[0]}"
+echo "keep_app=\$keep_app"
+echo "rel_len=\${#enc_related}"
+echo "sys_len=\${#enc_system}"
+echo "diag_len=\${#enc_diag}"
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"keep_app=true"* ]]
+    [[ "$output" == *"rel_len=0"* ]]
+    [[ "$output" == *"sys_len=0"* ]]
+    [[ "$output" == *"diag_len=0"* ]]
+}
+
+@test "_recompute_uninstall_aggregates drops sudo + brew_cask entries for kept apps" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+# Two apps:
+#  A: brew cask, system files present, keep_app=false  -> sudo + brew_cask
+#  B: brew cask, kept (keep_app=true), no system files -> neither
+sys_a_enc="\$(enc "/Library/LaunchDaemons/com.a.plist")"
+app_details=(
+  "A|/Applications/A.app|com.a|100|||false|true|true|caskA||false|false"
+  "B|/Applications/B.app|com.b|100|||false|true|true|caskB||false|true"
+)
+# Inject sys for A by rewriting row.
+app_details[0]="A|/Applications/A.app|com.a|100||\$sys_a_enc|false|true|true|caskA||false|false"
+sudo_apps=()
+brew_cask_apps=()
+_recompute_uninstall_aggregates
+printf 'sudo_apps='; printf '%s ' "\${sudo_apps[@]}"; echo
+printf 'brew_cask_apps='; printf '%s ' "\${brew_cask_apps[@]}"; echo
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sudo_apps=A "* ]]
+    [[ "$output" != *"sudo_apps=A B"* ]]
+    [[ "$output" == *"brew_cask_apps=A "* ]]
+    [[ "$output" != *"brew_cask_apps=A B"* ]]
+}
+
+@test "_recompute_uninstall_aggregates marks needs_sudo apps when bundle still being removed" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+# App C: not brew, no system files left, but original needs_sudo=true and keep_app=false.
+# Expectation: still in sudo_apps because mole_delete on app_path will need sudo.
+app_details=("C|/Applications/C.app|com.c|100|||false|true|false|||false|false")
+sudo_apps=()
+brew_cask_apps=()
+_recompute_uninstall_aggregates
+printf 'sudo_apps='; printf '%s ' "\${sudo_apps[@]}"; echo
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sudo_apps=C "* ]]
+}
+
+@test "confirm prompt copy advertises the R review keystroke" {
+    run grep -E 'Enter.*confirm.*R.*review.*ESC.*cancel' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "_recompute_uninstall_aggregates rebuilds total_estimated_size and size_display from current rows" {
+    run bash --noprofile --norc <<EOF
+$(prelude)
+app_details=(
+  "A|/Applications/A.app|com.a|100|||false|false|false|||false|false"
+  "B|/Applications/B.app|com.b|250|||false|false|false|||false|true"
+)
+sudo_apps=()
+brew_cask_apps=()
+total_estimated_size=99999
+size_display="STALE"
+_recompute_uninstall_aggregates
+echo "total=\$total_estimated_size"
+echo "display=\$size_display"
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"total=350"* ]]
+    [[ "$output" != *"display=STALE"* ]]
+}
+
+@test "deletion success branch routes keep_app=true rows to kept_items, not success_items" {
+    run grep -nE 'kept_items\+=\("\$app_path"\)' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
+    [ "$status" -eq 0 ]
+    run grep -nE 'kept_count=\$\(\(kept_count \+ 1\)\)' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "Dock cleanup invocation is gated to success_items only" {
+    run grep -nE 'remove_apps_from_dock "\$\{success_items\[@\]\}"' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
+    [ "$status" -eq 0 ]
+    # Negative: must NOT pass kept_items into Dock removal.
+    run grep -nE 'remove_apps_from_dock "\$\{kept_items' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
+    [ "$status" -ne 0 ]
+}
+
+# Safety regression for tw93's launch-services bug:
+# `stop_launch_services` historically deleted the plist files itself via
+# `safe_remove`/`safe_sudo_remove`, which silently overrode the picker's
+# selection. The function must be unload-only now -- plist deletion is owned by
+# `remove_file_list`, which respects the picker's surviving paths.
+@test "stop_launch_services never invokes safe_remove or safe_sudo_remove" {
+    run grep -nE '^[[:space:]]*safe_(sudo_)?remove[[:space:]]' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
+    if [ "$status" -eq 0 ]; then
+        # If any safe_remove/safe_sudo_remove appears, ensure none of them are
+        # inside stop_launch_services. Easiest: extract the function body and
+        # grep again.
+        body=$(awk '/^stop_launch_services\(\) \{/,/^}/' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh")
+        echo "$body" | grep -E '^[[:space:]]*safe_(sudo_)?remove[[:space:]]'
+        [ "$?" -ne 0 ]
+    fi
+}
+
+# Safety regression for tw93 case B (kept .app + kept LaunchDaemon plist):
+# `stop_launch_services` must run regardless of `keep_app` so the daemon is
+# unloaded before `remove_file_list` deletes its plist. Otherwise we leave a
+# zombie root daemon registered with launchd until reboot.
+@test "stop_launch_services is called outside the keep_app != true gate" {
+    # The unload call should appear before the keep_app gate that wraps the
+    # bundle-removal block, not inside it.
+    run awk '
+        /^[[:space:]]*stop_launch_services / { print NR": "$0 }
+        /^[[:space:]]*if \[\[ "\$keep_app" != "true" \]\]; then$/ { print NR": "$0 }
+    ' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
+    [ "$status" -eq 0 ]
+    # Find the line number of the first stop_launch_services call inside
+    # batch_uninstall_applications and the first keep_app gate after it. The
+    # call must come BEFORE that gate (so it always runs).
+    call_line=$(awk '/^[[:space:]]*stop_launch_services "\$bundle_id"/ { print NR; exit }' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh")
+    [ -n "$call_line" ]
+    # The keep_app gate that wraps unregister_app_bundle / remove_login_item /
+    # force_kill_app starts somewhere after $call_line. We grab the first one.
+    gate_line=$(awk -v start="$call_line" 'NR>start && /^[[:space:]]*if \[\[ "\$keep_app" != "true" \]\]; then$/ { print NR; exit }' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh")
+    [ -n "$gate_line" ]
+    [ "$call_line" -lt "$gate_line" ]
+}

--- a/tests/uninstall_review_files.bats
+++ b/tests/uninstall_review_files.bats
@@ -261,6 +261,7 @@ EOF
 }
 
 @test "deletion success branch routes keep_app=true rows to kept_items, not success_items" {
+    # shellcheck disable=SC2016 # regex pattern; literal $app_path is intentional
     run grep -nE 'kept_items\+=\("\$app_path"\)' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
     [ "$status" -eq 0 ]
     run grep -nE 'kept_count=\$\(\(kept_count \+ 1\)\)' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh"
@@ -287,8 +288,9 @@ EOF
         # inside stop_launch_services. Easiest: extract the function body and
         # grep again.
         body=$(awk '/^stop_launch_services\(\) \{/,/^}/' "${BATS_TEST_DIRNAME}/../lib/uninstall/batch.sh")
-        echo "$body" | grep -E '^[[:space:]]*safe_(sudo_)?remove[[:space:]]'
-        [ "$?" -ne 0 ]
+        if echo "$body" | grep -nE '^[[:space:]]*safe_(sudo_)?remove[[:space:]]'; then
+            return 1
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary

Closes #852. Lets the user opt OUT of individual paths during `mo uninstall` instead of removing every preference and cache as one batch.

At the existing confirm prompt, press `R` to open a review picker. Every row is preselected; SPACE deselects. Deselect a preference plist or a cache file → that path is skipped. Deselect the `.app` bundle row → the app stays on disk and only the leftover files are cleaned ("kept .app" appears in the summary).

The picker reuses the existing `paginated_multi_select` UI used for app selection. No new flag, no new subcommand, no new config option.

```
→ Remove 2 apps, 412 MB  Enter confirm, R review, ESC cancel:
```

## Safety Review

Yes — touches the uninstall path. Walked the safety boundaries carefully:

- **Picker selection is the source of truth for what gets deleted.** `stop_launch_services` is now unload-only — it never calls `safe_remove`/`safe_sudo_remove` on plists. Plist deletion is owned by `remove_file_list`, which iterates the post-review surviving paths. If the user deselects a LaunchDaemon plist in the picker, the plist stays on disk.
- **`launchctl unload` always runs before deletion**, regardless of `keep_app`. When the user keeps the `.app` but removes a LaunchDaemon plist, the daemon is unloaded first so we never strand a registered-but-fileless daemon (zombie until reboot).
- **Sudo / brew / size aggregates rebuilt from scratch after each review pass** via `_recompute_uninstall_aggregates` — kept apps drop out of `sudo_apps` and `brew_cask_apps`, system files left after deselection still trigger sudo, and `size_display` reflects the trimmed selection.
- **Kept apps don't leak into removal side effects.** `success_items` only collects fully-removed apps; `kept_items` is separate. Dock cleanup (`remove_apps_from_dock`), Local Network warnings, and System Extension warnings only fire for non-kept apps. Brew uninstall, login-item removal, `unregister_app_bundle`, `mole_delete` of the `.app`, and `defaults delete` are all gated behind `keep_app != true`.
- Bundle ID validation in `stop_launch_services` (reverse-DNS regex) is unchanged.
- Dry-run path is unchanged.

## Tests

Automated:

- `bats tests/uninstall_review_files.bats` — 14 new tests covering `interactive_review_files` flatten/picker/rebuild/cancel, `keep_app` polarity, empty-bucket edge case, sudo + brew_cask + size recompute, `kept_items` vs `success_items` routing, Dock-gating, and the two safety invariants on `stop_launch_services` (no `safe_remove`, called outside the `keep_app != true` gate).
- `bats tests/uninstall.bats tests/uninstall_remove_file_list.bats tests/uninstall_naming_variants.bats tests/brew_uninstall.bats` — full uninstall suite, no regressions.
- `bats tests/scripts.bats tests/cli.bats tests/completion.bats` — broader sanity, no regressions.
- 139/139 green across the suites above.
- `shellcheck -S warning lib/uninstall/batch.sh` clean. `bash -n` clean.

Manual:

- Walked the destructive paths in source: confirmed `remove_file_list` only touches the post-review surviving paths, confirmed `_recompute_uninstall_aggregates` runs before the sudo gate so the prompt asks for sudo only when a kept app's surviving system files actually need it.
- I have not yet exercised the picker against a real cask uninstall on a live machine — would appreciate a maintainer's eye on the brew-cask + kept-`.app` interaction in particular, since `brew_cask_apps` correctly drops kept entries but the manual cleanup path still runs for non-kept casks as before.

## Safety-related changes

Yes:

- `stop_launch_services` is now unload-only. Previously it deleted plists itself via `safe_remove`/`safe_sudo_remove`, which would override an explicit deselect from the picker. Plist removal is now exclusively owned by `remove_file_list`, which respects the picker's surviving paths.
- `stop_launch_services` is now called regardless of `keep_app`, so daemons are unloaded before any plist deletion even when the `.app` is being preserved.
- `app_details` rows gain a 13th column, `keep_app=true|false`, default `false`. Existing call sites that read 12 columns were updated; legacy rows without the 13th column would parse `keep_app` as empty, which is treated as `false` everywhere it's read.