### PR TITLE
feat(uninstall): add interactive file selection before removal

### DIFF
--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -472,6 +472,9 @@ batch_uninstall_applications() {
     local _fs_i _fs_detail _fs_an _fs_ap _fs_bi _fs_tk _fs_ef _fs_esf _fs_hs _fs_ns _fs_ib _fs_cn _fs_eds _fs_hln
     local _fs_rel _fs_sys _fs_diag _fs_rel_kb _fs_sys_kb _fs_app_kb _fs_new_tk _fs_new_ef _fs_new_esf
 
+    sudo_apps=()
+    brew_cask_apps=()
+
     for ((_fs_i = 0; _fs_i < ${#app_details[@]}; _fs_i++)); do
         _fs_detail="${app_details[_fs_i]}"
         IFS='|' read -r _fs_an _fs_ap _fs_bi _fs_tk _fs_ef _fs_esf _fs_hs _fs_ns _fs_ib _fs_cn _fs_eds _fs_hln <<< "$_fs_detail"
@@ -528,10 +531,27 @@ batch_uninstall_applications() {
         local _fs_ap_final="$_fs_ap"
         [[ "$_fs_has_app" != true ]] && _fs_ap_final=""
 
+        local _fs_new_ns="false"
+        if [[ "$_fs_has_app" == true ]]; then
+            local _fs_app_owner
+            _fs_app_owner=$(get_file_owner "$_fs_ap")
+            if [[ ! -w "$(dirname "$_fs_ap")" ]] ||
+                [[ "$_fs_app_owner" == "root" ]] ||
+                [[ -n "$_fs_app_owner" && "$_fs_app_owner" != "$current_user" ]]; then
+                _fs_new_ns="true"
+            fi
+        fi
+        [[ -n "$_fs_sys" ]] && _fs_new_ns="true"
+        [[ "$_fs_new_ns" == "true" ]] && sudo_apps+=("$_fs_an")
+        [[ "$_fs_has_app" == true && "$_fs_ib" == "true" ]] && brew_cask_apps+=("$_fs_an")
+
+        local _fs_hln_final="$_fs_hln"
+        [[ "$_fs_has_app" != true ]] && _fs_hln_final="false"
+
         _fs_new_ef=$(printf '%s' "$_fs_rel" | base64 | tr -d '\n' || echo "")
         _fs_new_esf=$(printf '%s' "$_fs_sys" | base64 | tr -d '\n' || echo "")
 
-        _new_app_details+=("$_fs_an|$_fs_ap_final|$_fs_bi|$_fs_new_tk|$_fs_new_ef|$_fs_new_esf|$_fs_hs|$_fs_ns|$_fs_ib|$_fs_cn||$_fs_hln")
+        _new_app_details+=("$_fs_an|$_fs_ap_final|$_fs_bi|$_fs_new_tk|$_fs_new_ef|$_fs_new_esf|$_fs_hs|$_fs_new_ns|$_fs_ib|$_fs_cn||$_fs_hln_final")
         _new_selected_apps+=("${selected_apps[_fs_i]}")
     done
 
@@ -578,7 +598,9 @@ batch_uninstall_applications() {
             echo "$diag_system_display"
         )
 
-        echo -e "  ${GREEN}${ICON_SUCCESS}${NC} ${app_path/$HOME/~}"
+        if [[ -n "$app_path" ]]; then
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} ${app_path/$HOME/~}"
+        fi
 
         # Show all related files so users can fully review before deletion.
         while IFS= read -r file; do
@@ -721,8 +743,8 @@ batch_uninstall_applications() {
             start_inline_spinner "${_phase_prefix}Removing ${app_name} (${_phase_size})..."
         fi
 
+        local used_brew_successfully=false
         if [[ -n "$app_path" ]]; then
-            local used_brew_successfully=false
             if [[ -z "$reason" ]]; then
                 if [[ "$is_brew_cask" == "true" && -n "$cask_name" ]]; then
                     # Use brew_uninstall_cask helper (handles env vars, timeout, verification)
@@ -924,13 +946,13 @@ batch_uninstall_applications() {
             [[ "$used_brew_successfully" == "true" ]] && brew_apps_removed=$((brew_apps_removed + 1))
             files_cleaned=$((files_cleaned + 1))
             total_items=$((total_items + 1))
-            success_items+=("$app_path")
-            if [[ "$has_local_network_usage" == "true" ]]; then
+            [[ -n "$app_path" ]] && success_items+=("$app_path")
+            if [[ -n "$app_path" && "$has_local_network_usage" == "true" ]]; then
                 local_network_warning_apps+=("$app_name")
             fi
 
             # Check for orphaned system extensions (camera, network, endpoint security, etc.)
-            if [[ -n "$bundle_id" && "$bundle_id" != "unknown" && "$bundle_id" =~ ^[A-Za-z0-9._-]+$ && -d /Library/SystemExtensions ]]; then
+            if [[ -n "$app_path" && -n "$bundle_id" && "$bundle_id" != "unknown" && "$bundle_id" =~ ^[A-Za-z0-9._-]+$ && -d /Library/SystemExtensions ]]; then
                 if command find /Library/SystemExtensions -maxdepth 3 -name "*.systemextension" -path "*${bundle_id}*" -print -quit 2> /dev/null | grep -q .; then
                     system_extension_warning_apps+=("$app_name")
                 fi

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -9,6 +9,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # Load Homebrew cask support (provides get_brew_cask_name, brew_uninstall_cask)
 [[ -f "$SCRIPT_DIR/lib/uninstall/brew.sh" ]] && source "$SCRIPT_DIR/lib/uninstall/brew.sh"
 
+# Load interactive file selection for uninstall
+[[ -f "$SCRIPT_DIR/lib/uninstall/file_selector.sh" ]] && source "$SCRIPT_DIR/lib/uninstall/file_selector.sh"
+
 # Batch uninstall with a single confirmation.
 
 is_uninstall_dry_run() {
@@ -462,6 +465,87 @@ batch_uninstall_applications() {
     done
     if [[ -t 1 ]]; then stop_inline_spinner; fi
 
+    # Interactive file selection before confirmation.
+    local -a _new_app_details=()
+    local -a _new_selected_apps=()
+    local _new_total_estimated_size=0
+    local _fs_i _fs_detail _fs_an _fs_ap _fs_bi _fs_tk _fs_ef _fs_esf _fs_hs _fs_ns _fs_ib _fs_cn _fs_eds _fs_hln
+    local _fs_rel _fs_sys _fs_diag _fs_rel_kb _fs_sys_kb _fs_app_kb _fs_new_tk _fs_new_ef _fs_new_esf
+
+    for ((_fs_i = 0; _fs_i < ${#app_details[@]}; _fs_i++)); do
+        _fs_detail="${app_details[_fs_i]}"
+        IFS='|' read -r _fs_an _fs_ap _fs_bi _fs_tk _fs_ef _fs_esf _fs_hs _fs_ns _fs_ib _fs_cn _fs_eds _fs_hln <<< "$_fs_detail"
+
+        _fs_rel=$(decode_file_list "$_fs_ef" "$_fs_an")
+        _fs_sys=$(decode_file_list "$_fs_esf" "$_fs_an")
+        _fs_diag=$(decode_file_list "$_fs_eds" "$_fs_an")
+        if [[ -n "$_fs_diag" ]]; then
+            if [[ -n "$_fs_sys" ]]; then
+                _fs_sys+=$'\n'
+            fi
+            _fs_sys+="$_fs_diag"
+        fi
+
+        # Include app bundle itself in the selection list
+        local _fs_all_user="$_fs_ap"
+        if [[ -n "$_fs_rel" ]]; then
+            _fs_all_user+=$'\n'
+            _fs_all_user+="$_fs_rel"
+        fi
+
+        MOLE_SFR_USER_FILES="$_fs_all_user"
+        MOLE_SFR_SYSTEM_FILES="$_fs_sys"
+        if ! select_files_for_removal "$_fs_an"; then
+            echo -e "${GRAY}Skipped ${_fs_an}${NC}"
+            continue
+        fi
+        _fs_rel="${MOLE_SFR_USER_FILES}"
+        _fs_sys="${MOLE_SFR_SYSTEM_FILES}"
+
+        if [[ -z "$_fs_rel" && -z "$_fs_sys" ]]; then
+            echo -e "${GRAY}Skipped ${_fs_an} (no files selected)${NC}"
+            continue
+        fi
+
+        # Check whether the app bundle itself was selected
+        local _fs_has_app=false
+        if printf '%s\n' "$_fs_rel" | grep -qxF "$_fs_ap"; then
+            _fs_has_app=true
+            # Remove app path from related files
+            _fs_rel=$(printf '%s\n' "$_fs_rel" | grep -vxF "$_fs_ap" || true)
+        fi
+
+        _fs_rel_kb=$(calculate_total_size "$_fs_rel" || echo "0")
+        _fs_sys_kb=$(calculate_total_size "$_fs_sys" || echo "0")
+        _fs_app_kb=0
+        if [[ "$_fs_has_app" == true ]]; then
+            _fs_app_kb=$(get_path_size_kb "$_fs_ap" || echo "0")
+        fi
+        _fs_new_tk=$((_fs_app_kb + _fs_rel_kb + _fs_sys_kb))
+        _new_total_estimated_size=$((_new_total_estimated_size + _fs_new_tk))
+
+        # If app was deselected, clear app_path so execution skips bundle removal
+        local _fs_ap_final="$_fs_ap"
+        [[ "$_fs_has_app" != true ]] && _fs_ap_final=""
+
+        _fs_new_ef=$(printf '%s' "$_fs_rel" | base64 | tr -d '\n' || echo "")
+        _fs_new_esf=$(printf '%s' "$_fs_sys" | base64 | tr -d '\n' || echo "")
+
+        _new_app_details+=("$_fs_an|$_fs_ap_final|$_fs_bi|$_fs_new_tk|$_fs_new_ef|$_fs_new_esf|$_fs_hs|$_fs_ns|$_fs_ib|$_fs_cn||$_fs_hln")
+        _new_selected_apps+=("${selected_apps[_fs_i]}")
+    done
+
+    app_details=("${_new_app_details[@]}")
+    selected_apps=("${_new_selected_apps[@]}")
+    total_estimated_size=$_new_total_estimated_size
+
+    if [[ ${#app_details[@]} -eq 0 ]]; then
+        echo ""
+        echo "No files selected for removal."
+        _restore_uninstall_traps
+        return 0
+    fi
+
     local size_display=$(bytes_to_human "$((total_estimated_size * 1024))")
 
     echo -e "\n${PURPLE_BOLD}Files to be removed:${NC}"
@@ -606,18 +690,20 @@ batch_uninstall_applications() {
         local has_system_files="false"
         [[ -n "$system_files" ]] && has_system_files="true"
 
-        stop_launch_services "$bundle_id" "$has_system_files" "$app_path"
-        unregister_app_bundle "$app_path"
+        if [[ -n "$app_path" ]]; then
+            stop_launch_services "$bundle_id" "$has_system_files" "$app_path"
+            unregister_app_bundle "$app_path"
 
-        # Remove from Login Items
-        remove_login_item "$app_name" "$bundle_id"
+            # Remove from Login Items
+            remove_login_item "$app_name" "$bundle_id"
 
-        # Best-effort termination. macOS allows removing a running app bundle
-        # (the running process keeps using its mmap'd code), so a stuck app
-        # process must NOT block the uninstall. Track it so we can surface a
-        # warning at the end without scaring the user with a "failed" status.
-        if ! force_kill_app "$app_name" "$app_path"; then
-            running_at_uninstall_apps+=("$app_name")
+            # Best-effort termination. macOS allows removing a running app bundle
+            # (the running process keeps using its mmap'd code), so a stuck app
+            # process must NOT block the uninstall. Track it so we can surface a
+            # warning at the end without scaring the user with a "failed" status.
+            if ! force_kill_app "$app_name" "$app_path"; then
+                running_at_uninstall_apps+=("$app_name")
+            fi
         fi
 
         # Keep the spinner alive through the heavy work. For large apps the
@@ -635,89 +721,91 @@ batch_uninstall_applications() {
             start_inline_spinner "${_phase_prefix}Removing ${app_name} (${_phase_size})..."
         fi
 
-        local used_brew_successfully=false
-        if [[ -z "$reason" ]]; then
-            if [[ "$is_brew_cask" == "true" && -n "$cask_name" ]]; then
-                # Use brew_uninstall_cask helper (handles env vars, timeout, verification)
-                if brew_uninstall_cask "$cask_name" "$app_path"; then
-                    used_brew_successfully=true
-                else
-                    # Only fall back to manual app removal when Homebrew no longer
-                    # tracks the cask. Otherwise we would recreate the mismatch
-                    # where brew still reports the app as installed after Mole
-                    # removes the bundle manually.
-                    local cask_state=2
-                    if command -v is_brew_cask_installed > /dev/null 2>&1; then
-                        if is_brew_cask_installed "$cask_name"; then
-                            cask_state=0
-                        else
-                            cask_state=$?
+        if [[ -n "$app_path" ]]; then
+            local used_brew_successfully=false
+            if [[ -z "$reason" ]]; then
+                if [[ "$is_brew_cask" == "true" && -n "$cask_name" ]]; then
+                    # Use brew_uninstall_cask helper (handles env vars, timeout, verification)
+                    if brew_uninstall_cask "$cask_name" "$app_path"; then
+                        used_brew_successfully=true
+                    else
+                        # Only fall back to manual app removal when Homebrew no longer
+                        # tracks the cask. Otherwise we would recreate the mismatch
+                        # where brew still reports the app as installed after Mole
+                        # removes the bundle manually.
+                        local cask_state=2
+                        if command -v is_brew_cask_installed > /dev/null 2>&1; then
+                            if is_brew_cask_installed "$cask_name"; then
+                                cask_state=0
+                            else
+                                cask_state=$?
+                            fi
                         fi
-                    fi
 
-                    if [[ $cask_state -eq 1 ]]; then
-                        if ! mole_delete "$app_path" "$needs_sudo"; then
-                            reason="brew cleanup incomplete, manual removal failed"
+                        if [[ $cask_state -eq 1 ]]; then
+                            if ! mole_delete "$app_path" "$needs_sudo"; then
+                                reason="brew cleanup incomplete, manual removal failed"
+                            fi
+                        elif [[ $cask_state -eq 0 ]]; then
+                            reason="brew uninstall failed, package still installed"
+                            suggestion="Run brew uninstall --cask --zap $cask_name"
+                        else
+                            reason="brew uninstall failed, package state unknown"
+                            suggestion="Run brew uninstall --cask --zap $cask_name"
                         fi
-                    elif [[ $cask_state -eq 0 ]]; then
-                        reason="brew uninstall failed, package still installed"
-                        suggestion="Run brew uninstall --cask --zap $cask_name"
-                    else
-                        reason="brew uninstall failed, package state unknown"
-                        suggestion="Run brew uninstall --cask --zap $cask_name"
                     fi
-                fi
-            elif [[ "$needs_sudo" == true ]]; then
-                if [[ -L "$app_path" ]]; then
-                    local link_target
-                    link_target=$(readlink "$app_path" 2> /dev/null)
-                    if [[ -n "$link_target" ]]; then
-                        local resolved_target="$link_target"
-                        if [[ "$link_target" != /* ]]; then
-                            local link_dir
-                            link_dir=$(dirname "$app_path")
-                            resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$(dirname "$link_target")" 2> /dev/null && pwd)/$(basename "$link_target") 2> /dev/null || echo ""
+                elif [[ "$needs_sudo" == true ]]; then
+                    if [[ -L "$app_path" ]]; then
+                        local link_target
+                        link_target=$(readlink "$app_path" 2> /dev/null)
+                        if [[ -n "$link_target" ]]; then
+                            local resolved_target="$link_target"
+                            if [[ "$link_target" != /* ]]; then
+                                local link_dir
+                                link_dir=$(dirname "$app_path")
+                                resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$(dirname "$link_target")" 2> /dev/null && pwd)/$(basename "$link_target") 2> /dev/null || echo ""
+                            fi
+                            case "$resolved_target" in
+                                /System/* | /usr/bin/* | /usr/lib/* | /bin/* | /sbin/* | /private/etc/*)
+                                    reason="protected system symlink, cannot remove"
+                                    ;;
+                                *)
+                                    if ! mole_delete "$app_path" "true"; then
+                                        reason="failed to remove symlink"
+                                    fi
+                                    ;;
+                            esac
+                        else
+                            if ! mole_delete "$app_path" "true"; then
+                                reason="failed to remove symlink"
+                            fi
                         fi
-                        case "$resolved_target" in
-                            /System/* | /usr/bin/* | /usr/lib/* | /bin/* | /sbin/* | /private/etc/*)
-                                reason="protected system symlink, cannot remove"
-                                ;;
-                            *)
-                                if ! mole_delete "$app_path" "true"; then
-                                    reason="failed to remove symlink"
-                                fi
-                                ;;
-                        esac
                     else
-                        if ! mole_delete "$app_path" "true"; then
-                            reason="failed to remove symlink"
+                        if is_uninstall_dry_run; then
+                            if ! mole_delete "$app_path" "false"; then
+                                reason="dry-run path validation failed"
+                            fi
+                        else
+                            local ret=0
+                            mole_delete "$app_path" "true" || ret=$?
+                            if [[ $ret -ne 0 ]]; then
+                                local diagnosis
+                                diagnosis=$(diagnose_removal_failure "$ret" "$app_name")
+                                IFS='|' read -r reason suggestion <<< "$diagnosis"
+                            fi
                         fi
                     fi
                 else
-                    if is_uninstall_dry_run; then
-                        if ! mole_delete "$app_path" "false"; then
-                            reason="dry-run path validation failed"
+                    if ! mole_delete "$app_path" "false"; then
+                        if [[ ! -w "$(dirname "$app_path")" ]]; then
+                            reason="parent directory not writable"
+                        else
+                            reason="remove failed, check permissions"
                         fi
-                    else
-                        local ret=0
-                        mole_delete "$app_path" "true" || ret=$?
-                        if [[ $ret -ne 0 ]]; then
-                            local diagnosis
-                            diagnosis=$(diagnose_removal_failure "$ret" "$app_name")
-                            IFS='|' read -r reason suggestion <<< "$diagnosis"
-                        fi
-                    fi
-                fi
-            else
-                if ! mole_delete "$app_path" "false"; then
-                    if [[ ! -w "$(dirname "$app_path")" ]]; then
-                        reason="parent directory not writable"
-                    else
-                        reason="remove failed, check permissions"
                     fi
                 fi
             fi
-        fi
+        fi # [[ -n "$app_path" ]]
 
         # Remove related files if app removal succeeded.
         if [[ -z "$reason" ]]; then
@@ -772,20 +860,33 @@ batch_uninstall_applications() {
                 remove_file_list "$system_all" "true" > /dev/null
             fi
 
-            # Defaults writes are side effects that should never run in dry-run mode.
+            # defaults delete and ByHost cleanup must respect the file selector:
+            # only run when the user actually selected the corresponding plists.
+            # $related_files is the user-filtered list after file selection.
+            local _prefs_selected=false
+            local _byhost_selected=false
+            if printf '%s\n' "$related_files" | grep -qxF "$HOME/Library/Preferences/$bundle_id.plist"; then
+                _prefs_selected=true
+            fi
+            if printf '%s\n' "$related_files" | grep -qF "$HOME/Library/Preferences/ByHost/$bundle_id"; then
+                _byhost_selected=true
+            fi
+
             if [[ -n "$bundle_id" && "$bundle_id" != "unknown" ]]; then
-                if is_uninstall_dry_run; then
-                    debug_log "[DRY RUN] Would clear defaults domain: $bundle_id"
-                else
-                    if defaults read "$bundle_id" &> /dev/null; then
-                        defaults delete "$bundle_id" 2> /dev/null || true
+                if [[ "$_prefs_selected" == "true" ]]; then
+                    if is_uninstall_dry_run; then
+                        debug_log "[DRY RUN] Would clear defaults domain: $bundle_id"
+                    else
+                        if defaults read "$bundle_id" &> /dev/null; then
+                            defaults delete "$bundle_id" 2> /dev/null || true
+                        fi
                     fi
                 fi
 
                 # ByHost preferences (machine-specific).
                 # User-owned plists, so route through user-mode mole_delete to
                 # avoid prompting for sudo when uninstalling a normal app.
-                if [[ -d "$HOME/Library/Preferences/ByHost" ]]; then
+                if [[ "$_byhost_selected" == "true" && -d "$HOME/Library/Preferences/ByHost" ]]; then
                     if [[ "$bundle_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
                         while IFS= read -r -d '' plist_file; do
                             mole_delete "$plist_file" "false" || true

--- a/lib/uninstall/file_selector.sh
+++ b/lib/uninstall/file_selector.sh
@@ -1,0 +1,317 @@
+#!/bin/bash
+# Interactive file selection for uninstall.
+# Requires: common.sh (provides read_key, hide_cursor, show_cursor, icons, colors).
+
+set -euo pipefail
+
+# Detect if a path is a "team prefix" match — a Group Container whose directory
+# name starts with a 10-char Apple Developer Team ID (e.g. FN2V63AD2J.com.foo).
+# These Group Containers are shared across apps from the same developer, so they
+# are deselected by default to avoid accidentally removing shared data.
+is_team_prefix_path() {
+    local path="$1"
+    [[ "$path" =~ /Group[[:space:]]Containers/[A-Z0-9]{10}\. ]]
+}
+
+# Terminal helpers — lightweight, no dependency on menu scripts.
+_sfr_enter_alt_screen() { tput smcup 2> /dev/null || true; }
+_sfr_leave_alt_screen() { tput rmcup 2> /dev/null || true; }
+
+_sfr_get_terminal_height() {
+    local h
+    if [[ -t 0 ]] || [[ -t 2 ]]; then
+        h=$(stty size < /dev/tty 2> /dev/null | awk '{print $1}')
+    fi
+    if [[ -n "$h" && $h -gt 0 ]]; then echo "$h"; else tput lines 2> /dev/null || echo 24; fi
+}
+
+# Lightweight multi-select menu — no sort, no filter, no pagination.
+# Reads:  MOLE_PRESELECTED_INDICES (comma-separated indices, optional)
+# Writes: MOLE_SELECTION_RESULT (comma-separated selected indices)
+# Args:   title, then display items
+# Returns: 0 on Enter, 1 on Q/ESC.
+_sfr_multi_select() {
+    local title="$1"
+    shift
+    local -a items=("$@")
+
+    if [[ ${#items[@]} -eq 0 ]]; then
+        echo "No items provided" >&2
+        return 1
+    fi
+
+    local total=${#items[@]}
+    local term_height=$(_sfr_get_terminal_height)
+    local reserved=5
+    local items_per_page=$((term_height - reserved))
+    [[ $items_per_page -lt 1 ]] && items_per_page=1
+    [[ $items_per_page -gt 50 ]] && items_per_page=50
+
+    local cursor_pos=0 top_index=0
+    local -a selected=()
+    local i
+    for ((i = 0; i < total; i++)); do selected[i]=false; done
+
+    if [[ -n "${MOLE_PRESELECTED_INDICES:-}" ]]; then
+        local cleaned="${MOLE_PRESELECTED_INDICES//[[:space:]]/}"
+        local -a ps=()
+        local IFS=','
+        read -ra ps <<< "$cleaned"
+        for i in "${ps[@]}"; do
+            [[ "$i" =~ ^[0-9]+$ && $i -ge 0 && $i -lt $total ]] && selected[i]=true
+        done
+    fi
+
+    # Preserve TTY settings
+    local original_stty=""
+    if [[ -t 0 ]] && command -v stty > /dev/null 2>&1; then
+        original_stty=$(stty -g 2> /dev/null || echo "")
+    fi
+
+    _sfr_restore_terminal() {
+        show_cursor
+        if [[ -n "${original_stty:-}" ]]; then
+            stty "${original_stty}" 2> /dev/null || stty sane 2> /dev/null || true
+        else
+            stty sane 2> /dev/null || stty echo icanon 2> /dev/null || true
+        fi
+        _sfr_leave_alt_screen
+    }
+
+    _sfr_cleanup() {
+        trap - EXIT INT TERM
+        _sfr_restore_terminal
+    }
+    trap _sfr_cleanup EXIT
+    trap '_sfr_cleanup; exit 130' INT TERM
+
+    stty -echo -icanon intr ^C 2> /dev/null || true
+    _sfr_enter_alt_screen
+    printf "\033[2J\033[H" >&2
+    hide_cursor
+
+    _sfr_draw() {
+        printf "\033[H" >&2
+        local clear="\r\033[2K"
+        local sel_count=0
+        local i
+        for ((i = 0; i < total; i++)); do
+            [[ ${selected[i]} == true ]] && sel_count=$((sel_count + 1))
+        done
+        printf "${clear}${PURPLE_BOLD}%s${NC}  ${GRAY}%d/%d selected${NC}\n" "$title" "$sel_count" "$total" >&2
+        printf "${clear}\n" >&2
+
+        # Clamp viewport
+        if [[ $top_index -gt $((total - 1)) ]]; then
+            top_index=$((total - items_per_page))
+            [[ $top_index -lt 0 ]] && top_index=0
+        fi
+        local visible=$((total - top_index))
+        [[ $visible -gt $items_per_page ]] && visible=$items_per_page
+        [[ $visible -le 0 ]] && visible=1
+        if [[ $cursor_pos -ge $visible ]]; then
+            cursor_pos=$((visible - 1))
+            [[ $cursor_pos -lt 0 ]] && cursor_pos=0
+        fi
+
+        local end=$((top_index + items_per_page - 1))
+        [[ $end -ge $total ]] && end=$((total - 1))
+
+        local idx
+        for ((i = top_index; i <= end; i++)); do
+            local is_cur=false
+            [[ $((i - top_index)) -eq $cursor_pos ]] && is_cur=true
+            local cb="$ICON_EMPTY"
+            [[ ${selected[i]} == true ]] && cb="$ICON_SOLID"
+            if [[ $is_cur == true ]]; then
+                printf "${clear}${CYAN}${ICON_ARROW} %s %s${NC}\n" "$cb" "${items[i]}" >&2
+            else
+                printf "${clear}  %s %s\n" "$cb" "${items[i]}" >&2
+            fi
+        done
+
+        local shown=$((end - top_index + 1))
+        [[ $shown -lt 0 ]] && shown=0
+        for ((i = shown; i < items_per_page; i++)); do
+            printf "${clear}\n" >&2
+        done
+
+        printf "${clear}\n" >&2
+        printf "${clear}${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN} | Space Select | Enter Save | Q Cancel${NC}\n" >&2
+        printf "${clear}" >&2
+    }
+
+    while true; do
+        _sfr_draw
+        local key
+        key=$(read_key)
+
+        case "$key" in
+            QUIT)
+                _sfr_cleanup
+                return 1
+                ;;
+            UP)
+                if [[ $cursor_pos -gt 0 ]]; then
+                    cursor_pos=$((cursor_pos - 1))
+                elif [[ $top_index -gt 0 ]]; then
+                    top_index=$((top_index - 1))
+                fi
+                ;;
+            DOWN)
+                local abs_idx=$((top_index + cursor_pos))
+                if [[ $abs_idx -lt $((total - 1)) ]]; then
+                    local vis=$((total - top_index))
+                    [[ $vis -gt $items_per_page ]] && vis=$items_per_page
+                    if [[ $cursor_pos -lt $((vis - 1)) ]]; then
+                        cursor_pos=$((cursor_pos + 1))
+                    elif [[ $((top_index + vis)) -lt $total ]]; then
+                        top_index=$((top_index + 1))
+                        vis=$((total - top_index))
+                        [[ $vis -gt $items_per_page ]] && vis=$items_per_page
+                        [[ $cursor_pos -ge $vis ]] && cursor_pos=$((vis - 1))
+                    fi
+                fi
+                ;;
+            LEFT | RIGHT)
+                # Swallow — no horizontal navigation in this view
+                :
+                ;;
+            SPACE)
+                local idx=$((top_index + cursor_pos))
+                [[ $idx -lt $total ]] && selected[idx]=$([[ ${selected[idx]} == true ]] && echo false || echo true)
+                ;;
+            ENTER)
+                local -a sel_idx=()
+                for ((i = 0; i < total; i++)); do
+                    [[ ${selected[i]} == true ]] && sel_idx+=("$i")
+                done
+                trap - EXIT INT TERM
+                _sfr_restore_terminal
+                if [[ ${#sel_idx[@]} -gt 0 ]]; then
+                    local IFS=','
+                    MOLE_SELECTION_RESULT="${sel_idx[*]}"
+                else
+                    MOLE_SELECTION_RESULT=""
+                fi
+                return 0
+                ;;
+        esac
+    done
+}
+
+# Usage:
+#   MOLE_SFR_USER_FILES="..."  MOLE_SFR_SYSTEM_FILES="..."  select_files_for_removal <app_name>
+#
+# Input:  MOLE_SFR_USER_FILES   — newline-separated user file paths
+#         MOLE_SFR_SYSTEM_FILES — newline-separated system file paths
+# Output: same variables, filtered to only the files the user kept selected
+# Returns: 0 on confirm, 1 on cancel (Q or ESC).
+select_files_for_removal() {
+    local app_name="$1"
+
+    # ---- build combined file list -------------------------------------------
+    local -a _paths=()
+    local -a _is_system=()
+    local -a _displays=()
+    local -a _pre=()
+    local _f _disp _kb _hum _dw _maxw=0
+
+    while IFS= read -r _f; do
+        [[ -n "$_f" && -e "$_f" ]] || continue
+        _paths+=("$_f")
+        _is_system+=(false)
+        _disp="${_f/$HOME/~}"
+        _kb=$(get_path_size_kb "$_f" 2> /dev/null || echo 0)
+        _hum=$(bytes_to_human $((_kb * 1024)))
+        _dw=$(get_display_width "$_disp")
+        ((_dw > _maxw)) && _maxw=$_dw
+        if is_team_prefix_path "$_f"; then
+            _pre+=(false)
+        else
+            _pre+=(true)
+        fi
+        _displays+=("$_disp|$_hum|$_dw")
+    done <<< "${MOLE_SFR_USER_FILES:-}"
+
+    while IFS= read -r _f; do
+        [[ -n "$_f" && -e "$_f" ]] || continue
+        _paths+=("$_f")
+        _is_system+=(true)
+        _kb=$(get_path_size_kb "$_f" 2> /dev/null || echo 0)
+        _hum=$(bytes_to_human $((_kb * 1024)))
+        _dw=$(get_display_width "$_f")
+        ((_dw > _maxw)) && _maxw=$_dw
+        if is_team_prefix_path "$_f"; then
+            _pre+=(false)
+        else
+            _pre+=(true)
+        fi
+        _displays+=("$_f|$_hum|$_dw")
+    done <<< "${MOLE_SFR_SYSTEM_FILES:-}"
+
+    local _total=${#_paths[@]}
+    if [[ $_total -eq 0 ]]; then
+        return 0
+    fi
+
+    # ---- format menu items with aligned size column --------------------------
+    local _min_col=30
+    ((_maxw < _min_col)) && _maxw=$_min_col
+    local _gap=2
+
+    local -a _items=()
+    local -a _ps=()
+    local _i _path _size _dw2 _pad _fmt
+    for ((_i = 0; _i < _total; _i++)); do
+        IFS='|' read -r _path _size _dw2 <<< "${_displays[_i]}"
+        _pad=$((_maxw - _dw2 + _gap))
+        printf -v _fmt "%s%*s%s" "$_path" "$_pad" "" "$_size"
+        _items+=("$_fmt")
+        [[ ${_pre[_i]} == true ]] && _ps+=("$_i")
+    done
+
+    # ---- run the menu -------------------------------------------------------
+    local _saved_preselect="${MOLE_PRESELECTED_INDICES:-}"
+    local IFS=','
+    MOLE_PRESELECTED_INDICES="${_ps[*]}"
+
+    _sfr_multi_select "Select Files to Remove" "${_items[@]}"
+    local _rc=$?
+
+    if [[ -n "${_saved_preselect+x}" ]]; then
+        MOLE_PRESELECTED_INDICES="$_saved_preselect"
+    else
+        unset MOLE_PRESELECTED_INDICES
+    fi
+
+    if [[ $_rc -ne 0 ]]; then
+        return 1
+    fi
+
+    # ---- filter file lists from selection -----------------------------------
+    if [[ -z "${MOLE_SELECTION_RESULT:-}" ]]; then
+        MOLE_SFR_USER_FILES=""
+        MOLE_SFR_SYSTEM_FILES=""
+        return 0
+    fi
+
+    local -a _sel=()
+    IFS=',' read -ra _sel <<< "$MOLE_SELECTION_RESULT"
+
+    local _u="" _s="" _idx
+    for _idx in "${_sel[@]}"; do
+        [[ "$_idx" =~ ^[0-9]+$ && $_idx -ge 0 && $_idx -lt $_total ]] || continue
+        if [[ ${_is_system[_idx]} == true ]]; then
+            [[ -n "$_s" ]] && _s+=$'\n'
+            _s+="${_paths[_idx]}"
+        else
+            [[ -n "$_u" ]] && _u+=$'\n'
+            _u+="${_paths[_idx]}"
+        fi
+    done
+
+    MOLE_SFR_USER_FILES="$_u"
+    MOLE_SFR_SYSTEM_FILES="$_s"
+    return 0
+}

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -299,7 +299,7 @@ EOF
 @test "mo uninstall --help directs leftover-only cleanup to clean" {
 	run env HOME="$HOME" "$PROJECT_ROOT/mole" uninstall --help
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"already gone, use mo clean"* ]]
+	[[ "$output" == *"leftover files and offer to clean them"* ]]
 }
 
 @test "mo clean --external accepts canonicalized custom root" {

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -299,7 +299,7 @@ EOF
 @test "mo uninstall --help directs leftover-only cleanup to clean" {
 	run env HOME="$HOME" "$PROJECT_ROOT/mole" uninstall --help
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"leftover files and offer to clean them"* ]]
+	[[ "$output" == *"For leftovers from apps that are already gone, use mo clean."* ]]
 }
 
 @test "mo clean --external accepts canonicalized custom root" {

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -206,7 +206,7 @@ files_cleaned=0
 total_items=0
 total_size_cleaned=0
 
-batch_uninstall_applications
+printf '\n' | batch_uninstall_applications
 
 [[ ! -d "$app_bundle" ]] || exit 1
 [[ ! -d "$HOME/Library/Application Support/TestApp" ]] || exit 1
@@ -390,7 +390,7 @@ total_size_cleaned=0
 # `read -r -s -n1 key` does not steal a byte from the heredoc script source
 # (which would silently corrupt the next bash command into 127).
 output_file="$HOME/batch_output.log"
-batch_uninstall_applications < /dev/null > "$output_file" 2>&1
+printf '\n' | batch_uninstall_applications > "$output_file" 2>&1
 output=$(cat "$output_file")
 
 # Bundle and leftovers must be gone even though kill failed.
@@ -583,7 +583,7 @@ files_cleaned=0
 total_items=0
 total_size_cleaned=0
 
-printf 'q' | batch_uninstall_applications
+printf '\nq' | batch_uninstall_applications
 EOF
 
 	[ "$status" -eq 0 ]

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -1532,3 +1532,186 @@ INNER
 	[[ "$output" == *'"uninstall_name": "visual-studio-code"'* ]]
 	[[ "$output" == *'"source": "Homebrew"'* ]]
 }
+
+# ---------------------------------------------------------------------------
+# File selector regression: defaults delete / ByHost cleanup respect selection
+# ---------------------------------------------------------------------------
+
+@test "defaults delete is skipped when preferences plist is deselected in file selector" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+request_sudo_access() { return 0; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+enter_alt_screen() { :; }
+leave_alt_screen() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+remove_apps_from_dock() { :; }
+pgrep() { return 1; }
+pkill() { return 0; }
+sudo() { return 0; }
+has_sensitive_data() { return 1; }
+find_app_system_files() { return 0; }
+
+trace="$HOME/defaults_trace.log"
+defaults() {
+	printf 'defaults %s\n' "$*" >> "$trace"
+	return 0
+}
+
+app_bundle="$HOME/Applications/TestApp.app"
+mkdir -p "$app_bundle"
+mkdir -p "$HOME/Library/Preferences"
+touch "$HOME/Library/Preferences/com.example.TestApp.plist"
+
+# find_app_files returns the plist — but we'll simulate deselection
+# by matching what the selector would do (the file won't be in related_files)
+find_app_files() {
+	printf '%s\n' "$HOME/Library/Application Support/TestApp"
+	printf '%s\n' "$HOME/Library/Caches/TestApp"
+	# Preferences plist is NOT included — simulating deselection
+}
+
+selected_apps=()
+selected_apps+=("0|$app_bundle|TestApp|com.example.TestApp|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+printf '\n' | batch_uninstall_applications
+
+# defaults delete must NOT have been called
+if grep -q 'defaults delete com.example.TestApp' "$trace"; then
+	echo "FAIL: defaults delete ran despite deselection"
+	exit 1
+fi
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
+@test "ByHost cleanup is skipped when ByHost plists are deselected in file selector" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+request_sudo_access() { return 0; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+enter_alt_screen() { :; }
+leave_alt_screen() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+remove_apps_from_dock() { :; }
+pgrep() { return 1; }
+pkill() { return 0; }
+sudo() { return 0; }
+has_sensitive_data() { return 1; }
+find_app_system_files() { return 0; }
+
+trace="$HOME/byhost_trace.log"
+mole_delete() {
+	printf 'mole_delete %s %s\n' "$1" "$2" >> "$trace"
+	return 0
+}
+defaults() { return 0; }
+
+app_bundle="$HOME/Applications/TestApp.app"
+mkdir -p "$app_bundle"
+mkdir -p "$HOME/Library/Preferences/ByHost"
+touch "$HOME/Library/Preferences/ByHost/com.example.TestApp.ABC123.plist"
+
+# find_app_files returns files but NOT ByHost — simulating deselection
+find_app_files() {
+	printf '%s\n' "$HOME/Library/Application Support/TestApp"
+	printf '%s\n' "$HOME/Library/Caches/TestApp"
+	# ByHost plist deliberately omitted
+}
+
+selected_apps=()
+selected_apps+=("0|$app_bundle|TestApp|com.example.TestApp|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+printf '\n' | batch_uninstall_applications
+
+# ByHost mole_delete must NOT have been called
+if grep -q 'ByHost.*com.example.TestApp' "$trace"; then
+	echo "FAIL: ByHost cleanup ran despite deselection"
+	cat "$trace"
+	exit 1
+fi
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
+@test "defaults delete and ByHost cleanup run when preferences are selected" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+request_sudo_access() { return 0; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+enter_alt_screen() { :; }
+leave_alt_screen() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+remove_apps_from_dock() { :; }
+pgrep() { return 1; }
+pkill() { return 0; }
+sudo() { return 0; }
+has_sensitive_data() { return 1; }
+find_app_system_files() { return 0; }
+
+trace="$HOME/selected_trace.log"
+mole_delete() {
+	printf 'mole_delete %s %s\n' "$1" "$2" >> "$trace"
+	return 0
+}
+defaults() {
+	printf 'defaults %s\n' "$*" >> "$trace"
+	return 0
+}
+
+app_bundle="$HOME/Applications/TestApp.app"
+mkdir -p "$app_bundle"
+mkdir -p "$HOME/Library/Preferences"
+touch "$HOME/Library/Preferences/com.example.TestApp.plist"
+mkdir -p "$HOME/Library/Preferences/ByHost"
+touch "$HOME/Library/Preferences/ByHost/com.example.TestApp.ABC123.plist"
+
+# find_app_files includes the plist and ByHost — simulating user selected them
+find_app_files() {
+	printf '%s\n' "$HOME/Library/Application Support/TestApp"
+	printf '%s\n' "$HOME/Library/Caches/TestApp"
+	printf '%s\n' "$HOME/Library/Preferences/com.example.TestApp.plist"
+	printf '%s\n' "$HOME/Library/Preferences/ByHost/com.example.TestApp.ABC123.plist"
+}
+
+selected_apps=()
+selected_apps+=("0|$app_bundle|TestApp|com.example.TestApp|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+printf '\n' | batch_uninstall_applications
+
+# defaults delete must have been called
+grep -q 'defaults delete com.example.TestApp' "$trace" \
+	|| { echo "FAIL: defaults delete not called"; cat "$trace"; exit 1; }
+# ByHost mole_delete must have been called
+grep -q 'ByHost.*com.example.TestApp.*plist' "$trace" \
+	|| { echo "FAIL: ByHost cleanup not called"; cat "$trace"; exit 1; }
+EOF
+
+	[ "$status" -eq 0 ]
+}

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -1537,6 +1537,82 @@ INNER
 # File selector regression: defaults delete / ByHost cleanup respect selection
 # ---------------------------------------------------------------------------
 
+@test "file selector deselecting app bundle does not request sudo for leftover-only cleanup" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+enter_alt_screen() { :; }
+leave_alt_screen() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+remove_apps_from_dock() {
+	printf 'dock %s\n' "$*" >> "$trace"
+}
+pgrep() { return 1; }
+pkill() { return 0; }
+sudo() { return 0; }
+has_sensitive_data() { return 1; }
+find_app_system_files() { return 0; }
+get_brew_cask_name() { echo "testapp"; }
+ensure_sudo_session() {
+	printf 'ensure_sudo %s\n' "$*" >> "$trace"
+	return 0
+}
+
+trace="$HOME/leftover_only_trace.log"
+mole_delete() {
+	printf 'mole_delete %s %s\n' "$1" "$2" >> "$trace"
+	return 0
+}
+defaults() { return 1; }
+
+app_bundle="$HOME/Applications/TestApp.app"
+leftover="$HOME/Library/Caches/TestApp"
+mkdir -p "$app_bundle" "$leftover"
+
+find_app_files() {
+	printf '%s\n' "$leftover"
+}
+
+select_files_for_removal() {
+	MOLE_SFR_USER_FILES="$leftover"
+	MOLE_SFR_SYSTEM_FILES=""
+	return 0
+}
+
+selected_apps=()
+selected_apps+=("0|$app_bundle|TestApp|com.example.TestApp|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+printf '\n' | batch_uninstall_applications
+
+if grep -q 'ensure_sudo' "$trace"; then
+	echo "FAIL: sudo requested for leftover-only cleanup"
+	cat "$trace"
+	exit 1
+fi
+if grep -q "mole_delete $app_bundle" "$trace"; then
+	echo "FAIL: app bundle removed despite deselection"
+	cat "$trace"
+	exit 1
+fi
+grep -q "mole_delete $leftover false" "$trace"
+if grep -q '^dock ' "$trace"; then
+	echo "FAIL: Dock cleanup ran without a removed app bundle"
+	cat "$trace"
+	exit 1
+fi
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "defaults delete is skipped when preferences plist is deselected in file selector" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/uninstall_safety.bats
+++ b/tests/uninstall_safety.bats
@@ -238,7 +238,7 @@ files_cleaned=0
 total_items=0
 total_size_cleaned=0
 
-batch_uninstall_applications
+printf '\n' | batch_uninstall_applications
 
 if grep -q "ByHost.*com.example.TestApp.*plist|true" "$trace"; then
 	echo "ByHost plist routed through sudo mole_delete"


### PR DESCRIPTION
## Summary
Add interactive file selection before uninstall confirmation — users can now review and deselect individual files before removal. Also fix a bug where defaults delete and ByHost cleanup would run even when the user deselected those plists.

## Details

### New module: `lib/uninstall/file_selector.sh`
- Lightweight multi-select TUI for choosing which files to remove
- Team-prefix Group Containers (e.g. `FN2V63AD2J.com.foo`) are deselected by default — shared across apps from the same developer
- Integrated into `batch_uninstall_applications()` flow before final confirmation

### Bug fix: defaults delete / ByHost cleanup respects file selector
Previously, `defaults delete "$bundle_id"` and ByHost `find`+`mole_delete` ran unconditionally after successful app removal, ignoring the user's file selection. Now both operations check whether the corresponding plists were actually selected before executing.

### Integration
- `batch_uninstall_applications()`: pre-scan phase collects files → file selector filters them → execution uses filtered list
- When no files are selected for an app, it is skipped entirely
- When the app bundle is deselected but leftovers are kept, only the leftovers are removed

## Test plan
- [x] Deselecting preferences plist prevents defaults delete
- [x] Deselecting ByHost plists prevents ByHost cleanup
- [x] Selecting all files runs both defaults delete and ByHost cleanup
- [x] Pre-commit checks pass (bash syntax, shfmt, shellcheck)