### PR TITLE
fix: harden cleanup hints and purge empty artifacts

### DIFF
--- a/bin/completion.sh
+++ b/bin/completion.sh
@@ -13,6 +13,7 @@ done
 command_words="${command_names[*]}"
 clean_option_words="--dry-run -n --external --whitelist --debug --help -h"
 analyze_option_words="--json --help -h"
+purge_option_words="--paths --dry-run -n --include-empty --debug --help -h"
 
 emit_zsh_subcommands() {
     for entry in "${MOLE_COMMANDS[@]}"; do
@@ -37,6 +38,11 @@ emit_fish_completions() {
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from analyze analyse" -l json -d "Output analysis as JSON"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from analyze analyse" -l help -s h -d "Show help"\n' "$cmd"
     printf 'complete -c %s -n "__fish_seen_subcommand_from analyze analyse; and not __fish_seen_argument -l json -l help -s h" -a "(__fish_complete_directories)" -d "Path to analyze"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l paths -d "Edit custom scan directories"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l dry-run -s n -d "Preview purge actions without making changes"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l include-empty -d "Show zero-size project artifact directories"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l debug -d "Show detailed logs"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l help -s h -d "Show help"\n' "$cmd"
     printf '\n'
     printf 'complete -f -c %s -n "not __fish_mole_no_subcommand" -a bash -d "generate bash completion" -n "__fish_see_subcommand_path completion"\n' "$cmd"
     printf 'complete -f -c %s -n "not __fish_mole_no_subcommand" -a zsh -d "generate zsh completion" -n "__fish_see_subcommand_path completion"\n' "$cmd"
@@ -329,6 +335,9 @@ _mole_completions()
                     COMPREPLY=( \$(compgen -f -- "\$cur_word") )
                 fi
                 ;;
+            purge)
+                COMPREPLY=( \$(compgen -W "$purge_option_words" -- "\$cur_word") )
+                ;;
             completion)
                 COMPREPLY=( \$(compgen -W "bash zsh fish" -- "\$cur_word") )
                 ;;
@@ -368,6 +377,15 @@ EOF
         printf "                '--json[Output analysis as JSON]' \\\\\n"
         printf "                '(-h --help)'{-h,--help}'[Show help]' \\\\\n"
         printf "                '*:path:_files'\n"
+        printf '            ;;\n'
+        printf '        purge)\n'
+        printf '            _arguments \\\n'
+        printf "                '--paths[Edit custom scan directories]' \\\\\n"
+        printf "                '--dry-run[Preview purge actions without making changes]' \\\\\n"
+        printf "                '-n[Preview purge actions without making changes]' \\\\\n"
+        printf "                '--include-empty[Show zero-size project artifact directories]' \\\\\n"
+        printf "                '--debug[Show detailed logs]' \\\\\n"
+        printf "                '(-h --help)'{-h,--help}'[Show help]'\n"
         printf '            ;;\n'
         printf '        completion)\n'
         printf "            _arguments '1:shell:(bash zsh fish)'\n"

--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -282,6 +282,7 @@ show_help() {
     echo -e "${YELLOW}Options:${NC}"
     echo "  --paths         Edit custom scan directories"
     echo "  --dry-run       Preview purge actions without making changes"
+    echo "  --include-empty Show zero-size project artifact directories"
     echo "  --debug         Enable debug logging"
     echo "  --help          Show this help message"
     echo ""
@@ -313,6 +314,9 @@ main() {
                 ;;
             "--dry-run" | "-n")
                 export MOLE_DRY_RUN=1
+                ;;
+            "--include-empty")
+                export MOLE_PURGE_INCLUDE_EMPTY=1
                 ;;
             *)
                 echo "Unknown option: $arg"

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -510,6 +510,19 @@ uninstall_resolve_eligible_bundle_id() {
     printf '%s\n' "$bundle_id"
 }
 
+uninstall_print_app_paths_with_mtime() {
+    local app_dir="$1"
+    local app_path app_mtime
+
+    [[ -d "$app_dir" ]] || return 0
+
+    while IFS= read -r -d '' app_path; do
+        [[ -n "$app_path" ]] || continue
+        app_mtime=$(get_file_mtime "$app_path")
+        printf '%s\t%s\n' "${app_mtime:-0}" "$app_path"
+    done < <(command find "$app_dir" -maxdepth 3 -name "*.app" -print0 2> /dev/null)
+}
+
 uninstall_app_inventory_fingerprint() {
     local app_dir app_path app_mtime pkg_app_path
 
@@ -526,7 +539,7 @@ uninstall_app_inventory_fingerprint() {
                 [[ -n "$app_path" ]] || continue
                 uninstall_should_skip_app_path "$app_path" && continue
                 printf '%s|%s\n' "$app_path" "${app_mtime:-0}"
-            done < <(command find "$app_dir" -maxdepth 3 -name "*.app" -exec stat -f $'%m\t%N' {} + 2> /dev/null)
+            done < <(uninstall_print_app_paths_with_mtime "$app_dir")
         done < <(uninstall_print_app_search_dirs)
     } | sort -u
 }
@@ -666,7 +679,7 @@ scan_applications() {
             uninstall_should_skip_app_path "$app_path" && continue
 
             printf "%s|%s|%s\n" "$app_path" "$app_name" "${app_mtime:-0}" >> "$discovered_file"
-        done < <(command find "$app_dir" -maxdepth 3 -name "*.app" -exec stat -f $'%m\t%N' {} + 2> /dev/null)
+        done < <(uninstall_print_app_paths_with_mtime "$app_dir")
     done
 
     if [[ -s "$discovered_file" ]]; then

--- a/lib/clean/hints.sh
+++ b/lib/clean/hints.sh
@@ -139,6 +139,99 @@ hint_launch_agent_bundle_exists() {
 }
 
 # shellcheck disable=SC2329
+hint_normalize_app_match_text() {
+    printf '%s' "${1:-}" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -cd '[:alnum:]'
+}
+
+# shellcheck disable=SC2329
+hint_dotdir_candidate_matches_text() {
+    local text="$1"
+    shift || true
+    [[ $# -gt 0 ]] || return 1
+
+    local normalized_text
+    normalized_text=$(hint_normalize_app_match_text "$text")
+    [[ -n "$normalized_text" ]] || return 1
+
+    local candidate normalized_candidate
+    for candidate in "$@"; do
+        normalized_candidate=$(hint_normalize_app_match_text "$candidate")
+        [[ ${#normalized_candidate} -ge 4 ]] || continue
+        if [[ "$normalized_text" == "$normalized_candidate" || "$normalized_text" == *"$normalized_candidate"* ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# shellcheck disable=SC2329
+hint_collect_installed_gui_app_match_texts() {
+    local -a app_roots=(
+        "/Applications"
+        "/Applications/Setapp"
+        "/Applications/Utilities"
+        "$HOME/Applications"
+        "/Library/Input Methods"
+        "$HOME/Library/Input Methods"
+        "$HOME/Library/Application Support/Setapp/Applications"
+    )
+
+    local app_root app_path app_name info value
+    for app_root in "${app_roots[@]}"; do
+        [[ -d "$app_root" ]] || continue
+        while IFS= read -r -d '' app_path; do
+            [[ -n "$app_path" ]] || continue
+
+            app_name="${app_path##*/}"
+            app_name="${app_name%.app}"
+            printf '%s\n' "$app_name"
+
+            info="$app_path/Contents/Info.plist"
+            [[ -f "$info" ]] || continue
+            for value in \
+                "$(plutil -extract CFBundleIdentifier raw "$info" 2> /dev/null || echo "")" \
+                "$(plutil -extract CFBundleName raw "$info" 2> /dev/null || echo "")" \
+                "$(plutil -extract CFBundleDisplayName raw "$info" 2> /dev/null || echo "")"; do
+                [[ -n "$value" && "$value" != "(null)" ]] && printf '%s\n' "$value"
+            done
+        done < <(run_with_timeout 2 find "$app_root" -maxdepth 2 -name "*.app" -print0 2> /dev/null || true)
+    done
+
+    local -a cask_roots=(
+        "/opt/homebrew/Caskroom"
+        "/usr/local/Caskroom"
+    )
+
+    local cask_root cask_dir cask_name
+    for cask_root in "${cask_roots[@]}"; do
+        [[ -d "$cask_root" ]] || continue
+        while IFS= read -r -d '' cask_dir; do
+            [[ -n "$cask_dir" ]] || continue
+            cask_name="${cask_dir##*/}"
+            printf '%s\n' "$cask_name"
+        done < <(run_with_timeout 1 find "$cask_root" -mindepth 1 -maxdepth 1 -type d -print0 2> /dev/null || true)
+    done
+}
+
+# shellcheck disable=SC2329
+hint_dotdir_owned_by_installed_gui_app() {
+    local installed_app_texts="$1"
+    shift || true
+    [[ -n "$installed_app_texts" && $# -gt 0 ]] || return 1
+
+    local value
+    while IFS= read -r value; do
+        [[ -n "$value" ]] || continue
+        if hint_dotdir_candidate_matches_text "$value" "$@"; then
+            return 0
+        fi
+    done <<< "$installed_app_texts"
+
+    return 1
+}
+
+# shellcheck disable=SC2329
 record_project_artifact_hint() {
     local path="$1"
 
@@ -433,7 +526,11 @@ show_project_artifact_hint_notice() {
     if [[ -n "$example_text" ]]; then
         echo -e "  ${GRAY}${ICON_SUBLIST}${NC} Examples: ${GRAY}${example_text}${NC}"
     fi
-    echo -e "  ${GRAY}${ICON_REVIEW}${NC} Review: mo purge"
+    local review_command="mo purge"
+    if [[ $PROJECT_ARTIFACT_HINT_ESTIMATE_SAMPLES -gt 0 && $PROJECT_ARTIFACT_HINT_ESTIMATED_KB -eq 0 ]]; then
+        review_command="mo purge --include-empty"
+    fi
+    echo -e "  ${GRAY}${ICON_REVIEW}${NC} Review: ${review_command}"
 }
 
 # shellcheck disable=SC2329
@@ -554,6 +651,8 @@ show_orphan_dotdir_hint_notice() {
 
     local -a labels=()
     local -a details=()
+    local installed_gui_app_texts=""
+    local installed_gui_app_texts_loaded=false
 
     while IFS= read -r dotdir; do
         [[ -d "$dotdir" ]] || continue
@@ -601,6 +700,14 @@ show_orphan_dotdir_hint_notice() {
             fi
         done
         [[ "$has_binary" == "true" ]] && continue
+
+        if [[ "$installed_gui_app_texts_loaded" != "true" ]]; then
+            installed_gui_app_texts=$(hint_collect_installed_gui_app_match_texts)
+            installed_gui_app_texts_loaded=true
+        fi
+        if hint_dotdir_owned_by_installed_gui_app "$installed_gui_app_texts" "${candidates[@]}"; then
+            continue
+        fi
 
         if [[ -d "$HOME/Library/LaunchAgents" ]]; then
             if run_with_timeout 2 grep -rlq "$basename" "$HOME/Library/LaunchAgents/" 2> /dev/null; then

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -629,7 +629,8 @@ get_dir_size_kb() {
     fi
 
     if [[ $du_exit -ne 0 ]]; then
-        echo "0"
+        debug_log "Size calculation failed (exit $du_exit): $path"
+        echo "ERROR"
         return
     fi
 
@@ -638,7 +639,8 @@ get_dir_size_kb() {
     if [[ "$size_kb" =~ ^[0-9]+$ ]]; then
         echo "$size_kb"
     else
-        echo "0"
+        debug_log "Size calculation returned invalid output: $path"
+        echo "ERROR"
     fi
 }
 # Purge category selector.
@@ -1381,14 +1383,17 @@ clean_project_artifacts() {
         if [[ "$size_raw" == "TIMEOUT" ]]; then
             size_unknown=true
             size_human="unknown"
+        elif [[ "$size_raw" == "ERROR" ]]; then
+            debug_log "Skipping purge target with unknown size: $item"
+            continue
         elif [[ "$size_raw" =~ ^[0-9]+$ ]]; then
             size_kb="$size_raw"
-            # Skip empty directories (0 bytes)
-            if [[ $size_kb -eq 0 ]]; then
+            if [[ $size_kb -eq 0 && "${MOLE_PURGE_INCLUDE_EMPTY:-0}" != "1" ]]; then
                 continue
             fi
             size_human=$(bytes_to_human "$((size_kb * 1024))")
         else
+            debug_log "Skipping purge target with invalid size result '$size_raw': $item"
             continue
         fi
 

--- a/tests/clean_hints.bats
+++ b/tests/clean_hints.bats
@@ -76,6 +76,30 @@ EOT2
     [[ "$output" == *"Review: mo purge"* ]]
 }
 
+@test "show_project_artifact_hint_notice points zero-size samples to include-empty (#869)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOT2B'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+probe_project_artifact_hints() {
+    PROJECT_ARTIFACT_HINT_DETECTED=true
+    PROJECT_ARTIFACT_HINT_COUNT=1
+    PROJECT_ARTIFACT_HINT_TRUNCATED=false
+    PROJECT_ARTIFACT_HINT_EXAMPLES=("~/www/demo/node_modules")
+    PROJECT_ARTIFACT_HINT_ESTIMATED_KB=0
+    PROJECT_ARTIFACT_HINT_ESTIMATE_SAMPLES=1
+    PROJECT_ARTIFACT_HINT_ESTIMATE_PARTIAL=false
+}
+bytes_to_human() { echo "0B"; }
+note_activity() { :; }
+show_project_artifact_hint_notice
+EOT2B
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sampled 0B"* ]]
+    [[ "$output" == *"Review: mo purge --include-empty"* ]]
+}
+
 @test "show_system_data_hint_notice reports large clue paths" {
     mkdir -p "$HOME/Library/Developer/Xcode/DerivedData"
 
@@ -255,6 +279,39 @@ EOTD
     [[ "$output" == *"Potential orphan dotfile"* ]]
     [[ "$output" == *".fakecli-test-orphan"* ]]
     [[ "$output" == *"No matching binary in PATH"* ]]
+}
+
+@test "show_orphan_dotdir_hint_notice skips dotdir owned by installed GUI app (#872)" {
+    mkdir -p "$HOME/.bridge"
+    touch -t 202401010000 "$HOME/.bridge"
+
+    local app_path="$HOME/Applications/Proton Mail Bridge.app"
+    mkdir -p "$app_path/Contents"
+    cat > "$app_path/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>ch.protonmail.bridge</string>
+    <key>CFBundleName</key>
+    <string>Proton Mail Bridge</string>
+</dict>
+</plist>
+PLIST
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+hint_get_path_size_kb_with_timeout() { echo "1024"; }
+show_orphan_dotdir_hint_notice
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *".bridge"* ]]
 }
 
 @test "show_orphan_dotdir_hint_notice skips dir with existing binary" {

--- a/tests/completion.bats
+++ b/tests/completion.bats
@@ -78,11 +78,12 @@ setup() {
 	[[ "$output" == *"complete -F _mole_completions mole mo"* ]]
 }
 
-@test "completion bash includes current clean and analyze options only" {
+@test "completion bash includes current clean, analyze, and purge options only" {
 	run "$PROJECT_ROOT/bin/completion.sh" bash
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"--dry-run -n --external --whitelist --debug --help -h"* ]]
 	[[ "$output" == *"--json --help -h"* ]]
+	[[ "$output" == *"--paths --dry-run -n --include-empty --debug --help -h"* ]]
 	[[ "$output" != *"--select"* ]]
 	[[ "$output" != *"--categories"* ]]
 	[[ "$output" != *"--exclude-paths"* ]]
@@ -108,13 +109,14 @@ setup() {
 	[[ "$output" == *"clean:Free up disk space"* ]]
 }
 
-@test "completion zsh includes current clean and analyze options only" {
+@test "completion zsh includes current clean, analyze, and purge options only" {
 	run "$PROJECT_ROOT/bin/completion.sh" zsh
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"--dry-run"* ]]
 	[[ "$output" == *"--external"* ]]
 	[[ "$output" == *"--whitelist"* ]]
 	[[ "$output" == *"--json"* ]]
+	[[ "$output" == *"--include-empty"* ]]
 	[[ "$output" != *"--select"* ]]
 	[[ "$output" != *"--categories"* ]]
 	[[ "$output" != *"--exclude-paths"* ]]
@@ -136,13 +138,14 @@ setup() {
 	[ "$mo_count" -gt 0 ]
 }
 
-@test "completion fish includes current clean and analyze options only" {
+@test "completion fish includes current clean, analyze, and purge options only" {
 	run "$PROJECT_ROOT/bin/completion.sh" fish
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"-l dry-run"* ]]
 	[[ "$output" == *"-l external"* ]]
 	[[ "$output" == *"-l whitelist"* ]]
 	[[ "$output" == *"-l json"* ]]
+	[[ "$output" == *"-l include-empty"* ]]
 	[[ "$output" != *"-l select"* ]]
 	[[ "$output" != *"-l categories"* ]]
 	[[ "$output" != *"-l exclude-paths"* ]]

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -783,6 +783,19 @@ EOF
 	[[ "$result" == "TIMEOUT" ]]
 }
 
+@test "get_dir_size_kb: returns ERROR when du fails without timing out" {
+	mkdir -p "$HOME/www/error-project/node_modules"
+
+	result=$(bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/clean/project.sh'
+        run_with_timeout() { return 2; }
+        get_dir_size_kb '$HOME/www/error-project/node_modules'
+    ")
+
+	[[ "$result" == "ERROR" ]]
+}
+
 @test "clean_project_artifacts: restores caller INT/TERM traps" {
 	result=$(bash -c "
         set -euo pipefail
@@ -841,6 +854,58 @@ EOF
 
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"No artifacts found to purge"* ]]
+}
+
+@test "clean_project_artifacts: include-empty exposes zero-size artifacts (#869)" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+mkdir -p "$HOME/.cache/mole"
+echo "0" > "$HOME/.cache/mole/purge_stats"
+
+mkdir -p "$HOME/www/test-project/node_modules"
+touch "$HOME/www/test-project/package.json"
+touch -t 202001010101 "$HOME/www/test-project/node_modules" "$HOME/www/test-project/package.json" "$HOME/www/test-project"
+
+PURGE_SEARCH_PATHS=("$HOME/www")
+get_dir_size_kb() { echo 0; }
+
+export MOLE_PURGE_INCLUDE_EMPTY=1
+export MOLE_DRY_RUN=1
+clean_project_artifacts </dev/null
+
+stats_dir="${XDG_CACHE_HOME:-$HOME/.cache}/mole"
+echo "COUNT=$(cat "$stats_dir/purge_count" 2> /dev/null || echo missing)"
+echo "SIZE=$(cat "$stats_dir/purge_stats" 2> /dev/null || echo missing)"
+[[ -d "$HOME/www/test-project/node_modules" ]]
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"COUNT=1"* ]]
+	[[ "$output" == *"SIZE=0"* ]]
+}
+
+@test "clean_project_artifacts: skips size calculation errors instead of showing 0B (#869)" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+mkdir -p "$HOME/www/test-project/node_modules"
+touch "$HOME/www/test-project/package.json"
+touch -t 202001010101 "$HOME/www/test-project/node_modules" "$HOME/www/test-project/package.json" "$HOME/www/test-project"
+
+PURGE_SEARCH_PATHS=("$HOME/www")
+get_dir_size_kb() { echo ERROR; }
+
+clean_project_artifacts </dev/null
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"No artifacts found to purge"* ]]
+	[[ "$output" != *"0B"* ]]
 }
 
 @test "clean_project_artifacts: dry-run does not count failed removals" {
@@ -909,6 +974,13 @@ EOF
 	[[ "$output" == *"mo purge"* ]]
 }
 
+@test "mo purge --help includes include-empty option" {
+	run env HOME="$HOME" "$PROJECT_ROOT/mole" purge --help
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"--include-empty"* ]]
+	[[ "$output" == *"Show zero-size project artifact directories"* ]]
+}
+
 @test "mo purge: accepts --debug flag" {
 	if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
 		skip "gtimeout/timeout not available"
@@ -938,6 +1010,23 @@ EOF
     "
 
 	[[ "$output" == *"DRY RUN MODE"* ]] || [[ "$output" == *"Dry run complete"* ]]
+}
+
+@test "mo purge: accepts --include-empty flag" {
+	if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+		skip "gtimeout/timeout not available"
+	fi
+
+	timeout_cmd="timeout"
+	command -v timeout >/dev/null 2>&1 || timeout_cmd="gtimeout"
+
+	run bash -c "
+        export HOME='$HOME'
+        $timeout_cmd 10 '$PROJECT_ROOT/mole' purge --include-empty --dry-run < /dev/null 2>&1
+    "
+
+	[ "$status" -eq 0 ] || [ "$status" -eq 2 ]
+	[[ "$output" != *"Unknown option"* ]]
 }
 
 @test "mo purge: creates cache directory for stats" {

--- a/tests/regression.bats
+++ b/tests/regression.bats
@@ -189,7 +189,7 @@ EOF
 }
 
 @test "normalize_paths_for_cleanup handles large nested batches without hanging" {
-    local limit_ms="${MOLE_PERF_NORMALIZE_PATHS_LIMIT_MS:-4000}"
+    local limit_ms="${MOLE_PERF_NORMALIZE_PATHS_LIMIT_MS:-10000}"
 
     run env PROJECT_ROOT="$PROJECT_ROOT" LIMIT_MS="$limit_ms" bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -163,3 +163,50 @@ EOF
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"|$app_path|Artpaper|andriiliakh.Artpaper|"* ]]
 }
+
+@test "scan_applications ignores PATH stat shims (#865)" {
+	src="$HOME/uninstall_source.sh"
+	sourceable_uninstall_sh "$src"
+
+	apps_root="$HOME/Applications"
+	app_path="$apps_root/Plain.app"
+	mkdir -p "$app_path/Contents"
+	cat > "$app_path/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Plain</string>
+    <key>CFBundleName</key>
+    <string>Plain</string>
+</dict>
+</plist>
+PLIST
+
+	stub_dir="$HOME/stub-bin"
+	mkdir -p "$stub_dir"
+	cat > "$stub_dir/stat" <<'SH'
+#!/bin/sh
+exit 64
+SH
+	chmod +x "$stub_dir/stat"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+		MOLE_TEST_NO_AUTH=1 APPS_ROOT="$apps_root" SRC_PATH="$src" \
+		PATH="$stub_dir:$PATH" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$SRC_PATH"
+
+uninstall_print_app_search_dirs() { printf '%s\n' "$APPS_ROOT"; }
+
+apps_file=$(scan_applications)
+cat "$apps_file"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"|$app_path|Plain|com.example.Plain|"* ]]
+}


### PR DESCRIPTION
Summary:
- harden mo uninstall app scanning so PATH stat shims cannot hide installed apps
- suppress orphan dotdir hints when a matching GUI app or cask is still installed
- add mo purge --include-empty and skip purge size measurement errors instead of showing them as 0B

Verification:
- ./scripts/check.sh --format
- MOLE_TEST_NO_AUTH=1 bats tests/uninstall_scan_bash32.bats tests/clean_hints.bats tests/purge.bats tests/completion.bats
- go test ./cmd/...
- MOLE_TEST_NO_AUTH=1 MOLE_TEST_JOBS=2 BATS_FORMATTER=tap ./scripts/test.sh

Closes #872
Closes #869
Related #865