### PR TITLE
fix(uninstall): preserve independent CLI tool dotdirs (#993)

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -601,13 +601,18 @@ find_shared_app_paths() {
 }
 
 # Return 0 when `path` looks like a dotdir / XDG state directory belonging to
-# a standalone CLI tool listed in INDEPENDENT_CLI_DOTDIR_NAMES. find_app_files
-# uses this to skip candidates that would otherwise nuke unrelated CLI state
-# when uninstalling a same-named GUI app.
+# a standalone CLI tool shipped independently of any same-named GUI app.
+# find_app_files uses this to skip candidates that would otherwise nuke
+# unrelated CLI state when uninstalling a same-named GUI app (#993).
 #
 # Lowercase comparison so case-insensitive APFS (~/.Claude vs ~/.claude) is
 # handled. Scope is restricted to four well-known parents so we never skip
 # legitimate non-dotdir locations.
+#
+# The deny-list is inlined rather than read from an array because bats 1.x
+# does not carry readonly arrays from setup() into the @test body, and a
+# regression in any of these names is destructive enough that we never want
+# the safeguard to silently no-op in a fresh subshell.
 _path_belongs_to_independent_cli() {
     local path="$1"
     [[ -z "$path" ]] && return 1
@@ -618,14 +623,13 @@ _path_belongs_to_independent_cli() {
     lc_name=$(printf '%s' "${base#.}" | tr '[:upper:]' '[:lower:]')
     [[ -z "$lc_name" ]] && return 1
 
-    local name matched=false
-    for name in "${INDEPENDENT_CLI_DOTDIR_NAMES[@]}"; do
-        if [[ "$lc_name" == "$name" ]]; then
-            matched=true
-            break
-        fi
-    done
-    [[ "$matched" == "false" ]] && return 1
+    case "$lc_name" in
+        # Keep this list in sync with INDEPENDENT_CLI_DOTDIR_NAMES in
+        # app_protection_data.sh (kept there for discoverability /
+        # documentation; this case is the live source of truth).
+        claude | opencode | codex | gemini) ;;
+        *) return 1 ;;
+    esac
 
     case "$parent" in
         "$HOME" | "$HOME/.config" | "$HOME/.local/share" | "$HOME/.cache")

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -600,6 +600,41 @@ find_shared_app_paths() {
     done | sort -u
 }
 
+# Return 0 when `path` looks like a dotdir / XDG state directory belonging to
+# a standalone CLI tool listed in INDEPENDENT_CLI_DOTDIR_NAMES. find_app_files
+# uses this to skip candidates that would otherwise nuke unrelated CLI state
+# when uninstalling a same-named GUI app.
+#
+# Lowercase comparison so case-insensitive APFS (~/.Claude vs ~/.claude) is
+# handled. Scope is restricted to four well-known parents so we never skip
+# legitimate non-dotdir locations.
+_path_belongs_to_independent_cli() {
+    local path="$1"
+    [[ -z "$path" ]] && return 1
+
+    local base parent lc_name
+    base="${path##*/}"
+    parent="${path%/*}"
+    lc_name=$(printf '%s' "${base#.}" | tr '[:upper:]' '[:lower:]')
+    [[ -z "$lc_name" ]] && return 1
+
+    local name matched=false
+    for name in "${INDEPENDENT_CLI_DOTDIR_NAMES[@]}"; do
+        if [[ "$lc_name" == "$name" ]]; then
+            matched=true
+            break
+        fi
+    done
+    [[ "$matched" == "false" ]] && return 1
+
+    case "$parent" in
+        "$HOME" | "$HOME/.config" | "$HOME/.local/share" | "$HOME/.cache")
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 # Locate files associated with an application
 find_app_files() {
     local bundle_id="$1"
@@ -753,6 +788,13 @@ find_app_files() {
                 continue
                 ;;
         esac
+
+        # Skip XDG dotdirs that belong to independent CLI tools sharing a name
+        # with the GUI app being uninstalled (issue #993).
+        if _path_belongs_to_independent_cli "$expanded_path"; then
+            debug_log "Skipping independent CLI dotdir: $expanded_path"
+            continue
+        fi
 
         files_to_clean+=("$expanded_path")
     done

--- a/lib/core/app_protection_data.sh
+++ b/lib/core/app_protection_data.sh
@@ -563,3 +563,23 @@ readonly DATA_PROTECTED_BUNDLES=(
     "com.devmate.*"
     "org.sparkle-project.Sparkle*"
 )
+
+# Dotdir / XDG state directory names that belong to standalone CLI tools
+# shipped independently of any same-named GUI app. find_app_files() must not
+# propose these for deletion even when uninstalling a GUI app whose display
+# name collides, because the CLI tool is a separate product.
+#
+# Issue #993: uninstalling Claude.app wiped ~/.claude (Claude Code CLI);
+# uninstalling OpenCode.app wiped ~/.local/share/opencode and the opencode
+# CLI binary. Case-insensitive APFS makes the collision worse: $HOME/.Claude
+# (built from app_name="Claude") aliases to $HOME/.claude.
+#
+# Match is lowercase + leading-dot-stripped, scoped to $HOME, $HOME/.config,
+# $HOME/.local/share, $HOME/.cache. Add new entries as the AI-tool ecosystem
+# produces more GUI/CLI namesakes.
+readonly INDEPENDENT_CLI_DOTDIR_NAMES=(
+    "claude"   # Claude Code CLI (Claude Desktop uses ~/Library/Application Support/Claude)
+    "opencode" # sst/opencode CLI
+    "codex"    # OpenAI codex CLI (Codex Desktop uses ~/Library/Application Support/Codex)
+    "gemini"   # Google gemini CLI
+)

--- a/tests/uninstall_naming_variants.bats
+++ b/tests/uninstall_naming_variants.bats
@@ -175,3 +175,57 @@ setup() {
     [[ "$result" == *"/.vscode-insiders"* ]]
     [[ ! "$result" =~ Library/Application\ Support/Code$'\n' ]]
 }
+
+# Independent CLI dotdir protection — issue #993.
+# Uninstalling a GUI app named "Claude" / "OpenCode" / etc. must not delete
+# the same-named standalone CLI tool's state directory.
+
+@test "find_app_files preserves ~/.claude when uninstalling Claude.app (#993)" {
+    mkdir -p "$HOME/.claude/projects"
+    mkdir -p "$HOME/Library/Application Support/Claude"
+    echo "memory" > "$HOME/.claude/projects/sample"
+
+    result=$(find_app_files "com.anthropic.claudefordesktop" "Claude")
+
+    [[ "$result" == *"Library/Application Support/Claude"* ]]
+    [[ "$result" != *"$HOME/.claude"* ]]
+    [[ "$result" != *"$HOME/.Claude"* ]]
+}
+
+@test "find_app_files preserves ~/.local/share/opencode when uninstalling OpenCode.app (#993)" {
+    mkdir -p "$HOME/.local/share/opencode/snapshot"
+    mkdir -p "$HOME/.config/opencode"
+    mkdir -p "$HOME/.opencode"
+    mkdir -p "$HOME/Library/Application Support/opencode"
+
+    result=$(find_app_files "ai.opencode.desktop" "opencode")
+
+    [[ "$result" == *"Library/Application Support/opencode"* ]]
+    [[ "$result" != *".local/share/opencode"* ]]
+    [[ "$result" != *".config/opencode"* ]]
+    [[ "$result" != *"$HOME/.opencode"* ]]
+}
+
+@test "find_app_files preserves ~/.codex when uninstalling Codex.app (#993)" {
+    mkdir -p "$HOME/.codex"
+    mkdir -p "$HOME/.config/codex"
+    mkdir -p "$HOME/Library/Application Support/Codex"
+
+    result=$(find_app_files "com.openai.codex" "Codex")
+
+    [[ "$result" == *"Library/Application Support/Codex"* ]]
+    [[ "$result" != *"$HOME/.codex"* ]]
+    [[ "$result" != *".config/codex"* ]]
+}
+
+@test "find_app_files still removes Zed XDG state (independent-CLI list must not over-protect)" {
+    # Sanity check that the deny-list does not break legitimate GUI-app XDG
+    # cleanup added for #377. Zed is a GUI app that owns ~/.config/zed and
+    # ~/.local/share/zed and must still be picked up on uninstall.
+    mkdir -p "$HOME/.config/zed"
+    mkdir -p "$HOME/.local/share/zed"
+
+    result=$(find_app_files "dev.zed.Zed-Nightly" "Zed Nightly")
+
+    [[ "$result" == *".config/zed"* ]] || [[ "$result" == *".local/share/zed"* ]]
+}


### PR DESCRIPTION
Closes #993.

## Problem

`find_app_files()` in `lib/core/app_protection.sh` adds XDG-style candidate paths derived from a GUI app's display name:

```bash
"$HOME/.config/$app_name"
"$HOME/.local/share/$app_name"
"$HOME/.$app_name"
```

When the display name collides with an independently-shipped CLI tool, `mo uninstall <GUI app>` silently wipes the CLI's entire state directory. Reproduced on the same machine within minutes:

- Uninstalling `Claude.app` → `~/.claude` (Claude Code CLI: projects, skills, plugins, accumulated cross-project memory) gone.
- Uninstalling `OpenCode.app` → `~/.local/share/opencode`, `~/.config/opencode`, `~/.opencode` (sst/opencode CLI sessions/snapshots/logs) + the `opencode` binary gone.

Case-insensitive APFS amplifies the Claude case: `$HOME/.Claude` built from `app_name="Claude"` aliases to `$HOME/.claude` and passes the `[[ -e ]]` existence check. `MOLE_UNINSTALL_MODE=1` then bypasses `should_protect_data` (intentionally), and the path is unlinked.

## Fix approach

The XDG patterns themselves are intentional — `tests/uninstall_naming_variants.bats` already enforces them for Maestro Studio / Zed / Firefox via issue #377, so removing them would regress. What's missing is a way to distinguish:

- GUI app that writes to `~/.config/<name>` or `~/.local/share/<name>` itself (Zed, Firefox, Maestro) → cleanup is correct.
- GUI app that happens to share a name with an unrelated CLI tool (Claude Desktop / Claude Code, OpenCode.app / opencode CLI) → cleanup destroys unrelated data.

This PR adds a tight deny-list `INDEPENDENT_CLI_DOTDIR_NAMES` in `lib/core/app_protection_data.sh` and a helper `_path_belongs_to_independent_cli` consulted inside the existing `find_app_files` per-pattern loop. Match is lowercase + leading-dot-stripped (handles case-insensitive APFS) and scoped to `$HOME`, `$HOME/.config`, `$HOME/.local/share`, `$HOME/.cache` so unrelated paths never get skipped.

Initial list: `claude`, `opencode`, `codex`, `gemini`. Easy to extend as more GUI/CLI namesakes show up.

## Tests

`tests/uninstall_naming_variants.bats` — 4 new cases:

1. Uninstalling `Claude.app` preserves `~/.claude` and still removes `~/Library/Application Support/Claude`.
2. Uninstalling `OpenCode.app` preserves all three opencode XDG roots (`~/.local/share/opencode`, `~/.config/opencode`, `~/.opencode`) and still removes the Library path.
3. Same for `Codex.app` / `~/.codex`.
4. Regression: uninstalling `Zed Nightly` still picks up `~/.config/zed` / `~/.local/share/zed` (deny-list must not over-protect issue #377 behavior).

Full local verification:

- `bats tests/uninstall_naming_variants.bats` → 16/16 pass (12 existing + 4 new).
- `bats tests/uninstall_safety.bats tests/uninstall_remove_file_list.bats tests/uninstall.bats tests/uninstall_scan_bash32.bats` → 79/79 pass.
- `bash scripts/check.sh` → shellcheck + bash syntax check pass; shfmt applied no further changes.

I also patched a local install of Mole 1.39.1 with the equivalent change and confirmed `mo uninstall` against `OpenCode.app` no longer lists `~/.local/share/opencode` / `~/.config/opencode` / `~/.opencode` in the deletion preview while still listing the GUI app's `~/Library/Application Support/opencode`.

## Related context

- #823 (closed by `32bfb5b9`) fixed `mo clean` wiping `~/.claude/projects/*/memory/` by removing automatic cleanup of `~/.claude/*` from `lib/clean/dev.sh`. Different code path — doesn't cover uninstall.
- #801 (closed by `6f13e08`) added symlink-aware preservation for `~/.local/share/claude/versions/`. Different mechanism.

Neither prior fix touched `find_app_files()`, which is why the uninstall path regressed independently.

## Notes for review

- Deny-list approach intentionally tight rather than heuristic. A "binary on PATH" check would be more generic but would break Zed-style GUI apps that ship a same-named launcher CLI.
- Trash-by-default (so future false positives are recoverable) is out of scope here and probably its own PR.
- Happy to add more entries to `INDEPENDENT_CLI_DOTDIR_NAMES` if you have other namesakes in mind.