### PR TITLE
feat(clean): add UTM virtualization cache cleanup

### DIFF
--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -1516,10 +1516,22 @@ clean_office_applications() {
 }
 
 # Virtualization caches.
+clean_utm_caches() {
+    if pgrep -x "UTM" > /dev/null 2>&1; then
+        debug_log "Skipping UTM caches while UTM is running"
+        return 0
+    fi
+
+    safe_clean ~/Library/Caches/com.utmapp.UTM/* "UTM app cache"
+    safe_clean ~/Library/Containers/com.utmapp.UTM/Data/Library/Caches/* "UTM sandbox cache"
+    safe_clean ~/Library/Containers/com.utmapp.UTM/Data/tmp/* "UTM temporary files"
+}
+
 clean_virtualization_tools() {
     stop_section_spinner
     safe_clean ~/Library/Caches/com.vmware.fusion "VMware Fusion cache"
     safe_clean ~/Library/Caches/com.parallels.* "Parallels cache"
+    clean_utm_caches
     safe_clean ~/VirtualBox\ VMs/.cache "VirtualBox cache"
     safe_clean ~/.vagrant.d/tmp/* "Vagrant temporary files"
 }

--- a/tests/clean_misc.bats
+++ b/tests/clean_misc.bats
@@ -45,6 +45,29 @@ set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/user.sh"
 stop_section_spinner() { :; }
+pgrep() { return 1; }
+safe_clean() { echo "$2|$1"; }
+clean_virtualization_tools
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"VMware Fusion cache"* ]]
+    [[ "$output" == *"Parallels cache"* ]]
+    [[ "$output" == *"UTM app cache|$HOME/Library/Caches/com.utmapp.UTM/"* ]]
+    [[ "$output" == *"UTM sandbox cache|$HOME/Library/Containers/com.utmapp.UTM/Data/Library/Caches/"* ]]
+    [[ "$output" == *"UTM temporary files|$HOME/Library/Containers/com.utmapp.UTM/Data/tmp/"* ]]
+}
+
+@test "clean_virtualization_tools skips UTM caches while UTM is running" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+stop_section_spinner() { :; }
+debug_log() { :; }
+pgrep() {
+    [[ "${1:-}" == "-x" && "${2:-}" == "UTM" ]]
+}
 safe_clean() { echo "$2"; }
 clean_virtualization_tools
 EOF
@@ -52,6 +75,8 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"VMware Fusion cache"* ]]
     [[ "$output" == *"Parallels cache"* ]]
+    [[ "$output" != *"UTM app cache"* ]]
+    [[ "$output" != *"UTM sandbox cache"* ]]
 }
 
 @test "clean_email_clients calls expected caches" {


### PR DESCRIPTION
## Summary
- Add UTM to the virtualization cleanup section.
- Clean the regular app cache, sandbox cache, and sandbox temp directory.
- Skip UTM cache cleanup while the UTM app is running to avoid touching active VM/cache files.

## Safety Review
- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
  - Yes, `mo clean` can now remove UTM cache/temp files from cache-only locations.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
  - No. It uses existing `safe_clean` paths and does not touch UTM VM packages, documents, or application support data.
- If yes, describe the new boundary or risk change clearly.
  - Cleanup is limited to `~/Library/Caches/com.utmapp.UTM/*`, `~/Library/Containers/com.utmapp.UTM/Data/Library/Caches/*`, and `~/Library/Containers/com.utmapp.UTM/Data/tmp/*`, and it is skipped when `UTM` is running.

## Tests
- `./scripts/check.sh --no-format`
- `git diff --check`
- Direct regression shell checks for UTM cache inclusion and running-app skip behavior

## Safety-related changes
- Skips UTM cache cleanup while UTM is running.
