### PR TITLE
fix(uninstall): detect Anki support files

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1116,9 +1116,9 @@ find_app_files() {
         [[ -d ~/.mobiledev ]] && files_to_clean+=("$HOME/.mobiledev")
     fi
 
-    # Anki stores profile data outside the app-name and bundle-id defaults.
+    # Anki's profile directory (Anki2) contains decks, media, and backups.
+    # Only collect the launcher-managed support files here.
     if [[ "$bundle_id" == "net.ankiweb.anki" ]] || [[ "$app_name" == "Anki" ]]; then
-        [[ -d "$HOME/Library/Application Support/Anki2" ]] && files_to_clean+=("$HOME/Library/Application Support/Anki2")
         [[ -d "$HOME/Library/Application Support/AnkiProgramFiles" ]] && files_to_clean+=("$HOME/Library/Application Support/AnkiProgramFiles")
     fi
 

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1116,6 +1116,12 @@ find_app_files() {
         [[ -d ~/.mobiledev ]] && files_to_clean+=("$HOME/.mobiledev")
     fi
 
+    # Anki stores profile data outside the app-name and bundle-id defaults.
+    if [[ "$bundle_id" == "net.ankiweb.anki" ]] || [[ "$app_name" == "Anki" ]]; then
+        [[ -d "$HOME/Library/Application Support/Anki2" ]] && files_to_clean+=("$HOME/Library/Application Support/Anki2")
+        [[ -d "$HOME/Library/Application Support/AnkiProgramFiles" ]] && files_to_clean+=("$HOME/Library/Application Support/AnkiProgramFiles")
+    fi
+
     # 7. Raycast
     if [[ "$bundle_id" == "com.raycast.macos" ]]; then
         # Standard user directories

--- a/tests/uninstall_naming_variants.bats
+++ b/tests/uninstall_naming_variants.bats
@@ -206,13 +206,13 @@ find_app_files 'invalid_bundle' ''"
     [[ ! "$result" =~ Library/Application\ Support/Code$'\n' ]]
 }
 
-@test "find_app_files detects Anki profile Application Support folders (#1145)" {
+@test "find_app_files detects Anki support files but preserves user profile data (#1145)" {
     mkdir -p "$HOME/Library/Application Support/Anki2"
     mkdir -p "$HOME/Library/Application Support/AnkiProgramFiles"
 
     result=$(find_app_files "net.ankiweb.anki" "Anki")
 
-    [[ "$result" == *"Library/Application Support/Anki2"* ]]
+    [[ "$result" != *"Library/Application Support/Anki2"* ]]
     [[ "$result" == *"Library/Application Support/AnkiProgramFiles"* ]]
 }
 

--- a/tests/uninstall_naming_variants.bats
+++ b/tests/uninstall_naming_variants.bats
@@ -206,6 +206,16 @@ find_app_files 'invalid_bundle' ''"
     [[ ! "$result" =~ Library/Application\ Support/Code$'\n' ]]
 }
 
+@test "find_app_files detects Anki profile Application Support folders (#1145)" {
+    mkdir -p "$HOME/Library/Application Support/Anki2"
+    mkdir -p "$HOME/Library/Application Support/AnkiProgramFiles"
+
+    result=$(find_app_files "net.ankiweb.anki" "Anki")
+
+    [[ "$result" == *"Library/Application Support/Anki2"* ]]
+    [[ "$result" == *"Library/Application Support/AnkiProgramFiles"* ]]
+}
+
 # Independent CLI dotdir protection — issue #993.
 # Uninstalling a GUI app named "Claude" / "OpenCode" / etc. must not delete
 # the same-named standalone CLI tool's state directory.


### PR DESCRIPTION
## Summary
- detect Anki's exact `~/Library/Application Support/AnkiProgramFiles` support directory during uninstall
- keep `~/Library/Application Support/Anki2` out of automatic uninstall cleanup because it contains decks, media, and backups
- cover both the collected support path and preserved profile path with a naming-variants regression test

Addresses #1145.

## Maintainer update
I narrowed the original patch before merge so Mole cleans the launcher-managed support files without deleting Anki profile data.

## Validation
- `bash -n lib/core/app_protection.sh`
- `./scripts/check.sh --format`
- `git diff --check`
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_naming_variants.bats tests/uninstall_safety.bats tests/bundle_resolver.bats`
- temporary-HOME smoke check for `find_app_files "net.ankiweb.anki" "Anki"` returning only `AnkiProgramFiles`