### PR TITLE
feat(clean): colorize dry-run sizes by unit

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -751,7 +751,9 @@ safe_clean() {
         fi
 
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $label${NC}, ${YELLOW}$size_human dry${NC}"
+            local size_display
+            size_display=$(colorize_human_size "$size_human")
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $label${NC}, ${size_display} ${YELLOW}dry${NC}"
 
             local paths_temp
             paths_temp=$(create_temp_file)
@@ -974,7 +976,7 @@ perform_cleanup() {
         fi
         if [[ "$DRY_RUN" == "true" ]]; then
             echo ""
-            echo "Potential space: 0.00GB"
+            echo -e "Potential space: $(colorize_human_size "0.00GB")"
         fi
         total_items=1
         files_cleaned=0
@@ -1191,7 +1193,7 @@ perform_cleanup() {
         freed_size_human=$(bytes_to_human_kb "$total_size_cleaned")
 
         if [[ "$DRY_RUN" == "true" ]]; then
-            local stats="Potential space: ${GREEN}${freed_size_human}${NC}"
+            local stats="Potential space: $(colorize_human_size "$freed_size_human")"
             [[ $files_cleaned -gt 0 ]] && stats+=" | Items: $files_cleaned"
             [[ $total_items -gt 0 ]] && stats+=" | Categories: $total_items"
             summary_details+=("$stats")

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -50,7 +50,7 @@ clean_ds_store_tree() {
         size_human=$(bytes_to_human "$total_bytes")
         local size_kb=$(((total_bytes + 1023) / 1024))
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $label${NC}, ${YELLOW}$file_count files, $size_human dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $label${NC}, ${YELLOW}$file_count files, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$size_kb")

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -99,7 +99,7 @@ clean_service_worker_cache() {
                 echo -e "  ${line_color}${ICON_SUCCESS}${NC} $browser_name Service Worker${NC}, ${line_color}${cleaned_mb}MB${NC}"
             fi
         else
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $browser_name Service Worker, would clean ${cleaned_mb}MB, ${protected_count} protected"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $browser_name Service Worker, would clean $(colorize_human_size "${cleaned_mb}MB"), ${protected_count} protected"
         fi
         note_activity
         if [[ "$spinner_was_running" == "true" ]]; then
@@ -436,9 +436,9 @@ clean_python_bytecode_cache_group() {
         fi
 
         if [[ $skipped_count -gt 0 ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Python bytecode cache · ${display_root}${NC}, ${YELLOW}${removed_count} dirs, ${size_human} dry, ${skipped_count} skipped${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Python bytecode cache · ${display_root}${NC}, ${YELLOW}${removed_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry, ${skipped_count} skipped${NC}"
         else
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Python bytecode cache · ${display_root}${NC}, ${YELLOW}${removed_count} dirs, ${size_human} dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Python bytecode cache · ${display_root}${NC}, ${YELLOW}${removed_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         fi
     else
         local line_color

--- a/lib/clean/system.sh
+++ b/lib/clean/system.sh
@@ -395,7 +395,7 @@ clean_time_machine_failed_backups() {
                 local size_human
                 size_human=$(bytes_to_human "$((size_kb * 1024))")
                 if [[ "$DRY_RUN" == "true" ]]; then
-                    echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Incomplete backup: $backup_name${NC}, ${YELLOW}$size_human dry${NC}"
+                    echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Incomplete backup: $backup_name${NC}, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
                     tm_cleaned=$((tm_cleaned + 1))
                     note_activity
                     continue
@@ -449,7 +449,7 @@ clean_time_machine_failed_backups() {
                     local size_human
                     size_human=$(bytes_to_human "$((size_kb * 1024))")
                     if [[ "$DRY_RUN" == "true" ]]; then
-                        echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Incomplete APFS backup in $bundle_name: $backup_name${NC}, ${YELLOW}$size_human dry${NC}"
+                        echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Incomplete APFS backup in $bundle_name: $backup_name${NC}, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
                         tm_cleaned=$((tm_cleaned + 1))
                         note_activity
                         continue

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -287,7 +287,7 @@ _clean_darwin_user_runtime_dir() {
         local cap_note=""
         [[ "$hit_cap" == "true" ]] && cap_note=", capped"
         if [[ "${DRY_RUN:-false}" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} ${label}${NC}, ${YELLOW}${count} old items, ${size_human} dry${cap_note}${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} ${label}${NC}, ${YELLOW}${count} old items, $(colorize_human_size "$size_human") ${YELLOW}dry${cap_note}${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size_kb")
@@ -423,7 +423,7 @@ clean_chrome_old_versions() {
         local size_human
         size_human=$(bytes_to_human "$((total_size * 1024))")
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Chrome old versions${NC}, ${YELLOW}${cleaned_count} dirs, $size_human dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Chrome old versions${NC}, ${YELLOW}${cleaned_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size")
@@ -518,7 +518,7 @@ clean_edge_old_versions() {
         local size_human
         size_human=$(bytes_to_human "$((total_size * 1024))")
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Edge old versions${NC}, ${YELLOW}${cleaned_count} dirs, $size_human dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Edge old versions${NC}, ${YELLOW}${cleaned_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size")
@@ -582,7 +582,7 @@ clean_edge_updater_old_versions() {
         local size_human
         size_human=$(bytes_to_human "$((total_size * 1024))")
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Edge updater old versions${NC}, ${YELLOW}${cleaned_count} dirs, $size_human dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Edge updater old versions${NC}, ${YELLOW}${cleaned_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size")
@@ -674,7 +674,7 @@ clean_brave_old_versions() {
         local size_human
         size_human=$(bytes_to_human "$((total_size * 1024))")
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Brave old versions${NC}, ${YELLOW}${cleaned_count} dirs, $size_human dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Brave old versions${NC}, ${YELLOW}${cleaned_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size")
@@ -901,7 +901,7 @@ clean_app_caches() {
             else
                 local size_human
                 size_human=$(bytes_to_human "$((total_size * 1024))")
-                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Sandboxed app caches${NC}, ${YELLOW}$size_human dry${NC}"
+                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Sandboxed app caches${NC}, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
             fi
         else
             if [[ "$total_size_partial" == "true" ]]; then
@@ -1118,7 +1118,7 @@ clean_group_container_caches() {
             else
                 local size_human
                 size_human=$(bytes_to_human "$((total_size * 1024))")
-                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Group Containers logs/caches${NC}, ${YELLOW}$size_human dry${NC}"
+                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Group Containers logs/caches${NC}, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
             fi
         else
             if [[ "$total_size_partial" == "true" ]]; then
@@ -1293,7 +1293,7 @@ clean_external_volume_target() {
         local size_human
         size_human=$(bytes_to_human "$((total_size * 1024))")
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} External volume cleanup${NC}, ${YELLOW}${volume_name}, $size_human dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} External volume cleanup${NC}, ${YELLOW}${volume_name}, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size")
@@ -1839,9 +1839,9 @@ clean_application_support_logs() {
         local total_size_kb=$(((total_size_bytes + 1023) / 1024))
         if [[ "$DRY_RUN" == "true" ]]; then
             if [[ "$total_size_partial" == "true" ]]; then
-                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Application Support logs/caches${NC}, ${YELLOW}at least $size_human dry${NC}"
+                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Application Support logs/caches${NC}, ${YELLOW}at least $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
             else
-                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Application Support logs/caches${NC}, ${YELLOW}$size_human dry${NC}"
+                echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Application Support logs/caches${NC}, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
             fi
         else
             local line_color
@@ -1926,7 +1926,7 @@ clean_cached_device_firmware() {
         local size_human
         size_human=$(bytes_to_human "$((total_size_kb * 1024))")
         if [[ "$DRY_RUN" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Cached device firmware${NC}, ${YELLOW}${cleaned_count} files, $size_human dry${NC}"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Cached device firmware${NC}, ${YELLOW}${cleaned_count} files, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size_kb")

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -921,3 +921,10 @@ is_ansi_supported() {
             ;;
     esac
 }
+
+# Prime ANSI support while the parent process still has the real stdout.
+# This keeps later command substitutions from misdetecting interactive output
+# as non-TTY while preserving no-color behavior for redirected runs.
+if [[ -z "${MOLE_ANSI_SUPPORTED_CACHE:-}" ]]; then
+    is_ansi_supported > /dev/null 2>&1 || true
+fi

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -549,6 +549,30 @@ bytes_to_human_kb() {
     bytes_to_human "$((${1:-0} * 1024))"
 }
 
+# Colorize an already-formatted human size string by unit.
+colorize_human_size() {
+    local size_human="$1"
+
+    if ! is_ansi_supported; then
+        printf '%s' "$size_human"
+        return 0
+    fi
+
+    local size_color=""
+    case "$size_human" in
+        *GB) size_color="$RED" ;;
+        *MB) size_color="$YELLOW" ;;
+        *KB) size_color="$GREEN" ;;
+        *B) size_color="$GRAY" ;;
+        *)
+            printf '%s' "$size_human"
+            return 0
+            ;;
+    esac
+
+    printf '%s%s%s' "$size_color" "$size_human" "$NC"
+}
+
 # Pick a cleanup result color using the displayed decimal 1 GB threshold.
 cleanup_result_color_kb() {
     printf '%s' "$GREEN"

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -553,11 +553,6 @@ bytes_to_human_kb() {
 colorize_human_size() {
     local size_human="$1"
 
-    if ! is_ansi_supported; then
-        printf '%s' "$size_human"
-        return 0
-    fi
-
     local size_color=""
     case "$size_human" in
         *GB) size_color="$RED" ;;
@@ -921,10 +916,3 @@ is_ansi_supported() {
             ;;
     esac
 }
-
-# Prime ANSI support while the parent process still has the real stdout.
-# This keeps later command substitutions from misdetecting interactive output
-# as non-TTY while preserving no-color behavior for redirected runs.
-if [[ -z "${MOLE_ANSI_SUPPORTED_CACHE:-}" ]]; then
-    is_ansi_supported > /dev/null 2>&1 || true
-fi

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -163,6 +163,32 @@ EOF
     [ "${bytes_lines[3]}" = "3.00GB" ]
 }
 
+@test "colorize_human_size colors dry-run size units by suffix" {
+    output="$(
+        HOME="$HOME" bash --noprofile --norc << 'EOF'
+source "$PROJECT_ROOT/lib/core/common.sh"
+colorize_human_size "1.00GB"
+printf '\n'
+colorize_human_size "5.0MB"
+printf '\n'
+colorize_human_size "180KB"
+printf '\n'
+colorize_human_size "0B"
+printf '\n'
+EOF
+    )"
+
+    color_lines=()
+    while IFS= read -r line; do
+        color_lines+=("$line")
+    done <<< "$output"
+
+    [ "${color_lines[0]}" = $'\033[0;31m1.00GB\033[0m' ]
+    [ "${color_lines[1]}" = $'\033[0;33m5.0MB\033[0m' ]
+    [ "${color_lines[2]}" = $'\033[0;32m180KB\033[0m' ]
+    [ "${color_lines[3]}" = $'\033[0;90m0B\033[0m' ]
+}
+
 @test "create_temp_file and create_temp_dir are tracked and cleaned" {
     HOME="$HOME" bash --noprofile --norc << 'EOF'
 source "$PROJECT_ROOT/lib/core/common.sh"


### PR DESCRIPTION
## Summary
- colorize `mo clean --dry-run` size text by unit
- apply the helper across the clean-command dry-run renderers so the preview output stays consistent
- leave normal cleanup output and the Go-based `mo analyze` / `mo status` formatters unchanged

## What Changed
- add `colorize_human_size()` in `lib/core/base.sh` with `GB=red`, `MB=yellow`, `KB=green`, `B/0B=gray`
- use that helper in `bin/clean.sh` and the remaining `mo clean --dry-run` renderers under `lib/clean/*`
- preserve the existing yellow dry-run markers and keep `~/.config/mole/clean-list.txt` plain text

## Validation
- ran `./scripts/check.sh`
- smoke-tested `./mo clean --dry-run`
- verified the helper output for `0B`, `KB`, `MB`, and `GB`
- verified `~/.config/mole/clean-list.txt` contains no ANSI escapes

## Notes
- this is a presentation-only change
- no deletion, whitelist, path validation, sudo/session, or file-op logic was changed
- local validation environment did not have `shfmt`, `shellcheck`, or Go installed, so those checks were skipped by the project script
<img width="924" height="822" alt="Screenshot 2026-05-12 at 12 11 13 AM" src="https://github.com/user-attachments/assets/09eb4549-7b51-4a77-acc6-e22adbc0426a" />
<img width="614" height="881" alt="Screenshot 2026-05-12 at 12 12 19 AM" src="https://github.com/user-attachments/assets/49c89dea-4463-4ace-8fc6-7aae9cacd691" />

