### PR TITLE
Fix available memory shown in status

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-brew-quality-v2-
 
       - name: Install tools
-        run: brew install shfmt shellcheck golangci-lint
+        run: brew install shfmt shellcheck
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
@@ -55,7 +55,7 @@ jobs:
       - name: Check Go formatting (goimports -l)
         run: |
           export PATH=$(go env GOPATH)/bin:$PATH
-          UNFORMATTED=$(goimports -l -local github.com/tw93/Mole ./cmd)
+          UNFORMATTED=$(goimports -l -local github.com/tw93/mole ./cmd ./internal)
           if [[ -n "$UNFORMATTED" ]]; then
             echo "::error::Go files are not formatted:"
             echo "$UNFORMATTED"
@@ -87,12 +87,17 @@ jobs:
             ${{ runner.os }}-brew-quality-v2-
 
       - name: Install tools
-        run: brew install shfmt shellcheck golangci-lint
+        run: brew install shfmt shellcheck
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
           go-version-file: go.mod
+
+      - name: Install golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run check script
         run: ./scripts/check.sh --no-format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          fetch-depth: 0
 
       - name: Install tools
         run: brew install bats-core coreutils

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -134,6 +134,7 @@ type GPUStatus struct {
 type MemoryStatus struct {
 	Used        uint64  `json:"used"`
 	Total       uint64  `json:"total"`
+	Available   uint64  `json:"available"`
 	UsedPercent float64 `json:"used_percent"`
 	SwapUsed    uint64  `json:"swap_used"`
 	SwapTotal   uint64  `json:"swap_total"`

--- a/cmd/status/metrics_memory.go
+++ b/cmd/status/metrics_memory.go
@@ -31,6 +31,7 @@ func collectMemory() (MemoryStatus, error) {
 	return MemoryStatus{
 		Used:        vm.Used,
 		Total:       vm.Total,
+		Available:   vm.Available,
 		UsedPercent: vm.UsedPercent,
 		SwapUsed:    swap.Used,
 		SwapTotal:   swap.Total,

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -332,7 +332,10 @@ func renderMemoryCard(mem MemoryStatus, cardWidth int) cardData {
 	lines = append(lines, fmt.Sprintf("Used   %s  %5.1f%%", progressBar(mem.UsedPercent), mem.UsedPercent))
 
 	// Line 2: Free
-	freePercent := 100 - mem.UsedPercent
+	var freePercent float64
+	if mem.Total > 0 {
+		freePercent = (float64(mem.Available) / float64(mem.Total)) * 100.0
+	}
 	lines = append(lines, fmt.Sprintf("Free   %s  %5.1f%%", progressBar(freePercent), freePercent))
 
 	if hasSwap {
@@ -356,7 +359,7 @@ func renderMemoryCard(mem MemoryStatus, cardWidth int) cardData {
 		}
 
 		lines = append(lines, fmt.Sprintf("Total  %s / %s", humanBytes(mem.Used), humanBytes(mem.Total)))
-		lines = append(lines, fmt.Sprintf("Avail  %s", humanBytes(mem.Total-mem.Used))) // Simplified avail logic for consistency
+		lines = append(lines, fmt.Sprintf("Avail  %s", humanBytes(mem.Available)))
 	} else {
 		// Layout without Swap:
 		// 3. Total
@@ -367,13 +370,7 @@ func renderMemoryCard(mem MemoryStatus, cardWidth int) cardData {
 		if mem.Cached > 0 {
 			lines = append(lines, fmt.Sprintf("Cached %s", humanBytes(mem.Cached)))
 		}
-		// Calculate available if not provided directly, or use Total-Used as proxy if needed,
-		// but typically available is more nuanced. Using what we have.
-		// Re-calculating available based on logic if needed, but mem.Total - mem.Used is often "Avail"
-		// in simple terms for this view or we could use the passed definition.
-		// Original code calculated: available := mem.Total - mem.Used
-		available := mem.Total - mem.Used
-		lines = append(lines, fmt.Sprintf("Avail  %s", humanBytes(available)))
+		lines = append(lines, fmt.Sprintf("Avail  %s", humanBytes(mem.Available)))
 	}
 	// Memory pressure status.
 	if mem.Pressure != "" {

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1062,6 +1062,7 @@ func TestRenderMemoryCardHidesSwapSizeOnNarrowWidth(t *testing.T) {
 	card := renderMemoryCard(MemoryStatus{
 		Used:        8 << 30,
 		Total:       16 << 30,
+		Available:   8 << 30,
 		UsedPercent: 50.0,
 		SwapUsed:    482,
 		SwapTotal:   1000,
@@ -1081,6 +1082,7 @@ func TestRenderMemoryCardShowsSwapSizeOnWideWidth(t *testing.T) {
 	card := renderMemoryCard(MemoryStatus{
 		Used:        8 << 30,
 		Total:       16 << 30,
+		Available:   8 << 30,
 		UsedPercent: 50.0,
 		SwapUsed:    482,
 		SwapTotal:   1000,
@@ -1093,6 +1095,23 @@ func TestRenderMemoryCardShowsSwapSizeOnWideWidth(t *testing.T) {
 	swapLine := stripANSI(card.lines[2])
 	if !strings.Contains(swapLine, "/") {
 		t.Fatalf("renderMemoryCard() wide width should include swap size, got %q", swapLine)
+	}
+}
+
+func TestRenderMemoryCardUsesCollectedAvailableMemory(t *testing.T) {
+	card := renderMemoryCard(MemoryStatus{
+		Used:        12 << 30,
+		Total:       16 << 30,
+		Available:   9 << 30,
+		UsedPercent: 75.0,
+	}, 60)
+
+	plain := stripANSI(strings.Join(card.lines, "\n"))
+	if !strings.Contains(plain, "Free") || !strings.Contains(plain, "56.2%") {
+		t.Fatalf("renderMemoryCard() should derive free percent from Available, got %q", plain)
+	}
+	if !strings.Contains(plain, "Avail  9.0 GB") {
+		t.Fatalf("renderMemoryCard() should render collected Available memory, got %q", plain)
 	}
 }
 


### PR DESCRIPTION
The status view was calculating available memory as total - used.

That can be wrong because the OS reports reclaimable/cache memory separately. This adds Available to the memory snapshot, fills it from gopsutil, and renders the memory card from that value.

Validation:
go test ./cmd/status
go test ./...
