### PR TITLE
fix(purge): restore cursor and temp files on any exit path (#915)

### DIFF
--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -13,8 +13,13 @@ export LANG=C
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/core/common.sh"
 
-# Set up cleanup trap for temporary files
-trap cleanup_temp_files EXIT INT TERM
+# Restores cursor and clears temp files even when set -e aborts (#915).
+cleanup() {
+    show_cursor 2> /dev/null || true
+    cleanup_temp_files
+}
+trap cleanup EXIT
+trap 'trap - EXIT; cleanup; exit 130' INT TERM
 source "$SCRIPT_DIR/../lib/core/log.sh"
 source "$SCRIPT_DIR/../lib/clean/project.sh"
 
@@ -299,9 +304,6 @@ show_help() {
 
 # Main entry point
 main() {
-    # Set up signal handling
-    trap 'show_cursor; exit 130' INT TERM
-
     # Parse arguments
     for arg in "$@"; do
         case "$arg" in
@@ -338,7 +340,6 @@ main() {
     fi
     hide_cursor
     perform_purge
-    show_cursor
 }
 
 if [[ "${MOLE_SKIP_MAIN:-0}" == "1" ]]; then


### PR DESCRIPTION
## Summary

Fixes #915 (`mo purge` leaves the terminal cursor hidden after running).

`bin/purge.sh` hid the cursor before `perform_purge` and restored it via a single trailing `show_cursor`. Under `set -euo pipefail`, any abort path other than `INT`/`TERM` (e.g. an uncaught error inside `perform_purge`, a non-zero return, `SIGHUP` from closing the terminal) skipped that line, so the terminal stayed with the cursor invisible until the user ran `tput cnorm` themselves.

While fixing that I noticed the `main()`-scoped `trap 'show_cursor; exit 130' INT TERM` overwrote the existing file-scope `trap cleanup_temp_files EXIT INT TERM`. So a Ctrl-C during arg parsing (before `perform_purge` reinstalled its own trap) would also leak temp files — addressed as part of the same change.

## Fix

Fold `show_cursor` into the file-scope `cleanup` function alongside `cleanup_temp_files`, and reinstall the traps in the same shape `bin/installer.sh` already uses (`trap cleanup EXIT` + an `INT`/`TERM` trap that explicitly calls `cleanup` before `exit 130`). The `EXIT` trap is the catch-all, so every exit path — normal, `set -e` abort, or signal — runs cleanup exactly once.

Diff is +7 / −6 in a single file.

```diff
-# Set up cleanup trap for temporary files
-trap cleanup_temp_files EXIT INT TERM
+# Restores cursor and clears temp files even when set -e aborts (#915).
+cleanup() {
+    show_cursor 2> /dev/null || true
+    cleanup_temp_files
+}
+trap cleanup EXIT
+trap 'trap - EXIT; cleanup; exit 130' INT TERM
```

…and the corresponding deletions inside `main()` (the redundant in-`main()` INT/TERM trap and the trailing `show_cursor`).

## Why mirror `installer.sh` rather than `clean.sh`

The repo has three cleanup shapes today (`installer.sh`, `clean.sh`, `uninstall.sh`). `installer.sh` is the closest cousin to `purge.sh` — interactive UI, cursor hide/show, temp files, no need to pass the signal name to cleanup. Matching it keeps the variance between files lower.

## Test plan

- [x] `shellcheck bin/purge.sh` — clean
- [x] `bats tests/purge.bats tests/purge_config_paths.bats` — 76/76 pass
- [x] `bash bin/purge.sh --help` — parses
- [x] Walked the worst case mentally: Ctrl-C mid-`perform_purge` → `handle_interrupt` runs `show_cursor` and `exit 130` → `exit` fires the file-scope `EXIT` trap → `cleanup` calls `show_cursor` (idempotent) and `cleanup_temp_files`. Both windows (before and during `perform_purge`) are covered.

## Not in scope

`bin/clean.sh` and `bin/uninstall.sh` already wrap `show_cursor` inside a file-scope `cleanup`, so they are not affected by this bug. Keeping this PR narrow to #915.