### PR TITLE
Avoid recursive container stub cleanup

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -801,6 +801,23 @@ clean_orphaned_system_services() {
 # A stub container contains only .com.apple.containermanagerd.metadata.plist
 # with no Data/ subdirectory — it holds no user data and is safe to remove.
 # Only targets a hardcoded allowlist of apps known to leave such stubs.
+_remove_verified_container_stub() {
+    local container_dir="$1"
+    local metadata_plist="$2"
+
+    [[ -d "$container_dir" ]] || return 1
+    [[ ! -L "$container_dir" ]] || return 1
+    [[ "$metadata_plist" == "$container_dir/.com.apple.containermanagerd.metadata.plist" ]] || return 1
+    [[ -f "$metadata_plist" ]] || return 1
+
+    if find "$container_dir" -mindepth 1 -maxdepth 1 ! -name ".com.apple.containermanagerd.metadata.plist" -print -quit 2> /dev/null | grep -q .; then
+        return 1
+    fi
+
+    command rm -f -- "$metadata_plist" || return 1
+    command rmdir -- "$container_dir"
+}
+
 clean_orphaned_container_stubs() {
     local containers_dir="$HOME/Library/Containers"
     [[ -d "$containers_dir" ]] || return 0
@@ -883,11 +900,9 @@ clean_orphaned_container_stubs() {
 
             if [[ "$DRY_RUN" != "true" ]]; then
                 # These directories have already passed the narrow stub-only
-                # checks above. Use direct removal so broad app-protection rules
-                # for the parent vendor bundle do not keep empty metadata stubs.
-                # safe_remove cannot be used here: it runs should_protect_path
-                # which intentionally vetos vendor-bundle paths we just verified.
-                if command rm -rf -- "$container_dir" > /dev/null 2>&1; then # SAFE: verified stub-only container
+                # checks above. Remove only the exact metadata file, then rmdir,
+                # so any new content that appears before deletion is preserved.
+                if _remove_verified_container_stub "$container_dir" "$metadata_plist" > /dev/null 2>&1; then
                     removed_count=$((removed_count + 1))
                     log_operation "${MOLE_CURRENT_COMMAND:-clean}" "REMOVED" "$container_dir" "stub-container"
                 else

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -956,6 +956,64 @@ EOF
     [[ "$output" == *"Orphaned app container stubs"* ]]
 }
 
+@test "clean_orphaned_container_stubs preserves content that appears during removal" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+stub="$HOME/Library/Containers/com.macpaw.CleanMyMac-mas"
+mkdir -p "$stub"
+touch "$stub/.com.apple.containermanagerd.metadata.plist"
+
+fake_bin="$(mktemp -d "$HOME/fake-bin.XXXXXX")"
+cat > "$fake_bin/rm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+target=""
+for arg in "$@"; do
+    target="$arg"
+done
+if [[ -n "$target" ]]; then
+    if [[ -d "$target" ]]; then
+        touch "$target/raced-content"
+    else
+        parent=$(dirname "$target")
+        touch "$parent/raced-content"
+    fi
+fi
+exec /bin/rm "$@"
+SH
+chmod +x "$fake_bin/rm"
+PATH="$fake_bin:$PATH"
+export PATH
+hash -r
+
+mdfind() { echo ""; return 0; }
+run_with_timeout() { shift; "$@"; }
+note_activity() { :; }
+debug_log() { :; }
+is_path_whitelisted() { return 1; }
+
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+clean_orphaned_container_stubs
+
+if [[ -f "$stub/raced-content" ]]; then
+    echo "PASS: race content preserved"
+else
+    echo "FAIL: race content was deleted"
+    exit 1
+fi
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS: race content preserved"* ]]
+    [[ "$output" == *"could not be removed"* ]]
+}
+
 @test "clean_orphaned_container_stubs preserves container when app is installed" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
Summary:
Change orphaned container-stub cleanup to remove only the verified metadata plist, then rmdir the container instead of recursively deleting the directory.

Why:
The old path verified a metadata-only container, then ran rm -rf on the directory. If anything appeared after verification, that recursive delete could remove content that was no longer part of the verified stub.

Validation:
./scripts/check.sh --format
./scripts/check.sh
env -u NO_COLOR MOLE_TEST_NO_AUTH=1 bats tests/clean_apps.bats
MOLE_TEST_NO_AUTH=1 bats --filter "clean_orphaned_container_stubs preserves content that appears during removal" tests/clean_apps.bats
env -u NO_COLOR MOLE_TEST_NO_AUTH=1 ./scripts/test.sh
