### PR TITLE
refactor(analyze): use wg.Go instead of wg.Add+wg.Done

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - unused
     # Additional linters
     - modernize
+    - revive
 
   settings:
     govet:
@@ -30,6 +31,9 @@ linters:
         - (io.Closer).Close
         - (*os/exec.Cmd).Run
         - (*os/exec.Cmd).Start
+    revive:
+      rules:
+        - name: use-waitgroup-go
     staticcheck:
       checks: ["all", "-QF1003", "-SA9003"]
 

--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -403,9 +403,7 @@ func prefetchOverviewCache(ctx context.Context) {
 		default:
 		}
 
-		wg.Add(1)
-		go func(path string) {
-			defer wg.Done()
+		wg.Go(func() {
 			select {
 			case sem <- struct{}{}:
 				defer func() { <-sem }()
@@ -417,7 +415,7 @@ func prefetchOverviewCache(ctx context.Context) {
 			if err == nil && size > 0 {
 				_ = storeOverviewSize(path, size)
 			}
-		}(path)
+		})
 	}
 	wg.Wait()
 }

--- a/cmd/analyze/json.go
+++ b/cmd/analyze/json.go
@@ -122,10 +122,8 @@ func measureOverviewEntriesForJSON(overviewEntries []dirEntry, insightPaths map[
 	results := make(chan measurement, len(overviewEntries))
 
 	var wg sync.WaitGroup
-	for i, entry := range overviewEntries {
-		wg.Add(1)
-		go func(index int, item dirEntry) {
-			defer wg.Done()
+	for index, item := range overviewEntries {
+		wg.Go(func() {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
@@ -146,7 +144,7 @@ func measureOverviewEntriesForJSON(overviewEntries []dirEntry, insightPaths map[
 				item.Size = size
 			}
 			results <- measurement{index: index, entry: item}
-		}(i, entry)
+		})
 	}
 
 	wg.Wait()

--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -153,9 +153,7 @@ func scanPathConcurrentWithLimiter(root string, filesScanned, dirsScanned, bytes
 	largeFileChan := make(chan fileEntry, maxLargeFiles*2)
 
 	var collectorWg sync.WaitGroup
-	collectorWg.Add(2)
-	go func() {
-		defer collectorWg.Done()
+	collectorWg.Go(func() {
 		for entry := range entryChan {
 			if collectAllEntries {
 				collectedEntries = append(collectedEntries, entry)
@@ -169,9 +167,8 @@ func scanPathConcurrentWithLimiter(root string, filesScanned, dirsScanned, bytes
 				heap.Push(entriesHeap, entry)
 			}
 		}
-	}()
-	go func() {
-		defer collectorWg.Done()
+	})
+	collectorWg.Go(func() {
 		for file := range largeFileChan {
 			if largeFilesHeap.Len() < maxLargeFiles {
 				heap.Push(largeFilesHeap, file)
@@ -184,7 +181,7 @@ func scanPathConcurrentWithLimiter(root string, filesScanned, dirsScanned, bytes
 				atomic.StoreInt64(&largeFileMinSize, (*largeFilesHeap)[0].Size)
 			}
 		}
-	}()
+	})
 
 	isRootDir := root == "/"
 	home := os.Getenv("HOME")
@@ -254,12 +251,10 @@ func scanPathConcurrentWithLimiter(root string, filesScanned, dirsScanned, bytes
 					}, scanSendTimeout)
 				}
 				if limiter.tryAcquireEntry() {
-					wg.Add(1)
-					go func(name, path string) {
-						defer wg.Done()
+					wg.Go(func() {
 						defer limiter.releaseEntry()
-						processDir(name, path)
-					}(child.Name(), fullPath)
+						processDir(child.Name(), fullPath)
+					})
 				} else {
 					processDir(child.Name(), fullPath)
 				}
@@ -269,30 +264,28 @@ func scanPathConcurrentWithLimiter(root string, filesScanned, dirsScanned, bytes
 			// Folded dirs: fast size without expanding.
 			if shouldFoldDirWithPath(child.Name(), fullPath) {
 				duQueueSem <- struct{}{}
-				wg.Add(1)
-				go func(name, path string) {
-					defer wg.Done()
+				wg.Go(func() {
 					defer func() { <-duQueueSem }()
 
 					size, err := func() (int64, error) {
 						duSem <- struct{}{}
 						defer func() { <-duSem }()
-						return getDirectorySizeFromDu(path)
+						return getDirectorySizeFromDu(fullPath)
 					}()
 					if err != nil || size <= 0 {
-						size = calculateDirSizeFastWithLimiter(path, limiter, filesScanned, dirsScanned, bytesScanned, currentPath)
+						size = calculateDirSizeFastWithLimiter(fullPath, limiter, filesScanned, dirsScanned, bytesScanned, currentPath)
 					}
 					atomic.AddInt64(&total, size)
 					atomic.AddInt64(dirsScanned, 1)
 
 					trySend(entryChan, dirEntry{
-						Name:       name,
-						Path:       path,
+						Name:       child.Name(),
+						Path:       fullPath,
 						Size:       size,
 						IsDir:      true,
 						LastAccess: time.Time{},
 					}, scanSendTimeout)
-				}(child.Name(), fullPath)
+				})
 				continue
 			}
 
@@ -313,12 +306,10 @@ func scanPathConcurrentWithLimiter(root string, filesScanned, dirsScanned, bytes
 				}, scanSendTimeout)
 			}
 			if limiter.tryAcquireEntry() {
-				wg.Add(1)
-				go func(name, path string) {
-					defer wg.Done()
+				wg.Go(func() {
 					defer limiter.releaseEntry()
-					processDir(name, path)
-				}(child.Name(), fullPath)
+					processDir(child.Name(), fullPath)
+				})
 			} else {
 				processDir(child.Name(), fullPath)
 			}
@@ -511,12 +502,10 @@ func calculateDirSizeFastWithLimiter(root string, limiter *scanLimiter, filesSca
 
 				select {
 				case sem <- struct{}{}:
-					wg.Add(1)
-					go func(p string) {
-						defer wg.Done()
+					wg.Go(func() {
 						defer func() { <-sem }()
-						walk(p)
-					}(subDir)
+						walk(subDir)
+					})
 				default:
 					// Fallback to synchronous traversal to avoid semaphore deadlock under high fan-out.
 					walk(subDir)
@@ -664,36 +653,32 @@ func calculateDirSizeConcurrent(root string, largeFileChan chan<- fileEntry, lar
 
 			if shouldFoldDirWithPath(child.Name(), fullPath) {
 				duQueueSem <- struct{}{}
-				wg.Add(1)
-				go func(path string) {
-					defer wg.Done()
+				wg.Go(func() {
 					defer func() { <-duQueueSem }()
 
 					size, err := func() (int64, error) {
 						duSem <- struct{}{}
 						defer func() { <-duSem }()
-						return getDirectorySizeFromDu(path)
+						return getDirectorySizeFromDu(fullPath)
 					}()
 					if err != nil || size <= 0 {
-						size = calculateDirSizeFastWithLimiter(path, limiter, filesScanned, dirsScanned, bytesScanned, currentPath)
+						size = calculateDirSizeFastWithLimiter(fullPath, limiter, filesScanned, dirsScanned, bytesScanned, currentPath)
 					} else {
 						atomic.AddInt64(bytesScanned, size)
 					}
 					total.Add(size)
-				}(fullPath)
+				})
 				continue
 			}
 
 			select {
 			case dirSem <- struct{}{}:
-				wg.Add(1)
-				go func(path string) {
-					defer wg.Done()
+				wg.Go(func() {
 					defer func() { <-dirSem }()
 
-					size := calculateDirSizeConcurrent(path, largeFileChan, largeFileMinSize, limiter, dirSem, duSem, duQueueSem, filesScanned, dirsScanned, bytesScanned, currentPath)
+					size := calculateDirSizeConcurrent(fullPath, largeFileChan, largeFileMinSize, limiter, dirSem, duSem, duQueueSem, filesScanned, dirsScanned, bytesScanned, currentPath)
 					total.Add(size)
-				}(fullPath)
+				})
 			default:
 				size := calculateDirSizeConcurrent(fullPath, largeFileChan, largeFileMinSize, limiter, dirSem, duSem, duQueueSem, filesScanned, dirsScanned, bytesScanned, currentPath)
 				localTotal += size
@@ -971,18 +956,16 @@ func getDirectorySizeFromDuSkippingImmediateChild(path string, excludePath strin
 		}
 
 		sem <- struct{}{}
-		wg.Add(1)
-		go func(childPath string) {
-			defer wg.Done()
+		wg.Go(func() {
 			defer func() { <-sem }()
 
-			size, err := runDuSize(childPath)
+			size, err := runDuSize(fullPath)
 			if err != nil {
 				recordErr(err)
 				return
 			}
 			atomic.AddInt64(&total, size)
-		}(fullPath)
+		})
 	}
 
 	wg.Wait()


### PR DESCRIPTION
## Summary

Refactored the `analyze` package to use `wg.Go` instead of manual `sync.WaitGroup` bookkeeping.
Added a revive lint rule in .golangci.yml to enforce the new pattern.
The change is structural only; it simplifies goroutine lifecycle management in the `analyze` code without changing the core file operations. See ["Safer Goroutines with WaitGroup.Go() in Go 1.25"](https://medium.com/techtrends-digest/safer-goroutines-with-waitgroup-go-in-go-1-25-39bdd2d83b64)

## Safety Review

- Yes, this change affects analyze behavior, but only the internal concurrency implementation.
- Risk change: **low**. The boundary moved from manual WaitGroup accounting to a wg.Go wrapper, so the main risk is concurrency correctness in analyze code, not filesystem safety.


## Tests

- `./scripts/test.sh`

## Safety-related changes

- None.
