### PR TITLE
fix(purge): restore cursor when purge exits early

### DIFF
--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -13,13 +13,29 @@ export LANG=C
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/core/common.sh"
 
-# Set up cleanup trap for temporary files
-trap cleanup_temp_files EXIT INT TERM
 source "$SCRIPT_DIR/../lib/core/log.sh"
 source "$SCRIPT_DIR/../lib/clean/project.sh"
 
 # Configuration
 CURRENT_SECTION=""
+PURGE_CLEANUP_DONE=false
+
+cleanup_purge() {
+    local signal="${1:-EXIT}"
+    local exit_code="${2:-$?}"
+
+    if [[ "$PURGE_CLEANUP_DONE" == "true" ]]; then
+        return 0
+    fi
+    PURGE_CLEANUP_DONE=true
+
+    cleanup_temp_files
+    show_cursor 2> /dev/null || true
+}
+
+trap 'cleanup_purge EXIT $?' EXIT
+trap 'cleanup_purge INT 130; exit 130' INT
+trap 'cleanup_purge TERM 143; exit 143' TERM
 
 # IMPORTANT: This file overrides start_section / end_section / note_activity
 # from lib/core/base.sh by virtue of being sourced after it. The purge variant
@@ -300,7 +316,7 @@ show_help() {
 # Main entry point
 main() {
     # Set up signal handling
-    trap 'show_cursor; exit 130' INT TERM
+    trap 'cleanup_purge INT 130; exit 130' INT TERM
 
     # Parse arguments
     for arg in "$@"; do

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1036,6 +1036,24 @@ EOF
 	[[ "$output" != *"Unknown option"* ]]
 }
 
+@test "mo purge restores cursor when purge exits after hiding it" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_SKIP_MAIN=1 bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/purge.sh"
+
+hide_cursor() { printf 'hide\n'; }
+show_cursor() { printf 'show\n'; }
+start_purge() { :; }
+perform_purge() { return 42; }
+
+main
+EOF
+
+	[ "$status" -eq 42 ]
+	[[ "$output" == *"hide"* ]]
+	[[ "$output" == *"show"* ]]
+}
+
 @test "mo purge: creates cache directory for stats" {
 	if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
 		skip "gtimeout/timeout not available"


### PR DESCRIPTION
Summary
- Restore the cursor from a cleanup trap after `mo purge` hides it.
- Preserve the purge command exit status while still running cleanup.
- Add a focused regression test for early purge exit after cursor hide.

Testing
- bash -n bin/purge.sh tests/purge.bats
- shellcheck --rcfile .shellcheckrc bin/purge.sh tests/purge.bats
- BATS_FORMATTER=tap bats tests/purge.bats -f "mo purge restores cursor when purge exits after hiding it"
- git diff --check

Notes
- The full tests/purge.bats suite still has two unrelated tilde-expansion failures on upstream main.

Fixes #915