### PR TITLE
fix(clean): skip dotdir orphan when an enabled Claude plugin owns it (#889)

### DIFF
--- a/lib/clean/hints.sh
+++ b/lib/clean/hints.sh
@@ -672,6 +672,91 @@ _dotdir_owner_collect_tokens() {
     fi
 }
 
+# Emit every alnum token found in *enabled* agent-plugin names, lowercased,
+# one per line.  Currently covers Claude Code's plugin manifest at
+# ``~/.claude/settings.json`` — only entries whose value is ``true`` count,
+# so a stale dotdir for a disabled or uninstalled plugin is still surfaced
+# as an orphan (which is what the user usually wants).
+#
+# Parsing is bash/awk native to match Mole's existing "no jq dependency"
+# stance (see ``bin/optimize.sh``).
+# shellcheck disable=SC2329
+_dotdir_owner_collect_agent_plugin_tokens() {
+    local settings="$HOME/.claude/settings.json"
+    [[ -r "$settings" ]] || return 0
+
+    # The shape inside settings.json is:
+    #   "enabledPlugins": { "<name>@<marketplace>": true|false, ... }
+    # We only emit names whose value is ``true`` and strip the
+    # @marketplace suffix so the token list mirrors the GUI-app collector.
+    awk '
+        /"enabledPlugins"[[:space:]]*:[[:space:]]*\{/ { in_block=1; depth=1; next }
+        in_block {
+            n=gsub(/\{/, "&"); depth+=n
+            n=gsub(/\}/, "&"); depth-=n
+            if (depth <= 0) { exit }
+            if (match($0, /"[^"]+"[[:space:]]*:[[:space:]]*true/)) {
+                line = substr($0, RSTART)
+                if (match(line, /"[^"]+"/)) {
+                    key = substr(line, RSTART + 1, RLENGTH - 2)
+                    sub(/@.*$/, "", key)
+                    print key
+                }
+            }
+        }
+    ' "$settings" 2> /dev/null |
+        LC_ALL=C tr '[:upper:]' '[:lower:]' |
+        LC_ALL=C tr -cs 'a-z0-9' '\n'
+}
+
+# Return 0 if any ≥4-char token from `name` matches a token harvested from
+# enabled Claude Code agent plugins.  Cached for 5 minutes alongside the
+# GUI-app token cache.  Mirrors ``dotdir_has_owning_gui_app`` so an active
+# plugin's state directory (e.g. ``~/.cc-safety-net`` for the
+# ``safety-net@cc-marketplace`` plugin) is not flagged as an orphan
+# dotfile.  See issue #889.
+# shellcheck disable=SC2329
+dotdir_has_owning_agent_plugin() {
+    local name="$1"
+    [[ -z "$name" ]] && return 1
+    [[ ${#name} -lt 4 ]] && return 1
+
+    local cache_dir="$HOME/.cache/mole"
+    local cache_file="$cache_dir/installed_agent_plugin_tokens_cache"
+    local cache_ttl=300
+    local now
+    now=$(date +%s)
+
+    local rebuild=1
+    if [[ -f "$cache_file" ]]; then
+        local mtime
+        mtime=$(get_file_mtime "$cache_file" 2> /dev/null || echo 0)
+        if [[ -n "$mtime" ]] && [[ $((now - mtime)) -lt $cache_ttl ]]; then
+            rebuild=0
+        fi
+    fi
+    if [[ $rebuild -eq 1 ]]; then
+        ensure_user_dir "$cache_dir" 2> /dev/null || true
+        _dotdir_owner_collect_agent_plugin_tokens 2> /dev/null |
+            LC_ALL=C awk 'length($0) >= 4' |
+            LC_ALL=C sort -u > "$cache_file" 2> /dev/null || return 1
+    fi
+    [[ -s "$cache_file" ]] || return 1
+
+    local name_lower
+    name_lower=$(printf '%s' "$name" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+    local tok
+    while IFS= read -r tok; do
+        [[ -z "$tok" ]] && continue
+        [[ ${#tok} -ge 4 ]] || continue
+        if LC_ALL=C grep -Fxq "$tok" "$cache_file" 2> /dev/null; then
+            return 0
+        fi
+    done < <(printf '%s\n' "$name_lower" | LC_ALL=C tr -cs 'a-z0-9' '\n')
+
+    return 1
+}
+
 # Return 0 if any ≥4-char token from `name` matches a token harvested from
 # installed `.app` bundles or Homebrew casks. Cached for 5 minutes. Short
 # tokens (<4 chars) on either side are ignored to avoid false matches like
@@ -793,6 +878,10 @@ show_orphan_dotdir_hint_notice() {
         fi
 
         if dotdir_has_owning_gui_app "$name"; then
+            continue
+        fi
+
+        if dotdir_has_owning_agent_plugin "$name"; then
             continue
         fi
 

--- a/tests/clean_hints.bats
+++ b/tests/clean_hints.bats
@@ -488,3 +488,127 @@ EOTD
     count=$(echo "$output" | grep -c "Potential orphan dotfile" || true)
     [ "$count" -le 5 ]
 }
+
+@test "show_orphan_dotdir_hint_notice skips dotdir owned by enabled Claude plugin (#889)" {
+    mkdir -p "$HOME/.cc-safety-net/logs"
+    touch -t 202401010000 "$HOME/.cc-safety-net"
+
+    mkdir -p "$HOME/.claude/plugins"
+    cat > "$HOME/.claude/settings.json" << 'JSON'
+{
+    "enabledPlugins": {
+        "safety-net@cc-marketplace": true,
+        "other-plugin@somewhere": false
+    }
+}
+JSON
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+hint_get_path_size_kb_with_timeout() { echo "100"; }
+show_orphan_dotdir_hint_notice
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *".cc-safety-net"* ]]
+}
+
+@test "show_orphan_dotdir_hint_notice still flags dotdir for DISABLED plugin (#889)" {
+    mkdir -p "$HOME/.cc-safety-net/logs"
+    touch -t 202401010000 "$HOME/.cc-safety-net"
+
+    mkdir -p "$HOME/.claude/plugins"
+    cat > "$HOME/.claude/settings.json" << 'JSON'
+{
+    "enabledPlugins": {
+        "safety-net@cc-marketplace": false
+    }
+}
+JSON
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+hint_get_path_size_kb_with_timeout() { echo "100"; }
+show_orphan_dotdir_hint_notice
+EOTD
+
+    [ "$status" -eq 0 ]
+    # Plugin disabled → stale state legitimately surfaces as an orphan candidate.
+    [[ "$output" == *".cc-safety-net"* ]]
+}
+
+@test "dotdir_has_owning_agent_plugin returns 0 for enabled plugin match (#889)" {
+    mkdir -p "$HOME/.claude/plugins"
+    cat > "$HOME/.claude/settings.json" << 'JSON'
+{
+    "enabledPlugins": {
+        "safety-net@cc-marketplace": true
+    }
+}
+JSON
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+if dotdir_has_owning_agent_plugin "cc-safety-net"; then
+    echo "MATCH"
+else
+    echo "NOMATCH"
+fi
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"MATCH"* ]]
+}
+
+@test "dotdir_has_owning_agent_plugin returns 1 when settings.json missing (#889)" {
+    # No ~/.claude/settings.json at all.
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+if dotdir_has_owning_agent_plugin "something"; then
+    echo "MATCH"
+else
+    echo "NOMATCH"
+fi
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NOMATCH"* ]]
+}
+
+@test "dotdir_has_owning_agent_plugin rejects short names (#889)" {
+    # Even with a matching enabled plugin token, names <4 chars should not match.
+    mkdir -p "$HOME/.claude/plugins"
+    cat > "$HOME/.claude/settings.json" << 'JSON'
+{
+    "enabledPlugins": {
+        "ai@market": true
+    }
+}
+JSON
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOTD'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+if dotdir_has_owning_agent_plugin "ai"; then
+    echo "MATCH"
+else
+    echo "NOMATCH"
+fi
+EOTD
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NOMATCH"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes #889. `show_orphan_dotdir_hint_notice` was flagging active Claude Code plugin state directories (e.g. `~/.cc-safety-net` owned by `safety-net@cc-marketplace`) as "Potential orphan dotfile" because the existing ownership gates only know about installed `.app` bundles and Homebrew casks (PR #879's scope) — not agent plugins. The reporter's own example walks through this exact false-positive.

## Approach

Mirrors PR #879's GUI-app gate one-for-one:

| Existing (#879, GUI apps + casks) | New (this PR, agent plugins) |
|---|---|
| `_dotdir_owner_collect_tokens` | `_dotdir_owner_collect_agent_plugin_tokens` |
| `dotdir_has_owning_gui_app` | `dotdir_has_owning_agent_plugin` |
| Cached 5 min at `~/.cache/mole/installed_app_tokens_cache` | Cached 5 min at `~/.cache/mole/installed_agent_plugin_tokens_cache` |
| ≥4-char token threshold (avoids `.ai-old` vs `AI.app`) | Same threshold (avoids `ai@market` vs `.ai-old`) |
| Wired in via `dotdir_has_owning_gui_app "\$name"` | Wired in right after, via `dotdir_has_owning_agent_plugin "\$name"` |

## Why bash-native JSON parsing

`bin/optimize.sh` already has the comment `Bash-native JSON parsing helpers (no jq dependency)`, so adding a jq dep for one new feature would regress Mole's portability posture. The new `_dotdir_owner_collect_agent_plugin_tokens` uses a small awk script to walk `enabledPlugins` and emit the keys of `true`-valued entries.

## Only ENABLED plugins count

The reporter's hint warned: *"stale real orphans [should] not be hidden just because an enabled plugin has a similar generic name"*. So I only honor entries whose value is `true` in `enabledPlugins`. A plugin that's installed but disabled keeps its state directory eligible for the orphan flag — which is what the user probably wants when they disabled the plugin to clean it up.

## What I deliberately did NOT do

- **No installed_plugins.json parsing.** The reporter's implementation note mentioned it as a secondary signal, but it lists every install regardless of enabled status — which would over-suppress orphan detection. `enabledPlugins` is the right truth source for "is this plugin actively in use right now".
- **No plugin manifest scraping** for explicit dotdir references. The reporter mentioned this as an ideal but acknowledged token matching is the pragmatic v1 (matching PR #879). Manifest scraping can land in a follow-up.
- **No support for other agent platforms yet.** The function is named generically (`agent_plugin`, not `claude_plugin`) so a future PR for Codex/Cursor/etc. can extend the collector without an interface change.

## Test plan

5 new bats cases in `tests/clean_hints.bats`:

| Test | Asserts |
|---|---|
| skips dotdir owned by enabled Claude plugin | The exact `~/.cc-safety-net` + `safety-net@cc-marketplace` repro from #889 is no longer flagged. |
| still flags dotdir for DISABLED plugin | Same dotdir, plugin entry now `false` → still surfaces as orphan candidate (no over-suppression). |
| `dotdir_has_owning_agent_plugin` returns 0 for enabled plugin match | Helper returns success on the happy path. |
| `dotdir_has_owning_agent_plugin` returns 1 when settings.json missing | Graceful no-op when Claude isn't installed. |
| `dotdir_has_owning_agent_plugin` rejects short names | 4-char threshold honored so `.ai-old` isn't masked by an enabled `ai@market` plugin. |

```
$ bats tests/clean_hints.bats
... (snip)
ok 18 show_orphan_dotdir_hint_notice limits output to max 5 candidates
ok 19 show_orphan_dotdir_hint_notice skips dotdir owned by enabled Claude plugin (#889)
ok 20 show_orphan_dotdir_hint_notice still flags dotdir for DISABLED plugin (#889)
ok 21 dotdir_has_owning_agent_plugin returns 0 for enabled plugin match (#889)
ok 22 dotdir_has_owning_agent_plugin returns 1 when settings.json missing (#889)
ok 23 dotdir_has_owning_agent_plugin rejects short names (#889)

23 tests, 0 failures
```

## Files

- `lib/clean/hints.sh` — `+89 / -0`
- `tests/clean_hints.bats` — `+124 / -0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)