### PR TITLE
Fix stable channel update switch

### DIFF
--- a/mole
+++ b/mole
@@ -378,6 +378,7 @@ update_mole() {
     local download_label="Downloading latest version..."
     local install_label="Installing update..."
     local final_success_label="latest version"
+    local switch_to_stable_channel=false
 
     if [[ "$nightly_update" == "true" ]]; then
         latest="main"
@@ -400,7 +401,15 @@ update_mole() {
             exit 1
         fi
 
-        if [[ "$VERSION" == "$latest" && "$force_update" != "true" ]]; then
+        local install_channel
+        install_channel=$(get_install_channel)
+        if [[ "$install_channel" == "nightly" || "$install_channel" == "dev" ]]; then
+            switch_to_stable_channel=true
+        fi
+
+        if [[ "$switch_to_stable_channel" == "true" ]]; then
+            install_label="Switching to stable channel..."
+        elif [[ "$VERSION" == "$latest" && "$force_update" != "true" ]]; then
             echo ""
             echo -e "${GREEN}${ICON_SUCCESS}${NC} Already on latest version, ${VERSION}"
             echo ""
@@ -539,7 +548,7 @@ update_mole() {
             echo "$install_output" | tail -10 >&2 # Show last 10 lines of error
             exit 1
         fi
-    elif [[ "$force_update" == "true" ]]; then
+    elif [[ "$force_update" == "true" || "$switch_to_stable_channel" == "true" ]]; then
         if install_output=$(MOLE_VERSION="$update_tag" "$tmp_installer" --prefix "$install_dir" --config "$config_dir" 2>&1); then
             process_install_output "$install_output" "$latest" "$final_success_label"
         else

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -311,6 +311,67 @@ EOF
     [[ "$output" == *"Already on latest version"* ]]
 }
 
+@test "update_mole switches nightly install back to stable even when already latest" {
+    local test_home="$BATS_TMPDIR/nightly-to-stable-home"
+    mkdir -p "$test_home/.config/mole"
+    cat > "$test_home/.config/mole/install_channel" <<'EOF'
+CHANNEL=nightly
+COMMIT_HASH=0123456789abcdef
+EOF
+
+    run env HOME="$test_home" PROJECT_ROOT="$PROJECT_ROOT" CURRENT_VERSION="$CURRENT_VERSION" PATH="/usr/bin:/bin" TERM="dumb" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+export URL_LOG="$HOME/stable-switch-url.log"
+export INSTALLER_ARGS_LOG="$HOME/stable-switch-args.log"
+
+curl() {
+  local out=""
+  local url=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o) out="$2"; shift 2 ;;
+      http*://*) url="$1"; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  [[ -n "$url" ]] && printf '%s\n' "$url" >> "$URL_LOG"
+
+  if [[ -n "$out" ]]; then
+    cat > "$out" << 'INSTALLER'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$INSTALLER_ARGS_LOG"
+echo "INSTALLER_MOLE_VERSION=${MOLE_VERSION:-}"
+echo "Mole installed successfully, version ${MOLE_VERSION:-unknown}"
+INSTALLER
+    return 0
+  fi
+
+  if [[ "$url" == *"api.github.com"* ]]; then
+    echo "{\"tag_name\":\"$CURRENT_VERSION\"}"
+  else
+    echo "VERSION=\"$CURRENT_VERSION\""
+  fi
+}
+export -f curl
+
+brew() { exit 1; }
+export -f brew
+
+"$PROJECT_ROOT/mole" update
+
+grep -q "raw.githubusercontent.com/tw93/mole/V${CURRENT_VERSION#V}/install.sh" "$URL_LOG"
+! grep -q "raw.githubusercontent.com/tw93/mole/main/install.sh" "$URL_LOG"
+! grep -q -- "--update" "$INSTALLER_ARGS_LOG"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Already on latest version"* ]]
+    [[ "$output" == *"Switching to stable channel"* ]]
+    [[ "$output" == *"INSTALLER_MOLE_VERSION=V${CURRENT_VERSION#V}"* ]]
+    [[ "$output" == *"Updated to latest version, V${CURRENT_VERSION#V}"* ]]
+}
+
 @test "process_install_output shows install.sh success message with version" {
     run bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
Plain mo update now switches nightly or dev installs back to the stable tagged installer even when the current version already matches the latest release. The update test covers that same-version channel switch path.