### PR TITLE
Make Trash delete mode fail closed

### DIFF
--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -456,8 +456,12 @@ mole_delete() {
     case "$mode" in
         permanent | trash) ;;
         *)
-            _mole_delete_log "$mode" "0" "invalid-mode" "$path"
-            printf 'Error: invalid MOLE_DELETE_MODE: %s\n' "$mode" >&2
+            _mole_delete_log "$mode" "unknown" "invalid-mode" "$path"
+            if [[ -z "${_MOLE_INVALID_MODE_WARNED:-}" ]]; then
+                _MOLE_INVALID_MODE_WARNED=1
+                export _MOLE_INVALID_MODE_WARNED
+                printf 'Error: invalid MOLE_DELETE_MODE: %s (expected "permanent" or "trash")\n' "$mode" >&2
+            fi
             return 1
             ;;
     esac
@@ -523,7 +527,11 @@ mole_delete() {
         fi
         _mole_delete_log "trash" "$size_kb" "trash-failed" "$path"
         log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "SKIPPED" "$path" "trash-failed"
-        printf 'Error: Trash unavailable; refusing permanent delete. Use --permanent to delete immediately.\n' >&2
+        if [[ -z "${_MOLE_TRASH_UNAVAILABLE_WARNED:-}" ]]; then
+            _MOLE_TRASH_UNAVAILABLE_WARNED=1
+            export _MOLE_TRASH_UNAVAILABLE_WARNED
+            printf 'Error: Trash unavailable; refusing permanent delete. Use --permanent to delete immediately.\n' >&2
+        fi
         debug_log "Trash move failed, refusing permanent delete: $path"
         return 1
     fi

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -434,7 +434,7 @@ safe_sudo_remove() {
 # Usage: mole_delete <path> [needs_sudo=false]
 #
 # Environment:
-#   MOLE_DELETE_MODE      "permanent" (default) or "trash"
+#   MOLE_DELETE_MODE      "permanent" (default) or "trash"; other values fail
 #   MOLE_DRY_RUN=1        Log intent, do not delete
 #   MOLE_TEST_TRASH_DIR   Test-only override; Trash moves go here via `mv`
 #                         instead of Finder/trash CLI. Required for bats.
@@ -452,6 +452,15 @@ mole_delete() {
     local mode="${MOLE_DELETE_MODE:-permanent}"
 
     [[ -z "$path" ]] && return 1
+
+    case "$mode" in
+        permanent | trash) ;;
+        *)
+            _mole_delete_log "$mode" "0" "invalid-mode" "$path"
+            printf 'Error: invalid MOLE_DELETE_MODE: %s\n' "$mode" >&2
+            return 1
+            ;;
+    esac
 
     # Nothing to do if path does not exist (but a broken symlink still counts).
     if [[ ! -e "$path" && ! -L "$path" ]]; then
@@ -504,22 +513,19 @@ mole_delete() {
         fi
     fi
 
-    # Trash mode: attempt Trash move first, fall through to permanent removal
-    # on failure so destructive operations never get silently skipped.
+    # Trash mode is a recoverable-delete contract. If Trash is unavailable,
+    # fail closed instead of silently switching to permanent removal.
     if [[ "$mode" == "trash" ]]; then
         if _mole_move_to_trash "$path" "$needs_sudo"; then
             _mole_delete_log "trash" "$size_kb" "ok" "$path"
             log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "TRASHED" "$path" "${size_kb}KB"
             return 0
         fi
-        # User explicitly chose Trash for recoverability. Surface the fallback
-        # to permanent rm once per session so they know an "undo" isn't there.
-        if [[ -z "${_MOLE_TRASH_FALLBACK_WARNED:-}" ]]; then
-            _MOLE_TRASH_FALLBACK_WARNED=1
-            export _MOLE_TRASH_FALLBACK_WARNED
-            printf 'Warning: Trash unavailable, removing permanently. Subsequent files this session also bypass Trash.\n' >&2
-        fi
-        debug_log "Trash move failed, falling back to permanent delete: $path"
+        _mole_delete_log "trash" "$size_kb" "trash-failed" "$path"
+        log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "SKIPPED" "$path" "trash-failed"
+        printf 'Error: Trash unavailable; refusing permanent delete. Use --permanent to delete immediately.\n' >&2
+        debug_log "Trash move failed, refusing permanent delete: $path"
+        return 1
     fi
 
     # Permanent path. Delegate to the existing safe_* helpers so path
@@ -536,10 +542,6 @@ mole_delete() {
 
     local status_label="ok"
     [[ $rc -ne 0 ]] && status_label="error"
-    # Mark the trash-mode fallback so forensics can tell why rm was used.
-    if [[ "$mode" == "trash" && "$status_label" == "ok" ]]; then
-        status_label="trash-fallback-rm"
-    fi
     _mole_delete_log "$mode" "$size_kb" "$status_label" "$path"
     return "$rc"
 }

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -301,8 +301,8 @@ remove_file_list() {
             count=$((count + ${#trash_batch[@]}))
         else
             # Batch failed wholesale: route each path through mole_delete so
-            # the per-file fallback (Trash retry, then permanent rm) runs and
-            # forensic logging stays intact.
+            # per-file Trash handling fails closed and forensic logging stays
+            # intact.
             fallback_paths+=("${trash_batch[@]}")
         fi
     fi
@@ -311,8 +311,8 @@ remove_file_list() {
         local fb
         for fb in "${fallback_paths[@]}"; do
             # mole_delete routes through Trash when MOLE_DELETE_MODE=trash
-            # (uninstall default), falls back to the underlying safe_* helpers
-            # in permanent mode or when Trash is unavailable. See #723.
+            # (uninstall default) and only uses safe_* permanent removal when
+            # the caller explicitly selected permanent mode. See #723.
             mole_delete "$fb" "$use_sudo" && ((++count)) || true
         done
     fi

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -721,7 +721,7 @@ should_protect_path() { return 0; }
 
 tmp_dir="$(mktemp -d)"
 tmp_plist="$tmp_dir/com.microsoft.office.licensingV2.helper.plist"
-/usr/libexec/PlistBuddy -c "Add :Program string /Library/PrivilegedHelperTools/com.microsoft.office.licensingV2.helper" "$tmp_plist" 2>/dev/null || true
+/usr/libexec/PlistBuddy -c "Add :Program string $tmp_dir/missing-protected-helper" "$tmp_plist" 2>/dev/null || true
 
 sudo() {
   if [[ "$1" == "-n" && "$2" == "true" ]]; then

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -146,14 +146,14 @@ export MOLE_TEST_TRACE="$trace"
 mole_delete "$victim" true
 EOF
 
-    [ "$status" -eq 0 ]
-    [[ ! -e "$victim" ]]
+    [ "$status" -ne 0 ]
+    [[ -e "$victim" ]]
     [[ -z "$(ls -A "$redirected" 2> /dev/null || true)" ]]
     [[ "$(grep -c '^sudo mv ' "$trace" 2> /dev/null || true)" -eq 0 ]]
 
     local status_col
     status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
-    [ "$status_col" = "trash-fallback-rm" ]
+    [ "$status_col" = "trash-failed" ]
 }
 
 @test "mole_delete uses unique Trash name for sudo-required path conflicts" {
@@ -263,7 +263,27 @@ EOF
     [[ ! -s "$MOLE_DELETE_LOG" ]]
 }
 
-@test "mole_delete trash failure falls back to permanent rm" {
+@test "mole_delete rejects unknown delete mode without touching target" {
+    local victim="$SANDBOX/invalid_mode_target"
+    : > "$victim"
+
+    run bash --noprofile --norc <<EOF
+$(prelude)
+export MOLE_DELETE_MODE=surprise
+mole_delete "$victim"
+EOF
+
+    [ "$status" -ne 0 ]
+    [[ -e "$victim" ]]
+
+    local mode_col status_col
+    mode_col=$(awk -F'\t' 'END { print $2 }' "$MOLE_DELETE_LOG")
+    status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
+    [ "$mode_col" = "surprise" ]
+    [ "$status_col" = "invalid-mode" ]
+}
+
+@test "mole_delete trash failure leaves target in place" {
     local victim="$SANDBOX/fallback_target"
     : > "$victim"
 
@@ -282,14 +302,13 @@ EOF
 
     chmod 0755 "$(dirname "$blocked")"
 
-    [ "$status" -eq 0 ]
-    [[ ! -e "$victim" ]]
+    [ "$status" -ne 0 ]
+    [[ -e "$victim" ]]
 
     local status_col
     status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
-    [ "$status_col" = "trash-fallback-rm" ]
-    # User explicitly asked NOT to permanent-delete; fallback must surface.
-    [[ "$output" == *"Trash unavailable"* ]]
+    [ "$status_col" = "trash-failed" ]
+    [[ "$output" == *"refusing permanent delete"* ]]
 }
 
 @test "mole_delete records 'unknown' (not 0) when size measurement fails" {

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -281,6 +281,31 @@ EOF
     status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
     [ "$mode_col" = "surprise" ]
     [ "$status_col" = "invalid-mode" ]
+    [[ "$output" == *'expected "permanent" or "trash"'* ]]
+}
+
+@test "mole_delete warns once for repeated invalid delete mode" {
+    local first="$SANDBOX/invalid_mode_first"
+    local second="$SANDBOX/invalid_mode_second"
+    : > "$first"
+    : > "$second"
+
+    run bash --noprofile --norc <<EOF
+$(prelude)
+export MOLE_DELETE_MODE=surprise
+set +e
+mole_delete "$first"
+first_rc=\$?
+mole_delete "$second"
+second_rc=\$?
+set -e
+[[ \$first_rc -ne 0 && \$second_rc -ne 0 ]]
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ -e "$first" ]]
+    [[ -e "$second" ]]
+    [[ "$(grep -c 'invalid MOLE_DELETE_MODE' <<< "$output")" -eq 1 ]]
 }
 
 @test "mole_delete trash failure leaves target in place" {
@@ -309,6 +334,37 @@ EOF
     status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
     [ "$status_col" = "trash-failed" ]
     [[ "$output" == *"refusing permanent delete"* ]]
+}
+
+@test "mole_delete warns once for repeated Trash failures" {
+    local first="$SANDBOX/trash_fail_first"
+    local second="$SANDBOX/trash_fail_second"
+    : > "$first"
+    : > "$second"
+
+    local blocked="$SANDBOX/blocked/Trash"
+    mkdir -p "$(dirname "$blocked")"
+    chmod 0555 "$(dirname "$blocked")"
+
+    run bash --noprofile --norc <<EOF
+$(prelude)
+export MOLE_DELETE_MODE=trash
+export MOLE_TEST_TRASH_DIR="$blocked"
+set +e
+mole_delete "$first"
+first_rc=\$?
+mole_delete "$second"
+second_rc=\$?
+set -e
+[[ \$first_rc -ne 0 && \$second_rc -ne 0 ]]
+EOF
+
+    chmod 0755 "$(dirname "$blocked")"
+
+    [ "$status" -eq 0 ]
+    [[ -e "$first" ]]
+    [[ -e "$second" ]]
+    [[ "$(grep -c "Trash unavailable" <<< "$output")" -eq 1 ]]
 }
 
 @test "mole_delete records 'unknown' (not 0) when size measurement fails" {


### PR DESCRIPTION
mo uninstall defaults to moving files to Trash. If Trash is unavailable, the helper could fall through to permanent removal, which is not what users expect from the default path.

This makes Trash mode fail closed. Trash failures leave the file in place, log trash-failed, and tell the user to pass --permanent if they want immediate deletion. Unknown MOLE_DELETE_MODE values also fail instead of deleting.

I also kept the terminal output from repeating the same delete-mode warning for every failed path, while still logging each skipped path, and tightened the related tests.

Validation: ./scripts/check.sh --no-format and ./scripts/test.sh. Full test run passed with 786 tests, 0 failures, 2 skipped.