### PR TITLE
fix(clean): keep sudo noninteractive during cleanup

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1017,7 +1017,7 @@ start_cleanup() {
 EOF
 
         # Preview system section when sudo is already cached (no password prompt).
-        if has_sudo_session; then
+        if adopt_sudo_session; then
             SYSTEM_CLEAN=true
             echo -e "${GREEN}${ICON_SUCCESS}${NC} Admin access available, system preview included"
             echo ""
@@ -1030,7 +1030,7 @@ EOF
     fi
 
     if [[ -t 0 ]]; then
-        if has_sudo_session; then
+        if adopt_sudo_session; then
             SYSTEM_CLEAN=true
             echo -e "${GREEN}${ICON_SUCCESS}${NC} Admin access already available"
             echo ""
@@ -1040,7 +1040,7 @@ EOF
     else
         echo ""
         echo "Running in non-interactive mode"
-        if has_sudo_session; then
+        if adopt_sudo_session; then
             SYSTEM_CLEAN=true
             echo "  ${ICON_LIST} System-level cleanup enabled, sudo session active"
         else

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -605,7 +605,7 @@ clean_orphaned_system_services() {
                 orphaned_files+=("$plist")
                 orphaned_count=$((orphaned_count + 1))
             fi
-        done < <(sudo find /Library/LaunchDaemons -maxdepth 1 -name "*.plist" -print0 2> /dev/null)
+        done < <(sudo -n find /Library/LaunchDaemons -maxdepth 1 -name "*.plist" -print0 2> /dev/null)
     fi
 
     # Scan system LaunchAgents
@@ -624,7 +624,7 @@ clean_orphaned_system_services() {
                 orphaned_files+=("$plist")
                 orphaned_count=$((orphaned_count + 1))
             fi
-        done < <(sudo find /Library/LaunchAgents -maxdepth 1 -name "*.plist" -print0 2> /dev/null)
+        done < <(sudo -n find /Library/LaunchAgents -maxdepth 1 -name "*.plist" -print0 2> /dev/null)
     fi
 
     # Scan PrivilegedHelperTools
@@ -676,7 +676,7 @@ clean_orphaned_system_services() {
                     orphaned_count=$((orphaned_count + 1))
                 fi
             fi
-        done < <(sudo find /Library/PrivilegedHelperTools -maxdepth 1 -type f -print0 2> /dev/null)
+        done < <(sudo -n find /Library/PrivilegedHelperTools -maxdepth 1 -type f -print0 2> /dev/null)
     fi
 
     stop_section_spinner
@@ -714,11 +714,11 @@ clean_orphaned_system_services() {
                 debug_log "[DRY RUN] Would remove orphaned service: $orphan_file"
             else
                 local file_size_kb
-                file_size_kb=$(sudo du -skP "$orphan_file" 2> /dev/null | awk '{print $1}' || echo "0")
+                file_size_kb=$(sudo -n du -skP "$orphan_file" 2> /dev/null | awk '{print $1}' || echo "0")
 
                 # Unload if it's a LaunchDaemon/LaunchAgent
                 if [[ "$orphan_file" == *.plist ]]; then
-                    sudo launchctl unload "$orphan_file" 2> /dev/null || true
+                    sudo -n launchctl unload "$orphan_file" 2> /dev/null || true
                 fi
                 if safe_sudo_remove "$orphan_file"; then
                     debug_log "Removed orphaned service: $orphan_file"

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -775,7 +775,7 @@ _sim_runtime_size_kb() {
     local target_path="$1"
     local size_kb=0
     if has_sudo_session; then
-        size_kb=$(sudo du -skP "$target_path" 2> /dev/null | command awk 'NR==1 {print $1; exit}' || echo "0")
+        size_kb=$(sudo -n du -skP "$target_path" 2> /dev/null | command awk 'NR==1 {print $1; exit}' || echo "0")
     else
         size_kb=$(du -skP "$target_path" 2> /dev/null | command awk 'NR==1 {print $1; exit}' || echo "0")
     fi

--- a/lib/clean/system.sh
+++ b/lib/clean/system.sh
@@ -46,7 +46,7 @@ clean_deep_system() {
     local cache_cleaned=0
     start_section_spinner "Cleaning system caches..."
     # Optimized: Single pass for /Library/Caches (3 patterns in 1 scan)
-    if sudo test -d "/Library/Caches" 2> /dev/null; then
+    if sudo -n test -d "/Library/Caches" 2> /dev/null; then
         while IFS= read -r -d '' file; do
             if should_protect_path "$file"; then
                 continue
@@ -54,7 +54,7 @@ clean_deep_system() {
             if safe_sudo_remove "$file"; then
                 cache_cleaned=1
             fi
-        done < <(sudo find "/Library/Caches" -maxdepth 5 -type f \( \
+        done < <(sudo -n find "/Library/Caches" -maxdepth 5 -type f \( \
             \( -name "*.cache" -mtime "+$MOLE_TEMP_FILE_AGE_DAYS" \) -o \
             \( -name "*.tmp" -mtime "+$MOLE_TEMP_FILE_AGE_DAYS" \) -o \
             \( -name "*.log" -mtime "+$MOLE_LOG_AGE_DAYS" \) \
@@ -66,7 +66,7 @@ clean_deep_system() {
     local tmp_cleaned=0
     local -a sys_temp_dirs=("/private/tmp" "/private/var/tmp")
     for tmp_dir in "${sys_temp_dirs[@]}"; do
-        if sudo find "$tmp_dir" -maxdepth 1 -type f -mtime "+${MOLE_TEMP_FILE_AGE_DAYS}" -print -quit 2> /dev/null | grep -q .; then
+        if sudo -n find "$tmp_dir" -maxdepth 1 -type f -mtime "+${MOLE_TEMP_FILE_AGE_DAYS}" -print -quit 2> /dev/null | grep -q .; then
             if safe_sudo_find_delete "$tmp_dir" "*" "${MOLE_TEMP_FILE_AGE_DAYS}" "f"; then
                 tmp_cleaned=1
             fi
@@ -75,13 +75,13 @@ clean_deep_system() {
     stop_section_spinner
     [[ $tmp_cleaned -eq 1 ]] && log_success "System temp files"
     start_section_spinner "Cleaning system crash reports..."
-    if sudo find "/Library/Logs/DiagnosticReports" -maxdepth 1 -type f -mtime "+$MOLE_CRASH_REPORT_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
+    if sudo -n find "/Library/Logs/DiagnosticReports" -maxdepth 1 -type f -mtime "+$MOLE_CRASH_REPORT_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
         safe_sudo_find_delete "/Library/Logs/DiagnosticReports" "*" "$MOLE_CRASH_REPORT_AGE_DAYS" "f" || true
     fi
     stop_section_spinner
     log_success "System crash reports"
     start_section_spinner "Cleaning system logs..."
-    if sudo find "/private/var/log" -maxdepth 3 -type f \( -name "*.log" -o -name "*.gz" -o -name "*.asl" \) -mtime "+$MOLE_LOG_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
+    if sudo -n find "/private/var/log" -maxdepth 3 -type f \( -name "*.log" -o -name "*.gz" -o -name "*.asl" \) -mtime "+$MOLE_LOG_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
         safe_sudo_find_delete "/private/var/log" "*.log" "$MOLE_LOG_AGE_DAYS" "f" || true
         safe_sudo_find_delete "/private/var/log" "*.gz" "$MOLE_LOG_AGE_DAYS" "f" || true
         safe_sudo_find_delete "/private/var/log" "*.asl" "$MOLE_LOG_AGE_DAYS" "f" || true
@@ -96,15 +96,15 @@ clean_deep_system() {
     local third_party_logs_cleaned=0
     local third_party_log_dir=""
     for third_party_log_dir in "${third_party_log_dirs[@]}"; do
-        if sudo test -d "$third_party_log_dir" 2> /dev/null; then
-            if sudo find "$third_party_log_dir" -maxdepth 5 -type f -mtime "+$MOLE_LOG_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
+        if sudo -n test -d "$third_party_log_dir" 2> /dev/null; then
+            if sudo -n find "$third_party_log_dir" -maxdepth 5 -type f -mtime "+$MOLE_LOG_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
                 if safe_sudo_find_delete "$third_party_log_dir" "*" "$MOLE_LOG_AGE_DAYS" "f"; then
                     third_party_logs_cleaned=1
                 fi
             fi
         fi
     done
-    if sudo find "/Library/Logs" -maxdepth 1 -type f -name "adobegc.log" -mtime "+$MOLE_LOG_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
+    if sudo -n find "/Library/Logs" -maxdepth 1 -type f -name "adobegc.log" -mtime "+$MOLE_LOG_AGE_DAYS" -print -quit 2> /dev/null | grep -q .; then
         if safe_sudo_remove "/Library/Logs/adobegc.log"; then
             third_party_logs_cleaned=1
         fi
@@ -221,7 +221,7 @@ clean_deep_system() {
     )
     local rebuildable_cache_dir=""
     for rebuildable_cache_dir in "${rebuildable_cache_dirs[@]}"; do
-        if sudo test -e "$rebuildable_cache_dir" 2> /dev/null; then
+        if sudo -n test -e "$rebuildable_cache_dir" 2> /dev/null; then
             if safe_sudo_remove "$rebuildable_cache_dir"; then
                 rebuildable_cache_cleaned=$((rebuildable_cache_cleaned + 1))
             fi
@@ -270,13 +270,13 @@ clean_deep_system() {
     start_section_spinner "Cleaning memory exception reports..."
     local mem_reports_dir="/private/var/db/reportmemoryexception/MemoryLimitViolations"
     local mem_cleaned=0
-    if sudo test -d "$mem_reports_dir" 2> /dev/null; then
+    if sudo -n test -d "$mem_reports_dir" 2> /dev/null; then
         # Count and size old files before deletion
         local file_count=0
         local total_size_kb=0
         local total_bytes=0
         local stats_out
-        stats_out=$(sudo find "$mem_reports_dir" -type f -mtime +30 -exec stat -f "%z" {} + 2> /dev/null | awk '{c++; s+=$1} END {print c+0, s+0}' || true)
+        stats_out=$(sudo -n find "$mem_reports_dir" -type f -mtime +30 -exec stat -f "%z" {} + 2> /dev/null | awk '{c++; s+=$1} END {print c+0, s+0}' || true)
         if [[ -n "$stats_out" ]]; then
             read -r file_count total_bytes <<< "$stats_out"
             total_size_kb=$((total_bytes / 1024))

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -724,7 +724,7 @@ clean_support_app_data() {
     local sys_idle_assets_dir="/Library/Application Support/com.apple.idleassetsd/Customer"
     # Skip sudo operations during tests to avoid password prompts
     if [[ "${MOLE_TEST_MODE:-0}" != "1" && "${MOLE_TEST_NO_AUTH:-0}" != "1" ]]; then
-        if sudo test -d "$sys_idle_assets_dir" 2> /dev/null; then
+        if sudo -n test -d "$sys_idle_assets_dir" 2> /dev/null; then
             safe_sudo_find_delete "$sys_idle_assets_dir" "*" "$support_age_days" "f" || true
         fi
     fi

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -339,7 +339,7 @@ safe_remove_symlink() {
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "sudo blocked in test mode"
             return 1
         fi
-        sudo rm "$path" 2> /dev/null || rm_exit=$?
+        sudo -n rm "$path" 2> /dev/null || rm_exit=$?
     else
         rm "$path" 2> /dev/null || rm_exit=$?
     fi
@@ -392,16 +392,16 @@ safe_sudo_remove() {
             local file_size=""
             local file_age=""
 
-            if sudo test -e "$path" 2> /dev/null; then
+            if sudo -n test -e "$path" 2> /dev/null; then
                 local size_kb
-                size_kb=$(sudo du -skP "$path" 2> /dev/null | awk '{print $1}' || echo "0")
+                size_kb=$(sudo -n du -skP "$path" 2> /dev/null | awk '{print $1}' || echo "0")
                 if [[ "$size_kb" -gt 0 ]]; then
                     file_size=$(bytes_to_human "$((size_kb * 1024))")
                 fi
 
-                if sudo test -f "$path" 2> /dev/null || sudo test -d "$path" 2> /dev/null; then
+                if sudo -n test -f "$path" 2> /dev/null || sudo -n test -d "$path" 2> /dev/null; then
                     local mod_time
-                    mod_time=$(sudo stat -f%m "$path" 2> /dev/null || echo "0")
+                    mod_time=$(sudo -n stat -f%m "$path" 2> /dev/null || echo "0")
                     local now
                     now=$(date +%s 2> /dev/null || echo "0")
                     if [[ "$mod_time" -gt 0 && "$now" -gt 0 ]]; then
@@ -423,8 +423,8 @@ safe_sudo_remove() {
     local size_kb=0
     local size_human=""
     if oplog_enabled; then
-        if sudo test -e "$path" 2> /dev/null; then
-            size_kb=$(sudo du -skP "$path" 2> /dev/null | awk '{print $1}' || echo "0")
+        if sudo -n test -e "$path" 2> /dev/null; then
+            size_kb=$(sudo -n du -skP "$path" 2> /dev/null | awk '{print $1}' || echo "0")
             if [[ "$size_kb" =~ ^[0-9]+$ ]] && [[ "$size_kb" -gt 0 ]]; then
                 size_human=$(bytes_to_human "$((size_kb * 1024))" 2> /dev/null || echo "${size_kb}KB")
             fi
@@ -433,7 +433,7 @@ safe_sudo_remove() {
 
     local output
     local ret=0
-    output=$(sudo rm -rf "$path" 2>&1) || ret=$? # safe_remove
+    output=$(sudo -n rm -rf "$path" 2>&1) || ret=$? # safe_remove
 
     if [[ $ret -eq 0 ]]; then
         log_operation "${MOLE_CURRENT_COMMAND:-clean}" "REMOVED" "$path" "$size_human"
@@ -441,6 +441,10 @@ safe_sudo_remove() {
     fi
 
     case "$output" in
+        *"a password is required"* | *"a terminal is required"* | *"Password:"*)
+            log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "auth required"
+            return "$MOLE_ERR_AUTH_FAILED"
+            ;;
         *"Operation not permitted"*)
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "sip/mdm protected"
             return "$MOLE_ERR_SIP_PROTECTED"
@@ -531,7 +535,7 @@ mole_delete() {
             if [[ "${MOLE_TEST_MODE:-0}" == "1" || "${MOLE_TEST_NO_AUTH:-0}" == "1" ]]; then
                 du_rc=1
             else
-                raw_size=$(sudo du -skP "$path" 2> /dev/null | awk '{print $1; exit}')
+                raw_size=$(sudo -n du -skP "$path" 2> /dev/null | awk '{print $1; exit}')
                 du_rc=${PIPESTATUS[0]}
             fi
         else
@@ -665,7 +669,7 @@ _mole_move_sudo_path_to_user_trash() {
         return 1
     fi
     if ! mkdir -p "$trash_dir" 2> /dev/null; then
-        if ! sudo mkdir -p "$trash_dir" 2> /dev/null; then
+        if ! sudo -n mkdir -p "$trash_dir" 2> /dev/null; then
             debug_log "Failed to create invoking user Trash: $trash_dir"
             return 1
         fi
@@ -683,10 +687,10 @@ _mole_move_sudo_path_to_user_trash() {
         owner_gid=$(get_invoking_gid)
     fi
     if [[ "$owner_uid" =~ ^[0-9]+$ && "$owner_gid" =~ ^[0-9]+$ ]]; then
-        sudo chown "$owner_uid:$owner_gid" "$trash_dir" 2> /dev/null || true
+        sudo -n chown "$owner_uid:$owner_gid" "$trash_dir" 2> /dev/null || true
     fi
     if ! chmod 700 "$trash_dir" 2> /dev/null; then
-        sudo chmod 700 "$trash_dir" 2> /dev/null || true
+        sudo -n chmod 700 "$trash_dir" 2> /dev/null || true
     fi
 
     # Avoid Finder-style ':' path weirdness and keep generated names filesystem-safe.
@@ -710,7 +714,7 @@ _mole_move_sudo_path_to_user_trash() {
         dest="$trash_dir/$base.$ts.$$.$suffix"
     done
 
-    if ! sudo mv -n "$path" "$dest" > /dev/null 2>&1; then
+    if ! sudo -n mv -n "$path" "$dest" > /dev/null 2>&1; then
         debug_log "Failed to move sudo-required path to invoking user Trash: $path -> $dest"
         return 1
     fi
@@ -721,7 +725,7 @@ _mole_move_sudo_path_to_user_trash() {
 
     # Best-effort ownership repair makes restored Trash items behave like user files.
     if [[ "$owner_uid" =~ ^[0-9]+$ && "$owner_gid" =~ ^[0-9]+$ ]]; then
-        sudo chown -R "$owner_uid:$owner_gid" "$dest" 2> /dev/null || true
+        sudo -n chown -R "$owner_uid:$owner_gid" "$dest" 2> /dev/null || true
     fi
 
     debug_log "Moved sudo-required path to invoking user Trash: $path -> $dest"
@@ -870,12 +874,12 @@ safe_sudo_find_delete() {
     fi
 
     # Validate base directory (use sudo for permission-restricted dirs)
-    if ! sudo test -d "$base_dir" 2> /dev/null; then
+    if ! sudo -n test -d "$base_dir" 2> /dev/null; then
         debug_log "Directory does not exist, skipping: $base_dir"
         return 0
     fi
 
-    if sudo test -L "$base_dir" 2> /dev/null; then
+    if sudo -n test -L "$base_dir" 2> /dev/null; then
         log_error "Refusing to search symlinked directory: $base_dir"
         return 1
     fi
@@ -908,7 +912,7 @@ safe_sudo_find_delete() {
             continue
         fi
         safe_sudo_remove "$match" || true
-    done < <(sudo find "$base_dir" "${find_args[@]}" -print0 2> /dev/null || true)
+    done < <(sudo -n find "$base_dir" "${find_args[@]}" -print0 2> /dev/null || true)
 
     return 0
 }

--- a/lib/core/sudo.sh
+++ b/lib/core/sudo.sh
@@ -278,6 +278,36 @@ has_sudo_session() {
     sudo -n true 2> /dev/null
 }
 
+adopt_sudo_session() {
+    if [[ "${MOLE_TEST_MODE:-0}" == "1" || "${MOLE_TEST_NO_AUTH:-0}" == "1" ]]; then
+        MOLE_SUDO_ESTABLISHED="false"
+        return 1
+    fi
+
+    if [[ "$MOLE_SUDO_ESTABLISHED" == "true" && -n "$MOLE_SUDO_KEEPALIVE_PID" ]]; then
+        if has_sudo_session; then
+            return 0
+        fi
+        _stop_sudo_keepalive "$MOLE_SUDO_KEEPALIVE_PID"
+        MOLE_SUDO_KEEPALIVE_PID=""
+        MOLE_SUDO_ESTABLISHED="false"
+    fi
+
+    if ! sudo -n -v 2> /dev/null; then
+        MOLE_SUDO_ESTABLISHED="false"
+        return 1
+    fi
+
+    if [[ -n "$MOLE_SUDO_KEEPALIVE_PID" ]]; then
+        _stop_sudo_keepalive "$MOLE_SUDO_KEEPALIVE_PID"
+        MOLE_SUDO_KEEPALIVE_PID=""
+    fi
+
+    MOLE_SUDO_KEEPALIVE_PID=$(_start_sudo_keepalive)
+    MOLE_SUDO_ESTABLISHED="true"
+    return 0
+}
+
 # Request administrative access
 request_sudo() {
     local prompt_msg="${1:-Admin access required}"

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -575,6 +575,7 @@ sudo() {
   if [[ "$1" == "-n" && "$2" == "true" ]]; then
     return 0
   fi
+  [[ "${1:-}" == "-n" ]] && shift
   if [[ "$1" == "find" ]]; then
     printf '%s\0' "$tmp_plist"
     return 0
@@ -626,6 +627,7 @@ sudo() {
   if [[ "$1" == "-n" && "$2" == "true" ]]; then
     return 0
   fi
+  [[ "${1:-}" == "-n" ]] && shift
   if [[ "$1" == "find" ]]; then
     case "$2" in
       /Library/LaunchDaemons) printf '%s\0' "$tmp_plist" ;;
@@ -678,6 +680,7 @@ sudo() {
   if [[ "$1" == "-n" && "$2" == "true" ]]; then
     return 0
   fi
+  [[ "${1:-}" == "-n" ]] && shift
   if [[ "$1" == "find" ]]; then
     case "$2" in
       /Library/PrivilegedHelperTools) printf '%s\0' "$tmp_helper" ;;
@@ -729,6 +732,7 @@ sudo() {
   if [[ "$1" == "-n" && "$2" == "true" ]]; then
     return 0
   fi
+  [[ "${1:-}" == "-n" ]] && shift
   if [[ "$1" == "find" ]]; then
     case "$2" in
       /Library/LaunchDaemons) printf '%s\0' "$tmp_plist" ;;
@@ -773,6 +777,7 @@ sudo() {
   if [[ "$1" == "-n" && "$2" == "true" ]]; then
     return 0
   fi
+  [[ "${1:-}" == "-n" ]] && shift
   if [[ "$1" == "find" ]]; then
     case "$2" in
       /Library/LaunchDaemons) printf '%s\0' "$tmp_plist" ;;

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -116,6 +116,42 @@ MOCK
     [[ "$output" == *"full preview"* ]]
 }
 
+@test "mo clean adopts cached sudo before system cleanup (#1084)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+TRACE="$HOME/sudo-adopt.log"
+> "$TRACE"
+
+source "$PROJECT_ROOT/bin/clean.sh"
+
+DRY_RUN=false
+EXTERNAL_VOLUME_TARGET=""
+
+sudo() {
+    printf 'sudo %s\n' "$*" >> "$TRACE"
+    [[ "${1:-}" == "-n" && "${2:-}" == "-v" ]]
+}
+_start_sudo_keepalive() {
+    printf 'keepalive\n' >> "$TRACE"
+    echo "keepalive-pid"
+}
+_stop_sudo_keepalive() { :; }
+
+start_cleanup
+cat "$TRACE"
+printf 'SYSTEM_CLEAN=%s\n' "$SYSTEM_CLEAN"
+printf 'MOLE_SUDO_ESTABLISHED=%s\n' "$MOLE_SUDO_ESTABLISHED"
+printf 'MOLE_SUDO_KEEPALIVE_PID=%s\n' "$MOLE_SUDO_KEEPALIVE_PID"
+SCRIPT
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sudo -n -v"* ]]
+    [[ "$output" == *"keepalive"* ]]
+    [[ "$output" == *"SYSTEM_CLEAN=true"* ]]
+    [[ "$output" == *"MOLE_SUDO_ESTABLISHED=true"* ]]
+    [[ "$output" == *"MOLE_SUDO_KEEPALIVE_PID=keepalive-pid"* ]]
+}
+
 @test "mo clean sudo prompt preserves a directly typed password (#1059)" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
         bash --noprofile --norc <<'SCRIPT'

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -35,6 +35,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/system.sh"
 
 sudo() {
+    [[ "${1:-}" == "-n" ]] && shift
     if [[ "$1" == "test" ]]; then
         return 0
     fi
@@ -114,6 +115,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/system.sh"
 
 sudo() {
+    [[ "${1:-}" == "-n" ]] && shift
     if [[ "$1" == "test" ]]; then
         return 0
     fi
@@ -166,6 +168,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/system.sh"
 
 sudo() {
+    [[ "${1:-}" == "-n" ]] && shift
     if [[ "$1" == "test" ]]; then
         return 0
     fi
@@ -221,6 +224,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/system.sh"
 
 sudo() {
+    [[ "${1:-}" == "-n" ]] && shift
     if [[ "$1" == "test" ]]; then
         return 0
     fi

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -573,3 +573,31 @@ SCRIPT
     [ "$status" -eq 0 ]
     [[ "$output" == *"EXIT=0"* ]]
 }
+
+@test "adopt_sudo_session starts keepalive for cached sudo" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/base.sh"
+source "$PROJECT_ROOT/lib/core/sudo.sh"
+
+sudo() {
+    printf 'SUDO:%s\n' "$*"
+    [[ "${1:-}" == "-n" && "${2:-}" == "-v" ]]
+}
+_start_sudo_keepalive() {
+    echo "keepalive-pid"
+}
+_stop_sudo_keepalive() { :; }
+
+adopt_sudo_session
+echo "EXIT=$?"
+echo "FLAG=$MOLE_SUDO_ESTABLISHED"
+echo "PID=$MOLE_SUDO_KEEPALIVE_PID"
+SCRIPT
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SUDO:-n -v"* ]]
+    [[ "$output" == *"EXIT=0"* ]]
+    [[ "$output" == *"FLAG=true"* ]]
+    [[ "$output" == *"PID=keepalive-pid"* ]]
+}

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -244,6 +244,138 @@ EOF
     [[ "$output" == *"Refusing to sudo remove symlink"* ]]
 }
 
+@test "safe_sudo_remove never opens an interactive sudo prompt" {
+    local target_dir="$TEST_DIR/sudo-target"
+    mkdir -p "$target_dir"
+    touch "$target_dir/file"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+sudo() {
+    if [[ "${1:-}" != "-n" ]]; then
+        echo "INTERACTIVE_SUDO:$*" >&2
+        return 99
+    fi
+    shift
+    case "${1:-}" in
+        test)
+            shift
+            command test "$@"
+            ;;
+        du)
+            shift
+            command du "$@"
+            ;;
+        rm)
+            shift
+            command rm "$@"
+            ;;
+        *)
+            "$@"
+            ;;
+    esac
+}
+export -f sudo
+
+safe_sudo_remove "$TARGET_DIR"
+[[ ! -e "$TARGET_DIR" ]]
+SCRIPT
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"INTERACTIVE_SUDO"* ]]
+}
+
+@test "safe_sudo_remove returns auth failure when noninteractive sudo expires" {
+    local target_dir="$TEST_DIR/sudo-expired"
+    mkdir -p "$target_dir"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 bash --noprofile --norc <<'SCRIPT'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+sudo() {
+    if [[ "${1:-}" != "-n" ]]; then
+        echo "INTERACTIVE_SUDO:$*" >&2
+        return 99
+    fi
+    echo "sudo: a password is required" >&2
+    return 1
+}
+export -f sudo
+
+safe_sudo_remove "$TARGET_DIR" && rc=0 || rc=$?
+echo "RC=$rc"
+[[ -e "$TARGET_DIR" ]]
+SCRIPT
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RC=11"* ]]
+    [[ "$output" != *"INTERACTIVE_SUDO"* ]]
+}
+
+@test "safe_sudo_find_delete never opens an interactive sudo prompt" {
+    local target_dir="$TEST_DIR/sudo-find-target"
+    local script="$TEST_DIR/sudo-find-delete-test.sh"
+    mkdir -p "$target_dir"
+    touch "$target_dir/old.log"
+
+    cat > "$script" <<'SCRIPT'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+TRACE="$TARGET_DIR/sudo.trace"
+> "$TRACE"
+
+sudo() {
+    printf 'SUDO:%s\n' "$*" >> "$TRACE"
+    if [[ "${1:-}" != "-n" ]]; then
+        echo "INTERACTIVE_SUDO:$*" >&2
+        return 99
+    fi
+    shift
+    case "${1:-}" in
+        test)
+            shift
+            command test "$@"
+            ;;
+        find)
+            printf '%s\0' "$TARGET_DIR/old.log"
+            ;;
+        du)
+            shift
+            command du "$@"
+            ;;
+        rm)
+            return 0
+            ;;
+        *)
+            "$@"
+            ;;
+    esac
+}
+export -f sudo
+
+set +e
+safe_sudo_find_delete "$TARGET_DIR" "*.log" "0" "f"
+rc=$?
+set -e
+printf 'RC=%s\n' "$rc"
+cat "$TRACE" || true
+exit 0
+SCRIPT
+    chmod +x "$script"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 bash --noprofile --norc "$script"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RC=0"* ]]
+    [[ "$output" == *"SUDO:-n test -d "* ]]
+    [[ "$output" == *"SUDO:-n test -L "* ]]
+    [[ "$output" == *"SUDO:-n find "* ]]
+    [[ "$output" != *"INTERACTIVE_SUDO"* ]]
+}
+
 @test "safe_find_delete rejects symlinked directory" {
     local real_dir="$TEST_DIR/real"
     local link_dir="$TEST_DIR/link"

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -84,6 +84,9 @@ SH
     cat > "$fake_bin/sudo" <<'SH'
 #!/bin/bash
 printf 'sudo %s\n' "$*" >> "$MOLE_TEST_TRACE"
+if [[ "${1:-}" == "-n" ]]; then
+    shift
+fi
 "$@"
 SH
     cat > "$fake_bin/osascript" <<'SH'
@@ -107,8 +110,8 @@ EOF
     [ "$status" -eq 0 ]
     [[ ! -e "$victim" ]]
     [[ -d "$fake_home/.Trash/$(basename "$victim")" ]]
-    [[ "$(grep -c '^sudo mv ' "$trace" 2> /dev/null || true)" -eq 1 ]]
-    [[ "$(grep -c '^sudo trash ' "$trace" 2> /dev/null || true)" -eq 0 ]]
+    [[ "$(grep -c '^sudo -n mv ' "$trace" 2> /dev/null || true)" -eq 1 ]]
+    [[ "$(grep -c '^sudo -n trash ' "$trace" 2> /dev/null || true)" -eq 0 ]]
     [[ "$(grep -c '^trash ' "$trace" 2> /dev/null || true)" -eq 0 ]]
     [[ "$(grep -c '^osascript ' "$trace" 2> /dev/null || true)" -eq 0 ]]
 
@@ -131,6 +134,9 @@ EOF
     cat > "$fake_bin/sudo" <<'SH'
 #!/bin/bash
 printf 'sudo %s\n' "$*" >> "$MOLE_TEST_TRACE"
+if [[ "${1:-}" == "-n" ]]; then
+    shift
+fi
 "$@"
 SH
     chmod +x "$fake_bin/sudo"
@@ -149,7 +155,7 @@ EOF
     [ "$status" -ne 0 ]
     [[ -e "$victim" ]]
     [[ -z "$(ls -A "$redirected" 2> /dev/null || true)" ]]
-    [[ "$(grep -c '^sudo mv ' "$trace" 2> /dev/null || true)" -eq 0 ]]
+    [[ "$(grep -c '^sudo -n mv ' "$trace" 2> /dev/null || true)" -eq 0 ]]
 
     local status_col
     status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")
@@ -169,6 +175,9 @@ EOF
     cat > "$fake_bin/sudo" <<'SH'
 #!/bin/bash
 printf 'sudo %s\n' "$*" >> "$MOLE_TEST_TRACE"
+if [[ "${1:-}" == "-n" ]]; then
+    shift
+fi
 "$@"
 SH
     chmod +x "$fake_bin/sudo"
@@ -188,7 +197,7 @@ EOF
     [[ ! -e "$victim" ]]
     [[ -d "$fake_home/.Trash/$(basename "$victim")" ]]
     [[ -n "$(find "$fake_home/.Trash" -mindepth 1 -maxdepth 1 -name "$(basename "$victim").*" -print -quit)" ]]
-    [[ "$(grep -c '^sudo mv -n ' "$trace" 2> /dev/null || true)" -eq 1 ]]
+    [[ "$(grep -c '^sudo -n mv -n ' "$trace" 2> /dev/null || true)" -eq 1 ]]
 
     local status_col
     status_col=$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")


### PR DESCRIPTION
## Summary
- adopt cached sudo sessions into Mole's keepalive before system cleanup starts
- make cleanup sudo probes, size checks, Trash moves, and removals use non-interactive sudo so credentials never prompt behind spinners
- add regression coverage for cached sudo adoption and non-interactive sudo deletion paths

Fixes #1084

## Safety review
- Deletion scope is unchanged: existing cleanup paths, filters, and safe deletion helpers are preserved.
- Privileged operations now fail closed with `sudo -n` instead of opening an invisible password prompt mid-cleanup.
- The GPU cache path still uses the existing narrow `is_rebuildable_gpu_cache_dir` guard and stale-cache check before removal.

## Tests
- `./scripts/check.sh --format`
- `./scripts/check.sh --no-format`
- `env -u NO_COLOR MOLE_TEST_NO_AUTH=1 npx --yes bats tests/core_common.bats tests/clean_core.bats tests/core_safe_functions.bats tests/clean_system_maintenance.bats tests/file_ops_mole_delete.bats tests/user_file_ops.bats tests/clean_apps.bats tests/clean_user_core.bats tests/dev_extended.bats`
- `env -u NO_COLOR MOLE_TEST_NO_AUTH=1 npx --yes bats tests/cli.bats`
