### PR TITLE
feat(clean): add Chrome DevTools MCP browser profile cache cleanup

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1316,6 +1316,13 @@ antigravity_or_gemini_running() {
     return 1
 }
 
+chrome_devtools_mcp_running() {
+    command -v pgrep > /dev/null 2>&1 || return 1
+
+    pgrep -f "chrome-devtools-mcp" > /dev/null 2>&1 && return 0
+    return 1
+}
+
 is_codex_runtime_active() {
     local runtime_dir="$1"
     [[ -d "$runtime_dir" ]] || return 1
@@ -1452,6 +1459,34 @@ clean_antigravity_caches() {
     safe_clean "$HOME/.gemini/tmp"/* "Gemini CLI temp files"
 }
 
+clean_chrome_devtools_mcp_caches() {
+    local mcp_profile="$HOME/.cache/chrome-devtools-mcp/chrome-profile"
+
+    if chrome_devtools_mcp_running; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Chrome DevTools MCP caches · skipped (server running)"
+        note_activity
+        return 0
+    fi
+
+    [[ -d "$mcp_profile" ]] || return 0
+
+    safe_clean "$mcp_profile/Default/Cache"/* "Chrome DevTools MCP browser cache"
+    safe_clean "$mcp_profile/Default/Code Cache"/* "Chrome DevTools MCP code cache"
+    safe_clean "$mcp_profile/Default/GPUCache"/* "Chrome DevTools MCP GPU cache"
+    safe_clean "$mcp_profile/Default/DawnCache"/* "Chrome DevTools MCP Dawn cache"
+    safe_clean "$mcp_profile/Default/DawnGraphiteCache"/* "Chrome DevTools MCP Dawn cache"
+    safe_clean "$mcp_profile/Default/DawnWebGPUCache"/* "Chrome DevTools MCP WebGPU cache"
+    safe_clean "$mcp_profile/Default/GrShaderCache"/* "Chrome DevTools MCP shader cache"
+    safe_clean "$mcp_profile/Default/GraphiteDawnCache"/* "Chrome DevTools MCP Graphite cache"
+    safe_clean "$mcp_profile/GraphiteDawnCache"/* "Chrome DevTools MCP Graphite cache"
+    safe_clean "$mcp_profile/component_crx_cache"/* "Chrome DevTools MCP component cache"
+    safe_clean "$mcp_profile/extensions_crx_cache"/* "Chrome DevTools MCP extension cache"
+
+    if declare -f clean_service_worker_cache > /dev/null 2>&1; then
+        clean_service_worker_cache "Chrome DevTools MCP" "$mcp_profile/Default/Service Worker/CacheStorage"
+    fi
+}
+
 # Misc dev tool caches.
 clean_dev_misc() {
     safe_clean ~/Library/Caches/com.unity3d.*/* "Unity cache"
@@ -1516,10 +1551,8 @@ clean_dev_misc() {
     [[ -d "$HOME/.local/share/cursor-agent" ]] && safe_find_delete "$HOME/.local/share/cursor-agent" "*.log" "$MOLE_LOG_AGE_DAYS" "f"
     # Playwright cached browser binaries
     safe_clean ~/Library/Caches/ms-playwright/* "Playwright browsers"
-    # Chrome DevTools MCP browser profile cache (skip while MCP server is running)
-    if ! pgrep -f "chrome-devtools-mcp" > /dev/null 2>&1; then
-        safe_clean ~/.cache/chrome-devtools-mcp/chrome-profile/* "Chrome DevTools MCP cache"
-    fi
+    # Chrome DevTools MCP keeps a Chromium profile; clean only rebuildable caches.
+    clean_chrome_devtools_mcp_caches
     # Claude Code state under ~/.claude can include persistent memory,
     # plugin registry data, hooks, and session context. Do not clean it
     # automatically; users can remove specific paths manually if needed.

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1516,6 +1516,10 @@ clean_dev_misc() {
     [[ -d "$HOME/.local/share/cursor-agent" ]] && safe_find_delete "$HOME/.local/share/cursor-agent" "*.log" "$MOLE_LOG_AGE_DAYS" "f"
     # Playwright cached browser binaries
     safe_clean ~/Library/Caches/ms-playwright/* "Playwright browsers"
+    # Chrome DevTools MCP browser profile cache (skip while MCP server is running)
+    if ! pgrep -f "chrome-devtools-mcp" > /dev/null 2>&1; then
+        safe_clean ~/.cache/chrome-devtools-mcp/chrome-profile/* "Chrome DevTools MCP cache"
+    fi
     # Claude Code state under ~/.claude can include persistent memory,
     # plugin registry data, hooks, and session context. Do not clean it
     # automatically; users can remove specific paths manually if needed.

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -673,6 +673,9 @@ EOF
 }
 
 @test "clean_dev_misc includes Chrome DevTools MCP cache when server not running" {
+    mkdir -p "$HOME/.cache/chrome-devtools-mcp/chrome-profile/Default/Cache"
+    touch "$HOME/.cache/chrome-devtools-mcp/chrome-profile/Default/Cache/data"
+
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -683,14 +686,19 @@ note_activity() { :; }
 pgrep() { return 1; }
 safe_clean() { echo "$2"; }
 safe_find_delete() { :; }
+clean_service_worker_cache() { :; }
 clean_dev_misc
 EOF
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Chrome DevTools MCP cache"* ]]
+    [[ "$output" == *"Chrome DevTools MCP browser cache"* ]]
+    [[ "$output" != *"Chrome DevTools MCP cache"* ]]
 }
 
 @test "clean_dev_misc skips Chrome DevTools MCP cache when server is running" {
+    mkdir -p "$HOME/.cache/chrome-devtools-mcp/chrome-profile/Default/Cache"
+    touch "$HOME/.cache/chrome-devtools-mcp/chrome-profile/Default/Cache/data"
+
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -701,9 +709,42 @@ note_activity() { :; }
 pgrep() { return 0; }
 safe_clean() { echo "$2"; }
 safe_find_delete() { :; }
+clean_service_worker_cache() { :; }
 clean_dev_misc
 EOF
 
     [ "$status" -eq 0 ]
-    [[ "$output" != *"Chrome DevTools MCP cache"* ]]
+    [[ "$output" == *"Chrome DevTools MCP caches · skipped"* ]]
+    [[ "$output" != *"Chrome DevTools MCP browser cache"* ]]
+}
+
+@test "clean_chrome_devtools_mcp_caches preserves profile state" {
+    profile="$HOME/.cache/chrome-devtools-mcp/chrome-profile"
+    mkdir -p "$profile/Default/Cache" "$profile/Default/Code Cache" "$profile/Default/GPUCache"
+    mkdir -p "$profile/Default/Service Worker/CacheStorage"
+    mkdir -p "$profile/Default/Local Storage/leveldb"
+    touch "$profile/Default/Cache/data" "$profile/Default/Code Cache/data" "$profile/Default/GPUCache/data"
+    touch "$profile/Default/Service Worker/CacheStorage/data"
+    touch "$profile/Default/Cookies" "$profile/Default/Local Storage/leveldb/state"
+    touch "$profile/Local State"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+note_activity() { :; }
+pgrep() { return 1; }
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+clean_service_worker_cache() { echo "SWC:$1|$2"; }
+clean_chrome_devtools_mcp_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SAFE_CLEAN:Chrome DevTools MCP browser cache|$profile/Default/Cache/"* ]]
+    [[ "$output" == *"SAFE_CLEAN:Chrome DevTools MCP code cache|$profile/Default/Code Cache/"* ]]
+    [[ "$output" == *"SAFE_CLEAN:Chrome DevTools MCP GPU cache|$profile/Default/GPUCache/"* ]]
+    [[ "$output" == *"SWC:Chrome DevTools MCP|$profile/Default/Service Worker/CacheStorage"* ]]
+    [[ "$output" != *"Cookies"* ]]
+    [[ "$output" != *"Local Storage"* ]]
+    [[ "$output" != *"Local State"* ]]
 }

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -671,3 +671,39 @@ EOF
     [[ "$output" == *"Flutter build cache (.dart_tool)"* ]]
     [[ "$output" == *"Flutter build cache (build/)"* ]]
 }
+
+@test "clean_dev_misc includes Chrome DevTools MCP cache when server not running" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+pgrep() { return 1; }
+safe_clean() { echo "$2"; }
+safe_find_delete() { :; }
+clean_dev_misc
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Chrome DevTools MCP cache"* ]]
+}
+
+@test "clean_dev_misc skips Chrome DevTools MCP cache when server is running" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+pgrep() { return 0; }
+safe_clean() { echo "$2"; }
+safe_find_delete() { :; }
+clean_dev_misc
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Chrome DevTools MCP cache"* ]]
+}


### PR DESCRIPTION
## Summary

- Add safe cleanup for **Chrome DevTools MCP** headless browser profile cache at `~/.cache/chrome-devtools-mcp/chrome-profile/`
- This is a headless Chrome instance used by MCP servers, not the user's browser profile
- Protected by `pgrep` guard: cleanup is skipped when `chrome-devtools-mcp` process is running

Split from #921 as requested — one rebuildable cache family at a time.

## Safety

- `pgrep -f "chrome-devtools-mcp"` guard prevents cleanup while MCP server is running
- Same pattern used for other browser process checks in Mole
- Only targets the MCP-specific headless Chrome profile, not user browsers

## Test plan

- [x] 2 focused bats tests added (`clean_dev_caches.bats`)
- [x] All existing tests pass
- [x] `mo clean --dry-run` verified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)