### PR TITLE
fix(uninstall): guard empty array expansion for bash 3.2 compat

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -769,7 +769,7 @@ scan_applications() {
     ) &
     spinner_pid=$!
 
-    for app_data_tuple in "${app_data_tuples[@]}"; do
+    for app_data_tuple in "${app_data_tuples[@]+"${app_data_tuples[@]}"}"; do
         ((app_count++))
         process_app_metadata "$app_data_tuple" "$scan_raw_file" &
         pids+=($!)
@@ -781,7 +781,7 @@ scan_applications() {
         fi
     done
 
-    for pid in "${pids[@]}"; do
+    for pid in "${pids[@]+"${pids[@]}"}"; do
         wait "$pid" 2> /dev/null
     done
 


### PR DESCRIPTION
## Summary

Fixes #863. `mo uninstall` crashes immediately with `app_data_tuples[@]: unbound variable` and the spinner loops forever.

## Root cause

`bin/uninstall.sh` line 6 sets `set -euo pipefail`. Under bash 3.2 (macOS default), expanding an empty array via `"${arr[@]}"` triggers nounset. When every discovered `.app` is already cached, `app_data_tuples` stays empty, and the `for` loop at line 772 dies before the scan ever runs. The downstream `pids` loop has the same shape.

## Fix

Use the bash 3.2-safe expansion `"${arr[@]+"${arr[@]}"}"` for both loops — expands to nothing when the array has 0 elements, identical behavior when non-empty.

## Test plan

- [x] `bats tests/` → 763/763 pass locally
- [x] Reproduced original error path by forcing all apps into cache → loop now no-ops cleanly instead of erroring