### PR TITLE
fix: read system service plists with sudo

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -526,7 +526,8 @@ clean_orphaned_system_services() {
     }
 
     # Read a launchd program path from a system plist.
-    # The plist itself was discovered with sudo, so read it with sudo too:
+    # The plist itself was discovered with sudo, so read it with sudo too (the
+    # caller already cleared a `sudo -n true` probe, so keep it non-interactive):
     # unreadable root-owned plists make PlistBuddy print a non-path "File Doesn't
     # Exist, Will Create..." message on stdout, which must never be treated as a
     # missing binary path.
@@ -534,7 +535,7 @@ clean_orphaned_system_services() {
         local plist="$1"
         local key="$2"
         local value=""
-        value=$(sudo /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2> /dev/null || true)
+        value=$(sudo -n /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2> /dev/null || true)
 
         [[ -z "$value" ]] && return 1
         [[ "$value" != /* ]] && return 1

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -525,15 +525,30 @@ clean_orphaned_system_services() {
         return 1
     }
 
+    # Read a launchd program path from a system plist.
+    # The plist itself was discovered with sudo, so read it with sudo too:
+    # unreadable root-owned plists make PlistBuddy print a non-path "File Doesn't
+    # Exist, Will Create..." message on stdout, which must never be treated as a
+    # missing binary path.
+    _plist_program_value() {
+        local plist="$1"
+        local key="$2"
+        local value=""
+        value=$(sudo /usr/libexec/PlistBuddy -c "Print :$key" "$plist" 2> /dev/null || true)
+
+        [[ -z "$value" ]] && return 1
+        [[ "$value" != /* ]] && return 1
+
+        printf '%s\n' "$value"
+    }
+
     # Read the program binary from a plist (Program or ProgramArguments[0]).
-    # Prints the path; returns 1 if no Program key found.
+    # Prints the path; returns 1 if no usable absolute Program key found.
     _plist_binary_path() {
         local plist="$1"
         local binary=""
-        binary=$(/usr/libexec/PlistBuddy -c "Print :ProgramArguments:0" "$plist" 2> /dev/null || true)
-        if [[ -z "$binary" ]]; then
-            binary=$(/usr/libexec/PlistBuddy -c "Print :Program" "$plist" 2> /dev/null || true)
-        fi
+        binary=$(_plist_program_value "$plist" "ProgramArguments:0" || true)
+        [[ -z "$binary" ]] && binary=$(_plist_program_value "$plist" "Program" || true)
         [[ -z "$binary" ]] && return 1
         printf '%s\n' "$binary"
     }

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -637,6 +637,7 @@ sudo() {
   if [[ "$1" == "-n" && "$2" == "true" ]]; then
     return 0
   fi
+  [[ "${1:-}" == "-n" ]] && shift
   if [[ "$1" == "find" ]]; then
     case "$2" in
       /Library/LaunchDaemons) printf '%s\0' "$tmp_plist" ;;

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -603,6 +603,65 @@ EOF
     [[ "$output" != *"launchctl-called"* ]]
 }
 
+@test "clean_orphaned_system_services reads unreadable plists through sudo PlistBuddy" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 DRY_RUN=true MOLE_DRY_RUN=1 bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+debug_log() { echo "debug: $*"; }
+should_protect_path() { return 1; }
+
+tmp_dir="$(mktemp -d)"
+tmp_binary="$tmp_dir/live-helper"
+tmp_plist="$tmp_dir/com.example.live-helper.plist"
+touch "$tmp_binary"
+cat > "$tmp_plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.live-helper</string>
+    <key>Program</key>
+    <string>$tmp_binary</string>
+</dict>
+</plist>
+PLIST
+chmod 000 "$tmp_plist"
+
+sudo() {
+  if [[ "$1" == "-n" && "$2" == "true" ]]; then
+    return 0
+  fi
+  if [[ "$1" == "find" ]]; then
+    case "$2" in
+      /Library/LaunchDaemons) printf '%s\0' "$tmp_plist" ;;
+      *) : ;;
+    esac
+    return 0
+  fi
+  if [[ "$1" == "/usr/libexec/PlistBuddy" ]]; then
+    case "$3" in
+      "Print :ProgramArguments:0") return 1 ;;
+      "Print :Program") printf '%s\n' "$tmp_binary"; return 0 ;;
+    esac
+    return 1
+  fi
+  command "$@"
+}
+
+clean_orphaned_system_services
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Found 1 orphaned"* ]] || return 1
+    [[ "$output" != *"Would remove orphaned service"* ]] || return 1
+}
+
 @test "clean_orphaned_system_services does not count protected skips as cleaned" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false MOLE_DRY_RUN=0 bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Read system service plist `ProgramArguments:0` / `Program` values with `sudo PlistBuddy`.
- Reject non-absolute plist read output before using it as a service binary path.
- Add focused coverage for unreadable LaunchDaemon plists that point to an existing binary.

## Safety Review
 - Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior? Yes, `mo clean` orphaned system service detection now reads
  LaunchDaemon/LaunchAgent plist contents through the same sudo boundary used to discover those plist files.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity? Yes, sudo boundary handling changes for reading `/
  Library/LaunchDaemons` and `/Library/LaunchAgents` plist contents only. Deletion, path validation, symlink handling, protected-path checks, dry-run behavior, `launchctl unload`, and `safe_sudo_remove` are unchanged.

## Tests
- `./scripts/check.sh --no-format`
- Manual `/bin/bash` scenario for an unreadable system-service plist whose `Program` points to an existing binary.
- Manual `/bin/bash` scenario for `PlistBuddy` failure text on stdout, verifying it is not treated as a binary path.

Bats was not available locally, so the new Bats case was covered with the equivalent manual shell scenario.

## Safety-related changes
- System service plist reads now use `sudo PlistBuddy`, matching the existing `sudo find` scan boundary.
- Non-absolute plist read output is rejected before orphan detection, preventing `PlistBuddy` failure text from being interpreted as a missing binary path.