### PR TITLE
fix(uninstall): guard empty app_data_tuples iteration on bash 3.2 (#863)

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -769,21 +769,26 @@ scan_applications() {
     ) &
     spinner_pid=$!
 
-    for app_data_tuple in "${app_data_tuples[@]}"; do
-        ((app_count++))
-        process_app_metadata "$app_data_tuple" "$scan_raw_file" &
-        pids+=($!)
-        update_scan_status "Scanning applications..." "$app_count" "$total_apps"
+    # Skip Pass 2 when the warm cache already wrote every row to $scan_raw_file.
+    # Also avoids expanding an empty array — macOS bash 3.2 (the /bin/bash that
+    # this script targets) treats `"${empty[@]}"` as unbound under `set -u`.
+    if ((total_apps > 0)); then
+        for app_data_tuple in "${app_data_tuples[@]}"; do
+            ((app_count++))
+            process_app_metadata "$app_data_tuple" "$scan_raw_file" &
+            pids+=($!)
+            update_scan_status "Scanning applications..." "$app_count" "$total_apps"
 
-        if ((${#pids[@]} >= max_parallel)); then
-            wait "${pids[0]}" 2> /dev/null
-            pids=("${pids[@]:1}")
-        fi
-    done
+            if ((${#pids[@]} >= max_parallel)); then
+                wait "${pids[0]}" 2> /dev/null
+                pids=("${pids[@]:1}")
+            fi
+        done
 
-    for pid in "${pids[@]}"; do
-        wait "$pid" 2> /dev/null
-    done
+        for pid in "${pids[@]}"; do
+            wait "$pid" 2> /dev/null
+        done
+    fi
 
     update_scan_status "Building uninstall index..." "0" "0"
 

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -119,5 +119,9 @@ EOF
 		cat "$HOME/scan.err" >&2 2> /dev/null || true
 		false
 	}
-	! grep -q 'unbound variable' "$HOME/scan.err" 2> /dev/null
+	# Use `run` + status check rather than bare `! grep`: bats SC2314 rejects
+	# a trailing `!` because earlier bats versions ignored it. `run` records
+	# the inverted status explicitly so the assertion is portable.
+	run grep -q 'unbound variable' "$HOME/scan.err"
+	[ "$status" -ne 0 ]
 }

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+# Regression for #863 — "Can't Open App List, Scanning forever."
+#
+# macOS ships /bin/bash 3.2 (Apple does not upgrade past it, GPLv3). The
+# bin/uninstall.sh shebang is `#!/bin/bash`, so the installed script runs
+# under 3.2 regardless of any Homebrew bash also on the system. Under
+# `set -u`, bash 3.2 treats `"${empty_array[@]}"` as an unbound expansion
+# rather than expanding to zero elements.
+#
+# scan_applications declares `local -a app_data_tuples=()` and only appends
+# rows for apps that miss the warm metadata cache (uncached_rows_file). When
+# every discovered app is satisfied by the cache, app_data_tuples stays
+# empty while scan_raw_file is non-empty (use_cached_scan_metadata already
+# wrote rows to it). The early-return at the `[[ ... && ! -s ... ]]` guard
+# therefore does not fire, and the subsequent `for ... in
+# "${app_data_tuples[@]}"` iteration aborts with
+# "app_data_tuples[@]: unbound variable".
+
+setup_file() {
+	PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+	export PROJECT_ROOT
+}
+
+setup() {
+	HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-scan-bash32.XXXXXX")"
+	export HOME
+	export TERM="dumb"
+}
+
+teardown() {
+	rm -rf "$HOME"
+}
+
+# Build a sourceable copy of bin/uninstall.sh: rewrites SCRIPT_DIR so library
+# sources resolve, and strips the `main "$@"` invocation so we can drive
+# scan_applications directly. Mirrors tests/performance_uninstall_scan.sh.
+sourceable_uninstall_sh() {
+	local out="$1"
+	awk -v script_dir="$PROJECT_ROOT/bin" '
+		/^SCRIPT_DIR=/ { print "SCRIPT_DIR=\"" script_dir "\""; next }
+		/^main "\$@"/ { print "# main skipped by test"; next }
+		{ print }
+	' "$PROJECT_ROOT/bin/uninstall.sh" > "$out"
+}
+
+@test "scan_applications: Pass 2 tolerates empty app_data_tuples on /bin/bash 3.2 (#863)" {
+	src="$HOME/uninstall_source.sh"
+	sourceable_uninstall_sh "$src"
+
+	apps_root="$HOME/Applications"
+	mkdir -p "$apps_root/TestApp.app/Contents"
+	: > "$apps_root/TestApp.app/Contents/Info.plist"
+
+	# Seed the warm metadata cache so that the one discovered app
+	# (TestApp.app) is a cache hit: matching mtime, non-empty bundle id
+	# and display name are the conditions the awk classifier and
+	# use_cached_scan_metadata require for the cached branch to "stick".
+	app_mtime="$(stat -f %m "$apps_root/TestApp.app")"
+	cache_dir="$HOME/.cache/mole"
+	mkdir -p "$cache_dir"
+	printf '%s|%s|0|0|0|com.test.TestApp|TestApp\n' \
+		"$apps_root/TestApp.app" "$app_mtime" \
+		> "$cache_dir/uninstall_app_metadata_v1"
+
+	done_marker="$HOME/scan.done"
+
+	# The bug not only emits "unbound variable" — the spinner subshell
+	# `( ... ) &` launched just before the failing iteration keeps running
+	# after the parent script errors out (its `while true` loop has no
+	# inherited signal). The user-visible symptom is exactly "scanning
+	# forever". Mirror the marker-file watchdog from the #722 hang test
+	# (uninstall.bats: "uninstall_persist_cache_file does not hang…") so a
+	# regression surfaces as HANG rather than blocking the whole bats run.
+	(
+		env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+			MOLE_TEST_NO_AUTH=1 \
+			APPS_ROOT="$apps_root" SRC_PATH="$src" \
+			/bin/bash --noprofile --norc <<'EOF' > "$HOME/scan.out" 2> "$HOME/scan.err"
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$SRC_PATH"
+
+# Restrict the discovered search dirs to our sandboxed Applications folder
+# so scan_applications does not pick up real /Applications and dilute the
+# all-cached condition we are exercising.
+uninstall_print_app_search_dirs() { printf '%s\n' "$APPS_ROOT"; }
+
+# Bundle-id resolution would otherwise call /usr/bin/mdls and reject our
+# placeholder Info.plist. The cached branch only needs an echo-through here.
+uninstall_resolve_eligible_bundle_id() { printf '%s\n' "${2:-${1##*/}}"; }
+
+scan_applications > /dev/null
+EOF
+		: > "$done_marker"
+	) &
+	bgpid=$!
+
+	# Poll for completion marker for up to ~5s.
+	for _ in $(seq 1 50); do
+		[[ -e "$done_marker" ]] && break
+		sleep 0.1
+	done
+
+	status_msg=""
+	if [[ ! -e "$done_marker" ]]; then
+		kill -TERM "$bgpid" 2> /dev/null || true
+		# Reap the orphaned spinner subshell so it does not leak into the
+		# next test or the rest of the run.
+		pkill -P "$bgpid" 2> /dev/null || true
+		status_msg="HANG"
+	fi
+	wait "$bgpid" 2> /dev/null || true
+
+	[[ -z "$status_msg" ]] || {
+		echo "scan_applications hung — Pass 2 guard regressed" >&2
+		echo "stderr captured:" >&2
+		cat "$HOME/scan.err" >&2 2> /dev/null || true
+		false
+	}
+	! grep -q 'unbound variable' "$HOME/scan.err" 2> /dev/null
+}


### PR DESCRIPTION
## Summary

Fix for #863. macOS `/bin/bash` is 3.2.x — Apple does not upgrade past it (GPLv3 incompatibility). Under `set -u`, bash 3.2 treats `"${empty_array[@]}"` as an unbound expansion rather than expanding to zero elements. `scan_applications` declares `local -a app_data_tuples=()` and iterates it later; when the warm metadata cache satisfies every discovered app, the iteration aborts with `app_data_tuples[@]: unbound variable`, leaving the spinner subshell orphaned (user sees "scanning forever").

## Reproduction

The bash-3.2 quirk under `set -u`:

```bash
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ /bin/bash -c 'set -euo pipefail
foo() { local -a arr=(); for x in "${arr[@]}"; do :; done; }
foo'
/bin/bash: arr[@]: unbound variable

$ /opt/homebrew/bin/bash -c 'set -euo pipefail
foo() { local -a arr=(); for x in "${arr[@]}"; do :; done; echo done; }
foo'
done
```

In `scan_applications`, the trigger condition is:

- `discovered_file` non-empty (apps were found),
- every discovered app matched the warm cache (awk sent them to `cached_rows_file`),
- `use_cached_scan_metadata` accepted them (rows appended to `$scan_raw_file`),
- → `app_data_tuples` stays empty while `$scan_raw_file` is non-empty,
- → the early-return at `[[ ${#arr[@]} -eq 0 && ! -s "$scan_raw_file" ]]` does not fire,
- → execution reaches the `for ... in "${app_data_tuples[@]}"` loop and aborts on bash 3.2.

`${#arr[@]}` (length) at lines 703/713 is fine — bash 3.2 only chokes on full expansion `"${arr[@]}"`, not on `${#arr[@]}`.

## Fix

Guard Pass 2 with `if ((total_apps > 0))`. Semantically correct: when every discovered app was resolved by the warm cache, the cached rows are already in `$scan_raw_file`, so there is no per-app metadata work for Pass 2 to launch. The guard also avoids the empty-array expansion that trips bash 3.2.

## Tests

New `tests/uninstall_scan_bash32.bats`:

- Sandboxes `HOME`; creates a single `Applications/TestApp.app` placeholder.
- Pre-seeds `~/.cache/mole/uninstall_app_metadata_v1` with a row whose mtime matches the placeholder, so the awk split sends our app to the cached branch.
- Sources `bin/uninstall.sh` via the awk-strip-main pattern already used by `tests/performance_uninstall_scan.sh`.
- Overrides `uninstall_print_app_search_dirs` (to narrow the scan to the sandbox) and `uninstall_resolve_eligible_bundle_id` (the placeholder `Info.plist` would otherwise fail `mdls` resolution).
- Invokes `scan_applications` under `/bin/bash --noprofile --norc` inside a marker-file watchdog (mirrors the `#722` hang test in `tests/uninstall.bats`) so a regression surfaces as a fast failure rather than hanging the whole bats run on the orphaned spinner.
- Asserts no `unbound variable` on stderr and no watchdog timeout.

Verified the test is a real regression: removing the guard makes it fail on the stderr grep within ~5s. Full suite remains green:

- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats` — 43/43
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_naming_variants.bats` — 12/12
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_scan_bash32.bats` — 1/1

## Adjacent risk (not addressed here)

The same bash-3.2 empty-array hazard applies to a handful of other expansions in `bin/uninstall.sh` (lines 330, 406, 640, 657, 1113, 1123, 1154, 1404, 1505, 1539, 1561). Each is reachable only when its source array can be empty along some path. I kept this PR narrow to the reported bug (lines 772 and 784 in the same flow are both guarded by the single `if`); happy to do a follow-up audit if you'd prefer that done as a separate sweep.

## Validation

```bash
./scripts/check.sh --no-format
MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats tests/uninstall_naming_variants.bats tests/uninstall_scan_bash32.bats
HOME=$(mktemp -d) /bin/bash bin/uninstall.sh --list   # cold: exit 0, JSON output
# Re-run to exercise the warm path: exit 0, no "unbound variable"
```