### PR TITLE
fix: route sudo-required uninstall paths into user Trash to prevent System Data growth

### DIFF
--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -538,15 +538,14 @@ _mole_move_to_trash() {
         return 1
     fi
 
-    # Prefer the `trash` CLI (Homebrew formula) when available, it's faster
-    # and does not need Finder running. Fall back to AppleScript, which
-    # ships with macOS but prompts for auth on root-owned targets.
+    if [[ "$needs_sudo" == "true" ]]; then
+        _mole_move_sudo_path_to_user_trash "$path"
+        return $?
+    fi
+
+    # Prefer the `trash` CLI (Homebrew formula) for normal user-owned paths.
     if command -v trash > /dev/null 2>&1; then
-        if [[ "$needs_sudo" == "true" ]]; then
-            sudo trash "$path" > /dev/null 2>&1 && return 0
-        else
-            trash "$path" > /dev/null 2>&1 && return 0
-        fi
+        trash "$path" > /dev/null 2>&1 && return 0
     fi
 
     # AppleScript fallback. Pass the path via argv so special chars (quotes,
@@ -559,6 +558,98 @@ on run argv
     end tell
 end run
 APPLESCRIPT
+}
+
+_mole_move_sudo_path_to_user_trash() {
+    local path="$1"
+    local user_home=""
+
+    if declare -f get_invoking_home > /dev/null 2>&1; then
+        user_home=$(get_invoking_home)
+    else
+        user_home="${HOME:-}"
+    fi
+
+    if [[ -z "$user_home" || "$user_home" != /* || "$user_home" == "/" || "$user_home" == "/var/root" ]]; then
+        debug_log "Refusing sudo Trash move: invalid invoking user home: ${user_home:-<empty>}"
+        return 1
+    fi
+
+    if [[ -z "$path" ]] || [[ ! -e "$path" && ! -L "$path" ]]; then
+        debug_log "Refusing sudo Trash move: path does not exist: ${path:-<empty>}"
+        return 1
+    fi
+
+    local trash_dir="${user_home%/}/.Trash"
+
+    # The destination must be the invoking user's Trash, even though sudo is
+    # needed to unlink the original protected path.
+    if [[ -L "$trash_dir" ]]; then
+        debug_log "Refusing sudo Trash move: invoking user Trash is a symlink: $trash_dir"
+        return 1
+    fi
+    if ! mkdir -p "$trash_dir" 2> /dev/null; then
+        if ! sudo mkdir -p "$trash_dir" 2> /dev/null; then
+            debug_log "Failed to create invoking user Trash: $trash_dir"
+            return 1
+        fi
+    fi
+    if [[ ! -d "$trash_dir" || -L "$trash_dir" ]]; then
+        debug_log "Refusing sudo Trash move: invoking user Trash is not a normal directory: $trash_dir"
+        return 1
+    fi
+
+    local owner_uid="" owner_gid=""
+    if declare -f get_invoking_uid > /dev/null 2>&1; then
+        owner_uid=$(get_invoking_uid)
+    fi
+    if declare -f get_invoking_gid > /dev/null 2>&1; then
+        owner_gid=$(get_invoking_gid)
+    fi
+    if [[ "$owner_uid" =~ ^[0-9]+$ && "$owner_gid" =~ ^[0-9]+$ ]]; then
+        sudo chown "$owner_uid:$owner_gid" "$trash_dir" 2> /dev/null || true
+    fi
+    if ! chmod 700 "$trash_dir" 2> /dev/null; then
+        sudo chmod 700 "$trash_dir" 2> /dev/null || true
+    fi
+
+    # Avoid Finder-style ':' path weirdness and keep generated names filesystem-safe.
+    local base
+    base=$(basename "$path")
+    base="${base//:/__}"
+    base="${base//\//__}"
+    [[ -n "$base" && "$base" != "." && "$base" != ".." ]] || base="mole-trash-item"
+
+    local dest="$trash_dir/$base"
+    local ts suffix
+    ts=$(date +%s 2> /dev/null || echo 0)
+    suffix=0
+
+    while [[ -e "$dest" || -L "$dest" ]]; do
+        suffix=$((suffix + 1))
+        if [[ $suffix -gt 100 ]]; then
+            debug_log "Failed to choose unique Trash destination for: $path"
+            return 1
+        fi
+        dest="$trash_dir/$base.$ts.$$.$suffix"
+    done
+
+    if ! sudo mv -n "$path" "$dest" > /dev/null 2>&1; then
+        debug_log "Failed to move sudo-required path to invoking user Trash: $path -> $dest"
+        return 1
+    fi
+    if [[ -e "$path" || -L "$path" ]] || [[ ! -e "$dest" && ! -L "$dest" ]]; then
+        debug_log "Failed to move sudo-required path without overwriting destination: $path -> $dest"
+        return 1
+    fi
+
+    # Best-effort ownership repair makes restored Trash items behave like user files.
+    if [[ "$owner_uid" =~ ^[0-9]+$ && "$owner_gid" =~ ^[0-9]+$ ]]; then
+        sudo chown -R "$owner_uid:$owner_gid" "$dest" 2> /dev/null || true
+    fi
+
+    debug_log "Moved sudo-required path to invoking user Trash: $path -> $dest"
+    return 0
 }
 
 # Batched Trash move for non-sudo, non-symlink paths. Removes the per-file

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -66,6 +66,135 @@ EOF
     [[ -n "$(ls -A "$MOLE_TEST_TRASH_DIR" 2> /dev/null || true)" ]]
 }
 
+@test "mole_delete moves sudo-required paths to invoking user Trash" {
+    local victim="$SANDBOX/victim_sudo_trash"
+    local fake_bin="$SANDBOX/bin"
+    local fake_home="$SANDBOX/home"
+    local trace="$SANDBOX/trace.log"
+
+    mkdir -p "$fake_bin" "$fake_home"
+    mkdir -p "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    cat > "$fake_bin/trash" <<'SH'
+#!/bin/bash
+printf 'trash %s\n' "$*" >> "$MOLE_TEST_TRACE"
+exit 99
+SH
+    cat > "$fake_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >> "$MOLE_TEST_TRACE"
+"$@"
+SH
+    cat > "$fake_bin/osascript" <<'SH'
+#!/bin/bash
+printf 'osascript %s\n' "$*" >> "$MOLE_TEST_TRACE"
+exit 98
+SH
+    chmod +x "$fake_bin/trash" "$fake_bin/sudo" "$fake_bin/osascript"
+
+    run bash --noprofile --norc <<EOF
+$(prelude)
+unset MOLE_TEST_TRASH_DIR
+unset MOLE_TEST_NO_AUTH
+export MOLE_DELETE_MODE=trash
+export PATH="$fake_bin:\$PATH"
+export HOME="$fake_home"
+export MOLE_TEST_TRACE="$trace"
+mole_delete "$victim" true
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ ! -e "$victim" ]]
+    [[ -d "$fake_home/.Trash/$(basename "$victim")" ]]
+    [[ "$(grep -c '^sudo mv ' "$trace" 2> /dev/null || true)" -eq 1 ]]
+    [[ "$(grep -c '^sudo trash ' "$trace" 2> /dev/null || true)" -eq 0 ]]
+    [[ "$(grep -c '^trash ' "$trace" 2> /dev/null || true)" -eq 0 ]]
+    [[ "$(grep -c '^osascript ' "$trace" 2> /dev/null || true)" -eq 0 ]]
+
+    local status_col
+    status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
+    [ "$status_col" = "ok" ]
+}
+
+@test "mole_delete refuses symlinked invoking user Trash for sudo-required paths" {
+    local victim="$SANDBOX/victim_sudo_symlink_trash"
+    local fake_bin="$SANDBOX/bin"
+    local fake_home="$SANDBOX/home"
+    local redirected="$SANDBOX/redirected"
+    local trace="$SANDBOX/trace.log"
+
+    mkdir -p "$fake_bin" "$fake_home" "$redirected" "$victim"
+    printf 'payload' > "$victim/data.txt"
+    ln -s "$redirected" "$fake_home/.Trash"
+
+    cat > "$fake_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >> "$MOLE_TEST_TRACE"
+"$@"
+SH
+    chmod +x "$fake_bin/sudo"
+
+    run bash --noprofile --norc <<EOF
+$(prelude)
+unset MOLE_TEST_TRASH_DIR
+unset MOLE_TEST_NO_AUTH
+export MOLE_DELETE_MODE=trash
+export PATH="$fake_bin:\$PATH"
+export HOME="$fake_home"
+export MOLE_TEST_TRACE="$trace"
+mole_delete "$victim" true
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ ! -e "$victim" ]]
+    [[ -z "$(ls -A "$redirected" 2> /dev/null || true)" ]]
+    [[ "$(grep -c '^sudo mv ' "$trace" 2> /dev/null || true)" -eq 0 ]]
+
+    local status_col
+    status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
+    [ "$status_col" = "trash-fallback-rm" ]
+}
+
+@test "mole_delete uses unique Trash name for sudo-required path conflicts" {
+    local victim="$SANDBOX/conflict_app"
+    local fake_bin="$SANDBOX/bin"
+    local fake_home="$SANDBOX/home"
+    local trace="$SANDBOX/trace.log"
+
+    mkdir -p "$fake_bin" "$fake_home/.Trash" "$victim"
+    printf 'payload' > "$victim/data.txt"
+    mkdir -p "$fake_home/.Trash/$(basename "$victim")"
+
+    cat > "$fake_bin/sudo" <<'SH'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >> "$MOLE_TEST_TRACE"
+"$@"
+SH
+    chmod +x "$fake_bin/sudo"
+
+    run bash --noprofile --norc <<EOF
+$(prelude)
+unset MOLE_TEST_TRASH_DIR
+unset MOLE_TEST_NO_AUTH
+export MOLE_DELETE_MODE=trash
+export PATH="$fake_bin:\$PATH"
+export HOME="$fake_home"
+export MOLE_TEST_TRACE="$trace"
+mole_delete "$victim" true
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ ! -e "$victim" ]]
+    [[ -d "$fake_home/.Trash/$(basename "$victim")" ]]
+    [[ -n "$(find "$fake_home/.Trash" -mindepth 1 -maxdepth 1 -name "$(basename "$victim").*" -print -quit)" ]]
+    [[ "$(grep -c '^sudo mv -n ' "$trace" 2> /dev/null || true)" -eq 1 ]]
+
+    local status_col
+    status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
+    [ "$status_col" = "ok" ]
+}
+
 @test "mole_delete writes a tab-separated log line per call" {
     local victim="$SANDBOX/logged"
     : > "$victim"


### PR DESCRIPTION
## Summary
- Fix: sudo‑required files now move into the user’s `~/.Trash` instead of root’s hidden `/var/root/.Trash`.
- Stops “System Data” bloat; users can now see, restore, and manage those files via Finder.
- Uses a new function `_mole_move_sudo_path_to_user_trash` with `sudo mv`, ownership repair, safe home resolution, and fallback to permanent delete on failure.

## Safety Review
- **Affected behaviour:** Uninstall, remove, analyze delete (only files needing `sudo`). User‑owned file handling stays the same.
- **New boundary:** Admin‑assisted move from protected dirs into the user’s Trash, with:
  - Strict home dir validation (rejects `/`, `/var/root`, etc.).
  - User‑owned `~/.Trash` at `700` permissions.
  - Filename sanitisation and conflict resolution (timestamp/PID/suffix).
  - No cross‑volume risk; always falls back to permanent delete if the trash move fails.

## Tests
- **Automated:** `bash -n lib/core/file_ops.sh` ✔; dedicated Bats test with faked `sudo`, `trash`, `osascript` verifies only `sudo mv` is used; full suite: 754 tests, 0 failures, 15 skipped.
- **Manual:** Verified Finder visibility, “Put Back” restore, correct user ownership, safe renaming of duplicates, and graceful fallback on unwritable Trash.

## Safety‑related changes
None.