### PR TITLE
fix(optimize): log Broken Config Repair section under --debug (#904)

### DIFF
--- a/lib/optimize/maintenance.sh
+++ b/lib/optimize/maintenance.sh
@@ -45,6 +45,9 @@ _repair_preference_plists_in_dir() {
 
         plutil -lint "$plist_file" > /dev/null 2>&1 && continue
 
+        if [[ "${MO_DEBUG:-}" == "1" ]]; then
+            debug_file_action "  Removing corrupted plist" "$plist_file"
+        fi
         safe_remove "$plist_file" true > /dev/null 2>&1 || true
         broken_count=$((broken_count + 1))
     done < <(command find "${find_args[@]}" 2> /dev/null || true)

--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -274,6 +274,14 @@ opt_saved_state_cleanup() {
 # Removed: opt_local_snapshots - Deletes user Time Machine recovery points, breaks backup continuity
 
 opt_fix_broken_configs() {
+    if [[ "${MO_DEBUG:-}" == "1" ]]; then
+        debug_operation_start "Broken Config Repair" "Remove corrupted user preference plists"
+        debug_operation_detail "Method" "plutil -lint each .plist under $HOME/Library/Preferences (top level) and ByHost (recursive); delete files that fail validation"
+        debug_operation_detail "Safety checks" "Skip com.apple.*, .GlobalPreferences*, and loginwindow.plist"
+        debug_operation_detail "Expected outcome" "Corrupted preference plists removed; affected apps fall back to defaults on next launch"
+        debug_risk_level "LOW" "Apps regenerate preference files automatically on next launch"
+    fi
+
     local spinner_started="false"
     if [[ -t 1 ]]; then
         MOLE_SPINNER_PREFIX="  " start_inline_spinner "Checking preferences..."

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -565,6 +565,28 @@ EOF
     [[ "$output" == *"Repaired 2 corrupted preference files"* ]]
 }
 
+@test "opt_fix_broken_configs emits debug section under MO_DEBUG=1" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MO_DEBUG=1 bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/optimize/maintenance.sh"
+source "$PROJECT_ROOT/lib/optimize/tasks.sh"
+
+fix_broken_preferences() {
+    echo 3
+}
+
+opt_fix_broken_configs 2>&1
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"=== Broken Config Repair ==="* ]]
+    [[ "$output" == *"Method: plutil -lint"* ]]
+    [[ "$output" == *"Safety checks:"* ]]
+    [[ "$output" == *"Expected outcome:"* ]]
+    [[ "$output" == *"Risk Level:"* ]]
+}
+
 @test "clean_deep_system cleans memory exception reports" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Add the `=== Broken Config Repair ===` section to `~/Library/Logs/mole/mole_debug_session.log` under `MO_DEBUG=1`.
- Inside `_repair_preference_plists_in_dir`, log each removed plist via `debug_file_action` so per-file detail lands in the debug log too.

## Problem

`mo optimize --debug` prints `✓ Repaired N corrupted preference files` to the terminal, but `~/Library/Logs/mole/mole_debug_session.log` has no `=== Broken Config Repair ===` section, no method/safety narrative, and no per-file detail of which plists were removed. Every other optimize section emits a `=== Section ===` block in the debug log. This is the only one that does not.

## Fix

- `lib/optimize/tasks.sh`: wrap `opt_fix_broken_configs` with the standard `debug_operation_*` block (`Method`, `Safety checks`, `Expected outcome`, `Risk Level`), guarded by `MO_DEBUG=1`. Matches the pattern already in `opt_saved_state_cleanup`, `opt_network_optimization`, `opt_quarantine_cleanup`, and `opt_font_cache_rebuild`. No change to terminal-visible output.
- `lib/optimize/maintenance.sh`: inside `_repair_preference_plists_in_dir`, emit `debug_file_action "  Removing corrupted plist" "$plist_file"` before each `safe_remove`. The helper writes to stderr + the debug log, never stdout, so the function's `echo "$broken_count"` return value is preserved.
- `tests/clean_system_maintenance.bats`: new `MO_DEBUG=1` test asserting the section header, detail lines, and Risk Level are present.

## Testing

- `bats tests/clean_system_maintenance.bats` → 43/43 ok including the new `opt_fix_broken_configs emits debug section under MO_DEBUG=1`.
- `./scripts/check.sh --no-format` → ok

Closes #904
