### PR TITLE
fix(security): update Go 1.25.0 → 1.25.8 to patch 3 stdlib vulnerabil…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,23 @@ jobs:
                tests/regression.bats \
                tests/cli.bats
 
+  govulncheck:
+    name: Go Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
   security:
     name: Security Checks
     runs-on: macos-latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tw93/mole
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0


### PR DESCRIPTION
…ities

Fixes the following Go standard library vulnerabilities that affect Mole's code paths:

- GO-2026-4602: os.File.Readdir / filepath.WalkDir can escape from a Root (used in cmd/status/metrics_cpu.go, cmd/status/metrics_disk.go)
- GO-2026-4601: incorrect parsing of IPv6 host literals in net/url (used in cmd/status/metrics_network.go via url.Parse)
- GO-2025-4010: insufficient validation of bracketed IPv6 hostnames in net/url (same code path as above)

Also adds a govulncheck CI job to catch future stdlib and dependency vulnerabilities automatically on every PR.

## Summary

- Describe the change.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
- If yes, describe the new boundary or risk change clearly.

## Tests

- List the automated tests you ran.
- List any manual checks for high-risk paths or destructive flows.

## Safety-related changes

- None.
