### PR TITLE
fix(analyze): prune expired cache files

### DIFF
--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -338,22 +338,6 @@ func TestCacheSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
-func writeCacheEntryForPruneTest(t *testing.T, path string, scanTime time.Time) {
-	t.Helper()
-
-	file, err := os.Create(path)
-	if err != nil {
-		t.Fatalf("create %s: %v", path, err)
-	}
-	if err := gob.NewEncoder(file).Encode(cacheEntry{ScanTime: scanTime}); err != nil {
-		_ = file.Close()
-		t.Fatalf("encode %s: %v", path, err)
-	}
-	if err := file.Close(); err != nil {
-		t.Fatalf("close %s: %v", path, err)
-	}
-}
-
 func TestPruneAnalyzerCacheDirRemovesOnlyExpiredCacheFiles(t *testing.T) {
 	cacheDir := t.TempDir()
 	now := time.Now()
@@ -367,9 +351,7 @@ func TestPruneAnalyzerCacheDirRemovesOnlyExpiredCacheFiles(t *testing.T) {
 	symlinkTarget := filepath.Join(cacheDir, "target")
 	symlinkCache := filepath.Join(cacheDir, "link.cache")
 
-	writeCacheEntryForPruneTest(t, oldCache, oldTime)
-	writeCacheEntryForPruneTest(t, freshCache, freshTime)
-	for _, path := range []string{namedState, symlinkTarget} {
+	for _, path := range []string{oldCache, freshCache, namedState, symlinkTarget} {
 		if err := os.WriteFile(path, []byte("cache"), 0o644); err != nil {
 			t.Fatalf("write %s: %v", path, err)
 		}
@@ -381,16 +363,12 @@ func TestPruneAnalyzerCacheDirRemovesOnlyExpiredCacheFiles(t *testing.T) {
 		t.Fatalf("symlink cache entry: %v", err)
 	}
 
-	for _, path := range []string{namedState, cacheDirEntry, symlinkCache} {
+	for _, path := range []string{oldCache, namedState, cacheDirEntry, symlinkCache} {
 		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
 			t.Fatalf("chtimes %s: %v", path, err)
 		}
 	}
-	// Pruning must follow the decoded ScanTime, not the cache file mtime.
-	if err := os.Chtimes(oldCache, freshTime, freshTime); err != nil {
-		t.Fatalf("chtimes old cache: %v", err)
-	}
-	if err := os.Chtimes(freshCache, oldTime, oldTime); err != nil {
+	if err := os.Chtimes(freshCache, freshTime, freshTime); err != nil {
 		t.Fatalf("chtimes fresh cache: %v", err)
 	}
 
@@ -422,8 +400,10 @@ func TestPruneAnalyzerCacheDirIgnoresRemoveFailures(t *testing.T) {
 
 	cacheDir := t.TempDir()
 	oldCache := filepath.Join(cacheDir, "old.cache")
+	if err := os.WriteFile(oldCache, []byte("cache"), 0o644); err != nil {
+		t.Fatalf("write old cache: %v", err)
+	}
 	oldTime := time.Now().Add(-analyzerCacheTTL - time.Hour)
-	writeCacheEntryForPruneTest(t, oldCache, oldTime)
 	if err := os.Chtimes(oldCache, oldTime, oldTime); err != nil {
 		t.Fatalf("chtimes old cache: %v", err)
 	}

--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -338,6 +338,22 @@ func TestCacheSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+func writeCacheEntryForPruneTest(t *testing.T, path string, scanTime time.Time) {
+	t.Helper()
+
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	if err := gob.NewEncoder(file).Encode(cacheEntry{ScanTime: scanTime}); err != nil {
+		_ = file.Close()
+		t.Fatalf("encode %s: %v", path, err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close %s: %v", path, err)
+	}
+}
+
 func TestPruneAnalyzerCacheDirRemovesOnlyExpiredCacheFiles(t *testing.T) {
 	cacheDir := t.TempDir()
 	now := time.Now()
@@ -351,7 +367,9 @@ func TestPruneAnalyzerCacheDirRemovesOnlyExpiredCacheFiles(t *testing.T) {
 	symlinkTarget := filepath.Join(cacheDir, "target")
 	symlinkCache := filepath.Join(cacheDir, "link.cache")
 
-	for _, path := range []string{oldCache, freshCache, namedState, symlinkTarget} {
+	writeCacheEntryForPruneTest(t, oldCache, oldTime)
+	writeCacheEntryForPruneTest(t, freshCache, freshTime)
+	for _, path := range []string{namedState, symlinkTarget} {
 		if err := os.WriteFile(path, []byte("cache"), 0o644); err != nil {
 			t.Fatalf("write %s: %v", path, err)
 		}
@@ -363,12 +381,16 @@ func TestPruneAnalyzerCacheDirRemovesOnlyExpiredCacheFiles(t *testing.T) {
 		t.Fatalf("symlink cache entry: %v", err)
 	}
 
-	for _, path := range []string{oldCache, namedState, cacheDirEntry, symlinkCache} {
+	for _, path := range []string{namedState, cacheDirEntry, symlinkCache} {
 		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
 			t.Fatalf("chtimes %s: %v", path, err)
 		}
 	}
-	if err := os.Chtimes(freshCache, freshTime, freshTime); err != nil {
+	// Pruning must follow the decoded ScanTime, not the cache file mtime.
+	if err := os.Chtimes(oldCache, freshTime, freshTime); err != nil {
+		t.Fatalf("chtimes old cache: %v", err)
+	}
+	if err := os.Chtimes(freshCache, oldTime, oldTime); err != nil {
 		t.Fatalf("chtimes fresh cache: %v", err)
 	}
 
@@ -400,10 +422,8 @@ func TestPruneAnalyzerCacheDirIgnoresRemoveFailures(t *testing.T) {
 
 	cacheDir := t.TempDir()
 	oldCache := filepath.Join(cacheDir, "old.cache")
-	if err := os.WriteFile(oldCache, []byte("cache"), 0o644); err != nil {
-		t.Fatalf("write old cache: %v", err)
-	}
 	oldTime := time.Now().Add(-analyzerCacheTTL - time.Hour)
+	writeCacheEntryForPruneTest(t, oldCache, oldTime)
 	if err := os.Chtimes(oldCache, oldTime, oldTime); err != nil {
 		t.Fatalf("chtimes old cache: %v", err)
 	}

--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -338,6 +338,91 @@ func TestCacheSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPruneAnalyzerCacheDirRemovesOnlyExpiredCacheFiles(t *testing.T) {
+	cacheDir := t.TempDir()
+	now := time.Now()
+	oldTime := now.Add(-analyzerCacheTTL - time.Hour)
+	freshTime := now.Add(-time.Hour)
+
+	oldCache := filepath.Join(cacheDir, "old.cache")
+	freshCache := filepath.Join(cacheDir, "fresh.cache")
+	namedState := filepath.Join(cacheDir, overviewCacheFile)
+	cacheDirEntry := filepath.Join(cacheDir, "directory.cache")
+	symlinkTarget := filepath.Join(cacheDir, "target")
+	symlinkCache := filepath.Join(cacheDir, "link.cache")
+
+	for _, path := range []string{oldCache, freshCache, namedState, symlinkTarget} {
+		if err := os.WriteFile(path, []byte("cache"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	if err := os.Mkdir(cacheDirEntry, 0o755); err != nil {
+		t.Fatalf("mkdir cache dir entry: %v", err)
+	}
+	if err := os.Symlink(symlinkTarget, symlinkCache); err != nil {
+		t.Fatalf("symlink cache entry: %v", err)
+	}
+
+	for _, path := range []string{oldCache, namedState, cacheDirEntry, symlinkCache} {
+		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+			t.Fatalf("chtimes %s: %v", path, err)
+		}
+	}
+	if err := os.Chtimes(freshCache, freshTime, freshTime); err != nil {
+		t.Fatalf("chtimes fresh cache: %v", err)
+	}
+
+	if err := pruneAnalyzerCacheDir(cacheDir, now, analyzerCacheTTL); err != nil {
+		t.Fatalf("pruneAnalyzerCacheDir: %v", err)
+	}
+
+	if _, err := os.Stat(oldCache); !os.IsNotExist(err) {
+		t.Fatalf("expected expired cache file to be removed, stat err: %v", err)
+	}
+	for _, path := range []string{freshCache, namedState, cacheDirEntry, symlinkCache} {
+		if _, err := os.Lstat(path); err != nil {
+			t.Fatalf("expected %s to be preserved: %v", path, err)
+		}
+	}
+}
+
+func TestPruneAnalyzerCacheDirMissingDirectory(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	if err := pruneAnalyzerCacheDir(missing, time.Now(), analyzerCacheTTL); err != nil {
+		t.Fatalf("expected missing cache dir to be ignored, got: %v", err)
+	}
+}
+
+func TestPruneAnalyzerCacheDirIgnoresRemoveFailures(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can remove files from read-only directories")
+	}
+
+	cacheDir := t.TempDir()
+	oldCache := filepath.Join(cacheDir, "old.cache")
+	if err := os.WriteFile(oldCache, []byte("cache"), 0o644); err != nil {
+		t.Fatalf("write old cache: %v", err)
+	}
+	oldTime := time.Now().Add(-analyzerCacheTTL - time.Hour)
+	if err := os.Chtimes(oldCache, oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes old cache: %v", err)
+	}
+
+	if err := os.Chmod(cacheDir, 0o555); err != nil {
+		t.Fatalf("chmod cache dir read-only: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(cacheDir, 0o755)
+	}()
+
+	if err := pruneAnalyzerCacheDir(cacheDir, time.Now(), analyzerCacheTTL); err != nil {
+		t.Fatalf("expected remove failure to be ignored, got: %v", err)
+	}
+	if _, err := os.Stat(oldCache); err != nil {
+		t.Fatalf("expected failed removal to leave cache file in place: %v", err)
+	}
+}
+
 func TestScanPathConcurrentWarmsChildDirectoryCache(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -236,7 +236,18 @@ func pruneAnalyzerCacheDir(cacheDir string, now time.Time, maxAge time.Duration)
 		}
 
 		info, err := entry.Info()
-		if err != nil || !info.Mode().IsRegular() || info.ModTime().After(cutoff) {
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+
+		file, err := os.Open(filepath.Join(cacheDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var cache cacheEntry
+		decodeErr := gob.NewDecoder(file).Decode(&cache)
+		_ = file.Close()
+		if decodeErr != nil || cache.ScanTime.After(cutoff) {
 			continue
 		}
 

--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -207,6 +207,45 @@ func getCachePath(path string) (string, error) {
 	return filepath.Join(cacheDir, filename), nil
 }
 
+func pruneAnalyzerCache() {
+	cacheDir, err := getCacheDir()
+	if err != nil {
+		return
+	}
+	// Pruning is best-effort; errors are intentionally ignored to avoid blocking startup.
+	_ = pruneAnalyzerCacheDir(cacheDir, time.Now(), analyzerCacheTTL)
+}
+
+func pruneAnalyzerCacheDir(cacheDir string, now time.Time, maxAge time.Duration) error {
+	if cacheDir == "" || maxAge <= 0 {
+		return nil
+	}
+
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	cutoff := now.Add(-maxAge)
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 || filepath.Ext(entry.Name()) != ".cache" {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil || !info.Mode().IsRegular() || info.ModTime().After(cutoff) {
+			continue
+		}
+
+		_ = os.Remove(filepath.Join(cacheDir, entry.Name()))
+	}
+
+	return nil
+}
+
 func loadRawCacheFromDisk(path string) (*cacheEntry, error) {
 	cachePath, err := getCachePath(path)
 	if err != nil {
@@ -240,7 +279,7 @@ func loadCacheFromDisk(path string) (*cacheEntry, error) {
 	}
 
 	scanAge := time.Since(entry.ScanTime)
-	if scanAge > 7*24*time.Hour {
+	if scanAge > analyzerCacheTTL {
 		return nil, fmt.Errorf("cache expired: too old")
 	}
 

--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -236,18 +236,7 @@ func pruneAnalyzerCacheDir(cacheDir string, now time.Time, maxAge time.Duration)
 		}
 
 		info, err := entry.Info()
-		if err != nil || !info.Mode().IsRegular() {
-			continue
-		}
-
-		file, err := os.Open(filepath.Join(cacheDir, entry.Name()))
-		if err != nil {
-			continue
-		}
-		var cache cacheEntry
-		decodeErr := gob.NewDecoder(file).Decode(&cache)
-		_ = file.Close()
-		if decodeErr != nil || cache.ScanTime.After(cutoff) {
+		if err != nil || !info.Mode().IsRegular() || info.ModTime().After(cutoff) {
 			continue
 		}
 

--- a/cmd/analyze/constants.go
+++ b/cmd/analyze/constants.go
@@ -11,6 +11,7 @@ const (
 	spotlightMinFileSize   = 100 << 20
 	largeFileWarmupMinSize = 1 << 20
 	defaultViewport        = 12
+	analyzerCacheTTL       = 7 * 24 * time.Hour
 	overviewCacheTTL       = 7 * 24 * time.Hour
 	overviewCacheFile      = "overview_sizes.json"
 	duTimeout              = 30 * time.Second

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -139,7 +139,6 @@ func (m model) inOverviewMode() bool {
 
 func main() {
 	flag.Parse()
-	go pruneAnalyzerCache()
 
 	target := os.Getenv("MO_ANALYZE_PATH")
 	if target == "" && len(flag.Args()) > 0 {
@@ -163,8 +162,10 @@ func main() {
 	}
 
 	if *jsonMode {
+		pruneAnalyzerCache()
 		runJSONMode(abs, isOverview)
 	} else {
+		go pruneAnalyzerCache()
 		runTUIMode(abs, isOverview)
 	}
 }

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -139,6 +139,7 @@ func (m model) inOverviewMode() bool {
 
 func main() {
 	flag.Parse()
+	go pruneAnalyzerCache()
 
 	target := os.Getenv("MO_ANALYZE_PATH")
 	if target == "" && len(flag.Args()) > 0 {

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -161,11 +161,10 @@ func main() {
 		isOverview = false
 	}
 
+	go pruneAnalyzerCache()
 	if *jsonMode {
-		pruneAnalyzerCache()
 		runJSONMode(abs, isOverview)
 	} else {
-		go pruneAnalyzerCache()
 		runTUIMode(abs, isOverview)
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds startup pruning for expired `mo analyze` cache files under `~/.cache/mole`.

`mo analyze` stores rebuildable scan results as hashed `~/.cache/mole/*.cache` files. These files are useful for repeated scans and child-directory sizing, but they are currently only expired at read time. Expired files remain on disk indefinitely.

Mole already treats analyzer cache entries as time-limited:

- normal cache entries older than 7 days are rejected
- stale fallback entries older than 3 days are rejected

This PR aligns the on-disk lifecycle with that existing behavior by pruning anonymous analyzer `*.cache` files older than 7 days.

In a local cohort test, after preserving named Mole state and moving existing anonymous analyzer cache files aside, one interactive `mo analyze "$HOME"` run created `61,101` new `~/.cache/mole/*.cache` files, using `243M` on disk. Keeping expired entries indefinitely can therefore accumulate substantial filesystem overhead from many tiny files.

This does not change cache validity or refresh behavior; it only removes analyzer cache files after the existing read-time expiry window has passed.

## What Changed

Add startup pruning in the analyzer path, before scan work begins.

The pruning target is intentionally narrow:

`~/.cache/mole/*.cache`

Only regular files matching `*.cache` are eligible. Directories, symlinks, and named Mole state files are ignored.

Pruning uses the cache file's mtime as a proxy for age. This is appropriate because pruning is opportunistic disk reclamation, not a correctness mechanism — `loadCacheFromDisk` already enforces ScanTime-based expiry at read time and will reject any stale entry the pruner misses. Using mtime avoids opening and decoding tens of thousands of gob files on every startup.

Pruning runs as a background goroutine in both TUI and `--json` modes. It is best-effort; errors are silently ignored so startup is never blocked.

## Why In `mo analyze`

The cache is produced by the analyzer, so the analyzer should own its lifecycle.

Putting this only in `mo clean` would leave the cache unbounded during normal analyzer use and would require users to run a separate cleanup command after `mo analyze` has already grown its own cache.

## Tests

- `./scripts/check.sh`
- `go test ./cmd/analyze`
- `go test ./cmd/...`