### PR TITLE
Improve cleanup precision and safety

### DIFF
--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -1571,6 +1571,25 @@ app_support_item_size_bytes() {
     return 1
 }
 
+app_support_dir_has_regenerable_cache_markers() {
+    local app_dir="$1"
+    local marker
+
+    for marker in \
+        "$app_dir/Code Cache" \
+        "$app_dir/GPUCache" \
+        "$app_dir/DawnCache" \
+        "$app_dir/GrShaderCache" \
+        "$app_dir/GraphiteDawnCache" \
+        "$app_dir/DawnGraphiteCache" \
+        "$app_dir/DawnWebGPUCache" \
+        "$app_dir/Crashpad"; do
+        [[ -e "$marker" ]] && return 0
+    done
+
+    return 1
+}
+
 # Application Support logs/caches.
 clean_application_support_logs() {
     if [[ ! -d "$HOME/Library/Application Support" ]] || ! ls "$HOME/Library/Application Support" > /dev/null 2>&1; then
@@ -1640,8 +1659,16 @@ clean_application_support_logs() {
             "$app_dir/DawnCache"
             "$app_dir/GrShaderCache"
             "$app_dir/GraphiteDawnCache"
+            "$app_dir/DawnGraphiteCache"
+            "$app_dir/DawnWebGPUCache"
             "$app_dir/Crashpad/completed"
         )
+        if app_support_dir_has_regenerable_cache_markers "$app_dir"; then
+            start_candidates+=(
+                "$app_dir/Cache"
+                "$app_dir/CachedData"
+            )
+        fi
         for candidate in "${start_candidates[@]}"; do
             if [[ -d "$candidate" ]]; then
                 if should_protect_path "$candidate" 2> /dev/null || is_path_whitelisted "$candidate" 2> /dev/null; then

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -444,6 +444,7 @@ readonly DATA_PROTECTED_BUNDLES=(
 
     # Design & Creative
     "com.adobe.*"
+    "com.avid.mediacomposer*"
     "com.bohemiancoding.*"
     "com.figma.*"
     "com.framerx.*"
@@ -459,6 +460,13 @@ readonly DATA_PROTECTED_BUNDLES=(
     "com.maxon.cinema4d"
     "com.autodesk.*"
     "com.sketchup.*"
+    "com.native-instruments.*"
+    "com.fabfilter.*"
+    "com.paceap.*"
+    "com.izotope.*"
+    "iZotope"
+    "com.lasersoft-imaging.*"
+    "app.cotypist.Cotypist"
 
     # Communication
     "com.tencent.xinWeChat"
@@ -575,6 +583,8 @@ readonly DATA_PROTECTED_BUNDLES=(
     "org.mozilla.*"
 
     # Scientific & Professional Software
+    "com.crowdstrike.*"
+    "com.kolide.*"
     "com.sas.*"
     "com.mathworks.*"
     "com.ibm.spss.*"
@@ -585,6 +595,7 @@ readonly DATA_PROTECTED_BUNDLES=(
 
     # License & App Stores
     "com.paddle.Paddle*"
+    "com.quicken.*"
     "com.setapp.DesktopClient"
     "com.devmate.*"
     "org.sparkle-project.Sparkle*"
@@ -852,6 +863,53 @@ should_protect_path() {
             ;;
         # iCloud Drive - protect user's cloud synced data
         */Library/Mobile\ Documents* | */Mobile\ Documents*)
+            return 0
+            ;;
+        # High-risk cleanup denylist: these cache/preferences paths are known
+        # to contain license, account, plugin, MDM, or system-service state
+        # despite cache-like names. Keep this as a protection overlay only; it
+        # is not a cleanup allowlist.
+        */Library/Accounts | */Library/Accounts/* | \
+            */Library/Keychains | */Library/Keychains/* | \
+            */Library/Mail | */Library/Mail/* | \
+            */Library/Calendars | \
+            */Library/Contacts | */Library/Contacts/*)
+            return 0
+            ;;
+        /Library/Audio/Plug-Ins/Components | /Library/Audio/Plug-Ins/Components/* | \
+            /Library/Audio/Plug-Ins/VST | /Library/Audio/Plug-Ins/VST/* | \
+            /Library/Audio/Plug-Ins/VST3 | /Library/Audio/Plug-Ins/VST3/* | \
+            /Library/Application\ Support/iZotope | /Library/Application\ Support/iZotope/* | \
+            */Library/Application\ Support/iZotope | */Library/Application\ Support/iZotope/* | \
+            /Library/Application\ Support/LaserSoft\ Imaging | /Library/Application\ Support/LaserSoft\ Imaging/*)
+            return 0
+            ;;
+        */Library/Preferences/com.native-instruments* | \
+            */Library/Preferences/com.avid.mediacomposer*.plist | \
+            */Library/Preferences/com.fabfilter.*.[0-9].plist | \
+            */Library/Preferences/com.fabfilter.*.[0-9][0-9].plist | \
+            */Library/Preferences/com.paceap.*.plist)
+            return 0
+            ;;
+        /private/var/folders/*/C/com.native-instruments* | \
+            /private/var/folders/*/C/com.avid.mediacomposer* | \
+            /private/var/folders/*/C/com.paceap.eden.iLokLicenseManager*)
+            return 0
+            ;;
+        */Library/Caches/ms-playwright | */Library/Caches/ms-playwright/* | \
+            */Library/Caches/app.cotypist.Cotypist | */Library/Caches/app.cotypist.Cotypist/* | \
+            */Library/Caches/com.displaylink.DisplayLinkUserAgent | */Library/Caches/com.displaylink.DisplayLinkUserAgent/* | \
+            */Library/Caches/com.lasersoft-imaging.SilverFast9 | */Library/Caches/com.lasersoft-imaging.SilverFast9/* | \
+            */Library/Caches/com.lasersoft-imaging.SilverFast-9-Installer | */Library/Caches/com.lasersoft-imaging.SilverFast-9-Installer/* | \
+            */Library/Caches/Adobe\ * | \
+            */Library/Caches/*\ Adobe* | \
+            */Library/Caches/com.apple.containermanagerd | */Library/Caches/com.apple.containermanagerd/* | \
+            */Library/Caches/com.apple.homed | */Library/Caches/com.apple.homed/* | \
+            */Library/Caches/com.apple.ap.adprivacyd | */Library/Caches/com.apple.ap.adprivacyd/* | \
+            */Library/Caches/FamilyCircle | */Library/Caches/FamilyCircle/* | \
+            */Library/Caches/com.apple.HomeKit | */Library/Caches/com.apple.HomeKit/* | \
+            */Library/Caches/com.apple.WorkflowKit.BackgroundShortcutRunner.ShortcutsSandboxCache | */Library/Caches/com.apple.WorkflowKit.BackgroundShortcutRunner.ShortcutsSandboxCache/* | \
+            */Library/Caches/com.apple.siriactionsd.ShortcutsSandboxCache | */Library/Caches/com.apple.siriactionsd.ShortcutsSandboxCache/*)
             return 0
             ;;
         # CoreAudio and audio subsystem caches (issue #553)

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -156,7 +156,7 @@ EOF
     [[ "$output" != *"Library/Autosave Information"* ]]
 }
 
-@test "clean_app_caches includes CleanMyMac-observed Apple cache families" {
+@test "clean_app_caches includes additional Apple cache families" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -400,6 +400,46 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" != *"REMOVE:"* ]]
+}
+
+@test "clean_application_support_logs cleans Electron-style Cache only when cache markers exist" {
+    local support_home="$HOME/support-appsupport-electron-cache"
+    run env HOME="$support_home" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+mkdir -p "$HOME"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+update_progress_if_needed() { return 1; }
+should_protect_data() { return 1; }
+is_critical_system_component() { return 1; }
+WHITELIST_PATTERNS=()
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+mkdir -p "$HOME/Library/Application Support/ElectronLike/Code Cache"
+mkdir -p "$HOME/Library/Application Support/ElectronLike/Cache"
+mkdir -p "$HOME/Library/Application Support/ElectronLike/CachedData"
+touch "$HOME/Library/Application Support/ElectronLike/Code Cache/runtime.bin"
+touch "$HOME/Library/Application Support/ElectronLike/Cache/http-cache"
+touch "$HOME/Library/Application Support/ElectronLike/CachedData/v8-data"
+
+mkdir -p "$HOME/Library/Application Support/PlainApp/Cache"
+touch "$HOME/Library/Application Support/PlainApp/Cache/keep.db"
+
+clean_application_support_logs
+
+test ! -e "$HOME/Library/Application Support/ElectronLike/Code Cache/runtime.bin"
+test ! -e "$HOME/Library/Application Support/ElectronLike/Cache/http-cache"
+test ! -e "$HOME/Library/Application Support/ElectronLike/CachedData/v8-data"
+test -e "$HOME/Library/Application Support/PlainApp/Cache/keep.db"
+rm -rf "$HOME/Library/Application Support"
+EOF
+
+    [ "$status" -eq 0 ]
 }
 
 @test "clean_application_support_logs skips whitelisted application support directories" {

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -93,6 +93,20 @@ teardown() {
     [[ "$output" == *"critical system directory"* ]]
 }
 
+@test "should_protect_path applies high-risk cleanup denylist" {
+    run bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        should_protect_path '$HOME/Library/Caches/ms-playwright/chromium-123'
+        should_protect_path '$HOME/Library/Caches/com.apple.homed/state'
+        should_protect_path '$HOME/Library/Preferences/com.paceap.eden.iLokLicenseManager.plist'
+        should_protect_path '/private/var/folders/aa/bb/C/com.native-instruments.NativeAccess/license'
+        should_protect_path '/Library/Audio/Plug-Ins/VST3/Example.vst3'
+        should_protect_data 'com.native-instruments.NativeAccess'
+        ! should_protect_path '$HOME/Library/Application Support/Example/Cache/item'
+    "
+    [ "$status" -eq 0 ]
+}
+
 @test "safe_remove validates path before deletion" {
     run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; safe_remove '/System/test' 2>&1"
     [ "$status" -eq 1 ]


### PR DESCRIPTION
Summary: add a high-risk cleanup protection overlay and expand Application Support cleanup only for directories with clear regenerable cache markers. Tests: bats tests/core_safe_functions.bats tests/clean_user_core.bats; ./scripts/check.sh --no-format; MOLE_TEST_NO_AUTH=1 ./scripts/test.sh; MOLE_TEST_NO_AUTH=1 ./mole clean --dry-run.