### PR TITLE
feat(clean): clear Lima download cache

### DIFF
--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -1521,6 +1521,7 @@ clean_virtualization_tools() {
     safe_clean ~/Library/Caches/com.vmware.fusion "VMware Fusion cache"
     safe_clean ~/Library/Caches/com.parallels.* "Parallels cache"
     safe_clean ~/VirtualBox\ VMs/.cache "VirtualBox cache"
+    safe_clean ~/Library/Caches/lima/download/by-url-sha256/* "Lima download cache"
     safe_clean ~/.vagrant.d/tmp/* "Vagrant temporary files"
 }
 

--- a/tests/clean_misc.bats
+++ b/tests/clean_misc.bats
@@ -67,6 +67,20 @@ EOF
     [[ "$output" == *"Airmail cache"* ]]
 }
 
+@test "clean_virtualization_tools includes Lima download cache" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+stop_section_spinner() { :; }
+safe_clean() { echo "$2|$1"; }
+clean_virtualization_tools
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Lima download cache|$HOME/Library/Caches/lima/download/by-url-sha256/"* ]]
+}
+
 @test "clean_note_apps calls expected caches" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Add Lima's documented macOS download cache to the virtualization cleanup section.
- Limit cleanup to `~/Library/Caches/lima/download/by-url-sha256/*`, leaving Lima instances, disks, templates, and configs untouched.
- Add a regression test for the new cleanup path.

## Safety Review
- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
  - Yes, `mo clean` can now remove cached Lima VM image downloads.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
  - No. It uses the existing `safe_clean` helper and only targets the user cache directory.
- If yes, describe the new boundary or risk change clearly.
  - The new cleanup boundary is limited to Lima's download cache, not VM instance data under `~/.lima`.

## Tests
- `./scripts/check.sh --no-format`
- `git diff --check`
- Direct regression shell check for the Lima cache path

## Safety-related changes
- None.
