### PR TITLE
feat(clean): clean Codex CLI and Antigravity caches

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1306,6 +1306,16 @@ codex_running() {
     codex_desktop_running
 }
 
+antigravity_or_gemini_running() {
+    command -v pgrep > /dev/null 2>&1 || return 1
+
+    pgrep -x "Antigravity" > /dev/null 2>&1 && return 0
+    pgrep -f "/Antigravity.app/" > /dev/null 2>&1 && return 0
+    pgrep -x "gemini" > /dev/null 2>&1 && return 0
+    pgrep -f "antigravity-browser-profile" > /dev/null 2>&1 && return 0
+    return 1
+}
+
 is_codex_runtime_active() {
     local runtime_dir="$1"
     [[ -d "$runtime_dir" ]] || return 1
@@ -1421,6 +1431,13 @@ clean_codex_cli() {
 # caches, mirroring the Antigravity Electron cache cleanup in clean_dev_misc.
 clean_antigravity_caches() {
     local ag_profile="$HOME/.gemini/antigravity-browser-profile"
+
+    if antigravity_or_gemini_running; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Antigravity/Gemini caches · skipped (Antigravity or Gemini running)"
+        note_activity
+        return 0
+    fi
+
     if [[ -d "$ag_profile" ]]; then
         safe_clean "$ag_profile/Default/Cache"/* "Antigravity browser cache"
         safe_clean "$ag_profile/Default/Code Cache"/* "Antigravity code cache"

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1299,6 +1299,13 @@ codex_desktop_running() {
     return 1
 }
 
+# True when the Codex CLI or the Codex Desktop app is running.
+codex_running() {
+    command -v pgrep > /dev/null 2>&1 || return 1
+    pgrep -x "codex" > /dev/null 2>&1 && return 0
+    codex_desktop_running
+}
+
 is_codex_runtime_active() {
     local runtime_dir="$1"
     [[ -d "$runtime_dir" ]] || return 1
@@ -1391,6 +1398,43 @@ clean_codex_runtimes() {
     done < <(command find "$runtime_root" -mindepth 1 -maxdepth 1 -type d -print0 2> /dev/null)
 }
 
+# Codex CLI working directory: rebuildable cache, temp, and log files.
+# Conversation state (sessions, *.sqlite, history.jsonl, credentials) is
+# intentionally left untouched - see issue #913.
+clean_codex_cli() {
+    local codex_root="$HOME/.codex"
+    [[ -d "$codex_root" ]] || return 0
+
+    if codex_running; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Codex CLI caches · skipped (Codex running)"
+        note_activity
+        return 0
+    fi
+
+    safe_clean "$codex_root/cache"/* "Codex CLI cache"
+    safe_clean "$codex_root/.tmp"/* "Codex CLI temp files"
+    safe_clean "$codex_root/log"/* "Codex CLI logs"
+}
+
+# Antigravity (Gemini) keeps a full Chromium profile under
+# ~/.gemini/antigravity-browser-profile. Clean its regenerable browser
+# caches, mirroring the Antigravity Electron cache cleanup in clean_dev_misc.
+clean_antigravity_caches() {
+    local ag_profile="$HOME/.gemini/antigravity-browser-profile"
+    if [[ -d "$ag_profile" ]]; then
+        safe_clean "$ag_profile/Default/Cache"/* "Antigravity browser cache"
+        safe_clean "$ag_profile/Default/Code Cache"/* "Antigravity code cache"
+        safe_clean "$ag_profile/Default/GPUCache"/* "Antigravity GPU cache"
+        safe_clean "$ag_profile/Default/DawnGraphiteCache"/* "Antigravity Dawn cache"
+        safe_clean "$ag_profile/Default/DawnWebGPUCache"/* "Antigravity WebGPU cache"
+        safe_clean "$ag_profile/GraphiteDawnCache"/* "Antigravity Graphite cache"
+        safe_clean "$ag_profile/component_crx_cache"/* "Antigravity component cache"
+        safe_clean "$ag_profile/extensions_crx_cache"/* "Antigravity extension cache"
+        clean_service_worker_cache "Antigravity" "$ag_profile/Default/Service Worker/CacheStorage"
+    fi
+    safe_clean "$HOME/.gemini/tmp"/* "Gemini CLI temp files"
+}
+
 # Misc dev tool caches.
 clean_dev_misc() {
     safe_clean ~/Library/Caches/com.unity3d.*/* "Unity cache"
@@ -1407,6 +1451,8 @@ clean_dev_misc() {
         safe_clean ~/Library/Application\ Support/Antigravity/DawnGraphiteCache/* "Antigravity Dawn cache"
         safe_clean ~/Library/Application\ Support/Antigravity/DawnWebGPUCache/* "Antigravity WebGPU cache"
     fi
+    # Antigravity browser profile caches (~/.gemini)
+    clean_antigravity_caches
     # Filo (Electron)
     if [[ -d ~/Library/Application\ Support/Filo ]]; then
         safe_clean ~/Library/Application\ Support/Filo/production/Cache/* "Filo cache"
@@ -1447,6 +1493,8 @@ clean_dev_misc() {
     fi
     # Codex Desktop runtimes contain active Node/Python dependencies.
     clean_codex_runtimes
+    # Codex CLI working-directory caches (~/.codex)
+    clean_codex_cli
     # Cursor Agent session logs (versions cleaned separately in clean_dev_ai_agents)
     [[ -d "$HOME/.local/share/cursor-agent" ]] && safe_find_delete "$HOME/.local/share/cursor-agent" "*.log" "$MOLE_LOG_AGE_DAYS" "f"
     # Playwright cached browser binaries

--- a/tests/clean_ai_cli_caches.bats
+++ b/tests/clean_ai_cli_caches.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-ai-cli-caches.XXXXXX")"
+    export HOME
+
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    if [[ "$HOME" == "${BATS_TEST_DIRNAME}/tmp-"* ]]; then
+        rm -rf "$HOME"
+    fi
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+setup() {
+    [[ "$HOME" == "${BATS_TEST_DIRNAME}/tmp-"* ]] || {
+        echo "FATAL: HOME is not a test temp dir: $HOME"
+        exit 1
+    }
+    rm -rf "$HOME/.codex" "$HOME/.gemini"
+}
+
+assert_run_success() {
+    [ "$status" -eq 0 ] || {
+        echo "expected status 0, got $status"
+        echo "$output"
+        return 1
+    }
+}
+
+assert_output_contains() {
+    local expected="$1"
+    [[ "$output" == *"$expected"* ]] || {
+        echo "expected output to contain: $expected"
+        echo "$output"
+        return 1
+    }
+}
+
+assert_output_not_contains() {
+    local unexpected="$1"
+    [[ "$output" != *"$unexpected"* ]] || {
+        echo "expected output not to contain: $unexpected"
+        echo "$output"
+        return 1
+    }
+}
+
+@test "clean_codex_cli cleans codex cache, tmp, and log directories" {
+    mkdir -p "$HOME/.codex/cache" "$HOME/.codex/.tmp" "$HOME/.codex/log" "$HOME/.codex/sessions"
+    touch "$HOME/.codex/cache/c.bin" "$HOME/.codex/.tmp/t.bin" "$HOME/.codex/log/codex-tui.log"
+    touch "$HOME/.codex/sessions/s.jsonl" "$HOME/.codex/auth.json" "$HOME/.codex/history.jsonl"
+    touch "$HOME/.codex/state_5.sqlite" "$HOME/.codex/logs_2.sqlite"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+note_activity() { :; }
+pgrep() { return 1; }
+clean_codex_cli
+EOF
+
+    assert_run_success
+    assert_output_contains "SAFE_CLEAN:Codex CLI cache|$HOME/.codex/cache/"
+    assert_output_contains "SAFE_CLEAN:Codex CLI temp files|$HOME/.codex/.tmp/"
+    assert_output_contains "SAFE_CLEAN:Codex CLI logs|$HOME/.codex/log/"
+    assert_output_not_contains "sessions"
+    assert_output_not_contains "auth.json"
+    assert_output_not_contains "history.jsonl"
+    assert_output_not_contains "state_5.sqlite"
+    assert_output_not_contains "logs_2.sqlite"
+}
+
+@test "clean_codex_cli is a no-op when ~/.codex is absent" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+note_activity() { :; }
+pgrep() { return 1; }
+clean_codex_cli
+EOF
+
+    assert_run_success
+    assert_output_not_contains "SAFE_CLEAN:"
+}
+
+@test "clean_codex_cli skips all targets while Codex is running" {
+    mkdir -p "$HOME/.codex/cache" "$HOME/.codex/.tmp" "$HOME/.codex/log"
+    touch "$HOME/.codex/cache/c.bin"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+note_activity() { :; }
+pgrep() { return 0; }
+clean_codex_cli
+EOF
+
+    assert_run_success
+    assert_output_contains "Codex CLI caches · skipped (Codex running)"
+    assert_output_not_contains "SAFE_CLEAN:"
+}
+
+@test "clean_antigravity_caches cleans antigravity browser caches" {
+    ag="$HOME/.gemini/antigravity-browser-profile"
+    mkdir -p "$ag/Default/Cache" "$ag/Default/Code Cache" "$ag/Default/GPUCache"
+    mkdir -p "$ag/Default/DawnGraphiteCache" "$ag/Default/DawnWebGPUCache"
+    mkdir -p "$ag/GraphiteDawnCache" "$ag/component_crx_cache" "$ag/extensions_crx_cache"
+    mkdir -p "$ag/Default/Extensions" "$ag/Default/Storage"
+    touch "$ag/Default/Cache/a.bin" "$ag/Default/Code Cache/b.bin" "$ag/Default/GPUCache/c.bin"
+    touch "$ag/Default/DawnGraphiteCache/d.bin" "$ag/Default/DawnWebGPUCache/e.bin"
+    touch "$ag/GraphiteDawnCache/f.bin" "$ag/component_crx_cache/g.bin" "$ag/extensions_crx_cache/h.bin"
+    touch "$ag/Default/Extensions/x.js" "$ag/Default/Storage/y.bin"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+clean_service_worker_cache() { echo "SWC:$1"; }
+note_activity() { :; }
+clean_antigravity_caches
+EOF
+
+    assert_run_success
+    assert_output_contains "SAFE_CLEAN:Antigravity browser cache|"
+    assert_output_contains "SAFE_CLEAN:Antigravity code cache|"
+    assert_output_contains "SAFE_CLEAN:Antigravity GPU cache|"
+    assert_output_contains "SAFE_CLEAN:Antigravity Dawn cache|"
+    assert_output_contains "SAFE_CLEAN:Antigravity WebGPU cache|"
+    assert_output_contains "SAFE_CLEAN:Antigravity Graphite cache|"
+    assert_output_contains "SAFE_CLEAN:Antigravity component cache|"
+    assert_output_contains "SAFE_CLEAN:Antigravity extension cache|"
+    assert_output_contains "SWC:Antigravity"
+    assert_output_not_contains "Default/Extensions"
+    assert_output_not_contains "Default/Storage"
+}
+
+@test "clean_antigravity_caches is a no-op when the profile is absent" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+clean_service_worker_cache() { echo "SWC:$1"; }
+note_activity() { :; }
+clean_antigravity_caches
+EOF
+
+    assert_run_success
+    assert_output_not_contains "SAFE_CLEAN:Antigravity"
+    assert_output_not_contains "SWC:"
+}
+
+@test "clean_antigravity_caches cleans gemini CLI temp files without browser profile" {
+    mkdir -p "$HOME/.gemini/tmp"
+    touch "$HOME/.gemini/tmp/work.bin"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+clean_service_worker_cache() { echo "SWC:$1"; }
+note_activity() { :; }
+clean_antigravity_caches
+EOF
+
+    assert_run_success
+    assert_output_not_contains "SAFE_CLEAN:Antigravity"
+    assert_output_not_contains "SWC:"
+    assert_output_contains "SAFE_CLEAN:Gemini CLI temp files|$HOME/.gemini/tmp/"
+}
+
+@test "clean_dev_misc invokes clean_codex_cli and clean_antigravity_caches" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { :; }
+safe_find_delete() { :; }
+clean_service_worker_cache() { :; }
+clean_codex_runtimes() { :; }
+note_activity() { :; }
+clean_codex_cli() { echo "CODEX_CLI_CALLED"; }
+clean_antigravity_caches() { echo "ANTIGRAVITY_CALLED"; }
+clean_dev_misc
+EOF
+
+    assert_run_success
+    assert_output_contains "CODEX_CLI_CALLED"
+    assert_output_contains "ANTIGRAVITY_CALLED"
+}

--- a/tests/clean_ai_cli_caches.bats
+++ b/tests/clean_ai_cli_caches.bats
@@ -188,6 +188,31 @@ EOF
     assert_output_contains "SAFE_CLEAN:Gemini CLI temp files|$HOME/.gemini/tmp/"
 }
 
+@test "clean_antigravity_caches skips browser profile and gemini tmp while running" {
+    ag="$HOME/.gemini/antigravity-browser-profile"
+    mkdir -p "$ag/Default/Cache" "$HOME/.gemini/tmp"
+    touch "$ag/Default/Cache/a.bin" "$HOME/.gemini/tmp/work.bin"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+clean_service_worker_cache() { echo "SWC:$1"; }
+note_activity() { echo "NOTE_ACTIVITY"; }
+pgrep() {
+    [[ "$1" == "-x" && "$2" == "gemini" ]]
+}
+clean_antigravity_caches
+EOF
+
+    assert_run_success
+    assert_output_contains "Antigravity/Gemini caches · skipped"
+    assert_output_contains "NOTE_ACTIVITY"
+    assert_output_not_contains "SAFE_CLEAN:"
+    assert_output_not_contains "SWC:"
+}
+
 @test "clean_dev_misc invokes clean_codex_cli and clean_antigravity_caches" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

This adds `mo clean` coverage for regenerable Codex CLI and Antigravity cache data:

- Cleans Codex CLI cache, temp, and log directories under `~/.codex`
- Skips Codex CLI cleanup while Codex CLI or Codex Desktop is running
- Cleans Antigravity browser profile caches under `~/.gemini/antigravity-browser-profile`
- Cleans Gemini CLI temp files under `~/.gemini/tmp`
- Wires both new cleanup paths into `clean_dev_misc`

## Safety

The cleanup intentionally avoids Codex and browser state such as sessions, credentials, history files, SQLite databases, extensions, storage, and other user data. Deletions go through the existing `safe_clean` and Service Worker cleanup helpers.

## Tests

- `bats tests/clean_ai_cli_caches.bats tests/clean_dev_caches.bats`
- `./scripts/check.sh`
- `git diff --check main...HEAD`
