### PR TITLE
feat(analyze): incremental filter (/) for Top files and tree views

### DIFF
--- a/cmd/analyze/analyze_filter_test.go
+++ b/cmd/analyze/analyze_filter_test.go
@@ -1,0 +1,350 @@
+//go:build darwin
+
+package main
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func topFilesFixture() model {
+	files := []fileEntry{
+		{Name: "alpha.mp4", Path: "/tmp/p/alpha.mp4", Size: 300},
+		{Name: "photo.jpg", Path: "/tmp/p/photo.jpg", Size: 200},
+		{Name: "beta.mp4", Path: "/tmp/p/beta.mp4", Size: 100},
+	}
+	cloned := make([]fileEntry, len(files))
+	copy(cloned, files)
+	return model{
+		path:               "/tmp/p",
+		showLargeFiles:     true,
+		largeFilesAll:      files,
+		largeFiles:         cloned,
+		largeMultiSelected: map[string]bool{},
+		height:             40,
+		width:              120,
+	}
+}
+
+func filterKey(t *testing.T, m model, msg tea.KeyMsg) (model, tea.Cmd) {
+	t.Helper()
+	updated, cmd := m.updateKey(msg)
+	got, ok := updated.(model)
+	if !ok {
+		t.Fatalf("expected model, got %T", updated)
+	}
+	return got, cmd
+}
+
+func filterRune(t *testing.T, m model, r rune) (model, tea.Cmd) {
+	t.Helper()
+	return filterKey(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+}
+
+func filterType(t *testing.T, m model, s string) model {
+	t.Helper()
+	for _, r := range s {
+		m, _ = filterRune(t, m, r)
+	}
+	return m
+}
+
+func TestLargeFilterNarrowsApplyAndClear(t *testing.T) {
+	m := topFilesFixture()
+
+	m, _ = filterRune(t, m, '/')
+	if !m.largeFiltering {
+		t.Fatalf("expected to enter filter input mode")
+	}
+
+	m = filterType(t, m, "mp4")
+	if len(m.largeFiles) != 2 {
+		t.Fatalf("want 2 matches for mp4, got %d", len(m.largeFiles))
+	}
+
+	// Enter applies the filter and returns to navigation, keeping the subset.
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.largeFiltering {
+		t.Fatalf("Enter should exit input mode")
+	}
+	if len(m.largeFiles) != 2 {
+		t.Fatalf("filter should persist after Enter, got %d", len(m.largeFiles))
+	}
+
+	// Esc clears the filter and restores the full list.
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.largeFilter != "" {
+		t.Fatalf("Esc should clear the query, got %q", m.largeFilter)
+	}
+	if len(m.largeFiles) != 3 {
+		t.Fatalf("want full list of 3 after clear, got %d", len(m.largeFiles))
+	}
+}
+
+func TestLargeFilterSwallowsNavigationKeys(t *testing.T) {
+	m := topFilesFixture()
+	m, _ = filterRune(t, m, '/')
+
+	// 'q' would normally quit; while filtering it must edit the query instead.
+	m, cmd := filterRune(t, m, 'q')
+	if cmd != nil {
+		t.Fatalf("q while filtering must not emit a command (no quit)")
+	}
+	if m.largeFilter != "q" {
+		t.Fatalf("q should append to the query, got %q", m.largeFilter)
+	}
+}
+
+func TestLargeFilterBackspaceEditsQuery(t *testing.T) {
+	m := topFilesFixture()
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "mp")
+
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyBackspace})
+	if m.largeFilter != "m" {
+		t.Fatalf("backspace should trim the query to 'm', got %q", m.largeFilter)
+	}
+}
+
+func TestLargeFilterClearsMultiSelectOnQueryChange(t *testing.T) {
+	m := topFilesFixture()
+	m.largeMultiSelected = map[string]bool{"/tmp/p/photo.jpg": true}
+
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "a")
+
+	if len(m.largeMultiSelected) != 0 {
+		t.Fatalf("changing the query should clear multi-selection, got %d", len(m.largeMultiSelected))
+	}
+}
+
+func TestLargeFilterClampsSelection(t *testing.T) {
+	m := topFilesFixture()
+	m.largeSelected = 2 // beta.mp4 in the full list
+
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "photo") // single match, full index 1
+
+	if len(m.largeFiles) != 1 {
+		t.Fatalf("want 1 match for photo, got %d", len(m.largeFiles))
+	}
+	if m.largeSelected != 0 {
+		t.Fatalf("selection should clamp into the visible range, got %d", m.largeSelected)
+	}
+}
+
+func TestLargeFilterDeleteTargetsVisibleMatch(t *testing.T) {
+	m := topFilesFixture()
+
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "beta") // single visible match: beta.mp4 (hidden in full list at index 2)
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	// backspace maps to the delete action once we are out of input mode.
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyBackspace})
+	if !m.deleteConfirm {
+		t.Fatalf("expected delete confirmation to open")
+	}
+	if m.deleteTarget == nil || m.deleteTarget.Path != "/tmp/p/beta.mp4" {
+		t.Fatalf("delete must target the visible match, got %+v", m.deleteTarget)
+	}
+}
+
+func TestLargeFilterIgnoredOutsideTopView(t *testing.T) {
+	m := topFilesFixture()
+	m.showLargeFiles = false
+	m.entries = []dirEntry{{Name: "x", Path: "/tmp/p/x", Size: 1}}
+
+	m, _ = filterRune(t, m, '/')
+	if m.largeFiltering {
+		t.Fatalf("'/' should do nothing outside the Top-files view")
+	}
+}
+
+func treeFixture() model {
+	entries := []dirEntry{
+		{Name: "apps", Path: "/tmp/p/apps", Size: 300, IsDir: true},
+		{Name: "logs", Path: "/tmp/p/logs", Size: 200, IsDir: true},
+		{Name: "node_modules", Path: "/tmp/p/node_modules", Size: 100, IsDir: true},
+	}
+	var filesScanned, dirsScanned, bytesScanned int64
+	return model{
+		path:          "/tmp/p",
+		entriesAll:    entries,
+		entries:       slices.Clone(entries),
+		multiSelected: map[string]bool{},
+		cache:         map[string]historyEntry{},
+		filesScanned:  &filesScanned,
+		dirsScanned:   &dirsScanned,
+		bytesScanned:  &bytesScanned,
+		height:        40,
+		width:         120,
+	}
+}
+
+func TestEntryFilterNarrowsApplyAndClear(t *testing.T) {
+	m := treeFixture()
+
+	m, _ = filterRune(t, m, '/')
+	if !m.entryFiltering {
+		t.Fatalf("expected to enter directory filter input mode")
+	}
+
+	m = filterType(t, m, "s") // apps, logs, node_modules all end in 's'
+	if len(m.entries) != 3 {
+		t.Fatalf("want 3 matches for s, got %d", len(m.entries))
+	}
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyBackspace})
+	m = filterType(t, m, "ode") // only node_modules contains "ode"
+	if len(m.entries) != 1 {
+		t.Fatalf("want 1 match for ode, got %d", len(m.entries))
+	}
+
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if m.entryFilter != "" {
+		t.Fatalf("Esc should clear the query, got %q", m.entryFilter)
+	}
+	if len(m.entries) != 3 {
+		t.Fatalf("want full list of 3 after clear, got %d", len(m.entries))
+	}
+}
+
+func TestEntryFilterSwallowsNavigationKeys(t *testing.T) {
+	m := treeFixture()
+	m, _ = filterRune(t, m, '/')
+
+	m, cmd := filterRune(t, m, 'q')
+	if cmd != nil {
+		t.Fatalf("q while filtering must not emit a command (no quit)")
+	}
+	if m.entryFilter != "q" {
+		t.Fatalf("q should append to the query, got %q", m.entryFilter)
+	}
+}
+
+func TestEntryFilterClearsMultiSelectOnQueryChange(t *testing.T) {
+	m := treeFixture()
+	m.multiSelected = map[string]bool{"/tmp/p/logs": true}
+
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "a")
+
+	if len(m.multiSelected) != 0 {
+		t.Fatalf("changing the query should clear multi-selection, got %d", len(m.multiSelected))
+	}
+}
+
+func TestEntryFilterIgnoredInOverview(t *testing.T) {
+	m := treeFixture()
+	m.isOverview = true
+	m.path = "/"
+
+	m, _ = filterRune(t, m, '/')
+	if m.entryFiltering {
+		t.Fatalf("'/' should do nothing in overview mode")
+	}
+}
+
+// The load-bearing case: filter the tree, drill into a match, then go back.
+// The parent must be restored in full (not the one-row filtered view) with the
+// entered directory still highlighted.
+func TestEntryFilterDrillInPreservesFullParentOnBack(t *testing.T) {
+	m := treeFixture()
+	m.cache["/tmp/p/node_modules"] = historyEntry{
+		Path:      "/tmp/p/node_modules",
+		Entries:   []dirEntry{{Name: "pkg", Path: "/tmp/p/node_modules/pkg", Size: 50, IsDir: true}},
+		TotalSize: 50,
+	}
+
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "node") // single match: node_modules (full index 2)
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if len(m.entries) != 1 {
+		t.Fatalf("want 1 match before drilling in, got %d", len(m.entries))
+	}
+
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyEnter}) // drill into the match
+	if m.path != "/tmp/p/node_modules" {
+		t.Fatalf("expected to drill into node_modules, got %s", m.path)
+	}
+	if m.entryFilter != "" {
+		t.Fatalf("filter must be cleared after drilling in, got %q", m.entryFilter)
+	}
+
+	m, _ = filterKey(t, m, tea.KeyMsg{Type: tea.KeyEsc}) // go back to parent
+	if m.path != "/tmp/p" {
+		t.Fatalf("expected to return to /tmp/p, got %s", m.path)
+	}
+	if len(m.entries) != 3 {
+		t.Fatalf("parent must be restored with all 3 entries, got %d", len(m.entries))
+	}
+	if m.selected < 0 || m.selected >= len(m.entries) || m.entries[m.selected].Path != "/tmp/p/node_modules" {
+		t.Fatalf("entered entry should stay highlighted, selected=%d", m.selected)
+	}
+}
+
+// Deleting with no active filter must not corrupt the backing lists. Before the
+// rebuild-from-backing fix, removing from both a list and its aliased view
+// shifted the shared array twice, leaving a duplicated, stale entry behind.
+func TestRemovePathPreservesBackingLists(t *testing.T) {
+	m := treeFixture() // entriesAll aliases entries: [apps, logs, node_modules]
+	m.totalSize = 600
+
+	m.removePathFromView("/tmp/p/logs")
+
+	if len(m.entriesAll) != 2 {
+		t.Fatalf("entriesAll should drop to 2, got %d", len(m.entriesAll))
+	}
+	if len(m.entries) != 2 {
+		t.Fatalf("entries should drop to 2, got %d", len(m.entries))
+	}
+	seen := map[string]int{}
+	for _, e := range m.entriesAll {
+		seen[e.Path]++
+	}
+	if seen["/tmp/p/logs"] != 0 {
+		t.Fatalf("deleted path still present in entriesAll")
+	}
+	for p, c := range seen {
+		if c != 1 {
+			t.Fatalf("entry %s duplicated %d times in entriesAll", p, c)
+		}
+	}
+}
+
+func TestEntryFilterViewShowsHintAndQuery(t *testing.T) {
+	m := treeFixture()
+	if hint := m.View(); !strings.Contains(hint, "/ Filter") {
+		t.Fatalf("expected '/ Filter' footer hint, got:\n%s", hint)
+	}
+
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "node")
+	view := m.View()
+	if !strings.Contains(view, "Filter:") {
+		t.Fatalf("expected active 'Filter:' line, got:\n%s", view)
+	}
+	if !strings.Contains(view, "No matches") && !strings.Contains(view, "node_modules") {
+		t.Fatalf("expected the single match rendered, got:\n%s", view)
+	}
+}
+
+func TestLargeFilterViewShowsHintAndQuery(t *testing.T) {
+	m := topFilesFixture()
+	if hint := m.View(); !strings.Contains(hint, "/ Filter") {
+		t.Fatalf("expected '/ Filter' footer hint, got:\n%s", hint)
+	}
+
+	m, _ = filterRune(t, m, '/')
+	m = filterType(t, m, "mp4")
+	view := m.View()
+	if !strings.Contains(view, "Filter:") {
+		t.Fatalf("expected active 'Filter:' line, got:\n%s", view)
+	}
+	if !strings.Contains(view, "matches") {
+		t.Fatalf("expected match count in filter line, got:\n%s", view)
+	}
+}

--- a/cmd/analyze/model.go
+++ b/cmd/analyze/model.go
@@ -301,13 +301,6 @@ func removeByPath[T any](items []T, path string, pathOf func(T) string) []T {
 	return items
 }
 
-// visibleLargeFiles is the active Top-files slice: the filtered subset when a
-// query is set, otherwise the full list. largeFiles already holds the view, so
-// this is just an explicit accessor for call sites that want to be unambiguous.
-func (m model) visibleLargeFiles() []fileEntry {
-	return m.largeFiles
-}
-
 // applyLargeFilter rebuilds the rendered Top-files view from largeFilesAll
 // using the current query. An empty query restores the full list.
 func (m *model) applyLargeFilter() {

--- a/cmd/analyze/model.go
+++ b/cmd/analyze/model.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -120,6 +121,19 @@ type model struct {
 	lastTotalFiles      int64           // Total files from previous scan (for progress bar)
 	diskFree            int64           // Free disk space for the analyzed volume
 	viewNeedsRefresh    bool
+	// Top-files (T) view incremental filter. largeFilesAll is the full,
+	// size-ranked list; largeFiles is the view actually rendered and acted on,
+	// which equals largeFilesAll when no filter is set and the matching subset
+	// otherwise. largeFiltering is true only while the user is typing a query.
+	largeFilesAll  []fileEntry
+	largeFilter    string
+	largeFiltering bool
+	// Directory (drill-down) view incremental filter, mirroring the Top-files
+	// one. entriesAll is the full non-empty entry list; entries is the rendered,
+	// possibly filtered view. Disabled in overview mode.
+	entriesAll     []dirEntry
+	entryFilter    string
+	entryFiltering bool
 }
 
 func (m model) inOverviewMode() bool {
@@ -220,22 +234,21 @@ func (m *model) removePathFromView(path string) {
 	}
 
 	var removedSize int64
-	for i, entry := range m.entries {
+	for _, entry := range m.entriesAll {
 		if entry.Path == path {
 			if entry.Size > 0 {
 				removedSize = entry.Size
 			}
-			m.entries = append(m.entries[:i], m.entries[i+1:]...)
 			break
 		}
 	}
 
-	for i := 0; i < len(m.largeFiles); i++ {
-		if m.largeFiles[i].Path == path {
-			m.largeFiles = append(m.largeFiles[:i], m.largeFiles[i+1:]...)
-			break
-		}
-	}
+	// Trim the backing lists once, then rebuild each view from them. Removing
+	// directly from both a backing list and its (possibly aliased) view would
+	// shift the shared array twice and corrupt it; rebuilding via the filters
+	// keeps the view, the query, and the selection consistent.
+	m.entriesAll = removeByPath(m.entriesAll, path, dirEntryPath)
+	m.largeFilesAll = removeByPath(m.largeFilesAll, path, fileEntryPath)
 
 	if removedSize > 0 {
 		if removedSize > m.totalSize {
@@ -243,7 +256,90 @@ func (m *model) removePathFromView(path string) {
 		} else {
 			m.totalSize -= removedSize
 		}
-		m.clampEntrySelection()
 	}
+
+	m.applyEntryFilter()
+	m.applyLargeFilter()
+}
+
+func fileEntryName(f fileEntry) string { return f.Name }
+func fileEntryPath(f fileEntry) string { return f.Path }
+func dirEntryName(e dirEntry) string   { return e.Name }
+func dirEntryPath(e dirEntry) string   { return e.Path }
+
+// filterMatches reports whether an item with the given name and path matches a
+// case-insensitive substring query. Single source of truth for both the
+// Top-files and directory filters so their match semantics cannot drift.
+func filterMatches(name, path, query string) bool {
+	needle := strings.ToLower(query)
+	return strings.Contains(strings.ToLower(name), needle) ||
+		strings.Contains(strings.ToLower(displayPath(path)), needle)
+}
+
+// filterByQuery returns the items matching query, or the original slice
+// unchanged when the query is empty. nameOf/pathOf project the fields matched.
+func filterByQuery[T any](all []T, query string, nameOf, pathOf func(T) string) []T {
+	if query == "" {
+		return all
+	}
+	out := make([]T, 0, len(all))
+	for _, item := range all {
+		if filterMatches(nameOf(item), pathOf(item), query) {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// removeByPath drops the first item whose projected path equals path.
+func removeByPath[T any](items []T, path string, pathOf func(T) string) []T {
+	for i := range items {
+		if pathOf(items[i]) == path {
+			return append(items[:i], items[i+1:]...)
+		}
+	}
+	return items
+}
+
+// visibleLargeFiles is the active Top-files slice: the filtered subset when a
+// query is set, otherwise the full list. largeFiles already holds the view, so
+// this is just an explicit accessor for call sites that want to be unambiguous.
+func (m model) visibleLargeFiles() []fileEntry {
+	return m.largeFiles
+}
+
+// applyLargeFilter rebuilds the rendered Top-files view from largeFilesAll
+// using the current query. An empty query restores the full list.
+func (m *model) applyLargeFilter() {
+	m.largeFiles = filterByQuery(m.largeFilesAll, m.largeFilter, fileEntryName, fileEntryPath)
 	m.clampLargeSelection()
+}
+
+// resetLargeFilter clears any active Top-files filter and restores the full
+// list. Callers that leave the Top-files view use this so the next visit and
+// the per-path navigation state start clean.
+func (m *model) resetLargeFilter() {
+	m.largeFilter = ""
+	m.largeFiltering = false
+	if m.largeFilesAll != nil {
+		m.largeFiles = m.largeFilesAll
+	}
+}
+
+// applyEntryFilter rebuilds the rendered directory view from entriesAll using
+// the current query. The directory view is the drill-down list (m.entries) in
+// non-overview mode.
+func (m *model) applyEntryFilter() {
+	m.entries = filterByQuery(m.entriesAll, m.entryFilter, dirEntryName, dirEntryPath)
+	m.clampEntrySelection()
+}
+
+// resetEntryFilter clears any active directory filter and restores the full
+// entry list.
+func (m *model) resetEntryFilter() {
+	m.entryFilter = ""
+	m.entryFiltering = false
+	if m.entriesAll != nil {
+		m.entries = m.entriesAll
+	}
 }

--- a/cmd/analyze/update.go
+++ b/cmd/analyze/update.go
@@ -417,7 +417,7 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "down", "j", "J":
 		if m.showLargeFiles {
-			if m.largeSelected < len(m.visibleLargeFiles())-1 {
+			if m.largeSelected < len(m.largeFiles)-1 {
 				m.largeSelected++
 				viewport := calculateViewport(m.height, true)
 				if m.largeSelected >= m.largeOffset+viewport {

--- a/cmd/analyze/update.go
+++ b/cmd/analyze/update.go
@@ -214,13 +214,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		filteredEntries := filterNonEmptyEntries(msg.result.Entries)
 		result := msg.result
 		result.Entries = filteredEntries
+		m.entriesAll = filteredEntries
 		m.entries = filteredEntries
+		m.largeFilesAll = msg.result.LargeFiles
 		m.largeFiles = msg.result.LargeFiles
 		m.totalSize = msg.result.TotalSize
 		m.totalFiles = msg.result.TotalFiles
 		m.viewNeedsRefresh = msg.stale
-		m.clampEntrySelection()
-		m.clampLargeSelection()
+		// Re-narrow to the active query if a background refresh landed while a
+		// filter is showing; each is a no-op (restores the full list) when its
+		// query is empty.
+		m.applyEntryFilter()
+		m.applyLargeFilter()
 		m.cache[m.path] = historyEntryFromScanResult(m.path, result, m.cache[m.path], msg.stale)
 		if m.totalSize > 0 {
 			if m.overviewSizeCache == nil {
@@ -363,12 +368,32 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Filter prompts swallow all keys while the user types a query.
+	if m.largeFiltering {
+		return m.updateLargeFilterInput(msg)
+	}
+	if m.entryFiltering {
+		return m.updateEntryFilterInput(msg)
+	}
+
 	switch msg.String() {
 	case "q", "Q", "ctrl+c":
 		return m, tea.Quit
 	case "esc":
 		if m.showLargeFiles {
+			if m.largeFilter != "" {
+				m.resetLargeFilter()
+				m.clampLargeSelection()
+				m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
+				return m, nil
+			}
 			m.showLargeFiles = false
+			return m, nil
+		}
+		if m.entryFilter != "" {
+			m.resetEntryFilter()
+			m.clampEntrySelection()
+			m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
 			return m, nil
 		}
 		return m.goBack()
@@ -392,7 +417,7 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "down", "j", "J":
 		if m.showLargeFiles {
-			if m.largeSelected < len(m.largeFiles)-1 {
+			if m.largeSelected < len(m.visibleLargeFiles())-1 {
 				m.largeSelected++
 				viewport := calculateViewport(m.height, true)
 				if m.largeSelected >= m.largeOffset+viewport {
@@ -418,6 +443,7 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "b", "left", "h", "B", "H":
 		if m.showLargeFiles {
 			m.showLargeFiles = false
+			m.resetLargeFilter()
 			return m, nil
 		}
 		return m.goBack()
@@ -461,6 +487,8 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "t", "T":
 		if !m.inOverviewMode() {
 			m.showLargeFiles = !m.showLargeFiles
+			m.resetLargeFilter()
+			m.resetEntryFilter()
 			if m.showLargeFiles {
 				m.largeSelected = 0
 				m.largeOffset = 0
@@ -469,6 +497,19 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.multiSelected = make(map[string]bool)
 			}
 			m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
+		}
+	case "/":
+		if m.inOverviewMode() {
+			break
+		}
+		if m.showLargeFiles {
+			if len(m.largeFilesAll) > 0 {
+				m.largeFiltering = true
+				m.status = "Filter: type to match, Enter to apply, Esc to clear"
+			}
+		} else if len(m.entriesAll) > 0 {
+			m.entryFiltering = true
+			m.status = "Filter: type to match, Enter to apply, Esc to clear"
 		}
 	case "o", "O":
 		// Open selected entries (multi-select aware).
@@ -689,6 +730,94 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// updateLargeFilterInput handles keystrokes while the Top-files filter prompt
+// is active. Typing edits the query and re-filters live; Enter applies and
+// hands control back to navigation; Esc clears the filter entirely. Navigation
+// and action keys are intentionally swallowed so they edit the query instead of
+// moving the cursor or deleting files. Changing the query clears any
+// multi-selection so an action can never touch a row hidden by the filter.
+func (m model) updateLargeFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		m.resetLargeFilter()
+		m.clampLargeSelection()
+		m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
+		return m, nil
+	case tea.KeyEnter:
+		m.largeFiltering = false
+		if m.largeFilter == "" {
+			m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
+		} else {
+			m.status = fmt.Sprintf("Filter %q, %d matches", m.largeFilter, len(m.largeFiles))
+		}
+		return m, nil
+	case tea.KeyBackspace, tea.KeyDelete:
+		if r := []rune(m.largeFilter); len(r) > 0 {
+			m.largeFilter = string(r[:len(r)-1])
+			m.largeMultiSelected = make(map[string]bool)
+			m.applyLargeFilter()
+		}
+		return m, nil
+	case tea.KeySpace:
+		m.largeFilter += " "
+		m.largeMultiSelected = make(map[string]bool)
+		m.applyLargeFilter()
+		return m, nil
+	case tea.KeyRunes:
+		m.largeFilter += string(msg.Runes)
+		m.largeMultiSelected = make(map[string]bool)
+		m.applyLargeFilter()
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+// updateEntryFilterInput is the directory-view counterpart to
+// updateLargeFilterInput: it edits the drill-down filter query live, applies on
+// Enter, clears on Esc, and clears multi-selection on any query change so an
+// action can never touch a row hidden by the filter.
+func (m model) updateEntryFilterInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyCtrlC:
+		return m, tea.Quit
+	case tea.KeyEsc:
+		m.resetEntryFilter()
+		m.clampEntrySelection()
+		m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
+		return m, nil
+	case tea.KeyEnter:
+		m.entryFiltering = false
+		if m.entryFilter == "" {
+			m.status = fmt.Sprintf("Scanned %s", humanizeBytes(m.totalSize))
+		} else {
+			m.status = fmt.Sprintf("Filter %q, %d matches", m.entryFilter, len(m.entries))
+		}
+		return m, nil
+	case tea.KeyBackspace, tea.KeyDelete:
+		if r := []rune(m.entryFilter); len(r) > 0 {
+			m.entryFilter = string(r[:len(r)-1])
+			m.multiSelected = make(map[string]bool)
+			m.applyEntryFilter()
+		}
+		return m, nil
+	case tea.KeySpace:
+		m.entryFilter += " "
+		m.multiSelected = make(map[string]bool)
+		m.applyEntryFilter()
+		return m, nil
+	case tea.KeyRunes:
+		m.entryFilter += string(msg.Runes)
+		m.multiSelected = make(map[string]bool)
+		m.applyEntryFilter()
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
 func (m model) goBack() (tea.Model, tea.Cmd) {
 	if len(m.history) == 0 {
 		if !m.inOverviewMode() {
@@ -705,7 +834,11 @@ func (m model) goBack() (tea.Model, tea.Cmd) {
 	m.largeSelected = last.LargeSelected
 	m.largeOffset = last.LargeOffset
 	m.isOverview = last.IsOverview
+	m.resetEntryFilter()
+	m.resetLargeFilter()
+	m.entriesAll = last.Entries
 	m.entries = last.Entries
+	m.largeFilesAll = last.LargeFiles
 	m.largeFiles = last.LargeFiles
 	m.totalSize = last.TotalSize
 	m.totalFiles = last.TotalFiles
@@ -744,6 +877,10 @@ func (m *model) switchToOverviewMode() tea.Cmd {
 	m.path = "/"
 	m.scanning = false
 	m.showLargeFiles = false
+	m.entriesAll = nil
+	m.resetEntryFilter()
+	m.resetLargeFilter()
+	m.largeFilesAll = nil
 	m.largeFiles = nil
 	m.largeSelected = 0
 	m.largeOffset = 0
@@ -766,6 +903,20 @@ func (m model) enterSelectedDir() (tea.Model, tea.Cmd) {
 	}
 	selected := m.entries[m.selected]
 	if selected.IsDir {
+		// Drilling in commits and drops any active directory filter so the parent
+		// is snapshotted in full. Remap the selection onto the unfiltered list so
+		// the entry we enter stays highlighted when we navigate back.
+		if m.entryFilter != "" {
+			for i := range m.entriesAll {
+				if m.entriesAll[i].Path == selected.Path {
+					m.selected = i
+					break
+				}
+			}
+		}
+		m.resetEntryFilter()
+		m.clampEntrySelection()
+
 		if len(m.history) == 0 || m.history[len(m.history)-1].Path != m.path {
 			m.history = append(m.history, snapshotFromModel(m))
 		}
@@ -786,9 +937,12 @@ func (m model) enterSelectedDir() (tea.Model, tea.Cmd) {
 			m.currentPath.Store("")
 		}
 
+		m.resetLargeFilter()
 		if cached, ok := m.cache[m.path]; ok {
-			m.entries = slices.Clone(cached.Entries)
-			m.largeFiles = slices.Clone(cached.LargeFiles)
+			m.entriesAll = slices.Clone(cached.Entries)
+			m.entries = m.entriesAll
+			m.largeFilesAll = slices.Clone(cached.LargeFiles)
+			m.largeFiles = m.largeFilesAll
 			m.totalSize = cached.TotalSize
 			m.totalFiles = cached.TotalFiles
 			m.viewNeedsRefresh = cached.NeedsRefresh

--- a/cmd/analyze/view.go
+++ b/cmd/analyze/view.go
@@ -106,8 +106,21 @@ func (m model) View() string {
 	}
 
 	if m.showLargeFiles {
+		if m.largeFiltering || m.largeFilter != "" {
+			cursor := ""
+			if m.largeFiltering {
+				cursor = "▌"
+			}
+			fmt.Fprintf(&b, "  %sFilter:%s %s%s  %s(%d matches)%s\n\n",
+				colorCyan, colorReset, m.largeFilter, cursor,
+				colorGray, len(m.largeFiles), colorReset)
+		}
 		if len(m.largeFiles) == 0 {
-			fmt.Fprintln(&b, "  No large files found")
+			if m.largeFilter != "" {
+				fmt.Fprintf(&b, "  No matches for %q\n", m.largeFilter)
+			} else {
+				fmt.Fprintln(&b, "  No large files found")
+			}
 		} else {
 			viewport := calculateViewport(m.height, true)
 			start := max(m.largeOffset, 0)
@@ -146,8 +159,21 @@ func (m model) View() string {
 			}
 		}
 	} else {
+		if !m.inOverviewMode() && (m.entryFiltering || m.entryFilter != "") {
+			cursor := ""
+			if m.entryFiltering {
+				cursor = "▌"
+			}
+			fmt.Fprintf(&b, "  %sFilter:%s %s%s  %s(%d matches)%s\n\n",
+				colorCyan, colorReset, m.entryFilter, cursor,
+				colorGray, len(m.entries), colorReset)
+		}
 		if len(m.entries) == 0 {
-			fmt.Fprintln(&b, "  Empty directory")
+			if !m.inOverviewMode() && m.entryFilter != "" {
+				fmt.Fprintf(&b, "  No matches for %q\n", m.entryFilter)
+			} else {
+				fmt.Fprintln(&b, "  Empty directory")
+			}
 		} else {
 			if m.inOverviewMode() {
 				maxSize := maxDirEntrySize(m.entries)
@@ -295,26 +321,36 @@ func (m model) View() string {
 			fmt.Fprintf(&b, "%s↑↓→ | Enter | R Refresh | O Open | P Preview | F File | Esc/Q Quit%s\n", colorGray, colorReset)
 		}
 	} else if m.showLargeFiles {
-		selectCount := len(m.largeMultiSelected)
-		if selectCount > 0 {
-			fmt.Fprintf(&b, "%s↑↓← | Space Select | R Refresh | O Open | P Preview | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
+		if m.largeFiltering {
+			fmt.Fprintf(&b, "%sType to filter  |  Enter Apply  |  Esc Clear  |  Ctrl+C Quit%s\n", colorGray, colorReset)
+		} else if m.largeFilter != "" {
+			fmt.Fprintf(&b, "%s↑↓← | Space Select | / Edit | Esc Clear filter | O Open | P Preview | F File | ⌫ Del | Q Quit%s\n", colorGray, colorReset)
 		} else {
-			fmt.Fprintf(&b, "%s↑↓← | Space Select | R Refresh | O Open | P Preview | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
+			selectCount := len(m.largeMultiSelected)
+			if selectCount > 0 {
+				fmt.Fprintf(&b, "%s↑↓← | Space Select | / Filter | R Refresh | O Open | P Preview | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
+			} else {
+				fmt.Fprintf(&b, "%s↑↓← | Space Select | / Filter | R Refresh | O Open | P Preview | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
+			}
 		}
+	} else if m.entryFiltering {
+		fmt.Fprintf(&b, "%sType to filter  |  Enter Apply  |  Esc Clear  |  Ctrl+C Quit%s\n", colorGray, colorReset)
+	} else if m.entryFilter != "" {
+		fmt.Fprintf(&b, "%s↑↓←→ | Enter | Space Select | / Edit | Esc Clear filter | O Open | P Preview | F File | ⌫ Del | Q Quit%s\n", colorGray, colorReset)
 	} else {
 		largeFileCount := len(m.largeFiles)
 		selectCount := len(m.multiSelected)
 		if selectCount > 0 {
 			if largeFileCount > 0 {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del %d | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, largeFileCount, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | / Filter | R Refresh | O Open | P Preview | F File | ⌫ Del %d | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, largeFileCount, colorReset)
 			} else {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | / Filter | R Refresh | O Open | P Preview | F File | ⌫ Del %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, selectCount, colorReset)
 			}
 		} else {
 			if largeFileCount > 0 {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, largeFileCount, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | / Filter | R Refresh | O Open | P Preview | F File | ⌫ Del | T Top %d | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, largeFileCount, colorReset)
 			} else {
-				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | R Refresh | O Open | P Preview | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
+				fmt.Fprintf(&b, "%s↑↓←→ | Space Select | Enter | / Filter | R Refresh | O Open | P Preview | F File | ⌫ Del | Esc Back | Q/Ctrl+C Quit%s\n", colorGray, colorReset)
 			}
 		}
 	}


### PR DESCRIPTION
## What

Adds an incremental, type-to-filter to the `analyze` disk explorer. Press `/` to filter the current list as you type, `Enter` to apply, `Esc` to clear. Works in both:

- the **Top files** (`T`) view, and
- the **directory drill-down** view.

Matching is case-insensitive substring over the entry name and its display path. This makes a deep scan navigable when you already know what you are looking for (e.g. `node_modules`, `.mp4`), instead of only scrolling a size-ranked list.

## Usage

```
mo analyze
#   drill into a directory  → / → type "node" → Enter      (tree filter)
#   press t                 → / → type "mp4"  → Enter      (Top files filter)
#   Esc clears the filter; a second Esc leaves the view
```

The footer and a `Filter: <query> (N matches)` line show the active state.

## Implementation notes

- The full list is kept in `largeFilesAll` / `entriesAll`; `largeFiles` / `entries` hold the rendered view. Every existing reader (render, navigation, delete, open) is unchanged because it already reads the view slice.
- Match semantics are single-sourced (`filterMatches`, generic `filterByQuery` / `removeByPath`) so the two views cannot drift.
- Changing the query clears multi-selection, so a delete/open can never touch a row hidden by the filter. The single-item delete targets the visible match.
- Drilling into a filtered directory snapshots the parent in full and remaps the selection, so going back restores the unfiltered siblings with the entered directory still highlighted.
- Filtering is disabled in overview mode and is ephemeral per view (reset on refresh, view toggle, and navigation).

## Safety fix included

While wiring the shared `removeByPath`, this also fixes a list-corruption bug: when no filter is active the view aliases its backing list, and removing from both shifted the shared array twice, leaving a duplicated, stale entry after a delete. `removePathFromView` now trims the backing list once and rebuilds each view through the filters.

## Testing

- 15 new tests in `cmd/analyze/analyze_filter_test.go` (Top-files + tree filters, drill-in round-trip, multi-select safety, backing-list integrity).
- `go test ./cmd/...` green, `gofmt` clean, `go vet` clean, `make build` passes.

No new dependencies; matching is plain substring (fuzzy ranking left as a follow-up).