### PR TITLE
fix(clean): protect Raycast cache state

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -620,9 +620,10 @@ clean_note_apps() {
 clean_launcher_apps() {
     safe_clean ~/Library/Caches/com.runningwithcrayons.Alfred/* "Alfred cache"
     safe_clean ~/Library/Caches/cx.c3.theunarchiver/* "The Unarchiver cache"
-    # Raycast: only clean network and FS caches; Clipboard subfolder contains user's clipboard history.
-    safe_clean ~/Library/Caches/com.raycast.macos/urlcache/* "Raycast URL cache"
-    safe_clean ~/Library/Caches/com.raycast.macos/fsCachedData/* "Raycast FS cache"
+    if [[ -d "$HOME/Library/Caches/com.raycast.macos" ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Raycast cache · skipped by default"
+        note_activity
+    fi
 }
 # Remote desktop tools.
 clean_remote_desktop() {

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -620,10 +620,6 @@ clean_note_apps() {
 clean_launcher_apps() {
     safe_clean ~/Library/Caches/com.runningwithcrayons.Alfred/* "Alfred cache"
     safe_clean ~/Library/Caches/cx.c3.theunarchiver/* "The Unarchiver cache"
-    if [[ -d "$HOME/Library/Caches/com.raycast.macos" ]]; then
-        echo -e "  ${GRAY}${ICON_WARNING}${NC} Raycast cache · skipped by default"
-        note_activity
-    fi
 }
 # Remote desktop tools.
 clean_remote_desktop() {

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -275,6 +275,14 @@ should_protect_path() {
             ;;
     esac
 
+    if [[ "${MOLE_UNINSTALL_MODE:-0}" != "1" ]]; then
+        case "$path" in
+            */Library/Caches/com.raycast.macos | */Library/Caches/com.raycast.macos/ | */Library/Caches/com.raycast.macos/*)
+                return 0
+                ;;
+        esac
+    fi
+
     # 3. Extract bundle ID from sandbox paths
     # Matches: .../Library/Containers/bundle.id/...
     # Matches: .../Library/Group Containers/group.id/...

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -275,14 +275,6 @@ should_protect_path() {
             ;;
     esac
 
-    if [[ "${MOLE_UNINSTALL_MODE:-0}" != "1" ]]; then
-        case "$path" in
-            */Library/Caches/com.raycast.macos | */Library/Caches/com.raycast.macos/ | */Library/Caches/com.raycast.macos/*)
-                return 0
-                ;;
-        esac
-    fi
-
     # 3. Extract bundle ID from sandbox paths
     # Matches: .../Library/Containers/bundle.id/...
     # Matches: .../Library/Group Containers/group.id/...

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -708,21 +708,17 @@ EOF
     [[ -z "$output" ]]
 }
 
-@test "clean_launcher_apps skips Raycast cache by default" {
+@test "clean_launcher_apps does not touch Raycast cache" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
 mkdir -p "$HOME/Library/Caches/com.raycast.macos/urlcache"
 mkdir -p "$HOME/Library/Caches/com.raycast.macos/fsCachedData"
-note_activity() { echo "NOTE_ACTIVITY"; }
 safe_clean() { echo "CLEAN:$2|$1"; }
 clean_launcher_apps
 EOF
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Raycast cache · skipped by default"* ]]
-    [[ "$output" == *"NOTE_ACTIVITY"* ]]
-    [[ "$output" != *"Raycast URL cache"* ]]
-    [[ "$output" != *"Raycast FS cache"* ]]
+    [[ "$output" != *"Raycast"* ]] && [[ "$output" != *"raycast"* ]]
 }

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -707,3 +707,22 @@ EOF
     [ "$status" -eq 0 ]
     [[ -z "$output" ]]
 }
+
+@test "clean_launcher_apps skips Raycast cache by default" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+mkdir -p "$HOME/Library/Caches/com.raycast.macos/urlcache"
+mkdir -p "$HOME/Library/Caches/com.raycast.macos/fsCachedData"
+note_activity() { echo "NOTE_ACTIVITY"; }
+safe_clean() { echo "CLEAN:$2|$1"; }
+clean_launcher_apps
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Raycast cache · skipped by default"* ]]
+    [[ "$output" == *"NOTE_ACTIVITY"* ]]
+    [[ "$output" != *"Raycast URL cache"* ]]
+    [[ "$output" != *"Raycast FS cache"* ]]
+}

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -558,15 +558,3 @@ SCRIPT
     [ "$status" -eq 0 ]
     [[ "$output" == *"EXIT=0"* ]]
 }
-
-@test "should_protect_path protects Raycast cache during cleanup" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'SCRIPT'
-set -euo pipefail
-source "$PROJECT_ROOT/lib/core/common.sh"
-path="$HOME/Library/Caches/com.raycast.macos/urlcache/item"
-should_protect_path "$path" && echo "protected" || echo "not-protected"
-SCRIPT
-
-    [ "$status" -eq 0 ]
-    [[ "$output" == "protected" ]]
-}

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -558,3 +558,15 @@ SCRIPT
     [ "$status" -eq 0 ]
     [[ "$output" == *"EXIT=0"* ]]
 }
+
+@test "should_protect_path protects Raycast cache during cleanup" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+path="$HOME/Library/Caches/com.raycast.macos/urlcache/item"
+should_protect_path "$path" && echo "protected" || echo "not-protected"
+SCRIPT
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == "protected" ]]
+}


### PR DESCRIPTION
## Summary

- Stop deleting Raycast `urlcache` and `fsCachedData` during launcher cleanup.
- Protect the Raycast cache root during normal cleanup so moved beta state is not removed by broader cache paths.
- Add focused coverage for the launcher skip and path protection behavior.

Fixes #1033

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior? Yes, cleanup now skips Raycast cache state instead of deleting selected Raycast cache subfolders.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity? Yes, Raycast cache paths are added to normal cleanup protection only. Uninstall mode is left unchanged for user-selected Raycast removal.

## Tests

- `/bin/bash -n lib/core/app_protection.sh lib/clean/app_caches.sh tests/clean_app_caches.bats tests/core_common.bats`
- Manual `/bin/bash` scenario for `clean_launcher_apps` with Raycast `urlcache` and `fsCachedData` present.
- Manual `/bin/bash` scenario for `should_protect_path` on a Raycast cache child path.

Bats, shfmt, and shellcheck were not installed on this machine, so the exact Bats files could not be run locally.

## Safety-related changes

- Raycast cache paths are protected during normal cleanup to avoid removing clipboard, chat, or other state that Raycast stores under cache-shaped directories.