### PR TITLE
fix(clean): preserve Gradle DSL cache integrity

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -228,6 +228,33 @@ end_section() {
 normalize_paths_for_cleanup() {
     local -a input_paths=("$@")
 
+    local _normalized_cleanup_path=""
+    _normalize_single_cleanup_path() {
+        local raw_path="$1"
+        local normalized="${raw_path%/}"
+        [[ -z "$normalized" ]] && normalized="$raw_path"
+
+        local gradle_caches_root="$HOME/.gradle/caches"
+        case "$normalized" in
+            "$gradle_caches_root"/*/groovy-dsl/*/* | "$gradle_caches_root"/*/kotlin-dsl/*/*)
+                local rel version dsl_dir rest hash
+                rel="${normalized#"$gradle_caches_root"/}"
+                version="${rel%%/*}"
+                rest="${rel#*/}"
+                dsl_dir="${rest%%/*}"
+                rest="${rest#*/}"
+                hash="${rest%%/*}"
+                if [[ -n "$version" && -n "$hash" &&
+                    ("$dsl_dir" == "groovy-dsl" || "$dsl_dir" == "kotlin-dsl") ]]; then
+                    _normalized_cleanup_path="$gradle_caches_root/$version/$dsl_dir/$hash"
+                    return
+                fi
+                ;;
+        esac
+
+        _normalized_cleanup_path="$normalized"
+    }
+
     # Fast path for large batches: O(n log n) via sort|awk instead of O(n²) bash loops.
     # Lex sort guarantees every parent path precedes its children, so a single-pass
     # awk can filter child paths by tracking only the last kept path.
@@ -235,11 +262,30 @@ normalize_paths_for_cleanup() {
     # they are output directly with null-byte delimiters and skipped by the sort pass.
     if [[ ${#input_paths[@]} -gt 50 ]]; then
         local -a _fast_pipeline=()
-        local _fast_path
+        local _fast_path _fast_raw
         for _fast_path in "${input_paths[@]}"; do
             if [[ "$_fast_path" == *$'\n'* ]]; then
                 printf '%s\0' "$_fast_path"
             else
+                _fast_raw="$_fast_path"
+                _fast_path="${_fast_path%/}"
+                [[ -z "$_fast_path" ]] && _fast_path="$_fast_raw"
+                local _gradle_caches_root="$HOME/.gradle/caches"
+                case "$_fast_path" in
+                    "$_gradle_caches_root"/*/groovy-dsl/*/* | "$_gradle_caches_root"/*/kotlin-dsl/*/*)
+                        local _rel _version _dsl_dir _rest _hash
+                        _rel="${_fast_path#"$_gradle_caches_root"/}"
+                        _version="${_rel%%/*}"
+                        _rest="${_rel#*/}"
+                        _dsl_dir="${_rest%%/*}"
+                        _rest="${_rest#*/}"
+                        _hash="${_rest%%/*}"
+                        if [[ -n "$_version" && -n "$_hash" &&
+                            ("$_dsl_dir" == "groovy-dsl" || "$_dsl_dir" == "kotlin-dsl") ]]; then
+                            _fast_path="$_gradle_caches_root/$_version/$_dsl_dir/$_hash"
+                        fi
+                        ;;
+                esac
                 _fast_pipeline+=("$_fast_path")
             fi
         done
@@ -259,8 +305,9 @@ normalize_paths_for_cleanup() {
     local -a unique_paths=()
 
     for path in "${input_paths[@]}"; do
-        local normalized="${path%/}"
-        [[ -z "$normalized" ]] && normalized="$path"
+        local normalized
+        _normalize_single_cleanup_path "$path"
+        normalized="$_normalized_cleanup_path"
         local found=false
         if [[ ${#unique_paths[@]} -gt 0 ]]; then
             for existing in "${unique_paths[@]}"; do

--- a/tests/regression.bats
+++ b/tests/regression.bats
@@ -259,3 +259,57 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"COUNT=2"* ]]
 }
+
+@test "normalize_paths_for_cleanup removes whole Gradle DSL hash dirs" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "$PYTHON_BIN" ]]; then
+    PYTHON_BIN=$(command -v python3 || command -v python || true)
+fi
+[[ -n "$PYTHON_BIN" ]] || { echo "python unavailable"; exit 127; }
+
+"$PYTHON_BIN" - <<'PY'
+from pathlib import Path
+import os
+project_root = Path(os.environ["PROJECT_ROOT"])
+text = (project_root / "bin/clean.sh").read_text()
+start = text.index("normalize_paths_for_cleanup() {")
+depth = 0
+end = None
+for i in range(start, len(text)):
+    ch = text[i]
+    if ch == "{":
+        depth += 1
+    elif ch == "}":
+        depth -= 1
+        if depth == 0:
+            end = i + 1
+            break
+Path("/tmp/normalize_paths_for_cleanup_gradle.sh").write_text(text[start:end] + "\n")
+PY
+
+source /tmp/normalize_paths_for_cleanup_gradle.sh
+
+hash_dir="$HOME/.gradle/caches/8.13/groovy-dsl/abc123"
+paths=(
+    "$hash_dir/metadata.bin"
+    "$hash_dir/classes/cp.bin"
+    "$HOME/.gradle/caches/8.13/kotlin-dsl/def456/metadata.bin"
+)
+
+normalized=()
+while IFS= read -r -d '' line; do
+    normalized+=("$line")
+done < <(normalize_paths_for_cleanup "${paths[@]}")
+
+printf '%s\n' "${normalized[@]}"
+
+[[ ${#normalized[@]} -eq 2 ]]
+[[ "${normalized[0]}" == "$HOME/.gradle/caches/8.13/groovy-dsl/abc123" || "${normalized[1]}" == "$HOME/.gradle/caches/8.13/groovy-dsl/abc123" ]]
+[[ "${normalized[0]}" == "$HOME/.gradle/caches/8.13/kotlin-dsl/def456" || "${normalized[1]}" == "$HOME/.gradle/caches/8.13/kotlin-dsl/def456" ]]
+EOF
+
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- normalize clean targets inside Gradle groovy-dsl/kotlin-dsl hash caches to the whole hash directory
- keep the existing large-batch path normalization performance path intact
- add regression coverage for Gradle DSL cache files

Closes #873

## Verification
- ./scripts/check.sh --format
- MOLE_TEST_NO_AUTH=1 bats tests/regression.bats tests/clean_dev_caches.bats
- MOLE_TEST_NO_AUTH=1 MOLE_TEST_JOBS=2 BATS_FORMATTER=tap ./scripts/test.sh
