### PR TITLE
fix(clean): keep app scan find options portable

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -108,7 +108,7 @@ scan_installed_apps() {
             local -a app_paths=()
             while IFS= read -r app_path; do
                 [[ -n "$app_path" ]] && app_paths+=("$app_path")
-            done < <(find "$app_dir" -name '*.app' -maxdepth 3 -type d 2> /dev/null)
+            done < <(command find "$app_dir" -maxdepth 3 -type d -name '*.app' 2> /dev/null)
             local count=0
             for app_path in "${app_paths[@]:-}"; do
                 local plist_path="$app_path/Contents/Info.plist"

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -129,6 +129,54 @@ EOF
     [[ "$output" != *"missing value"* ]]
 }
 
+@test "scan_installed_apps keeps find traversal options before predicates" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+stub_dir="$HOME/stub-bin"
+mkdir -p "$stub_dir" "$HOME/Applications/Ordered.app/Contents"
+cat > "$stub_dir/find" <<'SH'
+#!/bin/sh
+root="$1"
+shift
+if [ "${1:-}" != "-maxdepth" ] ||
+    [ "${2:-}" != "3" ] ||
+    [ "${3:-}" != "-type" ] ||
+    [ "${4:-}" != "d" ] ||
+    [ "${5:-}" != "-name" ] ||
+    [ "${6:-}" != "*.app" ]; then
+    exit 64
+fi
+
+if [ "$root" = "$HOME/Applications" ]; then
+    printf '%s\n' "$HOME/Applications/Ordered.app"
+fi
+SH
+chmod +x "$stub_dir/find"
+
+cat > "$HOME/Applications/Ordered.app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Ordered</string>
+</dict>
+</plist>
+PLIST
+
+debug_log() { :; }
+export PATH="$stub_dir:$PATH"
+scan_installed_apps "$HOME/installed.txt"
+cat "$HOME/installed.txt"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"com.example.Ordered"* ]]
+}
+
 @test "is_bundle_orphaned returns true for old uninstalled bundle" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" ORPHAN_AGE_THRESHOLD=30 bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Keep the `scan_installed_apps` filesystem scan portable by placing `find` traversal options before predicates.
- Add a regression test with a strict fake `find` so the option ordering stays guarded.

## Safety Review
- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
  - Yes, clean's installed-app inventory now calls `find` with BSD/GNU-friendly option ordering. It only changes app discovery used for orphan detection.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
  - No. No deletion, sudo, validation, or install boundaries changed.
- If yes, describe the new boundary or risk change clearly.
  - None. The scan remains read-only and still limited to the same application directories and depth.

## Tests
- `./scripts/check.sh --no-format`
- `git diff --check`
- Direct regression shell check mirroring the new Bats case with a strict fake `find`

## Safety-related changes
- None.
