### PR TITLE
feat(clean): reclaim stale AI agent git worktrees

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1493,6 +1493,114 @@ clean_chrome_devtools_mcp_caches() {
     fi
 }
 
+# Project roots scanned for agent worktrees. Override with a colon-separated
+# MOLE_AGENT_WORKTREE_PATHS list (e.g. "$HOME/work:$HOME/oss").
+agent_worktree_search_roots() {
+    if [[ -n "${MOLE_AGENT_WORKTREE_PATHS:-}" ]]; then
+        local saved_ifs="$IFS"
+        IFS=':'
+        # shellcheck disable=SC2206
+        local -a custom=($MOLE_AGENT_WORKTREE_PATHS)
+        IFS="$saved_ifs"
+        [[ ${#custom[@]} -gt 0 ]] && printf '%s\n' "${custom[@]}"
+        return 0
+    fi
+    printf '%s\n' \
+        "$HOME/code" "$HOME/Code" "$HOME/dev" "$HOME/Projects" \
+        "$HOME/GitHub" "$HOME/Workspace" "$HOME/Repos" \
+        "$HOME/Development" "$HOME/www" "$HOME/src"
+}
+
+# Returns 0 only when a worktree is safe to remove: no uncommitted or untracked
+# changes, and no commits reachable from HEAD that are missing from every
+# remote-tracking ref. A repo with no remotes therefore keeps every worktree,
+# which is the intended conservative behavior.
+agent_worktree_is_disposable() {
+    local wt="$1"
+    git -C "$wt" rev-parse --is-inside-work-tree > /dev/null 2>&1 || return 1
+    if [[ -n "$(git -C "$wt" status --porcelain 2> /dev/null)" ]]; then
+        return 1
+    fi
+    local local_only
+    local_only=$(git -C "$wt" rev-list --count HEAD --not --remotes 2> /dev/null || echo 1)
+    [[ "$local_only" =~ ^[0-9]+$ ]] || return 1
+    [[ "$local_only" -eq 0 ]] || return 1
+    return 0
+}
+
+# AI coding agents (Claude Code and similar) create isolated git worktrees under
+# <project>/.claude/worktrees/ for background or parallel runs. Each is a full
+# checkout (node_modules, build output, and so on) that is never cleaned up
+# automatically, so they accumulate across projects. They may also hold
+# uncommitted or unpushed work, so this is skipped by default. Set
+# MOLE_AGENT_WORKTREES=1 to remove only the worktrees that are fully clean.
+clean_dev_agent_worktrees() {
+    local scan_timeout="${MOLE_AGENT_WORKTREE_SCAN_SEC:-20}"
+
+    local -a containers=()
+    local root container
+    while IFS= read -r root; do
+        [[ -d "$root" ]] || continue
+        while IFS= read -r -d '' container; do
+            containers+=("$container")
+        done < <(run_with_timeout "$scan_timeout" command find "$root" -maxdepth 6 -type d -path "*/.claude/worktrees" -prune -print0 2> /dev/null)
+    done < <(agent_worktree_search_roots)
+
+    [[ ${#containers[@]} -gt 0 ]] || return 0
+
+    local force="${MOLE_AGENT_WORKTREES:-}"
+
+    # Default: report reclaimable size only, never delete (may hold agent work).
+    if [[ -z "$force" || "$force" == "0" ]]; then
+        local total_kb=0 size_kb=0 count=0 wt
+        for container in "${containers[@]}"; do
+            while IFS= read -r -d '' wt; do
+                size_kb=$(get_path_size_kb "$wt" 2> /dev/null || echo 0)
+                [[ "$size_kb" =~ ^[0-9]+$ ]] || size_kb=0
+                total_kb=$((total_kb + size_kb))
+                count=$((count + 1))
+            done < <(command find "$container" -mindepth 1 -maxdepth 1 -type d -print0 2> /dev/null)
+        done
+        [[ "$count" -gt 0 ]] || return 0
+        note_activity
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} AI agent worktrees · skipped by default ($count in .claude/worktrees, $(bytes_to_human $((total_kb * 1024))))"
+        echo -e "  ${GRAY}${ICON_REVIEW}${NC} ${GRAY}Remove clean worktrees: MOLE_AGENT_WORKTREES=1 mo clean${NC}"
+        debug_log "AI agent worktrees left intact by default ($count dirs, $total_kb KB)"
+        return 0
+    fi
+
+    # Opt-in: remove only fully clean worktrees; keep anything with unsaved work.
+    local parent_repo kept=0
+    local wt
+    for container in "${containers[@]}"; do
+        parent_repo="${container%/.claude/worktrees}"
+        while IFS= read -r -d '' wt; do
+            if should_protect_path "$wt"; then
+                continue
+            fi
+            if agent_worktree_is_disposable "$wt"; then
+                safe_clean "$wt" "AI agent worktree"
+                # Tidy the parent repo's worktree registry once the dir is gone.
+                # In dry-run the directory remains, so prune is skipped. Agent
+                # worktrees are usually git-locked, and a plain prune skips a
+                # locked entry even when its directory is missing, so unlock it
+                # first and prune with --expire=now to drop the stale entry.
+                if [[ ! -d "$wt" && -e "$parent_repo/.git" ]]; then
+                    git -C "$parent_repo" worktree unlock "$wt" > /dev/null 2>&1 || true
+                    git -C "$parent_repo" worktree prune --expire=now > /dev/null 2>&1 || true
+                fi
+            else
+                kept=$((kept + 1))
+                note_activity
+                echo -e "  ${GRAY}${ICON_REVIEW}${NC} ${GRAY}Kept agent worktree (unsaved work): ${wt/#$HOME/~}${NC}"
+            fi
+        done < <(command find "$container" -mindepth 1 -maxdepth 1 -type d -print0 2> /dev/null)
+    done
+    if [[ "$kept" -gt 0 ]]; then
+        debug_log "Kept $kept AI agent worktree(s) with unsaved work"
+    fi
+}
+
 # Misc dev tool caches.
 clean_dev_misc() {
     safe_clean ~/Library/Caches/com.unity3d.*/* "Unity cache"
@@ -1656,6 +1764,7 @@ clean_developer_tools() {
     clean_dev_jetbrains_toolbox
     clean_dev_jetbrains_logs
     clean_dev_ai_agents
+    clean_dev_agent_worktrees
     clean_dev_other_langs
     clean_dev_cicd
     clean_dev_database

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1517,12 +1517,12 @@ agent_worktree_search_roots() {
 # which is the intended conservative behavior.
 agent_worktree_is_disposable() {
     local wt="$1"
-    git -C "$wt" rev-parse --is-inside-work-tree > /dev/null 2>&1 || return 1
-    if [[ -n "$(git -C "$wt" status --porcelain 2> /dev/null)" ]]; then
+    run_with_timeout "$MOLE_TIMEOUT_QUICK_DETECT_SEC" git -C "$wt" rev-parse --is-inside-work-tree > /dev/null 2>&1 || return 1
+    if [[ -n "$(run_with_timeout "$MOLE_TIMEOUT_QUICK_DETECT_SEC" git -C "$wt" status --porcelain 2> /dev/null)" ]]; then
         return 1
     fi
     local local_only
-    local_only=$(git -C "$wt" rev-list --count HEAD --not --remotes 2> /dev/null || echo 1)
+    local_only=$(run_with_timeout "$MOLE_TIMEOUT_QUICK_DETECT_SEC" git -C "$wt" rev-list --count HEAD --not --remotes 2> /dev/null || echo 1)
     [[ "$local_only" =~ ^[0-9]+$ ]] || return 1
     [[ "$local_only" -eq 0 ]] || return 1
     return 0
@@ -1586,8 +1586,8 @@ clean_dev_agent_worktrees() {
                 # locked entry even when its directory is missing, so unlock it
                 # first and prune with --expire=now to drop the stale entry.
                 if [[ ! -d "$wt" && -e "$parent_repo/.git" ]]; then
-                    git -C "$parent_repo" worktree unlock "$wt" > /dev/null 2>&1 || true
-                    git -C "$parent_repo" worktree prune --expire=now > /dev/null 2>&1 || true
+                    run_with_timeout "$MOLE_TIMEOUT_QUICK_DETECT_SEC" git -C "$parent_repo" worktree unlock "$wt" > /dev/null 2>&1 || true
+                    run_with_timeout "$MOLE_TIMEOUT_QUICK_DETECT_SEC" git -C "$parent_repo" worktree prune --expire=now > /dev/null 2>&1 || true
                 fi
             else
                 kept=$((kept + 1))

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -748,3 +748,68 @@ EOF
     [[ "$output" != *"Local Storage"* ]]
     [[ "$output" != *"Local State"* ]]
 }
+
+@test "clean_dev_agent_worktrees skips agent worktrees by default and reports size" {
+    mkdir -p "$HOME/code/proj/.claude/worktrees/wt-one"
+    mkdir -p "$HOME/code/proj/.claude/worktrees/wt-two"
+    echo "data" > "$HOME/code/proj/.claude/worktrees/wt-one/file"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        MOLE_AGENT_WORKTREE_PATHS="$HOME/code" \
+        bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+safe_clean() { echo "SHOULD_NOT_DELETE:$1"; }
+clean_dev_agent_worktrees
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"AI agent worktrees · skipped by default (2 in .claude/worktrees"* ]]
+    [[ "$output" == *"MOLE_AGENT_WORKTREES=1 mo clean"* ]]
+    [[ "$output" != *"SHOULD_NOT_DELETE"* ]]
+}
+
+@test "clean_dev_agent_worktrees removes clean worktrees but keeps dirty ones when opted in" {
+    local origin="$HOME/origin.git"
+    local proj="$HOME/code/proj"
+    git init --bare -q "$origin"
+    git -c init.defaultBranch=main init -q "$proj"
+    (
+        cd "$proj"
+        git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+        git remote add origin "$origin"
+        git push -q origin HEAD:main
+        git worktree add -q .claude/worktrees/clean-one HEAD
+        git worktree add -q .claude/worktrees/dirty-one HEAD
+        # Agents lock their worktrees; a plain prune would skip the stale entry.
+        git worktree lock .claude/worktrees/clean-one
+    )
+    echo "uncommitted" > "$proj/.claude/worktrees/dirty-one/scratch.txt"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        MOLE_AGENT_WORKTREES=1 MOLE_AGENT_WORKTREE_PATHS="$HOME/code" \
+        bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+safe_clean() { echo "REMOVED:$1"; rm -rf "$1"; }
+clean_dev_agent_worktrees
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOVED:$proj/.claude/worktrees/clean-one"* ]]
+    [[ "$output" == *"Kept agent worktree (unsaved work)"* ]]
+    [[ "$output" == *"dirty-one"* ]]
+    [[ "$output" != *"REMOVED:$proj/.claude/worktrees/dirty-one"* ]]
+    [ ! -d "$proj/.claude/worktrees/clean-one" ]
+    [ -d "$proj/.claude/worktrees/dirty-one" ]
+    # The stale (locked) registry entry must be reaped, the dirty one kept.
+    run git -C "$proj" worktree list
+    [[ "$output" != *"clean-one"* ]]
+    [[ "$output" == *"dirty-one"* ]]
+}


### PR DESCRIPTION
AI coding agents (Claude Code and similar) create isolated git worktrees under <project>/.claude/worktrees/ for background or parallel runs. Each is a full project checkout (node_modules, build output, and so on) that is never cleaned up automatically, so they accumulate across repos and can reach several GB. Existing cleanup only handled agent binary versions and global ~/.claude state, so these were missed entirely.

Add clean_dev_agent_worktrees to the developer-tools flow:

- Skipped by default; reports reclaimable size plus the opt-in hint.
- With MOLE_AGENT_WORKTREES=1, removes only worktrees that are fully clean (no uncommitted or untracked changes and no commits missing from a remote); anything that might hold unsaved work is kept and listed.
- Deletes via safe_clean (Trash routing, op log, dry-run) and honors should_protect_path; no raw rm.
- Reaps the parent repo's worktree registry with unlock + prune --expire=now, because agents lock their worktrees and a plain prune skips locked entries even when the directory is already gone.
- Search roots overridable via MOLE_AGENT_WORKTREE_PATHS.

Adds two bats cases: the skip-by-default report, and opt-in removal of a locked clean worktree while keeping a dirty one.

## Summary

- Describe the change.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
- If yes, describe the new boundary or risk change clearly.

## Tests

- List the automated tests you ran.
- List any manual checks for high-risk paths or destructive flows.

## Safety-related changes

- None.
