### PR TITLE
fix(status): report process resident memory

### DIFF
--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -102,12 +102,13 @@ type DiskIOStatus struct {
 }
 
 type ProcessInfo struct {
-	PID     int     `json:"pid"`
-	PPID    int     `json:"ppid"`
-	Name    string  `json:"name"`
-	Command string  `json:"command"`
-	CPU     float64 `json:"cpu"`
-	Memory  float64 `json:"memory"`
+	PID         int     `json:"pid"`
+	PPID        int     `json:"ppid"`
+	Name        string  `json:"name"`
+	Command     string  `json:"command"`
+	CPU         float64 `json:"cpu"`
+	Memory      float64 `json:"memory"` // Percent of physical memory, kept for compatibility.
+	MemoryBytes uint64  `json:"memory_bytes,omitempty"`
 }
 
 type CPUStatus struct {

--- a/cmd/status/metrics_process.go
+++ b/cmd/status/metrics_process.go
@@ -20,7 +20,7 @@ func collectProcesses() ([]ProcessInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,pcpu=,pmem=,comm=", "-r")
+	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,pcpu=,pmem=,rss=,comm=", "-r")
 	if err != nil {
 		out, err = runCmd(ctx, "ps", "aux")
 		if err != nil {
@@ -53,17 +53,27 @@ func parseProcessOutput(raw string) []ProcessInfo {
 			continue
 		}
 
-		command := strings.Join(fields[4:], " ")
+		rssBytes := uint64(0)
+		commandStart := 4
+		if len(fields) >= 6 {
+			if rssKB, err := strconv.ParseUint(fields[4], 10, 64); err == nil {
+				rssBytes = rssKB * 1024
+				commandStart = 5
+			}
+		}
+
+		command := strings.Join(fields[commandStart:], " ")
 		if command == "" {
 			continue
 		}
 		procs = append(procs, ProcessInfo{
-			PID:     pid,
-			PPID:    ppid,
-			Name:    processNameFromCommand(command),
-			Command: command,
-			CPU:     cpuVal,
-			Memory:  memVal,
+			PID:         pid,
+			PPID:        ppid,
+			Name:        processNameFromCommand(command),
+			Command:     command,
+			CPU:         cpuVal,
+			Memory:      memVal,
+			MemoryBytes: rssBytes,
 		})
 	}
 	return procs
@@ -95,17 +105,22 @@ func parsePsAuxOutput(raw string) []ProcessInfo {
 		if err != nil {
 			continue
 		}
+		rssKB, err := strconv.ParseUint(fields[5], 10, 64)
+		if err != nil {
+			rssKB = 0
+		}
 		command := strings.Join(fields[10:], " ")
 		if command == "" {
 			continue
 		}
 		procs = append(procs, ProcessInfo{
-			PID:     pid,
-			PPID:    0,
-			Name:    processNameFromCommand(command),
-			Command: command,
-			CPU:     cpuVal,
-			Memory:  memVal,
+			PID:         pid,
+			PPID:        0,
+			Name:        processNameFromCommand(command),
+			Command:     command,
+			CPU:         cpuVal,
+			Memory:      memVal,
+			MemoryBytes: rssKB * 1024,
 		})
 	}
 	return procs

--- a/cmd/status/process_watch_test.go
+++ b/cmd/status/process_watch_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestParseProcessOutput(t *testing.T) {
 	raw := strings.Join([]string{
-		"123 1 145.2 10.1 /Applications/Visual Studio Code.app/Contents/MacOS/Electron",
-		"456 1 99.5 2.2 /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder",
+		"123 1 145.2 10.1 7340032 /Applications/Visual Studio Code.app/Contents/MacOS/Electron",
+		"456 1 99.5 2.2 262144 /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder",
 		"bad line",
 	}, "\n")
 
@@ -27,6 +27,45 @@ func TestParseProcessOutput(t *testing.T) {
 	}
 	if !strings.Contains(procs[0].Command, "Visual Studio Code.app") {
 		t.Fatalf("command path missing spaces: %q", procs[0].Command)
+	}
+	if procs[0].MemoryBytes != 7340032*1024 {
+		t.Fatalf("unexpected memory bytes %d", procs[0].MemoryBytes)
+	}
+}
+
+func TestParseProcessOutputKeepsOldFiveColumnShape(t *testing.T) {
+	raw := "123 1 145.2 10.1 /Applications/Visual Studio Code.app/Contents/MacOS/Electron"
+
+	procs := parseProcessOutput(raw)
+	if len(procs) != 1 {
+		t.Fatalf("parseProcessOutput() len = %d, want 1", len(procs))
+	}
+	if procs[0].Memory != 10.1 {
+		t.Fatalf("unexpected memory percent %.1f", procs[0].Memory)
+	}
+	if procs[0].MemoryBytes != 0 {
+		t.Fatalf("old ps shape should not invent memory bytes, got %d", procs[0].MemoryBytes)
+	}
+	if procs[0].Command != "/Applications/Visual Studio Code.app/Contents/MacOS/Electron" {
+		t.Fatalf("unexpected command %q", procs[0].Command)
+	}
+}
+
+func TestParsePsAuxOutputCapturesResidentMemory(t *testing.T) {
+	raw := strings.Join([]string{
+		"USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND",
+		"raj 123 4.5 6.0 123456 2097152 ?? S 10:00AM 1:23 /Applications/Chrome.app/Contents/MacOS/Chrome --type=renderer",
+	}, "\n")
+
+	procs := parsePsAuxOutput(raw)
+	if len(procs) != 1 {
+		t.Fatalf("parsePsAuxOutput() len = %d, want 1", len(procs))
+	}
+	if procs[0].MemoryBytes != 2097152*1024 {
+		t.Fatalf("unexpected memory bytes %d", procs[0].MemoryBytes)
+	}
+	if !strings.Contains(procs[0].Command, "--type=renderer") {
+		t.Fatalf("command path missing args: %q", procs[0].Command)
 	}
 }
 

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -501,6 +501,13 @@ func renderProcessCard(procs []ProcessInfo) cardData {
 }
 
 func processHint(p ProcessInfo) string {
+	if p.MemoryBytes > 0 {
+		hint := " " + humanBytesCompact(p.MemoryBytes)
+		if p.CPU >= cpuHighThreshold {
+			hint += " hot"
+		}
+		return hint
+	}
 	if p.Memory >= 10 {
 		return fmt.Sprintf(" M%.0f%%", p.Memory)
 	}

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1015,19 +1015,30 @@ func TestStatusDiagnosisLineFallsBackToAllClear(t *testing.T) {
 
 func TestRenderProcessCardAddsInlineHintWithoutExtraRows(t *testing.T) {
 	card := renderProcessCard([]ProcessInfo{
-		{Name: "Chrome", CPU: 12, Memory: 22},
-		{Name: "Xcode", CPU: 82, Memory: 8},
+		{Name: "Chrome", CPU: 12, Memory: 22, MemoryBytes: 2 * 1024 * 1024 * 1024},
+		{Name: "Xcode", CPU: 82, Memory: 8, MemoryBytes: 512 * 1024 * 1024},
 	})
 
 	if len(card.lines) != 2 {
 		t.Fatalf("renderProcessCard() lines = %d, want 2", len(card.lines))
 	}
 	plain := stripANSI(strings.Join(card.lines, "\n"))
-	if !strings.Contains(plain, "M22%") {
-		t.Fatalf("renderProcessCard() missing memory hint, got %q", plain)
+	if !strings.Contains(plain, "2.0G") {
+		t.Fatalf("renderProcessCard() missing resident memory hint, got %q", plain)
 	}
 	if !strings.Contains(plain, "hot") {
 		t.Fatalf("renderProcessCard() missing cpu hint, got %q", plain)
+	}
+}
+
+func TestRenderProcessCardFallsBackToMemoryPercent(t *testing.T) {
+	card := renderProcessCard([]ProcessInfo{
+		{Name: "Chrome", CPU: 12, Memory: 22},
+	})
+
+	plain := stripANSI(strings.Join(card.lines, "\n"))
+	if !strings.Contains(plain, "M22%") {
+		t.Fatalf("renderProcessCard() missing memory percent fallback, got %q", plain)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `memory_bytes` to status process snapshots from `ps` RSS values.
- Keep the existing `memory` percent field for compatibility and render resident memory in the process card when available.

Fixes #1030

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior? No.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity? No.

## Tests

- `/Users/raj/.gimme/versions/go1.26.3.darwin.arm64/bin/go test ./cmd/status ./internal/units`
- `/Users/raj/.gimme/versions/go1.26.3.darwin.arm64/bin/go test ./...` failed in existing `cmd/analyze` `TestDeletePathWithProgress` with `timeout moving to Trash`; touched status package passed.

## Safety-related changes

- None.