### PR TITLE
fix: check scan deadline inside nested-dir loop to prevent hung Project artifacts (#1053)

### DIFF
--- a/lib/clean/hints.sh
+++ b/lib/clean/hints.sh
@@ -410,6 +410,13 @@ probe_project_artifact_hints() {
             done
             [[ "$stop_scan" == "true" ]] && break
 
+            if [[ $SECONDS -ge $scan_deadline ]]; then
+                PROJECT_ARTIFACT_HINT_TRUNCATED=true
+                PROJECT_ARTIFACT_HINT_SCAN_SKIPPED=true
+                stop_scan=true
+                break
+            fi
+
             local nested_count=0
             nested_dirs_file=$(mktemp_file "project_artifact_nested") || {
                 PROJECT_ARTIFACT_HINT_SCAN_SKIPPED=true
@@ -424,6 +431,12 @@ probe_project_artifact_hints() {
             fi
 
             while IFS= read -r -d '' nested_dir; do
+                if [[ $SECONDS -ge $scan_deadline ]]; then
+                    PROJECT_ARTIFACT_HINT_TRUNCATED=true
+                    PROJECT_ARTIFACT_HINT_SCAN_SKIPPED=true
+                    stop_scan=true
+                    break
+                fi
                 [[ -d "$nested_dir" ]] || continue
 
                 local nested_name
@@ -447,8 +460,6 @@ probe_project_artifact_hints() {
                         record_project_artifact_hint "$candidate"
                     fi
                 done
-
-                [[ "$stop_scan" == "true" ]] && break
             done < "$nested_dirs_file"
             rm -f "$nested_dirs_file"
 

--- a/tests/clean_hints.bats
+++ b/tests/clean_hints.bats
@@ -152,6 +152,53 @@ EOT2D
     [[ "$output" == *"skipped=true"* ]]
 }
 
+@test "probe_project_artifact_hints respects budget inside nested-dir loop (#1053)" {
+    # Regression: old code had no deadline check inside the nested-dir while loop.
+    # When a single scan root is used the outer-root deadline guard never fires for
+    # the second time (the loop ends before the next iteration), so the nested loop
+    # could run unchecked after SECONDS crossed the deadline.
+    #
+    # Setup: one root with one project containing two nested sub-projects, each
+    # with a build/ artifact.  hint_collect_child_dirs_with_timeout sleeps 2s on
+    # the nested call so SECONDS advances past the 1s budget before the nested-dir
+    # while loop starts.
+    #
+    # New code: deadline fires on the FIRST nested-dir iteration → count=0, skipped=true.
+    # Old code: nested loop runs without a deadline check → count=2, skipped=false.
+    local root="$HOME/hints-deadline-nested"
+    mkdir -p "$root/bigproject/sub1/build"
+    mkdir -p "$root/bigproject/sub2/build"
+    touch "$root/bigproject/package.json"
+    printf '%s\n' "$root" > "$HOME/.config/mole/purge_paths"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        MOLE_TIMEOUT_HINT_SCAN_SEC=1 \
+        HINTS_ROOT="$root" \
+        bash --noprofile --norc << 'EOT_NESTED'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/hints.sh"
+run_with_timeout() { shift; "$@"; }
+hint_collect_child_dirs_with_timeout() {
+    local dir="$1" out="$2"
+    if [[ "$dir" == "$HINTS_ROOT" ]]; then
+        printf '%s\0' "$HINTS_ROOT/bigproject" >> "$out"
+    else
+        # Simulate a slow nested find that lets SECONDS cross the 1s budget.
+        sleep 2
+        printf '%s\0' "$HINTS_ROOT/bigproject/sub1" "$HINTS_ROOT/bigproject/sub2" >> "$out"
+    fi
+}
+probe_project_artifact_hints
+printf 'count=%s\n' "$PROJECT_ARTIFACT_HINT_COUNT"
+printf 'skipped=%s\n' "$PROJECT_ARTIFACT_HINT_SCAN_SKIPPED"
+EOT_NESTED
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"count=0"* ]]
+    [[ "$output" == *"skipped=true"* ]]
+}
+
 @test "show_system_data_hint_notice reports large clue paths" {
     mkdir -p "$HOME/Library/Developer/Xcode/DerivedData"
 


### PR DESCRIPTION
## Problem

Fixes #1053 — `mo clean` would hang indefinitely on the **Project artifacts** section.

`probe_project_artifact_hints` had a wall-clock budget (`MOLE_TIMEOUT_HINT_SCAN_SEC`, default 15 s), but the innermost `while` loop over nested subdirectories had no deadline check. When a single scan root is used, the outer-root guard fires only at the **top** of each root iteration — once that iteration is entered it never re-checks the budget. A slow `hint_collect_child_dirs_with_timeout` call (large monorepo, cold disk) pushed `SECONDS` past the deadline, but the nested-dir loop ran all the way to `max_nested_per_project` (120) iterations before control returned to any existing guard.

## Fix

Two new checkpoints in `lib/clean/hints.sh`:

1. **Before** `hint_collect_child_dirs_with_timeout` for nested dirs — skips the `find` call entirely if the budget is already exhausted.
2. **At the top of each nested-dir iteration** — stops immediately when `SECONDS` crosses the deadline mid-loop.

Also removes a dead `[[ "$stop_scan" == "true" ]] && break` that followed the `for target_names` loop inside the nested-dir `while`: at that point `stop_scan` could never be true (it is only set in the `project_dir` loop above, which breaks before reaching nested processing).

## Test

New bats test in `tests/clean_hints.bats`:

- Creates one scan root with one project containing two nested sub-projects (each with a `build/` artifact).
- Mocks `hint_collect_child_dirs_with_timeout` to sleep 2 s on the nested call, advancing `SECONDS` past the 1 s budget before the nested-dir loop starts.
- **New code**: deadline fires on the first nested-dir iteration → `count=0`, `skipped=true`.
- **Old code**: nested loop ran without a check → `count=2`, `skipped=false`.

```
ok 6 probe_project_artifact_hints respects budget inside nested-dir loop (#1053)
```

All 24 hints tests pass.