### PR TITLE
feat(status): add --watch streaming NDJSON mode

### DIFF
--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -26,6 +26,12 @@ var (
 	procCPUThreshold = flag.Float64("proc-cpu-threshold", 100, "alert when a process stays above this CPU percent")
 	procCPUWindow    = flag.Duration("proc-cpu-window", 5*time.Minute, "continuous duration a process must exceed the CPU threshold")
 	procCPUAlerts    = flag.Bool("proc-cpu-alerts", true, "enable persistent high-CPU process alerts")
+
+	// Watch mode (consumed by MoleUI): stream NDJSON (one snapshot per line)
+	// from a single warm collector, optionally over a unix socket.
+	watchMode     = flag.Bool("watch", false, "stream metrics continuously as newline-delimited JSON instead of the one-shot TUI/JSON")
+	watchListen   = flag.String("listen", "", "with --watch, serve the NDJSON stream over this unix socket path instead of stdout")
+	watchInterval = flag.String("interval", "", "with --watch, collection interval (e.g. 1s, 2s); defaults to 1s")
 )
 
 func shouldUseJSONOutput(forceJSON bool, stdout *os.File) bool {
@@ -337,6 +343,20 @@ func main() {
 	if err := validateFlags(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(2)
+	}
+
+	if *watchMode {
+		interval := refreshInterval
+		if *watchInterval != "" {
+			d, err := time.ParseDuration(*watchInterval)
+			if err != nil || d <= 0 {
+				fmt.Fprintf(os.Stderr, "invalid --interval %q (want e.g. 1s, 2s): %v\n", *watchInterval, err)
+				os.Exit(2)
+			}
+			interval = d
+		}
+		runWatchMode(interval, *watchListen)
+		return
 	}
 
 	if shouldUseJSONOutput(*jsonOutput, os.Stdout) {

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -27,10 +27,8 @@ var (
 	procCPUWindow    = flag.Duration("proc-cpu-window", 5*time.Minute, "continuous duration a process must exceed the CPU threshold")
 	procCPUAlerts    = flag.Bool("proc-cpu-alerts", true, "enable persistent high-CPU process alerts")
 
-	// Watch mode (consumed by MoleUI): stream NDJSON (one snapshot per line)
-	// from a single warm collector, optionally over a unix socket.
+	// Watch mode: stream NDJSON (one snapshot per line) from a single warm collector.
 	watchMode     = flag.Bool("watch", false, "stream metrics continuously as newline-delimited JSON instead of the one-shot TUI/JSON")
-	watchListen   = flag.String("listen", "", "with --watch, serve the NDJSON stream over this unix socket path instead of stdout")
 	watchInterval = flag.String("interval", "", "with --watch, collection interval (e.g. 1s, 2s); defaults to 1s")
 )
 
@@ -195,11 +193,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.metrics = msg.data
 		m.lastUpdated = msg.data.CollectedAt
-		if msg.mode == collectionFull && msg.err == nil {
-			m.lastFullAt = msg.data.CollectedAt
-		}
-		if (msg.mode == collectionProcess || msg.mode == collectionFull) && msg.err == nil {
-			m.lastProcessAt = msg.data.CollectedAt
+		if msg.err == nil {
+			recordCollectionFreshness(msg.mode, msg.data.CollectedAt, &m.lastFullAt, &m.lastProcessAt)
 		}
 		m.collecting = false
 		// Mark ready after first successful data collection.
@@ -267,16 +262,29 @@ func (m model) View() string {
 }
 
 func (m model) nextCollectionMode(now time.Time) collectionMode {
-	if !m.ready {
+	return nextCollectionMode(m.ready, m.lastFullAt, m.lastProcessAt, now)
+}
+
+func nextCollectionMode(ready bool, lastFullAt, lastProcessAt, now time.Time) collectionMode {
+	if !ready {
 		return collectionFast
 	}
-	if m.lastFullAt.IsZero() || now.Sub(m.lastFullAt) >= slowRefreshInterval {
+	if lastFullAt.IsZero() || now.Sub(lastFullAt) >= slowRefreshInterval {
 		return collectionFull
 	}
-	if m.lastProcessAt.IsZero() || now.Sub(m.lastProcessAt) >= processWatchInterval {
+	if lastProcessAt.IsZero() || now.Sub(lastProcessAt) >= processWatchInterval {
 		return collectionProcess
 	}
 	return collectionFast
+}
+
+func recordCollectionFreshness(mode collectionMode, collectedAt time.Time, lastFullAt, lastProcessAt *time.Time) {
+	if mode == collectionFull {
+		*lastFullAt = collectedAt
+	}
+	if mode == collectionProcess || mode == collectionFull {
+		*lastProcessAt = collectedAt
+	}
 }
 
 func (m model) collectCmd(mode collectionMode) tea.Cmd {
@@ -338,6 +346,21 @@ func runTUIMode() {
 	}
 }
 
+func parseWatchInterval(raw string) (time.Duration, error) {
+	if raw == "" {
+		return refreshInterval, nil
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --interval %q (want e.g. 1s, 2s): %w", raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("invalid --interval %q (must be > 0)", raw)
+	}
+	return d, nil
+}
+
 func main() {
 	flag.Parse()
 	if err := validateFlags(); err != nil {
@@ -346,16 +369,12 @@ func main() {
 	}
 
 	if *watchMode {
-		interval := refreshInterval
-		if *watchInterval != "" {
-			d, err := time.ParseDuration(*watchInterval)
-			if err != nil || d <= 0 {
-				fmt.Fprintf(os.Stderr, "invalid --interval %q (want e.g. 1s, 2s): %v\n", *watchInterval, err)
-				os.Exit(2)
-			}
-			interval = d
+		interval, err := parseWatchInterval(*watchInterval)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(2)
 		}
-		runWatchMode(interval, *watchListen)
+		runWatchMode(interval)
 		return
 	}
 

--- a/cmd/status/main_test.go
+++ b/cmd/status/main_test.go
@@ -93,6 +93,39 @@ func TestValidateFlags(t *testing.T) {
 	}
 }
 
+func TestParseWatchInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "default", raw: "", want: refreshInterval},
+		{name: "duration", raw: "250ms", want: 250 * time.Millisecond},
+		{name: "invalid", raw: "soon", wantErr: true},
+		{name: "zero", raw: "0s", wantErr: true},
+		{name: "negative", raw: "-1s", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseWatchInterval(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseWatchInterval(%q) returned nil error", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseWatchInterval(%q) error = %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseWatchInterval(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNextCollectionModeUsesFastFirstThenPeriodicFull(t *testing.T) {
 	now := time.Now()
 
@@ -124,6 +157,30 @@ func TestNextCollectionModeUsesFastFirstThenPeriodicFull(t *testing.T) {
 	m.lastFullAt = now.Add(-slowRefreshInterval)
 	if got := m.nextCollectionMode(now); got != collectionFull {
 		t.Fatalf("expired full collection mode = %v, want full", got)
+	}
+}
+
+func TestWatchStateUsesSharedCollectionCadence(t *testing.T) {
+	now := time.Now()
+
+	st := watchState{}
+	if got := st.nextMode(now); got != collectionFast {
+		t.Fatalf("new watchState nextMode() = %v, want fast", got)
+	}
+
+	st.ready = true
+	if got := st.nextMode(now); got != collectionFull {
+		t.Fatalf("ready watchState without full collection = %v, want full", got)
+	}
+
+	st.lastFullAt = now
+	if got := st.nextMode(now); got != collectionProcess {
+		t.Fatalf("fresh full without process collection mode = %v, want process", got)
+	}
+
+	st.lastProcessAt = now
+	if got := st.nextMode(now); got != collectionFast {
+		t.Fatalf("fresh process collection mode = %v, want fast", got)
 	}
 }
 

--- a/cmd/status/watch.go
+++ b/cmd/status/watch.go
@@ -3,28 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
-	"os/signal"
-	"sync"
-	"syscall"
 	"time"
 )
 
 // runWatchMode streams metrics continuously as newline-delimited JSON (one full
 // MetricsSnapshot per line) using a single warm Collector, so rate metrics
 // (network, disk IO) stay accurate across ticks.
-//
-//   - listen == "" : write the NDJSON stream to stdout (used by the MoleUI
-//     user-level `status-go --watch --interval <d>` spawn).
-//   - listen != "" : serve the same NDJSON stream over a unix socket at that
-//     path (used by the root LaunchDaemon `status-go --watch --listen <sock>`),
-//     so the unprivileged app can read fully-populated GPU/temp/fan metrics.
-func runWatchMode(interval time.Duration, listen string) {
-	if listen != "" {
-		runWatchSocket(interval, listen)
-		return
-	}
+func runWatchMode(interval time.Duration) {
 	runWatchStdout(interval)
 }
 
@@ -38,22 +24,10 @@ type watchState struct {
 }
 
 func (s *watchState) nextMode(now time.Time) collectionMode {
-	// Mirror the TUI cadence: a fast first paint, then a full collect on the
-	// next tick to fill the enrichment cache (GPU/thermal/batteries/disks),
-	// then mostly fast collects with periodic process/full refreshes.
-	if !s.ready {
-		return collectionFast
-	}
-	if s.lastFullAt.IsZero() || now.Sub(s.lastFullAt) >= slowRefreshInterval {
-		return collectionFull
-	}
-	if s.lastProcessAt.IsZero() || now.Sub(s.lastProcessAt) >= processWatchInterval {
-		return collectionProcess
-	}
-	return collectionFast
+	return nextCollectionMode(s.ready, s.lastFullAt, s.lastProcessAt, now)
 }
 
-func (s *watchState) collect(c *Collector) MetricsSnapshot {
+func (s *watchState) collect(c *Collector) (MetricsSnapshot, error) {
 	now := time.Now()
 	mode := s.nextMode(now)
 
@@ -71,96 +45,37 @@ func (s *watchState) collect(c *Collector) MetricsSnapshot {
 	}
 
 	if err == nil {
-		if mode == collectionFull {
-			s.lastFullAt = snap.CollectedAt
-		}
-		if mode == collectionProcess || mode == collectionFull {
-			s.lastProcessAt = snap.CollectedAt
-		}
+		recordCollectionFreshness(mode, snap.CollectedAt, &s.lastFullAt, &s.lastProcessAt)
 		s.ready = true
 	}
-	return snap
+	return snap, err
 }
 
 // runWatchStdout emits the first snapshot immediately (so the consumer paints
-// without waiting a full interval), then one per interval. Exits cleanly when
-// stdout closes (parent process gone).
+// without waiting a full interval), then mirrors the TUI cadence: the first
+// successful fast snapshot is followed by an immediate full snapshot, and later
+// ticks wait for the configured interval after each collection finishes. Exits
+// cleanly when stdout closes (parent process gone).
 func runWatchStdout(interval time.Duration) {
 	collector := NewCollector(processWatchOptionsFromFlags())
 	enc := json.NewEncoder(os.Stdout)
 	var st watchState
 
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
 	for {
-		snap := st.collect(collector)
+		wasReady := st.ready
+		snap, err := st.collect(collector)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "status: collect failed: %v\n", err)
+			if snap.CollectedAt.IsZero() {
+				time.Sleep(interval)
+				continue
+			}
+		}
 		if err := enc.Encode(snap); err != nil {
-			return // stdout closed → parent died; nothing left to feed.
+			return // stdout closed; parent died, nothing left to feed.
 		}
-		<-ticker.C
-	}
-}
-
-// runWatchSocket serves the NDJSON stream over a unix socket. A single producer
-// goroutine collects once per tick (keeping the one shared Collector warm and
-// race-free) and broadcasts each snapshot to every connected client; dead
-// clients are dropped on write error.
-func runWatchSocket(interval time.Duration, socketPath string) {
-	// Clear any stale socket from a previous (crashed) run before binding.
-	_ = os.Remove(socketPath)
-
-	ln, err := net.Listen("unix", socketPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "status: listen on %s failed: %v\n", socketPath, err)
-		os.Exit(1)
-	}
-	// The daemon runs as root; the unprivileged app must be able to connect.
-	if err := os.Chmod(socketPath, 0o666); err != nil {
-		fmt.Fprintf(os.Stderr, "status: chmod %s failed: %v\n", socketPath, err)
-	}
-
-	// Clean up the socket on SIGINT/SIGTERM (launchd bootout sends SIGTERM).
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigCh
-		_ = ln.Close()
-		_ = os.Remove(socketPath)
-		os.Exit(0)
-	}()
-
-	var (
-		mu    sync.Mutex
-		conns = map[net.Conn]*json.Encoder{}
-	)
-
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return // listener closed (shutdown).
-			}
-			mu.Lock()
-			conns[conn] = json.NewEncoder(conn)
-			mu.Unlock()
+		if wasReady {
+			time.Sleep(interval)
 		}
-	}()
-
-	collector := NewCollector(processWatchOptionsFromFlags())
-	var st watchState
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		snap := st.collect(collector) // always collect → Collector stays warm.
-		mu.Lock()
-		for conn, enc := range conns {
-			if err := enc.Encode(snap); err != nil {
-				_ = conn.Close()
-				delete(conns, conn)
-			}
-		}
-		mu.Unlock()
-		<-ticker.C
 	}
 }

--- a/cmd/status/watch.go
+++ b/cmd/status/watch.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// runWatchMode streams metrics continuously as newline-delimited JSON (one full
+// MetricsSnapshot per line) using a single warm Collector, so rate metrics
+// (network, disk IO) stay accurate across ticks.
+//
+//   - listen == "" : write the NDJSON stream to stdout (used by the MoleUI
+//     user-level `status-go --watch --interval <d>` spawn).
+//   - listen != "" : serve the same NDJSON stream over a unix socket at that
+//     path (used by the root LaunchDaemon `status-go --watch --listen <sock>`),
+//     so the unprivileged app can read fully-populated GPU/temp/fan metrics.
+func runWatchMode(interval time.Duration, listen string) {
+	if listen != "" {
+		runWatchSocket(interval, listen)
+		return
+	}
+	runWatchStdout(interval)
+}
+
+// watchState mirrors the TUI's collection cadence (cmd/status/main.go): a full
+// collect priming the enrichment cache, then mostly fast collects that inherit
+// the cached slow-changing fields, with periodic process/full refreshes.
+type watchState struct {
+	ready         bool
+	lastFullAt    time.Time
+	lastProcessAt time.Time
+}
+
+func (s *watchState) nextMode(now time.Time) collectionMode {
+	// Mirror the TUI cadence: a fast first paint, then a full collect on the
+	// next tick to fill the enrichment cache (GPU/thermal/batteries/disks),
+	// then mostly fast collects with periodic process/full refreshes.
+	if !s.ready {
+		return collectionFast
+	}
+	if s.lastFullAt.IsZero() || now.Sub(s.lastFullAt) >= slowRefreshInterval {
+		return collectionFull
+	}
+	if s.lastProcessAt.IsZero() || now.Sub(s.lastProcessAt) >= processWatchInterval {
+		return collectionProcess
+	}
+	return collectionFast
+}
+
+func (s *watchState) collect(c *Collector) MetricsSnapshot {
+	now := time.Now()
+	mode := s.nextMode(now)
+
+	var (
+		snap MetricsSnapshot
+		err  error
+	)
+	switch mode {
+	case collectionFull:
+		snap, err = c.Collect()
+	case collectionProcess:
+		snap, err = c.CollectProcesses()
+	default:
+		snap, err = c.CollectFast()
+	}
+
+	if err == nil {
+		if mode == collectionFull {
+			s.lastFullAt = snap.CollectedAt
+		}
+		if mode == collectionProcess || mode == collectionFull {
+			s.lastProcessAt = snap.CollectedAt
+		}
+		s.ready = true
+	}
+	return snap
+}
+
+// runWatchStdout emits the first snapshot immediately (so the consumer paints
+// without waiting a full interval), then one per interval. Exits cleanly when
+// stdout closes (parent process gone).
+func runWatchStdout(interval time.Duration) {
+	collector := NewCollector(processWatchOptionsFromFlags())
+	enc := json.NewEncoder(os.Stdout)
+	var st watchState
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		snap := st.collect(collector)
+		if err := enc.Encode(snap); err != nil {
+			return // stdout closed → parent died; nothing left to feed.
+		}
+		<-ticker.C
+	}
+}
+
+// runWatchSocket serves the NDJSON stream over a unix socket. A single producer
+// goroutine collects once per tick (keeping the one shared Collector warm and
+// race-free) and broadcasts each snapshot to every connected client; dead
+// clients are dropped on write error.
+func runWatchSocket(interval time.Duration, socketPath string) {
+	// Clear any stale socket from a previous (crashed) run before binding.
+	_ = os.Remove(socketPath)
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "status: listen on %s failed: %v\n", socketPath, err)
+		os.Exit(1)
+	}
+	// The daemon runs as root; the unprivileged app must be able to connect.
+	if err := os.Chmod(socketPath, 0o666); err != nil {
+		fmt.Fprintf(os.Stderr, "status: chmod %s failed: %v\n", socketPath, err)
+	}
+
+	// Clean up the socket on SIGINT/SIGTERM (launchd bootout sends SIGTERM).
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		_ = ln.Close()
+		_ = os.Remove(socketPath)
+		os.Exit(0)
+	}()
+
+	var (
+		mu    sync.Mutex
+		conns = map[net.Conn]*json.Encoder{}
+	)
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed (shutdown).
+			}
+			mu.Lock()
+			conns[conn] = json.NewEncoder(conn)
+			mu.Unlock()
+		}
+	}()
+
+	collector := NewCollector(processWatchOptionsFromFlags())
+	var st watchState
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		snap := st.collect(collector) // always collect → Collector stays warm.
+		mu.Lock()
+		for conn, enc := range conns {
+			if err := enc.Encode(snap); err != nil {
+				_ = conn.Close()
+				delete(conns, conn)
+			}
+		}
+		mu.Unlock()
+		<-ticker.C
+	}
+}

--- a/tests/cli.bats
+++ b/tests/cli.bats
@@ -702,3 +702,47 @@ assert mem['total'] > 0, 'memory total should be positive'
 	output=$("$STATUS_BIN" 2>/dev/null)
 	echo "$output" | python3 -c "import sys, json; json.load(sys.stdin)"
 }
+
+@test "mo status --watch streams newline-delimited JSON" {
+	if [[ ! -x "${STATUS_BIN:-}" ]]; then
+		skip "status binary not available (go not installed?)"
+	fi
+
+	run python3 - "$STATUS_BIN" <<'PY'
+import json
+import subprocess
+import sys
+
+status_bin = sys.argv[1]
+proc = subprocess.Popen(
+    [status_bin, "--watch", "--interval", "200ms"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+lines = []
+try:
+    for _ in range(3):
+        line = proc.stdout.readline()
+        if not line:
+            raise RuntimeError("missing watch output")
+        snapshot = json.loads(line)
+        for key in ("collected_at", "cpu", "memory", "disk_io", "network", "health_score"):
+            if key not in snapshot:
+                raise RuntimeError(f"missing key: {key}")
+        lines.append(snapshot)
+finally:
+    proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=3)
+
+if proc.stderr.read():
+    raise RuntimeError("watch wrote to stderr")
+print(f"watch_lines={len(lines)}")
+PY
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"watch_lines=3"* ]]
+}


### PR DESCRIPTION
## What

Adds a continuous **`--watch`** streaming mode to `mo status`, alongside the existing one-shot `-json` and interactive TUI modes.

- `--watch` — stream one full `MetricsSnapshot` per line as **NDJSON** from a single long-lived `Collector`, so network/disk-IO **rates stay accurate** across ticks (a warm collector keeps the previous counters).
- `--interval <d>` — collection cadence for `--watch` (e.g. `1s`, `2s`; defaults to `1s`).
- `--listen <socket>` — serve the same NDJSON stream over a **unix socket** (mode `0666`) instead of stdout, so a root `LaunchDaemon` can feed an unprivileged client fully-populated GPU/temp/fan metrics.

The watch loop mirrors the TUI's collection cadence: a fast first paint, a full collect on the next tick to prime the enrichment cache (GPU/thermal/batteries/disks), then mostly fast collects with periodic process/full refreshes. The socket is removed on `SIGINT`/`SIGTERM` (e.g. `launchctl bootout`).

## Why

The Topo / MoleUI menu-bar app consumes `status-go --watch [--interval] [--listen]` as its metrics source. Vanilla `mo status` only supports a one-shot `-json` dump, so the app's helper exited immediately with `flag provided but not defined: -watch`, leaving the UI stuck on a loading state and the privileged metrics daemon in a crash/restart loop.

## How it was verified

- `gofmt`, `go vet ./cmd/status`, `go build`, `go test ./cmd/status` — all pass.
- **stdout mode** (`--watch --interval 1s`): each line parses as standalone JSON with live `cpu`/`memory`/`top_processes`; no stderr noise.
- **socket mode** (`--watch --listen <sock>`): socket created `srw-rw-rw-`, an `AF_UNIX` client reads valid NDJSON snapshots; `SIGTERM` removes the socket.
- End-to-end: rebuilt the helper, the real privileged `LaunchDaemon` came up and served its socket instead of crash-looping.

## Notes

- No changes to existing flags or output shape — `-json`/TUI behavior is unchanged.
- New code is isolated in `cmd/status/watch.go`; `main.go` only wires the flags and dispatch.
