### PR TITLE
Cover shared Go code and install script in checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-brew-quality-v2-
 
       - name: Install tools
-        run: brew install shfmt shellcheck golangci-lint
+        run: brew install shfmt shellcheck
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
@@ -55,7 +55,7 @@ jobs:
       - name: Check Go formatting (goimports -l)
         run: |
           export PATH=$(go env GOPATH)/bin:$PATH
-          UNFORMATTED=$(goimports -l -local github.com/tw93/Mole ./cmd)
+          UNFORMATTED=$(goimports -l -local github.com/tw93/mole ./cmd ./internal)
           if [[ -n "$UNFORMATTED" ]]; then
             echo "::error::Go files are not formatted:"
             echo "$UNFORMATTED"
@@ -87,12 +87,17 @@ jobs:
             ${{ runner.os }}-brew-quality-v2-
 
       - name: Install tools
-        run: brew install shfmt shellcheck golangci-lint
+        run: brew install shfmt shellcheck
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
           go-version-file: go.mod
+
+      - name: Install golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run check script
         run: ./scripts/check.sh --no-format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          fetch-depth: 0
 
       - name: Install tools
         run: brew install bats-core coreutils

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test:
 	MOLE_TEST_NO_AUTH=1 ./scripts/test.sh
 
 test-go:
-	$(GO) test ./cmd/...
+	$(GO) test ./...
 
 verify: check test-go
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,11 +76,11 @@ if [[ "$MODE" == "format" ]]; then
 
     if command -v goimports > /dev/null 2>&1; then
         echo -e "${YELLOW}Formatting Go code, goimports...${NC}"
-        goimports -w -local github.com/tw93/Mole ./cmd
+        goimports -w -local github.com/tw93/mole ./cmd ./internal
         echo -e "${GREEN}${ICON_SUCCESS} Go formatting complete${NC}\n"
     elif command -v go > /dev/null 2>&1; then
         echo -e "${YELLOW}Formatting Go code, gofmt...${NC}"
-        gofmt -w ./cmd
+        gofmt -w ./cmd ./internal
         echo -e "${GREEN}${ICON_SUCCESS} Go formatting complete${NC}\n"
     else
         echo -e "${YELLOW}${ICON_WARNING} go not installed, skipping gofmt${NC}\n"
@@ -101,11 +101,11 @@ if [[ "$MODE" != "check" ]]; then
 
     if command -v goimports > /dev/null 2>&1; then
         echo -e "${YELLOW}2. Formatting Go code, goimports...${NC}"
-        goimports -w -local github.com/tw93/Mole ./cmd
+        goimports -w -local github.com/tw93/mole ./cmd ./internal
         echo -e "${GREEN}${ICON_SUCCESS} Go formatting applied${NC}\n"
     elif command -v go > /dev/null 2>&1; then
         echo -e "${YELLOW}2. Formatting Go code, gofmt...${NC}"
-        gofmt -w ./cmd
+        gofmt -w ./cmd ./internal
         echo -e "${GREEN}${ICON_SUCCESS} Go formatting applied${NC}\n"
     fi
 fi
@@ -116,17 +116,17 @@ if command -v golangci-lint > /dev/null 2>&1; then
         echo -e "${RED}${ICON_ERROR} golangci-lint config invalid${NC}\n"
         exit 1
     fi
-    if golangci-lint run ./cmd/...; then
+    if golangci-lint run ./...; then
         echo -e "${GREEN}${ICON_SUCCESS} golangci-lint passed${NC}\n"
     else
         echo -e "${RED}${ICON_ERROR} golangci-lint failed${NC}\n"
         echo -e "${YELLOW}If the output points to deleted temporary worktrees or non-existent paths, run:${NC}"
-        echo -e "${YELLOW}  golangci-lint cache clean && golangci-lint run ./cmd/...${NC}\n"
+        echo -e "${YELLOW}  golangci-lint cache clean && golangci-lint run ./...${NC}\n"
         exit 1
     fi
 elif command -v go > /dev/null 2>&1; then
     echo -e "${YELLOW}${ICON_WARNING} golangci-lint not installed, falling back to go vet${NC}"
-    if go vet ./cmd/...; then
+    if go vet ./...; then
         echo -e "${GREEN}${ICON_SUCCESS} go vet passed${NC}\n"
     else
         echo -e "${RED}${ICON_ERROR} go vet failed${NC}\n"
@@ -138,7 +138,7 @@ fi
 
 echo -e "${YELLOW}4. Running ShellCheck...${NC}"
 if command -v shellcheck > /dev/null 2>&1; then
-    if shellcheck mole bin/*.sh lib/*/*.sh scripts/*.sh; then
+    if shellcheck mole install.sh bin/*.sh lib/*/*.sh scripts/*.sh; then
         echo -e "${GREEN}${ICON_SUCCESS} ShellCheck passed${NC}\n"
     else
         echo -e "${RED}${ICON_ERROR} ShellCheck failed${NC}\n"
@@ -153,7 +153,17 @@ if ! bash -n mole; then
     echo -e "${RED}${ICON_ERROR} Syntax check failed, mole${NC}\n"
     exit 1
 fi
+if ! bash -n install.sh; then
+    echo -e "${RED}${ICON_ERROR} Syntax check failed, install.sh${NC}\n"
+    exit 1
+fi
 for script in bin/*.sh; do
+    if ! bash -n "$script"; then
+        echo -e "${RED}${ICON_ERROR} Syntax check failed, $script${NC}\n"
+        exit 1
+    fi
+done
+for script in scripts/*.sh; do
     if ! bash -n "$script"; then
         echo -e "${RED}${ICON_ERROR} Syntax check failed, $script${NC}\n"
         exit 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -314,8 +314,8 @@ echo "3. Running Go tests..."
 if command -v go > /dev/null 2>&1; then
     mkdir -p "$GO_TEST_CACHE"
     if GOCACHE="$GO_TEST_CACHE" go build ./... > /dev/null 2>&1 &&
-        GOCACHE="$GO_TEST_CACHE" go vet ./cmd/... > /dev/null 2>&1 &&
-        GOCACHE="$GO_TEST_CACHE" go test ./cmd/... > /dev/null 2>&1; then
+        GOCACHE="$GO_TEST_CACHE" go vet ./... > /dev/null 2>&1 &&
+        GOCACHE="$GO_TEST_CACHE" go test ./... > /dev/null 2>&1; then
         printf "${GREEN}${ICON_SUCCESS} Go tests passed${NC}\n"
     else
         printf "${RED}${ICON_ERROR} Go tests failed${NC}\n"


### PR DESCRIPTION
The check scripts only covered ./cmd/... for Go, so shared Go packages could drift outside normal validation.

This updates Go format/lint/vet/test targets to cover ./.... It also adds install.sh and scripts/*.sh to the shell check and syntax check paths.

Validation:
go test ./...
go vet ./...
./scripts/check.sh --no-format
./scripts/test.sh
