### PR TITLE
Fix uninstall dry-run leftover warnings

### DIFF
--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -737,22 +737,24 @@ batch_uninstall_applications() {
             # and would just produce stderr noise we discard.
             local leftover_kb=0
             local -a leftover_paths=()
-            while IFS= read -r _lf; do
-                [[ -n "$_lf" && -e "$_lf" ]] || continue
-                # Skip macOS-managed container stubs: containermanagerd protects
-                # these directories via com.apple.provenance xattr; rm -rf always
-                # fails on them by design. User data is already gone at this point.
-                if [[ "$_lf" == */Library/Containers/* && -f "$_lf/.com.apple.containermanagerd.metadata.plist" ]]; then
-                    continue
-                fi
-                leftover_paths+=("$_lf")
-            done <<< "$related_files"
+            if ! is_uninstall_dry_run; then
+                while IFS= read -r _lf; do
+                    [[ -n "$_lf" && -e "$_lf" ]] || continue
+                    # Skip macOS-managed container stubs: containermanagerd protects
+                    # these directories via com.apple.provenance xattr; rm -rf always
+                    # fails on them by design. User data is already gone at this point.
+                    if [[ "$_lf" == */Library/Containers/* && -f "$_lf/.com.apple.containermanagerd.metadata.plist" ]]; then
+                        continue
+                    fi
+                    leftover_paths+=("$_lf")
+                done <<< "$related_files"
 
-            if [[ ${#leftover_paths[@]} -gt 0 ]]; then
-                local _du_total
-                _du_total=$(command du -skcP "${leftover_paths[@]}" 2> /dev/null | awk 'END {print $1}')
-                if [[ "$_du_total" =~ ^[0-9]+$ ]]; then
-                    leftover_kb=$_du_total
+                if [[ ${#leftover_paths[@]} -gt 0 ]]; then
+                    local _du_total
+                    _du_total=$(command du -skcP "${leftover_paths[@]}" 2> /dev/null | awk 'END {print $1}')
+                    if [[ "$_du_total" =~ ^[0-9]+$ ]]; then
+                        leftover_kb=$_du_total
+                    fi
                 fi
             fi
 

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -225,6 +225,56 @@ EOF
 	[ "$status" -eq 0 ]
 }
 
+@test "batch_uninstall_applications dry-run does not report expected leftovers as failures" {
+	create_app_artifacts
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+request_sudo_access() { return 0; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+enter_alt_screen() { :; }
+leave_alt_screen() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+remove_apps_from_dock() { :; }
+pgrep() { return 1; }
+pkill() { return 0; }
+sudo() { return 0; }
+
+export MOLE_DRY_RUN=1
+export MOLE_DELETE_MODE=trash
+
+app_bundle="$HOME/Applications/TestApp.app"
+mkdir -p "$app_bundle"
+
+selected_apps=()
+selected_apps+=("0|$app_bundle|TestApp|com.example.TestApp|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+output_file="$HOME/dry_run_uninstall.log"
+printf '\n' | batch_uninstall_applications > "$output_file" 2>&1
+output=$(cat "$output_file")
+
+[[ -d "$app_bundle" ]] || { echo "WRONG: dry-run removed app bundle"; cat "$output_file"; exit 1; }
+[[ -d "$HOME/Library/Application Support/TestApp" ]] || { echo "WRONG: dry-run removed app support"; cat "$output_file"; exit 1; }
+[[ -d "$HOME/Library/Caches/TestApp" ]] || { echo "WRONG: dry-run removed cache"; cat "$output_file"; exit 1; }
+[[ -f "$HOME/Library/Preferences/com.example.TestApp.plist" ]] || { echo "WRONG: dry-run removed prefs"; cat "$output_file"; exit 1; }
+
+[[ "$output" == *"Uninstall dry run complete"* ]] || { echo "WRONG: missing dry-run summary"; cat "$output_file"; exit 1; }
+[[ "$output" == *"Would remove 1 app"* ]] || { echo "WRONG: missing would-remove summary"; cat "$output_file"; exit 1; }
+[[ "$output" != *"Could not remove"* ]] || { echo "WRONG: dry-run reported expected leftovers"; cat "$output_file"; exit 1; }
+[[ "$output" != *"Uninstall incomplete"* ]] || { echo "WRONG: dry-run marked incomplete"; cat "$output_file"; exit 1; }
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "force_kill_app sends only an AppleScript Quit, never a kill signal" {
 	# run_with_timeout invokes its argv via gtimeout/timeout, which exec the
 	# real binary and bypass bash functions, so we shadow osascript via a


### PR DESCRIPTION
mo uninstall --dry-run was leaving files in place like it should, then checking those same files and printing Could not remove.

that made a preview look like a failed uninstall.

this skips that leftover check only in dry-run. real uninstall still reports leftovers.

tested with bats tests/uninstall.bats, ./scripts/check.sh --no-format, ./scripts/test.sh, make build