### PR TITLE
feat(clean): add CodeBuddy Extension and CN cache cleanup

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -168,6 +168,22 @@ clean_code_editors() {
     safe_clean ~/Library/Caches/Zed/* "Zed cache"
     safe_clean ~/Library/Logs/Zed/* "Zed logs"
     clean_editor_obsolete_extensions
+    # CodeBuddy Extension (VS Code fork, Electron)
+    if [[ -d ~/Library/Application\ Support/CodeBuddyExtension ]]; then
+        safe_clean ~/Library/Application\ Support/CodeBuddyExtension/Cache/* "CodeBuddy Extension cache"
+        safe_clean ~/Library/Application\ Support/CodeBuddyExtension/logs/* "CodeBuddy Extension logs"
+    fi
+    # CodeBuddy CN (VS Code fork, Electron)
+    if [[ -d ~/Library/Application\ Support/CodeBuddy\ CN ]]; then
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/Cache/* "CodeBuddy CN cache"
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/CachedData/* "CodeBuddy CN cached data"
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/CachedExtensionVSIXs/* "CodeBuddy CN extension cache"
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/Code\ Cache/* "CodeBuddy CN code cache"
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/GPUCache/* "CodeBuddy CN GPU cache"
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/DawnGraphiteCache/* "CodeBuddy CN Dawn cache"
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/DawnWebGPUCache/* "CodeBuddy CN WebGPU cache"
+        safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/logs/* "CodeBuddy CN logs"
+    fi
 }
 # Communication apps.
 clean_communication_apps() {

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -490,3 +490,51 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" != *"CLEAN:"* ]]
 }
+
+@test "clean_code_editors includes CodeBuddy Extension caches when directory exists" {
+    mkdir -p "$HOME/Library/Application Support/CodeBuddyExtension"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+safe_clean() { echo "$2"; }
+clean_code_editors
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CodeBuddy Extension cache"* ]]
+    [[ "$output" == *"CodeBuddy Extension logs"* ]]
+}
+
+@test "clean_code_editors includes CodeBuddy CN caches when directory exists" {
+    mkdir -p "$HOME/Library/Application Support/CodeBuddy CN"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+safe_clean() { echo "$2"; }
+clean_code_editors
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CodeBuddy CN cache"* ]]
+    [[ "$output" == *"CodeBuddy CN logs"* ]]
+    [[ "$output" == *"CodeBuddy CN GPU cache"* ]]
+}
+
+@test "clean_code_editors skips CodeBuddy when directories are absent" {
+    rm -rf "$HOME/Library/Application Support/CodeBuddyExtension" "$HOME/Library/Application Support/CodeBuddy CN"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+safe_clean() { echo "$2"; }
+clean_code_editors
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"CodeBuddy"* ]]
+}


### PR DESCRIPTION
## Summary

- Add safe cleanup for **CodeBuddy Extension** and **CodeBuddy CN** (VS Code forks using Electron)
- Targets standard Electron cache directories: Cache, CachedData, CachedExtensionVSIXs, Code Cache, GPUCache, DawnGraphiteCache, DawnWebGPUCache, and logs
- Same pattern as existing Cursor/Qoder cleanups, guarded by directory existence check

Split from #921 as requested — one rebuildable cache family at a time.

## Test plan

- [x] 3 focused bats tests added (`clean_app_caches.bats`)
- [x] All existing tests pass
- [x] `mo clean --dry-run` verified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)