### PR TITLE
Harden deletion path validation

### DIFF
--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -63,7 +63,7 @@ format_duration_human() {
 # Path Validation
 # ============================================================================
 
-_mole_deletion_policy_path() {
+_mole_normalize_deletion_policy_path() {
     local path="$1"
     local slash="/"
     local double_slash="//"
@@ -76,6 +76,7 @@ _mole_deletion_policy_path() {
     [[ -n "$trimmed" ]] && printf '%s\n' "$trimmed" || printf '%s\n' "$path"
 }
 
+# Deletion policy only. App/data protection stays in app_protection.sh.
 _mole_is_critical_deletion_path() {
     local path="$1"
 
@@ -139,7 +140,7 @@ validate_path_for_deletion() {
     fi
 
     local policy_path
-    policy_path=$(_mole_deletion_policy_path "$path")
+    policy_path=$(_mole_normalize_deletion_policy_path "$path")
 
     # Check symlink target if path is a symbolic link
     if [[ -L "$path" ]]; then
@@ -159,7 +160,7 @@ validate_path_for_deletion() {
 
         # Validate resolved target against protected paths
         if [[ -n "$resolved_target" ]]; then
-            resolved_target=$(_mole_deletion_policy_path "$resolved_target")
+            resolved_target=$(_mole_normalize_deletion_policy_path "$resolved_target")
             if _mole_is_critical_deletion_path "$resolved_target"; then
                 log_error "Symlink points to protected system path: $path -> $resolved_target"
                 return 1

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -63,6 +63,51 @@ format_duration_human() {
 # Path Validation
 # ============================================================================
 
+_mole_deletion_policy_path() {
+    local path="$1"
+    local slash="/"
+    local double_slash="//"
+
+    while [[ "$path" == *"$double_slash"* ]]; do
+        path="${path//$double_slash/$slash}"
+    done
+
+    local trimmed="${path%/}"
+    [[ -n "$trimmed" ]] && printf '%s\n' "$trimmed" || printf '%s\n' "$path"
+}
+
+_mole_is_critical_deletion_path() {
+    local path="$1"
+
+    case "$path" in
+        / | \
+            /bin | /bin/* | \
+            /sbin | /sbin/* | \
+            /usr | /usr/bin | /usr/bin/* | /usr/sbin | /usr/sbin/* | /usr/lib | /usr/lib/* | \
+            /System | /System/* | \
+            /Library/Apple | /Library/Apple/* | \
+            /Library/Extensions | /Library/Extensions/* | \
+            /Library/Keychains | /Library/Keychains/* | \
+            /Applications/Finder.app | /Applications/Finder.app/* | \
+            /Applications/Safari.app | /Applications/Safari.app/* | \
+            /Users | /Users/Shared | /Users/Guest | /Users/Guest/*)
+            return 0
+            ;;
+        /private)
+            return 0
+            ;;
+        /etc | /etc/* | /private/etc | /private/etc/*)
+            return 0
+            ;;
+        /var | /var/db | /var/db/* | /var/audit | /var/audit/* | \
+            /private/var | /private/var/db | /private/var/db/* | /private/var/audit | /private/var/audit/*)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
 # Validate path for deletion (absolute, no traversal, not system dir)
 validate_path_for_deletion() {
     local path="$1"
@@ -71,36 +116,6 @@ validate_path_for_deletion() {
     if [[ -z "$path" ]]; then
         log_error "Path validation failed: empty path"
         return 1
-    fi
-
-    # Check symlink target if path is a symbolic link
-    if [[ -L "$path" ]]; then
-        local link_target
-        link_target=$(readlink "$path" 2> /dev/null) || {
-            log_error "Cannot read symlink: $path"
-            return 1
-        }
-
-        # Resolve relative symlinks to absolute paths for validation
-        local resolved_target="$link_target"
-        if [[ "$link_target" != /* ]]; then
-            local link_dir
-            link_dir=$(dirname "$path")
-            resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$(dirname "$link_target")" 2> /dev/null && pwd)/$(basename "$link_target") || resolved_target=""
-        fi
-
-        # Validate resolved target against protected paths
-        if [[ -n "$resolved_target" ]]; then
-            case "$resolved_target" in
-                / | /System | /System/* | /bin | /bin/* | /sbin | /sbin/* | \
-                    /usr | /usr/bin | /usr/bin/* | /usr/lib | /usr/lib/* | \
-                    /etc | /etc/* | /private/etc | /private/etc/* | \
-                    /Library/Extensions | /Library/Extensions/*)
-                    log_error "Symlink points to protected system path: $path -> $resolved_target"
-                    return 1
-                    ;;
-            esac
-        fi
     fi
 
     # Check path is absolute
@@ -123,15 +138,44 @@ validate_path_for_deletion() {
         return 1
     fi
 
+    local policy_path
+    policy_path=$(_mole_deletion_policy_path "$path")
+
+    # Check symlink target if path is a symbolic link
+    if [[ -L "$path" ]]; then
+        local link_target
+        link_target=$(readlink "$path" 2> /dev/null) || {
+            log_error "Cannot read symlink: $path"
+            return 1
+        }
+
+        # Resolve relative symlinks to absolute paths for validation
+        local resolved_target="$link_target"
+        if [[ "$link_target" != /* ]]; then
+            local link_dir
+            link_dir=$(dirname "$path")
+            resolved_target=$(cd "$link_dir" 2> /dev/null && cd "$(dirname "$link_target")" 2> /dev/null && pwd)/$(basename "$link_target") || resolved_target=""
+        fi
+
+        # Validate resolved target against protected paths
+        if [[ -n "$resolved_target" ]]; then
+            resolved_target=$(_mole_deletion_policy_path "$resolved_target")
+            if _mole_is_critical_deletion_path "$resolved_target"; then
+                log_error "Symlink points to protected system path: $path -> $resolved_target"
+                return 1
+            fi
+        fi
+    fi
+
     # Allow deletion of coresymbolicationd cache (safe system cache that can be rebuilt)
-    case "$path" in
+    case "$policy_path" in
         /System/Library/Caches/com.apple.coresymbolicationd/data | /System/Library/Caches/com.apple.coresymbolicationd/data/*)
             return 0
             ;;
     esac
 
     # Allow known safe paths under /private
-    case "$path" in
+    case "$policy_path" in
         /private/tmp | /private/tmp/* | \
             /private/var/tmp | /private/var/tmp/* | \
             /private/var/log | /private/var/log/* | \
@@ -146,30 +190,16 @@ validate_path_for_deletion() {
     esac
 
     # Check path isn't critical system directory
-    case "$path" in
-        / | /bin | /bin/* | /sbin | /sbin/* | /usr | /usr/bin | /usr/bin/* | /usr/sbin | /usr/sbin/* | /usr/lib | /usr/lib/* | /System | /System/* | /Library/Extensions | /Library/Extensions/*)
-            log_error "Path validation failed: critical system directory: $path"
-            return 1
-            ;;
-        /private)
-            log_error "Path validation failed: critical system directory: $path"
-            return 1
-            ;;
-        /etc | /etc/* | /private/etc | /private/etc/*)
-            log_error "Path validation failed: /etc contains critical system files: $path"
-            return 1
-            ;;
-        /var | /var/db | /var/db/* | /private/var | /private/var/db | /private/var/db/*)
-            log_error "Path validation failed: /var/db contains system databases: $path"
-            return 1
-            ;;
-    esac
+    if _mole_is_critical_deletion_path "$policy_path"; then
+        log_error "Path validation failed: critical system path: $path"
+        return 1
+    fi
 
     # Check if path is protected (keychains, system settings, etc)
     if declare -f should_protect_path > /dev/null 2>&1; then
-        if should_protect_path "$path"; then
+        if should_protect_path "$policy_path"; then
             if [[ "${MO_DEBUG:-0}" == "1" ]]; then
-                log_warning "Path validation: protected path skipped: $path"
+                log_warning "Path validation: protected path skipped: $policy_path"
             fi
             return 1
         fi
@@ -287,6 +317,10 @@ safe_remove_symlink() {
     local use_sudo="${2:-false}"
 
     if [[ ! -L "$path" ]]; then
+        return 1
+    fi
+
+    if ! validate_path_for_deletion "$path"; then
         return 1
     fi
 
@@ -477,7 +511,7 @@ mole_delete() {
     # up front to avoid a no-op Trash move followed by a validation failure.
     # The rejection itself is recorded in the forensic log so audit trails
     # can distinguish refused-by-policy from never-attempted.
-    if [[ ! -L "$path" ]] && ! validate_path_for_deletion "$path"; then
+    if ! validate_path_for_deletion "$path"; then
         _mole_delete_log "$mode" "0" "rejected" "$path"
         return 1
     fi
@@ -807,7 +841,7 @@ safe_find_delete() {
     # #738, #744, #757); enforcing here makes the protection structural so
     # new clean_* functions get whitelist enforcement for free.
     while IFS= read -r -d '' match; do
-        if should_protect_path "$match"; then
+        if declare -f should_protect_path > /dev/null 2>&1 && should_protect_path "$match"; then
             continue
         fi
         if declare -f is_path_whitelisted > /dev/null && is_path_whitelisted "$match"; then

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -106,6 +106,9 @@ teardown() {
 @test "validate_path_for_deletion accepts valid path" {
     run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '$TEST_DIR/valid'"
     [ "$status" -eq 0 ]
+
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '$HOME/Library/Caches/com.example.app/cache.db'"
+    [ "$status" -eq 0 ]
 }
 
 @test "validate_path_for_deletion allows Darwin C cache shards but rejects protected extension paths" {

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -84,6 +84,23 @@ teardown() {
 
     run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/etc'"
     [ "$status" -eq 1 ]
+
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/Library/Apple'"
+    [ "$status" -eq 1 ]
+
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/Applications/Finder.app'"
+    [ "$status" -eq 1 ]
+
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/Users'"
+    [ "$status" -eq 1 ]
+}
+
+@test "validate_path_for_deletion rejects aliased critical paths" {
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '//etc/passwd'"
+    [ "$status" -eq 1 ]
+
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '///System'"
+    [ "$status" -eq 1 ]
 }
 
 @test "validate_path_for_deletion accepts valid path" {
@@ -97,7 +114,7 @@ teardown() {
 
     run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/Library/Extensions/com.example.driver/com.apple.metal' 2>&1"
     [ "$status" -eq 1 ]
-    [[ "$output" == *"critical system directory"* ]]
+    [[ "$output" == *"critical system path"* ]]
 }
 
 @test "should_protect_path applies high-risk cleanup denylist" {
@@ -223,6 +240,21 @@ teardown() {
 
     run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; safe_find_delete '$TEST_DIR' '*.tmp' 7 'f'"
     [ "$status" -eq 0 ]
+}
+
+@test "safe_find_delete works when app protection is not loaded" {
+    local old_file="$TEST_DIR/file-ops-only.tmp"
+    touch "$old_file"
+    touch -t "$(date -v-8d '+%Y%m%d%H%M.%S' 2>/dev/null || date -d '8 days ago' '+%Y%m%d%H%M.%S')" "$old_file" 2>/dev/null || true
+
+    run bash --noprofile --norc <<EOF
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/file_ops.sh"
+safe_find_delete "$TEST_DIR" "*.tmp" 7 "f"
+EOF
+
+    [ "$status" -eq 0 ]
+    [ ! -e "$old_file" ]
 }
 
 @test "MOLE_* constants are defined" {

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -218,6 +218,23 @@ EOF
     [ "$status_col" = "ok" ]
 }
 
+@test "mole_delete rejects symlinks to protected system paths" {
+    local victim="$SANDBOX/system-link"
+    ln -s "/System" "$victim"
+
+    run bash --noprofile --norc <<EOF
+$(prelude)
+mole_delete "$victim"
+EOF
+
+    [ "$status" -eq 1 ]
+    [[ -L "$victim" ]]
+
+    local status_col
+    status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
+    [ "$status_col" = "rejected" ]
+}
+
 @test "mole_delete dry-run does not touch the filesystem but still logs" {
     local victim="$SANDBOX/dry"
     : > "$victim"

--- a/tests/fuzz_corpus/dangerous_paths.txt
+++ b/tests/fuzz_corpus/dangerous_paths.txt
@@ -52,11 +52,8 @@ just-a-name
 /Users/me/Documents/../../../etc
 /../../../../../etc
 
-# ---- control / newline / null injection ----
-/Users/me/foo
-	bar
-/Users/me/with\nnewline
-/Users/me/with\x00null
+# ---- control character injection ----
+/Users/me/foo	bar
 
 # ---- protected system caches ----
 /System/Library/Caches

--- a/tests/path_validation_fuzz.bats
+++ b/tests/path_validation_fuzz.bats
@@ -49,15 +49,16 @@ setup() {
     local -a accepted_paths=()
     local line
 
-    # bats's ERR trap fires on any non-zero exit inside a @test, even under
-    # set +e or `||`. Use `run` (the bats wrapper) which always returns 0
-    # itself and exposes the real exit code via $status.
     while IFS= read -r line || [[ -n "$line" ]]; do
         # Skip comments and blank lines
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
         [[ -z "$line" ]] && continue
 
-        run validate_path_for_deletion "$line"
+        run bash --noprofile --norc -s -- "$line" <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+validate_path_for_deletion "$1"
+EOF
         if [[ "$status" -eq 0 ]]; then
             accepted=$((accepted + 1))
             accepted_paths+=("$line")

--- a/tests/path_validation_fuzz.bats
+++ b/tests/path_validation_fuzz.bats
@@ -75,6 +75,22 @@ EOF
     [ "$rejected" -ge 50 ]
 }
 
+@test "generated control-character paths are rejected" {
+    run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+validate_path_for_deletion $'/Users/me/with\nnewline'
+EOF
+    [ "$status" -eq 1 ]
+
+    run bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+validate_path_for_deletion $'/Users/me/with\tab'
+EOF
+    [ "$status" -eq 1 ]
+}
+
 @test "corpus has minimum coverage" {
     local active
     active=$(grep -cvE '^\s*(#|$)' "$CORPUS")


### PR DESCRIPTION
Tightens deletion path validation so aliased critical paths and protected symlink targets are rejected before cleanup runs.

The root cause was raw path comparison plus mole_delete skipping symlink validation. This normalizes deletion policy checks, validates symlink targets, and adds coverage for fuzz corpus paths, generated control characters, safe user cache paths, and file-ops-only safe_find_delete.

Validated locally with ./scripts/check.sh --format, ./scripts/check.sh --no-format, MOLE_TEST_NO_AUTH=1 bats tests/path_validation_fuzz.bats tests/core_safe_functions.bats tests/file_ops_mole_delete.bats, and MOLE_TEST_NO_AUTH=1 MOLE_TEST_JOBS=2 BATS_FORMATTER=tap ./scripts/test.sh.
