### PR TITLE
feat(clean): add QQ Music Mac and Tencent Video container cache cleanup

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -406,6 +406,16 @@ clean_media_players() {
     safe_clean ~/Library/Caches/tv.plex.player.desktop "Plex cache"
     safe_clean ~/Library/Caches/com.netease.163music "NetEase Music cache"
     safe_clean ~/Library/Caches/com.tencent.QQMusic/* "QQ Music cache"
+    safe_clean ~/Library/Caches/com.tencent.QQMusicMac/* "QQ Music Mac cache"
+    # QQ Music Mac sandboxed container caches (protect offline downloads in iDownloadProxy).
+    local _qqmusic_container="$HOME/Library/Containers/com.tencent.QQMusicMac/Data/Library/Application Support/QQMusicMac"
+    if [[ -d "$_qqmusic_container" ]]; then
+        safe_clean "$_qqmusic_container/iRRCache"/* "QQ Music streaming cache"
+        safe_clean "$_qqmusic_container/iLog"/* "QQ Music logs"
+        safe_clean "$_qqmusic_container/iCache"/* "QQ Music cache"
+        safe_clean "$_qqmusic_container/iTemp"/* "QQ Music temp files"
+    fi
+    safe_clean ~/Library/Containers/com.tencent.QQMusicMac/Data/Library/Caches/* "QQ Music container cache"
     safe_clean ~/Library/Caches/com.kugou.mac/* "Kugou Music cache"
     safe_clean ~/Library/Caches/com.kuwo.mac/* "Kuwo Music cache"
 }
@@ -416,6 +426,13 @@ clean_video_players() {
     safe_clean ~/Library/Caches/io.mpv "MPV cache"
     safe_clean ~/Library/Caches/com.iqiyi.player "iQIYI cache"
     safe_clean ~/Library/Caches/com.tencent.tenvideo "Tencent Video cache"
+    # Tencent Video sandboxed container caches.
+    local _tenvideo_as="$HOME/Library/Containers/com.tencent.tenvideo/Data/Library/Application Support"
+    if [[ -d "$_tenvideo_as" ]]; then
+        safe_clean "$_tenvideo_as/Upgrade"/* "Tencent Video old installer"
+        safe_clean "$_tenvideo_as/VideoNative"/* "Tencent Video native cache"
+        safe_clean "$_tenvideo_as/documentCache"/* "Tencent Video document cache"
+    fi
     safe_clean ~/Library/Caches/tv.danmaku.bili/* "Bilibili cache"
     safe_clean ~/Library/Caches/com.douyu.*/* "Douyu cache"
     safe_clean ~/Library/Caches/com.huya.*/* "Huya cache"

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -538,3 +538,53 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" != *"CodeBuddy"* ]]
 }
+
+@test "clean_media_players includes QQ Music Mac container caches" {
+    mkdir -p "$HOME/Library/Containers/com.tencent.QQMusicMac/Data/Library/Application Support/QQMusicMac"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+safe_clean() { echo "$2"; }
+clean_media_players
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"QQ Music Mac cache"* ]]
+    [[ "$output" == *"QQ Music streaming cache"* ]]
+    [[ "$output" == *"QQ Music logs"* ]]
+    [[ "$output" == *"QQ Music container cache"* ]]
+}
+
+@test "clean_media_players does not reference iDownloadProxy" {
+    mkdir -p "$HOME/Library/Containers/com.tencent.QQMusicMac/Data/Library/Application Support/QQMusicMac"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+safe_clean() { echo "$1 $2"; }
+clean_media_players
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"iDownloadProxy"* ]]
+}
+
+@test "clean_video_players includes Tencent Video container caches" {
+    mkdir -p "$HOME/Library/Containers/com.tencent.tenvideo/Data/Library/Application Support"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+safe_clean() { echo "$2"; }
+clean_video_players
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Tencent Video old installer"* ]]
+    [[ "$output" == *"Tencent Video native cache"* ]]
+    [[ "$output" == *"Tencent Video document cache"* ]]
+}


### PR DESCRIPTION
## Summary

- Add safe cleanup for **QQ Music Mac** sandboxed container caches (streaming cache, logs, temp files)
- Add safe cleanup for **Tencent Video** container residue (stale installer packages, native cache, document cache)
- QQ Music offline downloads (`iDownloadProxy` directory) explicitly excluded from cleanup scope

Split from #921 as requested — one rebuildable cache family at a time.

## Safety

- `iDownloadProxy` (offline music) is never in cleanup scope
- Only targets regenerable caches: `iRRCache`, `iLog`, `iCache`, `iTemp`
- Tencent Video `Upgrade/` contains stale `.dmg`/`.zip` from completed upgrades

## Test plan

- [x] 3 focused bats tests added (`clean_app_caches.bats`)
- [x] All existing tests pass
- [x] `mo clean --dry-run` verified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)