### PR TITLE
fix: resolve unbound variable error in pycache_has_bytecode

### DIFF
--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -207,12 +207,14 @@ pycache_has_bytecode() {
     local pycache_dir="$1"
     [[ -d "$pycache_dir" ]] || return 1
 
+    local prev_nullglob
+    prev_nullglob=$(shopt -p nullglob || true)
+    shopt -s nullglob
     local -a bytecode_files=("$pycache_dir"/*.pyc "$pycache_dir"/*.pyo)
-    local bytecode_file
-    for bytecode_file in "${bytecode_files[@]}"; do
-        [[ -e "$bytecode_file" ]] && return 0
-    done
-    return 1
+    $prev_nullglob
+
+    [[ ${#bytecode_files[@]} -eq 0 ]] && return 1
+    return 0
 }
 
 # Scan a project root for supported build caches while pruning heavy subtrees.


### PR DESCRIPTION
## Bug

Running `mo clean` crashes with:

```
caches.sh: line 206: bytecode_files[@]: unbound variable
```

This happens during the "Searching project caches..." phase.

## Root Cause

The script uses `set -euo pipefail` (line 3), where `-u` treats unset variables as errors. In `pycache_has_bytecode()` (line 206), when a `__pycache__` directory contains no `.pyc` or `.pyo` files, the glob pattern doesn't match any files. In bash, unmatched globs are kept as literal strings by default, but under certain conditions the array expansion `${bytecode_files[@]}` triggers the `unbound variable` error.

## Fix

Enable `nullglob` before the glob expansion so that unmatched patterns expand to nothing (empty array), then check `${#bytecode_files[@]}` instead of iterating. The previous `nullglob` state is saved and restored to avoid side effects.

**Before:**
```bash
local -a bytecode_files=("$pycache_dir"/*.pyc "$pycache_dir"/*.pyo)
local bytecode_file
for bytecode_file in "${bytecode_files[@]}"; do
    [[ -e "$bytecode_file" ]] && return 0
done
return 1
```

**After:**
```bash
local prev_nullglob
prev_nullglob=$(shopt -p nullglob || true)
shopt -s nullglob
local -a bytecode_files=("$pycache_dir"/*.pyc "$pycache_dir"/*.pyo)
$prev_nullglob

[[ ${#bytecode_files[@]} -eq 0 ]] && return 1
return 0
```

## Test

```bash
set -euo pipefail
# Empty __pycache__ — no crash, returns 1 ✅
# __pycache__ with .pyc — returns 0 ✅
# Nonexistent directory — returns 1 ✅
```

## Environment

- macOS 26.4.1 (Apple M4 Pro)
- Mole latest (installed via `mo update`)
- bash 3.2.57 (macOS default)