### PR TITLE
fix(clean): don't flag GUI app dotdirs as orphan when a matching .app or cask exists (#872)

### DIFF
--- a/lib/clean/hints.sh
+++ b/lib/clean/hints.sh
@@ -641,6 +641,83 @@ readonly ORPHAN_DOTDIR_KNOWN_SAFE=(
     ".fly" ".gemini"
 )
 
+# Standard locations for installed GUI apps. Overridable from tests.
+_MOLE_DOTDIR_OWNER_APP_ROOTS=(
+    "/Applications"
+    "/Applications/Setapp"
+    "$HOME/Applications"
+)
+
+# Emit every alnum token found in installed .app filenames + brew casks,
+# lowercased, one per line. Caller filters/dedups.
+# shellcheck disable=SC2329
+_dotdir_owner_collect_tokens() {
+    local root entry name
+    for root in "${_MOLE_DOTDIR_OWNER_APP_ROOTS[@]}"; do
+        [[ -d "$root" ]] || continue
+        for entry in "$root"/*.app; do
+            [[ -e "$entry" ]] || continue
+            name=$(basename "$entry")
+            name="${name%.app}"
+            printf '%s\n' "$name" | LC_ALL=C tr 'A-Z' 'a-z' | LC_ALL=C tr -cs 'a-z0-9' '\n'
+        done
+    done
+
+    if command -v brew > /dev/null 2>&1; then
+        local cask_list=""
+        cask_list=$(HOMEBREW_NO_ENV_HINTS=1 run_with_timeout 5 brew list --cask 2> /dev/null) || true
+        if [[ -n "$cask_list" ]]; then
+            printf '%s\n' "$cask_list" | LC_ALL=C tr 'A-Z' 'a-z' | LC_ALL=C tr -cs 'a-z0-9' '\n'
+        fi
+    fi
+}
+
+# Return 0 if any ≥4-char token from `name` matches a token harvested from
+# installed `.app` bundles or Homebrew casks. Cached for 5 minutes. Short
+# tokens (<4 chars) on either side are ignored to avoid false matches like
+# `.ai-old` vs `AI.app`. See issue #872.
+# shellcheck disable=SC2329
+dotdir_has_owning_gui_app() {
+    local name="$1"
+    [[ -z "$name" ]] && return 1
+    [[ ${#name} -lt 4 ]] && return 1
+
+    local cache_dir="$HOME/.cache/mole"
+    local cache_file="$cache_dir/installed_app_tokens_cache"
+    local cache_ttl=300
+    local now
+    now=$(date +%s)
+
+    local rebuild=1
+    if [[ -f "$cache_file" ]]; then
+        local mtime
+        mtime=$(get_file_mtime "$cache_file" 2> /dev/null || echo 0)
+        if [[ -n "$mtime" ]] && [[ $((now - mtime)) -lt $cache_ttl ]]; then
+            rebuild=0
+        fi
+    fi
+    if [[ $rebuild -eq 1 ]]; then
+        ensure_user_dir "$cache_dir" 2> /dev/null || true
+        _dotdir_owner_collect_tokens 2> /dev/null |
+            LC_ALL=C awk 'length($0) >= 4' |
+            LC_ALL=C sort -u > "$cache_file" 2> /dev/null || return 1
+    fi
+    [[ -s "$cache_file" ]] || return 1
+
+    local name_lower
+    name_lower=$(printf '%s' "$name" | LC_ALL=C tr 'A-Z' 'a-z')
+    local tok
+    while IFS= read -r tok; do
+        [[ -z "$tok" ]] && continue
+        [[ ${#tok} -ge 4 ]] || continue
+        if LC_ALL=C grep -Fxq "$tok" "$cache_file" 2> /dev/null; then
+            return 0
+        fi
+    done < <(printf '%s\n' "$name_lower" | LC_ALL=C tr -cs 'a-z0-9' '\n')
+
+    return 1
+}
+
 # Detect ~/.<dir> directories that may belong to uninstalled CLI tools.
 # shellcheck disable=SC2329
 show_orphan_dotdir_hint_notice() {
@@ -713,6 +790,10 @@ show_orphan_dotdir_hint_notice() {
             if run_with_timeout 2 grep -rlq "$basename" "$HOME/Library/LaunchAgents/" 2> /dev/null; then
                 continue
             fi
+        fi
+
+        if dotdir_has_owning_gui_app "$name"; then
+            continue
         fi
 
         local size_human=""

--- a/lib/clean/hints.sh
+++ b/lib/clean/hints.sh
@@ -659,7 +659,7 @@ _dotdir_owner_collect_tokens() {
             [[ -e "$entry" ]] || continue
             name=$(basename "$entry")
             name="${name%.app}"
-            printf '%s\n' "$name" | LC_ALL=C tr 'A-Z' 'a-z' | LC_ALL=C tr -cs 'a-z0-9' '\n'
+            printf '%s\n' "$name" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -cs 'a-z0-9' '\n'
         done
     done
 
@@ -667,7 +667,7 @@ _dotdir_owner_collect_tokens() {
         local cask_list=""
         cask_list=$(HOMEBREW_NO_ENV_HINTS=1 run_with_timeout 5 brew list --cask 2> /dev/null) || true
         if [[ -n "$cask_list" ]]; then
-            printf '%s\n' "$cask_list" | LC_ALL=C tr 'A-Z' 'a-z' | LC_ALL=C tr -cs 'a-z0-9' '\n'
+            printf '%s\n' "$cask_list" | LC_ALL=C tr '[:upper:]' '[:lower:]' | LC_ALL=C tr -cs 'a-z0-9' '\n'
         fi
     fi
 }
@@ -705,7 +705,7 @@ dotdir_has_owning_gui_app() {
     [[ -s "$cache_file" ]] || return 1
 
     local name_lower
-    name_lower=$(printf '%s' "$name" | LC_ALL=C tr 'A-Z' 'a-z')
+    name_lower=$(printf '%s' "$name" | LC_ALL=C tr '[:upper:]' '[:lower:]')
     local tok
     while IFS= read -r tok; do
         [[ -z "$tok" ]] && continue

--- a/tests/clean_hints.bats
+++ b/tests/clean_hints.bats
@@ -20,6 +20,7 @@ teardown_file() {
 
 setup() {
     rm -rf "${HOME:?}"/*
+    rm -rf "${HOME:?}"/.[!.]* "${HOME:?}"/..?* 2> /dev/null || true
     mkdir -p "$HOME/.config/mole"
 }
 
@@ -347,6 +348,123 @@ EOTD
 
     [ "$status" -eq 0 ]
     [[ "$output" != *".youngcli-test"* ]]
+}
+
+@test "show_orphan_dotdir_hint_notice skips dotdir whose name matches an installed .app token (#872)" {
+    mkdir -p "$HOME/.bridge"
+    touch -t 202401010000 "$HOME/.bridge"
+
+    local fake_apps_root="$HOME/fake-Applications"
+    mkdir -p "$fake_apps_root/Proton Mail Bridge.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" FAKE_APPS_ROOT="$fake_apps_root" \
+        bash --noprofile --norc <<'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+hint_get_path_size_kb_with_timeout() { echo "100"; }
+brew() { return 0; }
+export -f brew
+_MOLE_DOTDIR_OWNER_APP_ROOTS=("$FAKE_APPS_ROOT")
+show_orphan_dotdir_hint_notice
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *".bridge"* ]]
+    [[ "$output" != *"Potential orphan dotfile"* ]]
+}
+
+@test "show_orphan_dotdir_hint_notice skips dotdir whose name matches a brew cask token (#872)" {
+    mkdir -p "$HOME/.bridge"
+    touch -t 202401010000 "$HOME/.bridge"
+
+    local empty_apps_root="$HOME/empty-Applications"
+    mkdir -p "$empty_apps_root"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" EMPTY_APPS_ROOT="$empty_apps_root" \
+        bash --noprofile --norc <<'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+hint_get_path_size_kb_with_timeout() { echo "100"; }
+brew() {
+    if [[ "${1:-}" == "list" && "${2:-}" == "--cask" ]]; then
+        printf '%s\n' "proton-mail-bridge" "1password"
+        return 0
+    fi
+    return 0
+}
+export -f brew
+_MOLE_DOTDIR_OWNER_APP_ROOTS=("$EMPTY_APPS_ROOT")
+show_orphan_dotdir_hint_notice
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *".bridge"* ]]
+    [[ "$output" != *"Potential orphan dotfile"* ]]
+}
+
+@test "show_orphan_dotdir_hint_notice still flags dotdir whose name has no matching app or cask (#872)" {
+    mkdir -p "$HOME/.fakeorphan42xyz"
+    touch -t 202401010000 "$HOME/.fakeorphan42xyz"
+
+    local empty_apps_root="$HOME/empty-Applications2"
+    mkdir -p "$empty_apps_root"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" EMPTY_APPS_ROOT="$empty_apps_root" \
+        bash --noprofile --norc <<'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+hint_get_path_size_kb_with_timeout() { echo "100"; }
+brew() {
+    if [[ "${1:-}" == "list" && "${2:-}" == "--cask" ]]; then
+        printf '%s\n' "1password" "rectangle"
+        return 0
+    fi
+    return 0
+}
+export -f brew
+_MOLE_DOTDIR_OWNER_APP_ROOTS=("$EMPTY_APPS_ROOT")
+show_orphan_dotdir_hint_notice
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Potential orphan dotfile"* ]]
+    [[ "$output" == *".fakeorphan42xyz"* ]]
+}
+
+@test "show_orphan_dotdir_hint_notice ignores short app-name tokens (<4 chars) to avoid false matches (#872)" {
+    # `.ai-old` — token `ai` is 2 chars; an `AI.app` should NOT exempt it.
+    mkdir -p "$HOME/.ai-old"
+    touch -t 202401010000 "$HOME/.ai-old"
+
+    local fake_apps_root="$HOME/fake-Applications-short"
+    mkdir -p "$fake_apps_root/AI.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" FAKE_APPS_ROOT="$fake_apps_root" \
+        bash --noprofile --norc <<'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+hint_get_path_size_kb_with_timeout() { echo "100"; }
+brew() { return 0; }
+export -f brew
+_MOLE_DOTDIR_OWNER_APP_ROOTS=("$FAKE_APPS_ROOT")
+show_orphan_dotdir_hint_notice
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Potential orphan dotfile"* ]]
+    [[ "$output" == *".ai-old"* ]]
 }
 
 @test "show_orphan_dotdir_hint_notice limits output to max 5 candidates" {


### PR DESCRIPTION
## What

Adds a fifth ownership gate to `show_orphan_dotdir_hint_notice` so a hidden home directory is not reported as a potential orphan when an installed `.app` bundle or a Homebrew cask shares a name token with it.

## Why

Repro from #872:

1. `brew install --cask proton-mail-bridge`
2. `/Applications/Proton Mail Bridge.app` exists, `~/.bridge` is active app data.
3. `mo clean` reports `~/.bridge` as a potential orphan because there is no `bridge` binary on `PATH` and no LaunchAgent referencing it.

The existing gates (allowlist, user whitelist, `command -v`, LaunchAgents grep) cover CLI tools well but miss GUI apps that don't expose a binary in `PATH`.

## How

A new helper `dotdir_has_owning_gui_app NAME`:

- Scans `.app` filenames in `/Applications`, `/Applications/Setapp`, `$HOME/Applications`, plus `brew list --cask` output.
- Tokenizes both sides on non-alphanumeric chars, lowercases.
  - `Proton Mail Bridge.app` → `proton`, `mail`, `bridge`.
  - `proton-mail-bridge` (cask) → `proton`, `mail`, `bridge`.
- Considers tokens with length ≥ 4 only — avoids matching `.ai-old` to `AI.app`.
- Caches the token list under `$HOME/.cache/mole/installed_app_tokens_cache` with a 5-minute TTL (same pattern as `scan_installed_apps`).
- Returns 0 if any token from the dotdir name matches any token in the cache.

The gate is inserted between the LaunchAgents grep and the size calculation, so a positive match short-circuits exactly like the existing gates.

## Testing

`tests/clean_hints.bats` — 4 new bats tests covering:

- `.bridge` not flagged when fake `Proton Mail Bridge.app` is present.
- `.bridge` not flagged when fake cask `proton-mail-bridge` is reported by `brew list --cask`.
- `.fakeorphan42xyz` still flagged when no app/cask matches (existing behaviour preserved).
- `.ai-old` still flagged even with `AI.app` present, because the app token `ai` is below the 4-char threshold.

Adjacent sweep: `bats tests/clean_hints.bats tests/clean_apps.bats tests/clean_core.bats tests/clean_user_core.bats` — 92/92 ok locally.

## Trade-offs

- **False negative bias on purpose.** A dotdir gets a pass whenever any installed app/cask shares a long-enough name token. This errs on the side of *not* nagging the user about something that might be live app data. The hint is non-destructive (it only suggests review), so a missed orphan is strictly better than a false positive on active data.
- **Brew call cost.** First invocation per 5 minutes runs `brew list --cask` (typically 1–3 s). Cached after that. Wrapped in `run_with_timeout 5`.
- **Cache shape.** Plain text, one token per line, sorted and deduped. Lives next to the existing `installed_apps_cache`.

Closes #872.