### PR TITLE
install.sh: verify release attestation via gh CLI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -292,6 +292,39 @@ download_release_checksums() {
     curl -fsSL --connect-timeout 10 --max-time 60 -o "$output_file" "$url"
 }
 
+# Verify the Sigstore/GitHub Actions build-provenance attestation for a release
+# asset. Returns:
+#   0 - attestation verified
+#   1 - verification failed (asset has no matching attestation, or signature invalid)
+#   2 - cannot verify (gh CLI missing or unauthenticated); caller decides policy
+#
+# The release workflow generates attestations via actions/attest-build-provenance
+# covering SHA256SUMS, the per-arch binaries, and the homebrew tarballs.
+# Verifying the SHA256SUMS file is sufficient: the binary's sha256 is then
+# anchored to that attested file by verify_release_asset_checksum().
+verify_release_attestation() {
+    local file="$1"
+
+    if ! command -v gh > /dev/null 2>&1; then
+        return 2
+    fi
+    if ! gh auth status > /dev/null 2>&1; then
+        return 2
+    fi
+
+    # --owner restricts the trusted signer identity to the upstream repo's
+    # GitHub Actions workflow. --deny-self-hosted-runners blocks attestations
+    # produced by self-hosted runners, which a repo compromise could otherwise
+    # introduce as a sidechannel.
+    if gh attestation verify "$file" \
+        --owner tw93 \
+        --deny-self-hosted-runners \
+        > /dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
 extract_release_checksum() {
     local checksums_file="$1"
     local asset_name="$2"
@@ -324,12 +357,35 @@ verify_release_asset_checksum() {
     local expected=""
     local actual=""
     local result=1
+    local attestation_status=2
 
     if download_release_checksums "$tag" "$checksums_file" > /dev/null 2>&1; then
+        # Anchor the SHA256SUMS file to its GitHub Actions build-provenance
+        # attestation before reading checksums from it. If gh is available,
+        # an attestation mismatch is fatal; without gh, fall through to
+        # checksum-only verification (matches prior behavior).
+        verify_release_attestation "$checksums_file"
+        attestation_status=$?
+
+        if [[ "$attestation_status" -eq 1 ]]; then
+            log_error "Release attestation verification failed for ${asset_name}"
+            rm -f "$checksums_file"
+            return 1
+        fi
+
+        if [[ "$attestation_status" -eq 2 && "${MOLE_REQUIRE_ATTESTATION:-0}" == "1" ]]; then
+            log_error "MOLE_REQUIRE_ATTESTATION=1 set but gh CLI unavailable or unauthenticated"
+            rm -f "$checksums_file"
+            return 1
+        fi
+
         expected=$(extract_release_checksum "$checksums_file" "$asset_name" 2> /dev/null || true)
         actual=$(calculate_file_sha256 "$file" 2> /dev/null || true)
         if [[ -n "$expected" && -n "$actual" && "$expected" == "$actual" ]]; then
             result=0
+            if [[ "$attestation_status" -eq 0 ]]; then
+                log_success "Verified ${asset_name} (sha256 + attestation)"
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary

Adds optional GitHub Actions build-provenance attestation verification to `install.sh`. Anchors the downloaded `SHA256SUMS` file to the attestation already produced by `release.yml` (via `actions/attest-build-provenance@v4`) before reading checksums from it.

## Motivation

Today the installer trusts `SHA256SUMS` purely because it was fetched from the release URL. A compromise that gains GitHub release-asset write access can swap the binary and the sums entry together, and the current sha256 gate accepts it. The release workflow already mints Sigstore attestations covering `SHA256SUMS` and the binaries, but `install.sh` doesn't consume them. This wires that signal in.

Verifying `SHA256SUMS` is sufficient: the per-binary sha256 is then anchored to that attested file by the existing `verify_release_asset_checksum` flow.

## Behavior

- **`gh` CLI available + authenticated** → attestation is verified with `--owner tw93 --deny-self-hosted-runners`. Mismatch is fatal; install aborts.
- **`gh` unavailable or unauthenticated** → falls back to existing sha256-only verification. No behavior change for current users.
- **`MOLE_REQUIRE_ATTESTATION=1`** → turns the soft check into a hard requirement. Missing `gh` becomes an install failure. For users who want fail-closed semantics.

## Why a soft default

Most macOS users won't have `gh` installed, and breaking the install path for them would be a worse trade than the current state. The opt-in env var lets security-conscious users (and CI environments) lock it down without forcing a new dependency on everyone.

## Test plan

- [ ] `bash -n install.sh` — clean
- [ ] Local install with `gh` installed and authenticated → see "Verified <asset> (sha256 + attestation)" success line
- [ ] Local install without `gh` → falls back to existing behavior (silent), install succeeds
- [ ] Local install with `MOLE_REQUIRE_ATTESTATION=1` and `gh` uninstalled → install fails fast with clear error
- [ ] CI shellcheck / shfmt pass

## Notes

Drafting because I'd like a maintainer's read on:

1. Whether `--owner tw93` is the right scoping (vs. `--repo tw93/Mole`, which is stricter but breaks if you ever fork-and-rename).
2. Whether you'd prefer this opt-in via env (current) vs. opt-out via env (`MOLE_SKIP_ATTESTATION=1`).
3. Whether the success log line is too noisy — happy to drop it or gate behind `--verbose`.

Found while doing an external security audit of Mole. Audit verdict was already ACCEPTABLE / risk LOW — the project is unusually well-hardened for its category. This is one of two minor defense-in-depth items.