### PR TITLE
Draft: Explore ls-first analyze navigation

### DIFF
--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -27,24 +28,84 @@ func runScanResultCmd(t *testing.T, cmd tea.Cmd) scanResultMsg {
 	t.Helper()
 
 	msg := cmd()
+	if scanMsg, ok := scanResultMsgFromMsg(t, msg); ok {
+		return scanMsg
+	}
+	t.Fatalf("expected scanResultMsg or live scan result, got %T", msg)
+	return scanResultMsg{}
+}
+
+func scanResultMsgFromMsg(t *testing.T, msg tea.Msg) (scanResultMsg, bool) {
+	t.Helper()
+
 	switch typed := msg.(type) {
 	case scanResultMsg:
-		return typed
+		return typed, true
+	case liveScanStartMsg:
+		return drainLiveScanToResultMsg(t, typed), true
 	case tea.BatchMsg:
 		for _, batchCmd := range typed {
 			if batchCmd == nil {
 				continue
 			}
-			if scanMsg, ok := batchCmd().(scanResultMsg); ok {
-				return scanMsg
+			if scanMsg, ok := scanResultMsgFromMsg(t, batchCmd()); ok {
+				return scanMsg, true
 			}
 		}
-		t.Fatalf("expected tea.BatchMsg to contain a scanResultMsg, got %T", msg)
+		return scanResultMsg{}, false
 	default:
-		t.Fatalf("expected scanResultMsg or tea.BatchMsg, got %T", msg)
+		return scanResultMsg{}, false
 	}
+}
 
-	return scanResultMsg{}
+func drainLiveScanToResultMsg(t *testing.T, start liveScanStartMsg) scanResultMsg {
+	t.Helper()
+	if start.err != nil {
+		return scanResultMsg{path: start.path, err: start.err}
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case event, ok := <-start.events:
+			if !ok {
+				t.Fatalf("live scan event channel closed without completion")
+			}
+			switch event.kind {
+			case liveScanComplete:
+				return scanResultMsg{path: start.path, result: event.result}
+			case liveScanFailed:
+				return scanResultMsg{path: start.path, err: event.err}
+			case liveScanCanceled:
+				return scanResultMsg{path: start.path, err: event.err}
+			}
+		case <-deadline:
+			if start.cancel != nil {
+				start.cancel()
+			}
+			t.Fatalf("timed out waiting for live scan completion")
+		}
+	}
+}
+
+func cancelAndDrainLiveScan(start liveScanStartMsg) {
+	if start.cancel != nil {
+		start.cancel()
+	}
+	for range start.events {
+	}
+}
+
+func rowContaining(view, needle string) string {
+	for line := range strings.SplitSeq(view, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
+}
+
+func progressFillCount(row string) int {
+	return strings.Count(row, "█") + strings.Count(row, "▓") + strings.Count(row, "▒")
 }
 
 func TestScanPathConcurrentBasic(t *testing.T) {
@@ -713,6 +774,592 @@ func TestScanCmdTreatsWarmedCacheAsStale(t *testing.T) {
 	}
 	if scanMsg.result.TotalFiles != result.TotalFiles {
 		t.Fatalf("expected cached result to survive stale load, got %d", scanMsg.result.TotalFiles)
+	}
+}
+
+func TestLiveScanUXConfigFromEnv(t *testing.T) {
+	t.Setenv(liveSortModeEnv, "freeze-on-move")
+	t.Setenv(liveCursorModeEnv, "index")
+
+	m := newModel(t.TempDir(), false)
+	if m.liveSortMode != liveSortFreezeOnMove {
+		t.Fatalf("expected freeze-on-move sort mode, got %v", m.liveSortMode)
+	}
+	if m.liveCursorMode != liveCursorByIndex {
+		t.Fatalf("expected index cursor mode, got %v", m.liveCursorMode)
+	}
+}
+
+func TestLiveScanDefaultsToPathCursor(t *testing.T) {
+	m := newModel(t.TempDir(), false)
+	if m.liveCursorMode != liveCursorByPath {
+		t.Fatalf("expected default path cursor mode, got %v", m.liveCursorMode)
+	}
+}
+
+func TestLiveScanInitialListingShowsImmediateChildren(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := filepath.Join(home, "root")
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	filePath := filepath.Join(root, "root.txt")
+	if err := os.WriteFile(filePath, []byte("root-data"), 0o644); err != nil {
+		t.Fatalf("write root file: %v", err)
+	}
+
+	m := newModel(root, false)
+	msg := m.scanFreshCmd(root)()
+	start, ok := msg.(liveScanStartMsg)
+	if !ok {
+		t.Fatalf("expected liveScanStartMsg, got %T", msg)
+	}
+	defer cancelAndDrainLiveScan(start)
+
+	foundFile := false
+	foundDir := false
+	for _, entry := range start.entries {
+		switch entry.Path {
+		case filePath:
+			foundFile = true
+			if entry.Size <= 0 {
+				t.Fatalf("expected file size to be known immediately, got %d", entry.Size)
+			}
+		case child:
+			foundDir = true
+			if entry.Size != -1 {
+				t.Fatalf("expected child directory to start pending, got %d", entry.Size)
+			}
+		}
+	}
+	if !foundFile || !foundDir {
+		t.Fatalf("expected immediate file and directory entries, got %+v", start.entries)
+	}
+}
+
+func TestLiveScanStartDoesNotAddSecondSpinnerTick(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	m := newModel(root, false)
+	start := m.scanFreshCmd(root)().(liveScanStartMsg)
+	defer cancelAndDrainLiveScan(start)
+
+	_, cmd := m.Update(start)
+	if cmd == nil {
+		t.Fatalf("expected live scan start to wait for scan events")
+	}
+	if _, ok := cmd().(tickMsg); ok {
+		t.Fatalf("live scan start must not schedule an extra spinner tick")
+	}
+}
+
+func TestOverviewHomeNavigationRendersImmediateRows(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	downloads := filepath.Join(home, "Downloads")
+	desktop := filepath.Join(home, "Desktop")
+	for _, dir := range []string{downloads, desktop} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, "note.txt"), []byte("home-note"), 0o644); err != nil {
+		t.Fatalf("write home file: %v", err)
+	}
+
+	m := newModel("/", true)
+	for i, entry := range m.entries {
+		if entry.Path == home {
+			m.selected = i
+			break
+		}
+	}
+
+	updated, cmd := m.enterSelectedDir()
+	if cmd == nil {
+		t.Fatalf("expected Home navigation to start a scan")
+	}
+	got := updated.(model)
+	if got.path != home {
+		t.Fatalf("expected path %s, got %s", home, got.path)
+	}
+
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("expected navigation command batch, got %T", msg)
+	}
+	var start liveScanStartMsg
+	for _, batchCmd := range batch {
+		if batchCmd == nil {
+			continue
+		}
+		if candidate, ok := batchCmd().(liveScanStartMsg); ok {
+			start = candidate
+			break
+		}
+	}
+	if start.events == nil {
+		t.Fatalf("expected batch to include live scan start")
+	}
+	defer cancelAndDrainLiveScan(start)
+
+	updated, _ = got.Update(start)
+	got = updated.(model)
+	view := got.View()
+	for _, want := range []string{"Downloads", "Desktop", "note.txt"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected Home view to contain %q, got:\n%s", want, view)
+		}
+	}
+}
+
+func TestLiveScanChildUpdateUpdatesRowTotalAndCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	root := filepath.Join(home, "root")
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "data.bin"), []byte(strings.Repeat("x", 4096)), 0o644); err != nil {
+		t.Fatalf("write child file: %v", err)
+	}
+
+	m := newModel(root, false)
+	start := m.scanFreshCmd(root)().(liveScanStartMsg)
+	defer cancelAndDrainLiveScan(start)
+
+	updated, _ := m.Update(start)
+	liveModel := updated.(model)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case event := <-start.events:
+			if event.kind != liveScanChildDone {
+				continue
+			}
+			updated, _ = liveModel.Update(event)
+			liveModel = updated.(model)
+
+			var found dirEntry
+			for _, entry := range liveModel.entries {
+				if entry.Path == child {
+					found = entry
+					break
+				}
+			}
+			if found.Path == "" {
+				t.Fatalf("expected child row to remain visible")
+			}
+			if found.Size <= 0 {
+				t.Fatalf("expected child row size to update, got %d", found.Size)
+			}
+			if liveModel.totalSize != found.Size {
+				t.Fatalf("expected total size %d, got %d", found.Size, liveModel.totalSize)
+			}
+			cached, ok := liveModel.cache[child]
+			if !ok {
+				t.Fatalf("expected child result to warm in-memory cache")
+			}
+			if cached.TotalSize != found.Size {
+				t.Fatalf("cached child size mismatch: want %d, got %d", found.Size, cached.TotalSize)
+			}
+			return
+		case <-deadline:
+			t.Fatalf("timed out waiting for child update")
+		}
+	}
+}
+
+func TestLiveScanStartPreservesEntryFilterBackingList(t *testing.T) {
+	root := t.TempDir()
+	apps := filepath.Join(root, "apps")
+	logs := filepath.Join(root, "logs")
+
+	m := newModel(root, false)
+	m.entryFilter = "app"
+	start := liveScanStartMsg{
+		id:   1,
+		path: root,
+		entries: []dirEntry{
+			{Name: "apps", Path: apps, Size: -1, IsDir: true},
+			{Name: "logs", Path: logs, Size: -1, IsDir: true},
+		},
+		events: make(chan liveScanEventMsg),
+		cancel: func() {},
+	}
+
+	updated, _ := m.Update(start)
+	got := updated.(model)
+	if len(got.entriesAll) != 2 {
+		t.Fatalf("expected backing list to keep both live entries, got %+v", got.entriesAll)
+	}
+	if len(got.entries) != 1 || got.entries[0].Path != apps {
+		t.Fatalf("expected active filter to render only apps, got %+v", got.entries)
+	}
+}
+
+func TestLiveScanIgnoresStaleEventsAfterNavigation(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+
+	m := newModel(other, false)
+	m.liveScanID = 2
+	m.liveScanEvents = make(chan liveScanEventMsg)
+	m.entries = []dirEntry{{Name: "current", Path: filepath.Join(other, "current"), Size: 1}}
+	m.totalSize = 1
+
+	stale := liveScanEventMsg{
+		id:   1,
+		path: root,
+		kind: liveScanChildDone,
+		entry: dirEntry{
+			Name:  "stale",
+			Path:  filepath.Join(root, "stale"),
+			Size:  99,
+			IsDir: true,
+		},
+		result: scanResult{TotalSize: 99},
+	}
+
+	updated, _ := m.Update(stale)
+	got := updated.(model)
+	if got.totalSize != 1 || len(got.entries) != 1 || got.entries[0].Name != "current" {
+		t.Fatalf("stale event changed model: %+v", got)
+	}
+}
+
+func TestLiveScanDefaultCursorByPathKeepsSelectedPathAcrossReorder(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+
+	m := newModel(root, false)
+	m.liveScanID = 1
+	m.liveScanEvents = make(chan liveScanEventMsg)
+	m.scanning = true
+	m.autoSortLiveEntries = true
+	m.liveSortMode = liveSortContinuous
+	m.liveScanningPaths = map[string]bool{a: true, b: true}
+	m.entries = []dirEntry{
+		{Name: "a", Path: a, Size: -1, IsDir: true},
+		{Name: "b", Path: b, Size: -1, IsDir: true},
+	}
+	m.entriesAll = slices.Clone(m.entries)
+
+	updated, _ := m.Update(liveScanEventMsg{
+		id:     1,
+		path:   root,
+		kind:   liveScanChildDone,
+		entry:  dirEntry{Name: "b", Path: b, Size: 10, IsDir: true},
+		result: scanResult{TotalSize: 10},
+	})
+	m = updated.(model)
+	if got := []string{m.entries[0].Path, m.entries[1].Path}; !slices.Equal(got, []string{b, a}) {
+		t.Fatalf("expected live sort to reorder by size, got %v", got)
+	}
+	if m.entries[m.selected].Path != a {
+		t.Fatalf("expected default cursor to stay on %s, selected=%d entries=%+v", a, m.selected, m.entries)
+	}
+
+	updated, _ = m.enterSelectedDir()
+	got := updated.(model)
+	if got.path != a {
+		t.Fatalf("expected Enter to drill into selected path %s, got %s", a, got.path)
+	}
+}
+
+func TestLiveScanProgressUpdatesRowBarAndPercent(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	sibling := filepath.Join(root, "sibling.bin")
+
+	m := newModel(root, false)
+	m.liveScanID = 1
+	m.liveScanEvents = make(chan liveScanEventMsg)
+	m.scanning = true
+	m.autoSortLiveEntries = false
+	m.liveScanningPaths = map[string]bool{child: true}
+	m.entries = []dirEntry{
+		{Name: "child", Path: child, Size: -1, IsDir: true},
+		{Name: "sibling.bin", Path: sibling, Size: 100},
+	}
+	m.totalSize = 100
+
+	updated, _ := m.Update(liveScanEventMsg{
+		id:    1,
+		path:  root,
+		kind:  liveScanChildProgress,
+		entry: dirEntry{Name: "child", Path: child, Size: 10, IsDir: true},
+	})
+	m = updated.(model)
+	firstRow := rowContaining(m.View(), "child")
+	firstFill := progressFillCount(firstRow)
+	if !strings.Contains(firstRow, "9.1%") {
+		t.Fatalf("expected first progress row to show 9.1%%, got:\n%s", firstRow)
+	}
+
+	updated, _ = m.Update(liveScanEventMsg{
+		id:    1,
+		path:  root,
+		kind:  liveScanChildProgress,
+		entry: dirEntry{Name: "child", Path: child, Size: 50, IsDir: true},
+	})
+	m = updated.(model)
+	secondRow := rowContaining(m.View(), "child")
+	secondFill := progressFillCount(secondRow)
+	if !strings.Contains(secondRow, "33.3%") {
+		t.Fatalf("expected second progress row to show 33.3%%, got:\n%s", secondRow)
+	}
+	if secondFill <= firstFill {
+		t.Fatalf("expected child progress bar fill to increase, first=%d second=%d\nfirst: %s\nsecond: %s", firstFill, secondFill, firstRow, secondRow)
+	}
+	if m.totalSize != 150 {
+		t.Fatalf("expected total known size to grow to 150, got %d", m.totalSize)
+	}
+	if _, ok := m.cache[child]; ok {
+		t.Fatalf("progress event must not warm child cache before completion")
+	}
+	if !m.liveScanningPaths[child] {
+		t.Fatalf("progress event must keep child marked as scanning")
+	}
+}
+
+func TestLiveScanContinuousSortKeepsCursorByIndex(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+
+	m := newModel(root, false)
+	m.liveScanID = 1
+	m.liveScanEvents = make(chan liveScanEventMsg)
+	m.scanning = true
+	m.autoSortLiveEntries = true
+	m.liveSortMode = liveSortContinuous
+	m.liveCursorMode = liveCursorByIndex
+	m.liveScanningPaths = map[string]bool{a: true, b: true}
+	m.entries = []dirEntry{
+		{Name: "a", Path: a, Size: -1, IsDir: true},
+		{Name: "b", Path: b, Size: -1, IsDir: true},
+	}
+
+	updated, _ := m.Update(liveScanEventMsg{
+		id:     1,
+		path:   root,
+		kind:   liveScanChildDone,
+		entry:  dirEntry{Name: "b", Path: b, Size: 10, IsDir: true},
+		result: scanResult{TotalSize: 10},
+	})
+	m = updated.(model)
+	if m.entries[0].Path != b {
+		t.Fatalf("expected live auto-sort to move larger row first, got %+v", m.entries)
+	}
+
+	updated, _ = m.updateKey(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(model)
+	if !m.autoSortLiveEntries {
+		t.Fatalf("expected navigation key to keep live sort enabled")
+	}
+	if m.entries[m.selected].Path != a {
+		t.Fatalf("expected selection to move to a before reorder, got selected=%d entries=%+v", m.selected, m.entries)
+	}
+	selectedIndex := m.selected
+
+	updated, _ = m.Update(liveScanEventMsg{
+		id:     1,
+		path:   root,
+		kind:   liveScanChildDone,
+		entry:  dirEntry{Name: "a", Path: a, Size: 100, IsDir: true},
+		result: scanResult{TotalSize: 100},
+	})
+	m = updated.(model)
+	if got := []string{m.entries[0].Path, m.entries[1].Path}; !slices.Equal(got, []string{a, b}) {
+		t.Fatalf("expected live sort to continue after navigation, got %v", got)
+	}
+	if m.selected != selectedIndex {
+		t.Fatalf("expected selection index to stay %d, got %d", selectedIndex, m.selected)
+	}
+	if m.entries[m.selected].Path != b {
+		t.Fatalf("expected cursor-by-index to now point at row %d (%s), selected entries=%+v", selectedIndex, b, m.entries)
+	}
+}
+
+func TestLiveScanContinuousSortCanKeepCursorByPath(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+
+	m := newModel(root, false)
+	m.liveScanID = 1
+	m.liveScanEvents = make(chan liveScanEventMsg)
+	m.scanning = true
+	m.autoSortLiveEntries = true
+	m.liveSortMode = liveSortContinuous
+	m.liveCursorMode = liveCursorByPath
+	m.liveScanningPaths = map[string]bool{a: true, b: true}
+	m.entries = []dirEntry{
+		{Name: "a", Path: a, Size: -1, IsDir: true},
+		{Name: "b", Path: b, Size: -1, IsDir: true},
+	}
+
+	updated, _ := m.Update(liveScanEventMsg{
+		id:     1,
+		path:   root,
+		kind:   liveScanChildDone,
+		entry:  dirEntry{Name: "b", Path: b, Size: 10, IsDir: true},
+		result: scanResult{TotalSize: 10},
+	})
+	m = updated.(model)
+	updated, _ = m.updateKey(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(model)
+	if m.entries[m.selected].Path != a {
+		t.Fatalf("expected selection to move to a before reorder, got selected=%d entries=%+v", m.selected, m.entries)
+	}
+
+	updated, _ = m.Update(liveScanEventMsg{
+		id:     1,
+		path:   root,
+		kind:   liveScanChildDone,
+		entry:  dirEntry{Name: "a", Path: a, Size: 100, IsDir: true},
+		result: scanResult{TotalSize: 100},
+	})
+	m = updated.(model)
+	if got := []string{m.entries[0].Path, m.entries[1].Path}; !slices.Equal(got, []string{a, b}) {
+		t.Fatalf("expected live sort to continue after navigation, got %v", got)
+	}
+	if m.entries[m.selected].Path != a {
+		t.Fatalf("expected cursor-by-path to stay on %s after reorder, selected=%d entries=%+v", a, m.selected, m.entries)
+	}
+}
+
+func TestLiveScanSortCanFreezeAfterNavigationKey(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+
+	m := newModel(root, false)
+	m.liveScanID = 1
+	m.liveScanEvents = make(chan liveScanEventMsg)
+	m.scanning = true
+	m.autoSortLiveEntries = true
+	m.liveSortMode = liveSortFreezeOnMove
+	m.liveCursorMode = liveCursorByIndex
+	m.liveScanningPaths = map[string]bool{a: true, b: true}
+	m.entries = []dirEntry{
+		{Name: "a", Path: a, Size: -1, IsDir: true},
+		{Name: "b", Path: b, Size: -1, IsDir: true},
+	}
+
+	updated, _ := m.Update(liveScanEventMsg{
+		id:     1,
+		path:   root,
+		kind:   liveScanChildDone,
+		entry:  dirEntry{Name: "b", Path: b, Size: 10, IsDir: true},
+		result: scanResult{TotalSize: 10},
+	})
+	m = updated.(model)
+	updated, _ = m.updateKey(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(model)
+	if m.autoSortLiveEntries {
+		t.Fatalf("expected freeze-on-move to disable live sort")
+	}
+	before := []string{m.entries[0].Path, m.entries[1].Path}
+
+	updated, _ = m.Update(liveScanEventMsg{
+		id:     1,
+		path:   root,
+		kind:   liveScanChildDone,
+		entry:  dirEntry{Name: "a", Path: a, Size: 100, IsDir: true},
+		result: scanResult{TotalSize: 100},
+	})
+	m = updated.(model)
+	after := []string{m.entries[0].Path, m.entries[1].Path}
+	if !slices.Equal(before, after) {
+		t.Fatalf("expected freeze-on-move to keep row order %v, got %v", before, after)
+	}
+}
+
+func TestScanningViewRendersRowsWithSpinner(t *testing.T) {
+	m := model{
+		path:      "/tmp/project",
+		scanning:  true,
+		spinner:   1,
+		totalSize: 8,
+		entries: []dirEntry{
+			{Name: "child", Path: "/tmp/project/child", Size: -1, IsDir: true},
+			{Name: "file.txt", Path: "/tmp/project/file.txt", Size: 8},
+		},
+		liveScanningPaths: map[string]bool{"/tmp/project/child": true},
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "child") || !strings.Contains(view, "file.txt") {
+		t.Fatalf("expected scanning view to render rows, got:\n%s", view)
+	}
+	if !strings.Contains(view, spinnerFrames[m.spinner]+" scanning") {
+		t.Fatalf("expected pending directory spinner in row, got:\n%s", view)
+	}
+}
+
+func TestScanningViewShowsSpinnerDividerForPartiallySizedFolders(t *testing.T) {
+	m := model{
+		path:      "/tmp/project",
+		scanning:  true,
+		spinner:   1,
+		totalSize: 150,
+		entries: []dirEntry{
+			{Name: "child", Path: "/tmp/project/child", Size: 50, IsDir: true},
+			{Name: "file.txt", Path: "/tmp/project/file.txt", Size: 100},
+		},
+		liveScanningPaths: map[string]bool{"/tmp/project/child": true},
+	}
+
+	view := m.View()
+	childRow := rowContaining(view, "child")
+	fileRow := rowContaining(view, "file.txt")
+	if !strings.Contains(childRow, spinnerFrames[m.spinner]) {
+		t.Fatalf("expected active child row divider to show spinner, got:\n%s", childRow)
+	}
+	if strings.Contains(fileRow, spinnerFrames[m.spinner]) {
+		t.Fatalf("expected non-scanning file row to keep static divider, got:\n%s", fileRow)
+	}
+}
+
+func TestEnterSelectedDirMarksScanningParentForRefresh(t *testing.T) {
+	root := t.TempDir()
+	child := filepath.Join(root, "child")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	cancelled := false
+	m := newModel(root, false)
+	m.entries = []dirEntry{{Name: "child", Path: child, Size: -1, IsDir: true}}
+	m.scanning = true
+	m.liveScanID = 1
+	m.liveScanCancel = func() { cancelled = true }
+
+	updated, cmd := m.enterSelectedDir()
+	if cmd == nil {
+		t.Fatalf("expected child navigation to start a scan")
+	}
+	got := updated.(model)
+	if !cancelled {
+		t.Fatalf("expected active parent scan to be cancelled")
+	}
+	if len(got.history) != 1 || !got.history[0].NeedsRefresh {
+		t.Fatalf("expected scanning parent history to be marked for refresh, got %+v", got.history)
 	}
 }
 

--- a/cmd/analyze/cache.go
+++ b/cmd/analyze/cache.go
@@ -43,7 +43,7 @@ func snapshotFromModel(m model) historyEntry {
 		EntryOffset:   m.offset,
 		LargeSelected: m.largeSelected,
 		LargeOffset:   m.largeOffset,
-		NeedsRefresh:  m.viewNeedsRefresh,
+		NeedsRefresh:  m.viewNeedsRefresh || m.scanning,
 		IsOverview:    m.isOverview,
 	}
 }

--- a/cmd/analyze/live_config.go
+++ b/cmd/analyze/live_config.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	liveSortModeEnv   = "MOLE_ANALYZE_LIVE_SORT"
+	liveCursorModeEnv = "MOLE_ANALYZE_LIVE_CURSOR"
+)
+
+func liveScanSortModeFromEnv() liveSortMode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(liveSortModeEnv))) {
+	case "freeze", "freeze-on-move", "freeze_on_move", "stop-on-move", "stop_on_move":
+		return liveSortFreezeOnMove
+	default:
+		return liveSortContinuous
+	}
+}
+
+func liveScanCursorModeFromEnv() liveCursorMode {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(liveCursorModeEnv))) {
+	case "index":
+		return liveCursorByIndex
+	default:
+		return liveCursorByPath
+	}
+}
+
+func nextLiveSortMode(mode liveSortMode) liveSortMode {
+	if mode == liveSortContinuous {
+		return liveSortFreezeOnMove
+	}
+	return liveSortContinuous
+}
+
+func liveSortModeLabel(mode liveSortMode) string {
+	if mode == liveSortFreezeOnMove {
+		return "freeze-on-move"
+	}
+	return "continuous"
+}

--- a/cmd/analyze/live_scan.go
+++ b/cmd/analyze/live_scan.go
@@ -1,0 +1,469 @@
+//go:build darwin
+
+package main
+
+import (
+	"container/heap"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+var nextLiveScanID atomic.Int64
+
+type liveScanTargetKind int
+
+const (
+	liveScanTargetDirectory liveScanTargetKind = iota + 1
+	liveScanTargetFoldedDirectory
+	liveScanTargetHomeLibrary
+)
+
+type liveScanTarget struct {
+	name string
+	path string
+	kind liveScanTargetKind
+}
+
+func startLiveScanCmd(path string, filesScanned, dirsScanned, bytesScanned *int64, currentPath *atomic.Value) tea.Cmd {
+	return func() tea.Msg {
+		id := nextLiveScanID.Add(1)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		limiter := newScanLimiter(0)
+		entries, targets, totalSize, totalFiles, largeFiles, err := readLiveScanInitialEntries(path, limiter)
+		if err != nil {
+			cancel()
+			return liveScanStartMsg{id: id, path: path, err: err}
+		}
+
+		if totalFiles > 0 {
+			atomic.AddInt64(filesScanned, totalFiles)
+		}
+		if totalSize > 0 {
+			atomic.AddInt64(bytesScanned, totalSize)
+		}
+
+		events := make(chan liveScanEventMsg, max(len(targets)*4, 1))
+		go runLiveScan(ctx, id, path, entries, targets, totalSize, totalFiles, largeFiles, limiter, filesScanned, dirsScanned, bytesScanned, currentPath, events)
+
+		scanningPaths := make([]string, 0, len(targets))
+		for _, target := range targets {
+			scanningPaths = append(scanningPaths, target.path)
+		}
+
+		return liveScanStartMsg{
+			id:            id,
+			path:          path,
+			entries:       entries,
+			totalSize:     totalSize,
+			totalFiles:    totalFiles,
+			largeFiles:    largeFiles,
+			scanningPaths: scanningPaths,
+			events:        events,
+			cancel:        cancel,
+		}
+	}
+}
+
+func readLiveScanInitialEntries(root string, limiter *scanLimiter) ([]dirEntry, []liveScanTarget, int64, int64, []fileEntry, error) {
+	children, err := os.ReadDir(root)
+	if err != nil {
+		return nil, nil, 0, 0, nil, err
+	}
+	if limiter == nil {
+		limiter = newScanLimiter(len(children))
+	}
+
+	isRootDir := root == "/"
+	home := os.Getenv("HOME")
+	isHomeDir := home != "" && root == home
+
+	entries := make([]dirEntry, 0, len(children))
+	targets := make([]liveScanTarget, 0, len(children))
+	largeFiles := make([]fileEntry, 0)
+	var totalSize int64
+	var totalFiles int64
+
+	for _, child := range children {
+		fullPath := filepath.Join(root, child.Name())
+
+		if child.Type()&fs.ModeSymlink != 0 {
+			targetInfo, err := os.Stat(fullPath)
+			isDir := false
+			if err == nil && targetInfo.IsDir() {
+				isDir = true
+			}
+			info, err := child.Info()
+			if err != nil {
+				continue
+			}
+			size := getActualFileSize(fullPath, info)
+			totalSize += size
+			entries = append(entries, dirEntry{
+				Name:       child.Name() + " →",
+				Path:       fullPath,
+				Size:       size,
+				IsDir:      isDir,
+				LastAccess: getLastAccessTimeFromInfo(info),
+			})
+			continue
+		}
+
+		if child.IsDir() {
+			if defaultSkipDirs[child.Name()] {
+				continue
+			}
+			if isRootDir && skipSystemDirs[child.Name()] {
+				continue
+			}
+
+			targetKind := liveScanTargetDirectory
+			if isHomeDir && child.Name() == "Library" {
+				targetKind = liveScanTargetHomeLibrary
+			} else if shouldFoldDirWithPath(child.Name(), fullPath) {
+				targetKind = liveScanTargetFoldedDirectory
+			}
+
+			entries = append(entries, dirEntry{
+				Name:  child.Name(),
+				Path:  fullPath,
+				Size:  -1,
+				IsDir: true,
+			})
+			targets = append(targets, liveScanTarget{
+				name: child.Name(),
+				path: fullPath,
+				kind: targetKind,
+			})
+			continue
+		}
+
+		info, err := child.Info()
+		if err != nil {
+			continue
+		}
+		size, _ := countableFileSize(info, &limiter.seen)
+		totalSize += size
+		totalFiles++
+		entries = append(entries, dirEntry{
+			Name:       child.Name(),
+			Path:       fullPath,
+			Size:       size,
+			IsDir:      false,
+			LastAccess: getLastAccessTimeFromInfo(info),
+		})
+		if !shouldSkipFileForLargeTracking(fullPath) && size >= largeFileWarmupMinSize {
+			largeFiles = append(largeFiles, fileEntry{Name: child.Name(), Path: fullPath, Size: size})
+		}
+	}
+
+	sortDirEntriesBySize(entries)
+	largeFiles = topLargeFiles(largeFiles)
+	return entries, targets, totalSize, totalFiles, largeFiles, nil
+}
+
+func runLiveScan(
+	ctx context.Context,
+	id int64,
+	root string,
+	initialEntries []dirEntry,
+	targets []liveScanTarget,
+	initialTotalSize int64,
+	initialTotalFiles int64,
+	initialLargeFiles []fileEntry,
+	limiter *scanLimiter,
+	filesScanned, dirsScanned, bytesScanned *int64,
+	currentPath *atomic.Value,
+	events chan<- liveScanEventMsg,
+) {
+	defer close(events)
+
+	entriesByPath := make(map[string]dirEntry, len(initialEntries))
+	for _, entry := range initialEntries {
+		entriesByPath[entry.Path] = entry
+	}
+
+	var totalSize atomic.Int64
+	var totalFiles atomic.Int64
+	totalSize.Store(initialTotalSize)
+	totalFiles.Store(initialTotalFiles)
+
+	largeFileChan := make(chan fileEntry, maxLargeFiles*2)
+	largeFileMinSize := int64(largeFileWarmupMinSize)
+	largeFilesDone := make(chan []fileEntry, 1)
+	go collectLiveLargeFiles(initialLargeFiles, largeFileChan, &largeFileMinSize, largeFilesDone)
+
+	var dedupedHardlink atomic.Bool
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, target := range targets {
+		if ctx.Err() != nil {
+			break
+		}
+		target := target
+		scanTarget := func() {
+			defer wg.Done()
+			result, err := scanLiveTargetWithProgress(ctx, id, root, target, largeFileChan, &largeFileMinSize, limiter, currentPath, events)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				sendLiveScanEvent(ctx, events, liveScanEventMsg{id: id, path: root, kind: liveScanFailed, entry: dirEntry{Name: target.name, Path: target.path, IsDir: true}, err: err})
+				return
+			}
+			if ctx.Err() != nil {
+				return
+			}
+
+			entry := dirEntry{
+				Name:  target.name,
+				Path:  target.path,
+				Size:  result.TotalSize,
+				IsDir: true,
+			}
+			mu.Lock()
+			entriesByPath[target.path] = entry
+			mu.Unlock()
+
+			totalSize.Add(result.TotalSize)
+			if result.TotalFiles > 0 {
+				totalFiles.Add(result.TotalFiles)
+			}
+			if result.dedupedHardlink {
+				dedupedHardlink.Store(true)
+			}
+			atomic.AddInt64(dirsScanned, 1)
+			if result.TotalFiles > 0 {
+				atomic.AddInt64(filesScanned, result.TotalFiles)
+			}
+			if result.TotalSize > 0 {
+				atomic.AddInt64(bytesScanned, result.TotalSize)
+			}
+
+			sendLiveScanEvent(ctx, events, liveScanEventMsg{
+				id:     id,
+				path:   root,
+				kind:   liveScanChildDone,
+				entry:  entry,
+				result: result,
+			})
+		}
+
+		wg.Add(1)
+		if limiter.tryAcquireEntry() {
+			go func() {
+				defer limiter.releaseEntry()
+				scanTarget()
+			}()
+		} else {
+			scanTarget()
+		}
+	}
+
+	wg.Wait()
+	close(largeFileChan)
+	largeFiles := <-largeFilesDone
+
+	if ctx.Err() != nil {
+		sendLiveScanEvent(context.Background(), events, liveScanEventMsg{id: id, path: root, kind: liveScanCanceled, err: ctx.Err()})
+		return
+	}
+
+	mu.Lock()
+	finalEntries := make([]dirEntry, 0, len(entriesByPath))
+	for _, entry := range entriesByPath {
+		finalEntries = append(finalEntries, entry)
+	}
+	mu.Unlock()
+	sortDirEntriesBySize(finalEntries)
+	if len(finalEntries) > maxEntries {
+		finalEntries = finalEntries[:maxEntries]
+	}
+
+	result := scanResult{
+		Entries:         finalEntries,
+		LargeFiles:      largeFiles,
+		TotalSize:       totalSize.Load(),
+		TotalFiles:      totalFiles.Load(),
+		dedupedHardlink: dedupedHardlink.Load(),
+	}
+
+	sendLiveScanEvent(ctx, events, liveScanEventMsg{id: id, path: root, kind: liveScanComplete, result: result})
+}
+
+func scanLiveTargetWithProgress(ctx context.Context, id int64, root string, target liveScanTarget, largeFileChan chan<- fileEntry, largeFileMinSize *int64, limiter *scanLimiter, currentPath *atomic.Value, events chan<- liveScanEventMsg) (scanResult, error) {
+	var filesScanned int64
+	var dirsScanned int64
+	var bytesScanned int64
+	localCurrentPath := &atomic.Value{}
+	localCurrentPath.Store("")
+	done := make(chan struct{})
+	progressDone := make(chan struct{})
+
+	go func() {
+		defer close(progressDone)
+		ticker := time.NewTicker(uiTickInterval * 2)
+		defer ticker.Stop()
+
+		var lastSize int64
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-ticker.C:
+				size := atomic.LoadInt64(&bytesScanned)
+				if size <= 0 || size == lastSize {
+					continue
+				}
+				lastSize = size
+				if currentPath != nil {
+					if path, _ := localCurrentPath.Load().(string); path != "" {
+						currentPath.Store(path)
+					}
+				}
+				sendLiveScanProgress(ctx, events, liveScanEventMsg{
+					id:   id,
+					path: root,
+					kind: liveScanChildProgress,
+					entry: dirEntry{
+						Name:  target.name,
+						Path:  target.path,
+						Size:  size,
+						IsDir: true,
+					},
+				})
+			}
+		}
+	}()
+
+	result, err := scanLiveTarget(ctx, target, largeFileChan, largeFileMinSize, limiter, &filesScanned, &dirsScanned, &bytesScanned, localCurrentPath)
+	close(done)
+	<-progressDone
+	if result.TotalFiles == 0 {
+		result.TotalFiles = atomic.LoadInt64(&filesScanned)
+	}
+	if result.TotalSize == 0 {
+		result.TotalSize = atomic.LoadInt64(&bytesScanned)
+	}
+	return result, err
+}
+
+func scanLiveTarget(ctx context.Context, target liveScanTarget, largeFileChan chan<- fileEntry, largeFileMinSize *int64, limiter *scanLimiter, filesScanned, dirsScanned, bytesScanned *int64, currentPath *atomic.Value) (scanResult, error) {
+	if err := ctx.Err(); err != nil {
+		return scanResult{}, err
+	}
+
+	switch target.kind {
+	case liveScanTargetHomeLibrary:
+		if cached, err := loadStoredOverviewSize(target.path); err == nil && cached > 0 {
+			return scanResult{TotalSize: cached}, nil
+		}
+	case liveScanTargetFoldedDirectory:
+		size, err := getDirectorySizeFromDu(target.path)
+		if err != nil || size <= 0 {
+			size = calculateDirSizeFastWithLimiter(target.path, limiter, filesScanned, dirsScanned, bytesScanned, currentPath)
+		} else {
+			atomic.AddInt64(bytesScanned, size)
+		}
+		return scanResult{TotalSize: size}, nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return scanResult{}, err
+	}
+
+	result := scanSubdirWithCache(target.path, largeFileChan, largeFileMinSize, limiter, limiter.dirSem, limiter.duSem, limiter.duQueueSem, filesScanned, dirsScanned, bytesScanned, currentPath)
+	return result, ctx.Err()
+}
+
+func collectLiveLargeFiles(initial []fileEntry, largeFileChan <-chan fileEntry, largeFileMinSize *int64, done chan<- []fileEntry) {
+	h := &largeFileHeap{}
+	heap.Init(h)
+	for _, file := range initial {
+		pushLiveLargeFile(h, file, largeFileMinSize)
+	}
+	for file := range largeFileChan {
+		pushLiveLargeFile(h, file, largeFileMinSize)
+	}
+	files := make([]fileEntry, h.Len())
+	for i := range slices.Backward(files) {
+		files[i] = heap.Pop(h).(fileEntry)
+	}
+	done <- files
+}
+
+func pushLiveLargeFile(h *largeFileHeap, file fileEntry, largeFileMinSize *int64) {
+	if h.Len() < maxLargeFiles {
+		heap.Push(h, file)
+		if h.Len() == maxLargeFiles {
+			atomic.StoreInt64(largeFileMinSize, (*h)[0].Size)
+		}
+		return
+	}
+	if file.Size > (*h)[0].Size {
+		heap.Pop(h)
+		heap.Push(h, file)
+		atomic.StoreInt64(largeFileMinSize, (*h)[0].Size)
+	}
+}
+
+func sendLiveScanEvent(ctx context.Context, events chan<- liveScanEventMsg, msg liveScanEventMsg) {
+	select {
+	case <-ctx.Done():
+	case events <- msg:
+	}
+}
+
+func sendLiveScanProgress(ctx context.Context, events chan<- liveScanEventMsg, msg liveScanEventMsg) {
+	select {
+	case <-ctx.Done():
+	case events <- msg:
+	default:
+	}
+}
+
+func waitLiveScanEventCmd(events <-chan liveScanEventMsg) tea.Cmd {
+	return func() tea.Msg {
+		msg, ok := <-events
+		if !ok {
+			return nil
+		}
+		return msg
+	}
+}
+
+func sortDirEntriesBySize(entries []dirEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Size > entries[j].Size
+	})
+}
+
+func topLargeFiles(files []fileEntry) []fileEntry {
+	if len(files) <= maxLargeFiles {
+		sort.SliceStable(files, func(i, j int) bool {
+			return files[i].Size > files[j].Size
+		})
+		return files
+	}
+	h := &largeFileHeap{}
+	heap.Init(h)
+	var minSize int64 = largeFileWarmupMinSize
+	for _, file := range files {
+		pushLiveLargeFile(h, file, &minSize)
+	}
+	top := make([]fileEntry, h.Len())
+	for i := range slices.Backward(top) {
+		top[i] = heap.Pop(h).(fileEntry)
+	}
+	return top
+}

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -96,6 +96,8 @@ func newModel(path string, isOverview bool) model {
 		overviewScanningSet: make(map[string]bool),
 		multiSelected:       make(map[string]bool),
 		largeMultiSelected:  make(map[string]bool),
+		liveSortMode:        liveScanSortModeFromEnv(),
+		liveCursorMode:      liveScanCursorModeFromEnv(),
 	}
 
 	if isOverview {

--- a/cmd/analyze/model.go
+++ b/cmd/analyze/model.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -70,6 +71,52 @@ type scanResultMsg struct {
 	stale  bool
 }
 
+type liveScanStartMsg struct {
+	id            int64
+	path          string
+	entries       []dirEntry
+	totalSize     int64
+	totalFiles    int64
+	largeFiles    []fileEntry
+	scanningPaths []string
+	events        <-chan liveScanEventMsg
+	cancel        context.CancelFunc
+	err           error
+}
+
+type liveScanEventKind int
+
+const (
+	liveScanChildProgress liveScanEventKind = iota + 1
+	liveScanChildDone
+	liveScanComplete
+	liveScanFailed
+	liveScanCanceled
+)
+
+type liveScanEventMsg struct {
+	id     int64
+	path   string
+	kind   liveScanEventKind
+	entry  dirEntry
+	result scanResult
+	err    error
+}
+
+type liveSortMode int
+
+const (
+	liveSortContinuous liveSortMode = iota
+	liveSortFreezeOnMove
+)
+
+type liveCursorMode int
+
+const (
+	liveCursorByIndex liveCursorMode = iota
+	liveCursorByPath
+)
+
 type overviewSizeMsg struct {
 	Path  string
 	Index int
@@ -131,9 +178,16 @@ type model struct {
 	// Directory (drill-down) view incremental filter, mirroring the Top-files
 	// one. entriesAll is the full non-empty entry list; entries is the rendered,
 	// possibly filtered view. Disabled in overview mode.
-	entriesAll     []dirEntry
-	entryFilter    string
-	entryFiltering bool
+	entriesAll          []dirEntry
+	entryFilter         string
+	entryFiltering      bool
+	liveScanID          int64
+	liveScanCancel      context.CancelFunc
+	liveScanEvents      <-chan liveScanEventMsg
+	liveScanningPaths   map[string]bool
+	autoSortLiveEntries bool
+	liveSortMode        liveSortMode
+	liveCursorMode      liveCursorMode
 }
 
 func (m model) inOverviewMode() bool {

--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -20,11 +20,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
-
-	"golang.org/x/sync/singleflight"
 )
-
-var scanGroup singleflight.Group
 
 // scanLimiter bundles the concurrency budgets used by a single scan pass.
 //

--- a/cmd/analyze/update.go
+++ b/cmd/analyze/update.go
@@ -97,44 +97,13 @@ func (m model) scanCmd(path string) tea.Cmd {
 			return scanResultMsg{path: path, result: result, err: nil, stale: true}
 		}
 
-		v, err, _ := scanGroup.Do(path, func() (any, error) {
-			return scanPathConcurrent(path, m.filesScanned, m.dirsScanned, m.bytesScanned, m.currentPath)
-		})
-
-		if err != nil {
-			return scanResultMsg{path: path, err: err}
-		}
-
-		result := v.(scanResult)
-
-		go func(p string, r scanResult) {
-			if err := saveCacheToDisk(p, r); err != nil {
-				_ = err // Cache save failure is not critical
-			}
-		}(path, result)
-
-		return scanResultMsg{path: path, result: result, err: nil}
+		return startLiveScanCmd(path, m.filesScanned, m.dirsScanned, m.bytesScanned, m.currentPath)()
 	}
 }
 
 func (m model) scanFreshCmd(path string) tea.Cmd {
 	return func() tea.Msg {
-		v, err, _ := scanGroup.Do(path, func() (any, error) {
-			return scanPathConcurrent(path, m.filesScanned, m.dirsScanned, m.bytesScanned, m.currentPath)
-		})
-
-		if err != nil {
-			return scanResultMsg{path: path, err: err}
-		}
-
-		result := v.(scanResult)
-		go func(p string, r scanResult) {
-			if err := saveCacheToDisk(p, r); err != nil {
-				_ = err
-			}
-		}(path, result)
-
-		return scanResultMsg{path: path, result: result}
+		return startLiveScanCmd(path, m.filesScanned, m.dirsScanned, m.bytesScanned, m.currentPath)()
 	}
 }
 
@@ -142,6 +111,170 @@ func tickCmd() tea.Cmd {
 	return tea.Tick(uiTickInterval, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
+}
+
+func (m *model) cancelLiveScan() {
+	if m.liveScanCancel != nil {
+		m.liveScanCancel()
+	}
+	m.liveScanID = 0
+	m.liveScanCancel = nil
+	m.liveScanEvents = nil
+	m.liveScanningPaths = nil
+	m.autoSortLiveEntries = false
+}
+
+func (m model) isCurrentLiveScan(id int64, path string) bool {
+	return id != 0 && id == m.liveScanID && path == m.path && m.liveScanEvents != nil
+}
+
+func (m *model) noteLiveCursorMove() {
+	if m.scanning && !m.showLargeFiles && m.liveSortMode == liveSortFreezeOnMove {
+		m.autoSortLiveEntries = false
+	}
+}
+
+func (m *model) applyLiveChildProgress(entry dirEntry) {
+	m.applyLiveChildSize(entry, false, scanResult{})
+}
+
+func (m *model) applyLiveChildUpdate(entry dirEntry, result scanResult) {
+	m.applyLiveChildSize(entry, true, result)
+}
+
+func (m *model) ensureLiveEntryBacking() {
+	if m.entriesAll == nil {
+		m.entriesAll = slices.Clone(m.entries)
+	}
+}
+
+func (m *model) applyLiveChildSize(entry dirEntry, complete bool, result scanResult) {
+	if complete && m.liveScanningPaths != nil {
+		delete(m.liveScanningPaths, entry.Path)
+	}
+
+	m.ensureLiveEntryBacking()
+	previousSize := int64(-1)
+	found := false
+	for i := range m.entriesAll {
+		if m.entriesAll[i].Path == entry.Path {
+			previousSize = m.entriesAll[i].Size
+			m.entriesAll[i] = entry
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.entriesAll = append(m.entriesAll, entry)
+	}
+
+	if entry.Size > 0 {
+		if previousSize > 0 {
+			m.totalSize += entry.Size - previousSize
+		} else {
+			m.totalSize += entry.Size
+		}
+	}
+	if complete && result.TotalFiles > 0 {
+		m.totalFiles += result.TotalFiles
+	}
+	if complete && (len(result.Entries) > 0 || len(result.LargeFiles) > 0 || result.TotalSize > 0 || result.TotalFiles > 0) {
+		childResult := result
+		childResult.Entries = filterNonEmptyEntries(result.Entries)
+		m.cache[entry.Path] = historyEntryFromScanResult(entry.Path, childResult, m.cache[entry.Path], true)
+	}
+	if m.autoSortLiveEntries {
+		m.sortLiveEntriesForCurrentCursorMode()
+	} else {
+		m.applyEntryFilter()
+	}
+	m.clampEntrySelection()
+	m.status = fmt.Sprintf("Scanning %s...", displayPath(m.path))
+}
+
+func (m *model) finishLiveScan(result scanResult) {
+	m.scanning = false
+	m.liveScanID = 0
+	m.liveScanCancel = nil
+	m.liveScanEvents = nil
+	m.liveScanningPaths = nil
+	m.autoSortLiveEntries = false
+
+	filteredEntries := filterNonEmptyEntries(result.Entries)
+	result.Entries = filteredEntries
+	selectedPath := m.selectedEntryPath()
+	m.entriesAll = filteredEntries
+	m.largeFilesAll = result.LargeFiles
+	m.totalSize = result.TotalSize
+	m.totalFiles = result.TotalFiles
+	m.viewNeedsRefresh = false
+	m.applyEntryFilter()
+	m.applyLargeFilter()
+	if selectedPath != "" {
+		m.selectEntryPath(selectedPath)
+	}
+	m.cache[m.path] = historyEntryFromScanResult(m.path, result, m.cache[m.path], false)
+	if m.totalSize > 0 {
+		if m.overviewSizeCache == nil {
+			m.overviewSizeCache = make(map[string]int64)
+		}
+		m.overviewSizeCache[m.path] = m.totalSize
+		go func(path string, size int64) {
+			_ = storeOverviewSize(path, size)
+		}(m.path, m.totalSize)
+	}
+	go func(path string, scan scanResult) {
+		_ = saveCacheToDisk(path, scan)
+	}(m.path, result)
+	m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
+}
+
+func (m *model) finishCanceledLiveScan() {
+	m.scanning = false
+	m.liveScanID = 0
+	m.liveScanCancel = nil
+	m.liveScanEvents = nil
+	m.liveScanningPaths = nil
+	m.autoSortLiveEntries = false
+	m.status = "Scan cancelled"
+}
+
+func (m *model) sortLiveEntriesForCurrentCursorMode() {
+	m.ensureLiveEntryBacking()
+	selectedPath := ""
+	if m.liveCursorMode == liveCursorByPath {
+		selectedPath = m.selectedEntryPath()
+	}
+
+	if m.liveCursorMode == liveCursorByIndex {
+		sortDirEntriesBySize(m.entriesAll)
+		m.applyEntryFilter()
+		m.clampEntrySelection()
+		return
+	}
+	sortDirEntriesBySize(m.entriesAll)
+	m.applyEntryFilter()
+	if selectedPath == "" {
+		return
+	}
+	m.selectEntryPath(selectedPath)
+}
+
+func (m model) selectedEntryPath() string {
+	if len(m.entries) == 0 || m.selected < 0 || m.selected >= len(m.entries) {
+		return ""
+	}
+	return m.entries[m.selected].Path
+}
+
+func (m *model) selectEntryPath(path string) {
+	for i, entry := range m.entries {
+		if entry.Path == path {
+			m.selected = i
+			return
+		}
+	}
+	m.clampEntrySelection()
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -185,6 +318,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 				}
 
+				m.cancelLiveScan()
 				m.scanning = true
 				atomic.StoreInt64(m.filesScanned, 0)
 				atomic.StoreInt64(m.dirsScanned, 0)
@@ -254,6 +388,65 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
 		return m, nil
+	case liveScanStartMsg:
+		if msg.path != m.path {
+			if msg.cancel != nil {
+				msg.cancel()
+			}
+			return m, nil
+		}
+		m.cancelLiveScan()
+		if msg.err != nil {
+			m.scanning = false
+			m.status = fmt.Sprintf("Scan failed: %v", msg.err)
+			return m, nil
+		}
+		m.liveScanID = msg.id
+		m.liveScanCancel = msg.cancel
+		m.liveScanEvents = msg.events
+		m.liveScanningPaths = make(map[string]bool, len(msg.scanningPaths))
+		for _, path := range msg.scanningPaths {
+			m.liveScanningPaths[path] = true
+		}
+		m.autoSortLiveEntries = true
+		selectedPath := m.selectedEntryPath()
+		m.entriesAll = slices.Clone(msg.entries)
+		m.largeFilesAll = slices.Clone(msg.largeFiles)
+		m.totalSize = msg.totalSize
+		m.totalFiles = msg.totalFiles
+		m.viewNeedsRefresh = false
+		m.scanning = true
+		m.status = fmt.Sprintf("Scanning %s...", displayPath(m.path))
+		m.sortLiveEntriesForCurrentCursorMode()
+		m.applyLargeFilter()
+		if selectedPath != "" {
+			m.selectEntryPath(selectedPath)
+		}
+		m.clampEntrySelection()
+		return m, waitLiveScanEventCmd(msg.events)
+	case liveScanEventMsg:
+		if !m.isCurrentLiveScan(msg.id, msg.path) {
+			return m, nil
+		}
+		switch msg.kind {
+		case liveScanChildProgress:
+			m.applyLiveChildProgress(msg.entry)
+			return m, waitLiveScanEventCmd(m.liveScanEvents)
+		case liveScanChildDone:
+			m.applyLiveChildUpdate(msg.entry, msg.result)
+			return m, waitLiveScanEventCmd(m.liveScanEvents)
+		case liveScanComplete:
+			m.finishLiveScan(msg.result)
+			return m, nil
+		case liveScanFailed:
+			m.status = fmt.Sprintf("Scan failed: %v", msg.err)
+			return m, waitLiveScanEventCmd(m.liveScanEvents)
+		case liveScanCanceled:
+			m.finishCanceledLiveScan()
+			return m, nil
+		default:
+			return m, waitLiveScanEventCmd(m.liveScanEvents)
+		}
 	case overviewSizeMsg:
 		delete(m.overviewScanningSet, msg.Path)
 
@@ -398,6 +591,7 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m.goBack()
 	case "up", "k", "K":
+		m.noteLiveCursorMove()
 		if m.showLargeFiles {
 			if m.largeSelected > 0 {
 				m.largeSelected--
@@ -416,6 +610,7 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "down", "j", "J":
+		m.noteLiveCursorMove()
 		if m.showLargeFiles {
 			if m.largeSelected < len(m.largeFiles)-1 {
 				m.largeSelected++
@@ -448,6 +643,7 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m.goBack()
 	case "r", "R":
+		m.cancelLiveScan()
 		m.multiSelected = make(map[string]bool)
 		m.largeMultiSelected = make(map[string]bool)
 
@@ -485,6 +681,10 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(m.scanFreshCmd(m.path), tickCmd())
 	case "t", "T":
+		if m.scanning {
+			m.status = "Top files are available after the scan finishes"
+			return m, nil
+		}
 		if !m.inOverviewMode() {
 			m.showLargeFiles = !m.showLargeFiles
 			m.resetLargeFilter()
@@ -510,6 +710,15 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else if len(m.entriesAll) > 0 {
 			m.entryFiltering = true
 			m.status = "Filter: type to match, Enter to apply, Esc to clear"
+		}
+	case "s", "S":
+		if m.scanning && !m.inOverviewMode() {
+			m.liveSortMode = nextLiveSortMode(m.liveSortMode)
+			m.autoSortLiveEntries = m.liveSortMode == liveSortContinuous
+			if m.autoSortLiveEntries {
+				m.sortLiveEntriesForCurrentCursorMode()
+			}
+			m.status = fmt.Sprintf("Live sort: %s", liveSortModeLabel(m.liveSortMode))
 		}
 	case "o", "O":
 		// Open selected entries (multi-select aware).
@@ -623,6 +832,10 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case " ":
+		if m.scanning {
+			m.status = "Selection is available after the scan finishes"
+			return m, nil
+		}
 		// Toggle multi-select (paths as keys).
 		if m.showLargeFiles {
 			if len(m.largeFiles) > 0 && m.largeSelected < len(m.largeFiles) {
@@ -678,6 +891,10 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 		}
 	case "delete", "backspace":
+		if m.scanning {
+			m.status = "Delete is available after the scan finishes"
+			return m, nil
+		}
 		if m.showLargeFiles {
 			if len(m.largeFiles) > 0 {
 				if len(m.largeMultiSelected) > 0 {
@@ -819,6 +1036,7 @@ func (m model) updateEntryFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) goBack() (tea.Model, tea.Cmd) {
+	m.cancelLiveScan()
 	if len(m.history) == 0 {
 		if !m.inOverviewMode() {
 			return m, m.switchToOverviewMode()
@@ -873,6 +1091,7 @@ func (m model) goBack() (tea.Model, tea.Cmd) {
 }
 
 func (m *model) switchToOverviewMode() tea.Cmd {
+	m.cancelLiveScan()
 	m.isOverview = true
 	m.path = "/"
 	m.scanning = false
@@ -903,6 +1122,7 @@ func (m model) enterSelectedDir() (tea.Model, tea.Cmd) {
 	}
 	selected := m.entries[m.selected]
 	if selected.IsDir {
+		m.cancelLiveScan()
 		// Drilling in commits and drops any active directory filter so the parent
 		// is snapshotted in full. Remap the selection onto the unfiltered list so
 		// the entry we enter stays highlighted when we navigate back.

--- a/cmd/analyze/view.go
+++ b/cmd/analyze/view.go
@@ -17,6 +17,8 @@ func (m model) View() string {
 	// background refresh runs, instead of blanking to a scan-only screen. Fresh
 	// scans (no cached entries yet) still fall back to the scan-only view.
 	showingCachedView := m.scanning && !m.inOverviewMode() && m.viewNeedsRefresh && len(m.entries) > 0
+	showingLiveScanView := m.scanning && !m.inOverviewMode() && len(m.entries) > 0 &&
+		(m.liveScanEvents != nil || len(m.liveScanningPaths) > 0)
 
 	if m.inOverviewMode() {
 		freeLabel := ""
@@ -43,7 +45,7 @@ func (m model) View() string {
 		}
 	} else {
 		fmt.Fprintf(&b, "%sAnalyze Disk%s  %s%s%s", colorPurpleBold, colorReset, colorGray, displayPath(m.path), colorReset)
-		if !m.scanning {
+		if !m.scanning || m.totalSize > 0 {
 			fmt.Fprintf(&b, "  |  Total: %s", humanizeBytes(m.totalSize))
 		}
 		fmt.Fprintf(&b, "\n\n")
@@ -99,10 +101,14 @@ func (m model) View() string {
 			}
 		}
 
-		if !showingCachedView {
+		if !showingCachedView && !showingLiveScanView {
 			return b.String()
 		}
-		fmt.Fprintf(&b, "%sShowing cached results while refreshing...%s\n\n", colorGray, colorReset)
+		if showingCachedView {
+			fmt.Fprintf(&b, "%sShowing cached results while refreshing...%s\n\n", colorGray, colorReset)
+		} else {
+			fmt.Fprintln(&b)
+		}
 	}
 
 	if m.showLargeFiles {
@@ -259,16 +265,27 @@ func (m model) View() string {
 					if entry.IsDir {
 						icon = "📁"
 					}
-					size := humanizeBytes(entry.Size)
 					name := trimNameWithWidth(entry.Name, nameWidth)
 					paddedName := padName(name, nameWidth)
 
-					percent := float64(entry.Size) / float64(m.totalSize) * 100
+					sizeValue := max(entry.Size, 0)
+					percent := 0.0
+					if m.totalSize > 0 && entry.Size >= 0 {
+						percent = float64(entry.Size) / float64(m.totalSize) * 100
+					}
 					percentStr := fmt.Sprintf("%5.1f%%", percent)
+					if entry.Size < 0 || m.totalSize <= 0 {
+						percentStr = "  --  "
+					}
 
-					bar := coloredProgressBar(entry.Size, maxSize, percent)
+					bar := coloredProgressBar(sizeValue, maxSize, percent)
 
 					sizeColor := sizeColorForPercent(percent)
+					size := humanizeBytes(entry.Size)
+					if entry.Size < 0 {
+						size = fmt.Sprintf("%s %s", spinnerFrames[m.spinner], "scanning")
+						sizeColor = colorCyan
+					}
 
 					isMultiSelected := m.multiSelected != nil && m.multiSelected[entry.Path]
 					selectIcon := "○"
@@ -298,15 +315,19 @@ func (m model) View() string {
 					displayIndex := idx + 1
 
 					hintLabel := entryHintLabel(entry)
+					activityMarker := "|"
+					if entry.IsDir && m.liveScanningPaths != nil && m.liveScanningPaths[entry.Path] {
+						activityMarker = fmt.Sprintf("%s%s%s%s", colorCyan, colorBold, spinnerFrames[m.spinner], colorReset)
+					}
 
 					if hintLabel == "" {
-						fmt.Fprintf(&b, "%s%s %s%2d.%s %s %s%s%s  |  %s %s%10s%s\n",
+						fmt.Fprintf(&b, "%s%s %s%2d.%s %s %s%s%s  %s  %s %s%10s%s\n",
 							entryPrefix, selectIcon, numColor, displayIndex, colorReset, bar, percentColor, percentStr, colorReset,
-							nameSegment, sizeColor, size, colorReset)
+							activityMarker, nameSegment, sizeColor, size, colorReset)
 					} else {
-						fmt.Fprintf(&b, "%s%s %s%2d.%s %s %s%s%s  |  %s %s%10s%s  %s\n",
+						fmt.Fprintf(&b, "%s%s %s%2d.%s %s %s%s%s  %s  %s %s%10s%s  %s\n",
 							entryPrefix, selectIcon, numColor, displayIndex, colorReset, bar, percentColor, percentStr, colorReset,
-							nameSegment, sizeColor, size, colorReset, hintLabel)
+							activityMarker, nameSegment, sizeColor, size, colorReset, hintLabel)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Draft PR for #1062. This explores an ls-first navigation flow for `mo analyze`: rows render from `os.ReadDir` immediately, then child directory sizes fill in live as scans progress.

This follows the issue discussion with @tw93:
- show immediate children with pending sizes instead of waiting for the full scan,
- update rows as child scans make progress,
- keep navigation responsive while scanning,
- preserve or experiment with focus behavior across live reorders,
- when drilling into a child, cancel/suppress the parent live session and avoid saving a stale completed parent snapshot.

Demo from the issue thread:
https://screen.studio/share/TG62p8YU

## UX options to try

The current defaults favor continuous sort + cursor-by-index because that makes the live scan easy to feel out while rows settle:

- `MOLE_ANALYZE_LIVE_SORT=continuous` (default): rows keep sorting by current known size.
- `MOLE_ANALYZE_LIVE_SORT=freeze-on-move`: rows sort live until the first up/down key, then freeze.
- `MOLE_ANALYZE_LIVE_CURSOR=index` (default): selection stays on the visible row number as rows move.
- `MOLE_ANALYZE_LIVE_CURSOR=path`: selection follows the selected path across reorders.

While a scan is active:

- `s` toggles live sort mode.
- `c` toggles cursor anchoring.

Example:

```bash
MOLE_ANALYZE_LIVE_SORT=freeze-on-move MOLE_ANALYZE_LIVE_CURSOR=path mo analyze ~
```

## Implementation notes

- Adds a live scan session for non-overview TUI scans.
- Cache hits and JSON/overview behavior stay on existing paths.
- Live child progress events update row size, bar, percent, and scanning marker.
- Completed child scans warm child cache entries.
- Session ids/path checks ignore stale events after navigation.
- Active scans are canceled on navigation, refresh, back, and delete; completed parent cache is only written for the active completed session.
- The row divider before the folder icon spins for folders that are still scanning.

## Review focus

This is intentionally draft UX work. I’d especially like feedback on:

- whether the default should be cursor-by-index or cursor-by-path,
- whether rows should continuously reorder or freeze after navigation,
- whether the spinner divider is the right affordance for still-scanning rows,
- whether the live progress cadence feels too noisy or too slow.

One implementation constraint still worth reviewing: deep filesystem walks use the existing scanner internals, so cancellation suppresses stale UI/events and avoids writing a completed parent cache, but some underlying IO may continue until the current subtree walk returns.

## Verification

- `MOLE_SKIP_FINDER_TESTS=1 go test -count=1 ./cmd/...`
- `go test -race -run 'TestLiveScan|TestOverviewHome|TestScanningView' -count=1 ./cmd/analyze`
- `git diff --check`

The unskipped full `go test -count=1 ./cmd/...` hit Finder busy errors in existing Trash/Finder-dependent tests locally (`-15260`).
