### PR TITLE
fix(clean): guard empty kept_files expansion on bash 3.2 (#1127)

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -722,7 +722,15 @@ clean_orphaned_system_services() {
             kept_files+=("$orphan_file")
         done
         orphaned_count=${#kept_files[@]}
-        orphaned_files=("${kept_files[@]}")
+        # Guard the empty-array expansion: macOS /bin/bash is 3.2, which treats
+        # "${empty[@]}" as an unbound variable under `set -u`. When every orphan
+        # is whitelisted kept_files is empty, so a bare expansion would abort the
+        # whole clean run. See #1127.
+        if ((orphaned_count > 0)); then
+            orphaned_files=("${kept_files[@]}")
+        else
+            orphaned_files=()
+        fi
     fi
 
     # Report and clean

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -1121,3 +1121,54 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"PASS: non-stub container preserved"* ]]
 }
+
+@test "clean_orphaned_system_services tolerates all-whitelisted orphans on /bin/bash 3.2 (#1127)" {
+    # macOS ships /bin/bash 3.2 (Apple does not upgrade past it, GPLv3) and
+    # lib/clean/apps.sh runs under `set -u`, where bash 3.2 treats "${empty[@]}"
+    # as an unbound variable rather than an empty expansion. When orphans are
+    # found but every one is whitelisted, kept_files ends up empty and the
+    # whitelist filter's `orphaned_files=("${kept_files[@]}")` aborted the whole
+    # clean run with "kept_files[@]: unbound variable". Force /bin/bash so the
+    # 3.2 expansion behaviour is exercised regardless of any newer bash on PATH.
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 DRY_RUN=true /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+debug_log() { :; }
+
+should_protect_path() { return 1; }
+# Every detected orphan is whitelisted, so kept_files stays empty.
+is_path_whitelisted() { return 0; }
+WHITELIST_PATTERNS=("com.example.*")
+
+tmp_dir="$(mktemp -d)"
+tmp_plist="$tmp_dir/com.example.whitelisted.orphan.plist"
+/usr/libexec/PlistBuddy -c "Add :Program string $tmp_dir/missing-binary" "$tmp_plist" 2> /dev/null || true
+
+sudo() {
+  if [[ "$1" == "-n" && "$2" == "true" ]]; then
+    return 0
+  fi
+  [[ "${1:-}" == "-n" ]] && shift
+  if [[ "$1" == "find" ]]; then
+    case "$2" in
+      /Library/LaunchDaemons) printf '%s\0' "$tmp_plist" ;;
+      *) : ;;
+    esac
+    return 0
+  fi
+  command "$@"
+}
+
+clean_orphaned_system_services
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"unbound variable"* ]] || return 1
+    # Whitelisted orphan must be filtered out, so nothing is reported for removal.
+    [[ "$output" != *"Would remove orphaned service"* ]] || return 1
+}


### PR DESCRIPTION
## Summary

Fix for #1127. `mo clean` aborts during the **App leftovers** phase with:

```
➤ App leftovers
  ✓ Found 190 active/installed apps
.../lib/clean/apps.sh: line 725: kept_files[@]: unbound variable
```

macOS `/bin/bash` is 3.2.x (Apple does not upgrade past it, GPLv3). Under `set -u`, bash 3.2 treats `"${empty_array[@]}"` as an unbound expansion rather than expanding to zero elements. This is the same root cause as #863/#867 and #790/#792, in a code path that wasn't guarded yet.

In `clean_orphaned_system_services`, the whitelist filter declares `local -a kept_files=()` and only appends orphans that are **not** whitelisted:

```bash
orphaned_count=${#kept_files[@]}
orphaned_files=("${kept_files[@]}")   # line 725
```

The block runs when orphans were found **and** a whitelist exists. When **every** detected orphan matches the whitelist, `kept_files` stays empty, so the expansion aborts the whole clean run. Because it depends on the machine's current orphan state plus the user's whitelist, it surfaces intermittently.

## Reproduction

The bash-3.2 quirk under `set -u`:

```bash
$ /bin/bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin26)

$ /bin/bash -c 'set -euo pipefail; declare -a kept_files=(); orphaned_files=("${kept_files[@]}"); echo ok'
/bin/bash: kept_files[@]: unbound variable

$ /opt/homebrew/bin/bash -c 'set -euo pipefail; declare -a kept_files=(); orphaned_files=("${kept_files[@]}"); echo ok'
ok
```

## Fix

Guard the expansion with the same count check used for the prior bash 3.2 array fixes (#792, #867):

```bash
orphaned_count=${#kept_files[@]}
if ((orphaned_count > 0)); then
    orphaned_files=("${kept_files[@]}")
else
    orphaned_files=()
fi
```

## Testing

- Added a regression test in `tests/clean_apps.bats` that drives `clean_orphaned_system_services` under `/bin/bash` (forcing the 3.2 expansion behaviour) with an all-whitelisted orphan. It fails on `main` (exit non-zero, `kept_files[@]: unbound variable`) and passes with the fix.
- `shfmt -i 4 -ci -sr -d lib/clean/apps.sh` → clean.
- `shellcheck` on `lib/clean/apps.sh` → clean.
- Full `tests/clean_apps.bats` suite passes the same set of tests before and after this change. (One pre-existing, environment-dependent failure unrelated to this change — `protects AmneziaWG helpers`, which reads real `/Library/PrivilegedHelperTools` state — fails identically on pristine `main` on my machine.)
