### PR TITLE
fix(clean): never delete endpoint-security agent caches

### DIFF
--- a/cmd/analyze/delete.go
+++ b/cmd/analyze/delete.go
@@ -169,12 +169,24 @@ func validateTrashTarget(path string) error {
 }
 
 func isProtectedAnalyzeDeletePath(path string) bool {
-	home := os.Getenv("HOME")
-	if home == "" || path == "" {
+	if path == "" {
 		return false
 	}
 
 	cleanPath := filepath.Clean(path)
+
+	// EDR / Darwin-cache protection is based on the absolute path and does not
+	// depend on HOME, so check it first: an unset HOME must not let a Falcon
+	// cache slip through (e.g. `env -u HOME mo analyze`).
+	if isEndpointSecurityCachePath(cleanPath) {
+		return true
+	}
+
+	home := os.Getenv("HOME")
+	if home == "" {
+		return false
+	}
+
 	orbstackState := filepath.Join(home, ".orbstack")
 	if cleanPath == orbstackState || strings.HasPrefix(cleanPath, orbstackState+string(filepath.Separator)) {
 		return true
@@ -191,6 +203,38 @@ func isProtectedAnalyzeDeletePath(path string) bool {
 		containerName = containerName[:idx]
 	}
 	return strings.HasSuffix(containerName, "dev.orbstack")
+}
+
+// endpointSecurityBundlePrefixes mirrors ENDPOINT_SECURITY_BUNDLE_PREFIXES in
+// lib/core/app_protection_data.sh. Deleting anything inside one of these EDR/MDM
+// agents' per-user Darwin caches trips sensor tamper detection (e.g. CrowdStrike
+// MacFalconSensorTamper, MITRE T1562.001), so analyze must never Trash them.
+var endpointSecurityBundlePrefixes = []string{
+	"com.crowdstrike.",
+	"com.sentinelone.",
+	"com.sentinel-labs.",
+	"com.eset.",
+	"com.jamf.",
+	"com.jamfsoftware.",
+	"com.paloaltonetworks.",
+	"com.cisco.anyconnect",
+	"com.cisco.secureclient",
+}
+
+// isEndpointSecurityCachePath reports whether path is an endpoint-security / EDR
+// agent file under the per-user Darwin folder (/private/var/folders or its
+// /var/folders symlink form). Mirror of is_endpoint_security_cache_path() in
+// lib/core/app_protection.sh.
+func isEndpointSecurityCachePath(path string) bool {
+	if !strings.HasPrefix(path, "/private/var/folders/") && !strings.HasPrefix(path, "/var/folders/") {
+		return false
+	}
+	for _, prefix := range endpointSecurityBundlePrefixes {
+		if strings.Contains(path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // validatePath checks path safety for external commands.

--- a/cmd/analyze/delete_test.go
+++ b/cmd/analyze/delete_test.go
@@ -154,6 +154,50 @@ func TestValidateTrashTargetRejectsEndpointSecurityCachesWithoutHOME(t *testing.
 	}
 }
 
+func TestEndpointSecurityBundlePrefixesMirrorShellData(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "lib", "core", "app_protection_data.sh"))
+	if err != nil {
+		t.Fatalf("read app_protection_data.sh: %v", err)
+	}
+
+	shellPrefixes := endpointSecurityPrefixesFromShellData(t, string(data))
+	if len(shellPrefixes) != len(endpointSecurityBundlePrefixes) {
+		t.Fatalf("endpointSecurityBundlePrefixes length = %d, shell ENDPOINT_SECURITY_BUNDLE_PREFIXES length = %d",
+			len(endpointSecurityBundlePrefixes), len(shellPrefixes))
+	}
+	for i, prefix := range endpointSecurityBundlePrefixes {
+		if prefix != shellPrefixes[i] {
+			t.Fatalf("endpointSecurityBundlePrefixes[%d] = %q, shell ENDPOINT_SECURITY_BUNDLE_PREFIXES[%d] = %q",
+				i, prefix, i, shellPrefixes[i])
+		}
+	}
+}
+
+func endpointSecurityPrefixesFromShellData(t *testing.T, data string) []string {
+	t.Helper()
+
+	const marker = "readonly ENDPOINT_SECURITY_BUNDLE_PREFIXES=("
+	_, body, ok := strings.Cut(data, marker)
+	if !ok {
+		t.Fatalf("ENDPOINT_SECURITY_BUNDLE_PREFIXES array not found")
+	}
+
+	body, _, ok = strings.Cut(body, "\n)")
+	if !ok {
+		t.Fatalf("ENDPOINT_SECURITY_BUNDLE_PREFIXES array terminator not found")
+	}
+
+	var prefixes []string
+	for line := range strings.SplitSeq(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		prefixes = append(prefixes, strings.Trim(line, "\""))
+	}
+	return prefixes
+}
+
 func TestValidateTrashTargetAllowsRegularUserPaths(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/cmd/analyze/delete_test.go
+++ b/cmd/analyze/delete_test.go
@@ -115,6 +115,45 @@ func TestValidateTrashTargetRejectsOrbStackLiveData(t *testing.T) {
 	}
 }
 
+func TestValidateTrashTargetRejectsEndpointSecurityCaches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []string{
+		"/private/var/folders/zz/aa/C/com.crowdstrike.falcon.App/com.apple.metalfe",
+		"/private/var/folders/zz/aa/X/com.sentinelone.agent.code_sign_clone",
+		"/var/folders/zz/aa/C/com.jamf.management/cache",
+	}
+
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			if err := validateTrashTarget(path); err == nil || !strings.Contains(err.Error(), "protected path") {
+				t.Fatalf("validateTrashTarget(%q) error = %v, want protected path error", path, err)
+			}
+		})
+	}
+}
+
+func TestValidateTrashTargetAllowsNonEDRDarwinCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// A normal app's rebuildable GPU cache under var/folders stays deletable.
+	path := "/private/var/folders/zz/aa/C/com.example.App/com.apple.metalfe"
+	if err := validateTrashTarget(path); err != nil {
+		t.Fatalf("validateTrashTarget(%q) error = %v, want nil", path, err)
+	}
+}
+
+func TestValidateTrashTargetRejectsEndpointSecurityCachesWithoutHOME(t *testing.T) {
+	// The EDR check must not depend on HOME (e.g. `env -u HOME mo analyze`).
+	t.Setenv("HOME", "")
+	path := "/private/var/folders/zz/aa/C/com.crowdstrike.falcon.App/com.apple.metalfe"
+	if err := validateTrashTarget(path); err == nil || !strings.Contains(err.Error(), "protected path") {
+		t.Fatalf("validateTrashTarget(%q) with empty HOME error = %v, want protected path error", path, err)
+	}
+}
+
 func TestValidateTrashTargetAllowsRegularUserPaths(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/lib/clean/system.sh
+++ b/lib/clean/system.sh
@@ -207,6 +207,11 @@ clean_deep_system() {
     start_section_spinner "Scanning browser code signature caches..."
     local code_sign_cleaned=0
     while IFS= read -r -d '' cache_dir; do
+        # Never delete an EDR agent's code-signature clone -- same sensor-tamper
+        # risk as its caches below. Browsers are the intended target here.
+        if is_endpoint_security_cache_path "$cache_dir"; then
+            continue
+        fi
         if safe_sudo_remove "$cache_dir"; then
             code_sign_cleaned=$((code_sign_cleaned + 1))
         fi
@@ -239,6 +244,17 @@ clean_deep_system() {
     local gpu_cache_dir=""
     while IFS= read -r -d '' gpu_cache_dir; do
         is_rebuildable_gpu_cache_dir "$gpu_cache_dir" || continue
+        # Endpoint-security/EDR agents (CrowdStrike Falcon, SentinelOne, ...)
+        # tamper-protect their cache container, so deleting even a rebuildable
+        # Metal shader cache inside it raises a sensor-tamper alert reported as
+        # malware. Skip only those; every other app's GPU cache stays cleanable.
+        # Use the dedicated EDR predicate here, not should_protect_path(): this
+        # loop targets com.apple.metal* dirs, and should_protect_path() can treat
+        # those rebuildable cache names as protected (via should_protect_data),
+        # which would suppress the whole sweep.
+        if is_endpoint_security_cache_path "$gpu_cache_dir"; then
+            continue
+        fi
         gpu_cache_dir_is_stale "$gpu_cache_dir" "$MOLE_GPU_CACHE_AGE_DAYS" || continue
         if safe_sudo_remove "$gpu_cache_dir"; then
             gpu_cache_cleaned=$((gpu_cache_cleaned + 1))

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -243,6 +243,12 @@ _clean_darwin_user_runtime_dir() {
                 ;;
         esac
 
+        # Never touch endpoint-security/EDR agent caches (tamper detection),
+        # even when the file is user-owned and old enough to qualify here.
+        if is_endpoint_security_cache_path "$item"; then
+            continue
+        fi
+
         local item_size_kb=0
         item_size_kb=$(get_path_size_kb "$item" 2> /dev/null || echo "0")
         [[ "$item_size_kb" =~ ^[0-9]+$ ]] || item_size_kb=0
@@ -270,6 +276,9 @@ _clean_darwin_user_runtime_dir() {
         # still validates. Do not re-add per-item should_protect_path here.
         while IFS= read -r -d '' item; do
             [[ -d "$item" && ! -L "$item" ]] || continue
+            if is_endpoint_security_cache_path "$item"; then
+                continue
+            fi
             if [[ "${DRY_RUN:-false}" == "true" ]] || safe_remove "$item" true "0" > /dev/null 2>&1; then
                 found_any=true
                 count=$((count + 1))

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -216,6 +216,35 @@ should_protect_data() {
     return 1
 }
 
+# Endpoint security / EDR / MDM agents (CrowdStrike Falcon, SentinelOne, ESET,
+# Jamf, GlobalProtect, Cisco Secure Client) tamper-protect their on-disk state.
+# Deleting anything that belongs to them under the per-user Darwin folder -- a
+# rebuildable Metal/GPU shader cache (.../C/...), a code-signature clone
+# (.../X/<bundle-id>.code_sign_clone), or temp (.../T/...) -- trips sensor tamper
+# detection (e.g. CrowdStrike "MacFalconSensorTamper", MITRE T1562.001) that
+# corporate security reports as malware. Reclaim is only a few MB, so never touch
+# these. The vendor prefixes live in ENDPOINT_SECURITY_BUNDLE_PREFIXES
+# (app_protection_data.sh); matching a vendor id anywhere under var/folders is
+# protection-only, so a wide match is safe. Shared by should_protect_path() and
+# the cache/clone sweeps in lib/clean/system.sh and lib/clean/user.sh.
+is_endpoint_security_cache_path() {
+    local path="$1"
+    # Fast reject: only the per-user Darwin folders are in scope (the real
+    # /private/var/folders and its /var/folders symlink form). Anchored to the
+    # absolute root so an unrelated ".../var/folders/..." path cannot match.
+    case "$path" in
+        /private/var/folders/* | /var/folders/*) ;;
+        *) return 1 ;;
+    esac
+    local prefix
+    for prefix in "${ENDPOINT_SECURITY_BUNDLE_PREFIXES[@]}"; do
+        case "$path" in
+            *"$prefix"*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 # Check if a path is protected from deletion
 # Centralized logic to protect system settings, control center, and critical apps
 #
@@ -292,6 +321,13 @@ should_protect_path() {
             return 0
             ;;
     esac
+
+    # 4b. Endpoint security / EDR agent caches (CrowdStrike Falcon, SentinelOne,
+    # etc.). Dedicated predicate so the same vendor list is reused by the
+    # GPU-cache sweep in lib/clean/system.sh and matches deterministically.
+    if is_endpoint_security_cache_path "$path"; then
+        return 0
+    fi
 
     # 5. Protect critical preference files and user data
     case "$path" in

--- a/lib/core/app_protection_data.sh
+++ b/lib/core/app_protection_data.sh
@@ -150,6 +150,24 @@ readonly OFFICIAL_UNINSTALLER_RULES=(
     "Cisco|com.cisco.anyconnect,com.cisco.secureclient|cisco secure client,cisco anyconnect"
 )
 
+# Endpoint-security / EDR / MDM agent bundle-id prefixes. Their per-user Darwin
+# caches under /private/var/folders must never be deleted: removing anything
+# inside a sensor's container trips tamper detection (e.g. CrowdStrike
+# "MacFalconSensorTamper", MITRE T1562.001) that corporate security reports as
+# malware. Keep in sync with the vendors in OFFICIAL_UNINSTALLER_RULES above.
+# Consumed by is_endpoint_security_cache_path() in app_protection.sh.
+readonly ENDPOINT_SECURITY_BUNDLE_PREFIXES=(
+    "com.crowdstrike."
+    "com.sentinelone."
+    "com.sentinel-labs."
+    "com.eset."
+    "com.jamf."
+    "com.jamfsoftware."
+    "com.paloaltonetworks."
+    "com.cisco.anyconnect"
+    "com.cisco.secureclient"
+)
+
 # Applications with sensitive data; protected during cleanup but removable
 readonly DATA_PROTECTED_BUNDLES=(
     # Input Methods (protected during cleanup, uninstall allowed)

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -176,6 +176,18 @@ validate_path_for_deletion() {
             ;;
     esac
 
+    # Endpoint-security/EDR agent caches under var/folders look like ordinary
+    # rebuildable caches, but deleting anything in a sensor's container trips
+    # tamper detection (reported as malware). Reject here, before the
+    # /private/var/folders allowlist below, so every deletion caller is covered,
+    # not only the cleanup sweeps that pre-check the predicate.
+    if declare -f is_endpoint_security_cache_path > /dev/null 2>&1 && is_endpoint_security_cache_path "$policy_path"; then
+        if [[ "${MO_DEBUG:-0}" == "1" ]]; then
+            log_warning "Path validation: endpoint-security agent cache skipped: $policy_path"
+        fi
+        return 1
+    fi
+
     # Allow known safe paths under /private
     case "$policy_path" in
         /private/tmp | /private/tmp/* | \

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -936,6 +936,55 @@ EOF
     [[ "$output" != *"SUCCESS:Browser code signature caches"* ]]
 }
 
+@test "clean_deep_system skips EDR code_sign clones (CrowdStrike Falcon tamper)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+CALL_LOG="$HOME/edr_code_sign_calls.log"
+> "$CALL_LOG"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+sudo() {
+    if [[ "$1" == "test" ]]; then
+        return 1
+    fi
+    if [[ "$1" == "find" ]]; then
+        return 0
+    fi
+    return 0
+}
+safe_sudo_find_delete() { return 0; }
+safe_sudo_remove() {
+    echo "safe_sudo_remove:$1" >> "$CALL_LOG"
+    return 0
+}
+log_success() { echo "SUCCESS:$1" >> "$CALL_LOG"; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+find() { return 0; }
+run_with_timeout() {
+    local _timeout="$1"
+    shift
+    if [[ "${1:-}" == "command" && "${2:-}" == "find" && "${3:-}" == "/private/var/folders" ]]; then
+        printf '%s\0' \
+            "/private/var/folders/test/a/X/com.crowdstrike.falcon.App.code_sign_clone" \
+            "/private/var/folders/test/a/X/demo.code_sign_clone"
+        return 0
+    fi
+    "$@"
+}
+
+clean_deep_system
+cat "$CALL_LOG"
+EOF
+
+    [ "$status" -eq 0 ]
+    # A normal (browser-style) code-sign clone is still reclaimed.
+    [[ "$output" == *"safe_sudo_remove:/private/var/folders/test/a/X/demo.code_sign_clone"* ]] || return 1
+    # The EDR agent's code-sign clone must never be deleted.
+    [[ "$output" != *"com.crowdstrike"* ]] || return 1
+}
+
 @test "clean_deep_system cleans CleanMyMac-observed rebuildable system caches" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
 set -euo pipefail
@@ -1069,6 +1118,61 @@ EOF
     [[ "$output" != *"not-a-gpu-cache"* ]]
     [[ "$output" != *"-mtime +1"* ]]
     [[ "$output" == *"SUCCESS:Accessible rebuildable GPU caches, 3 items"* ]]
+}
+
+@test "clean_deep_system skips EDR/security-agent GPU caches (CrowdStrike Falcon tamper)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+CALL_LOG="$HOME/gpu_cache_edr_calls.log"
+> "$CALL_LOG"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+sudo() {
+    if [[ "$1" == "test" ]]; then
+        return 1
+    fi
+    return 0
+}
+safe_sudo_find_delete() { return 0; }
+safe_sudo_remove() {
+    echo "safe_sudo_remove:$1" >> "$CALL_LOG"
+    return 0
+}
+log_success() { echo "SUCCESS:$1" >> "$CALL_LOG"; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+find() { return 0; }
+gpu_cache_dir_is_stale() { return 0; }
+run_with_timeout() {
+    local _timeout="$1"
+    shift
+    # The GPU-cache sweep is the deep walk (maxdepth 8); feed candidates only to
+    # it and let every other find scan return nothing so this exercises just it.
+    if [[ "${1:-}" == "command" && "${2:-}" == "find" && "${5:-}" == "8" ]]; then
+        printf '%s\0' \
+            "/private/var/folders/test/a/C/com.crowdstrike.falcon.App/com.apple.metalfe" \
+            "/private/var/folders/test/a/C/com.sentinelone.agent/com.apple.metal" \
+            "/private/var/folders/test/a/C/com.example.App/com.apple.metalfe"
+        return 0
+    fi
+    if [[ "${1:-}" == "command" && "${2:-}" == "find" ]]; then
+        return 0
+    fi
+    "$@"
+}
+
+clean_deep_system
+cat "$CALL_LOG"
+EOF
+
+    [ "$status" -eq 0 ]
+    # The normal third-party GPU cache is still reclaimed.
+    [[ "$output" == *"safe_sudo_remove:/private/var/folders/test/a/C/com.example.App/com.apple.metalfe"* ]] || return 1
+    # EDR agent caches must never be touched (tamper alert -> corporate malware report).
+    [[ "$output" != *"com.crowdstrike"* ]] || return 1
+    [[ "$output" != *"com.sentinelone"* ]] || return 1
+    [[ "$output" == *"SUCCESS:Accessible rebuildable GPU caches, 1 item"* ]] || return 1
 }
 
 @test "opt_memory_pressure_relief skips when pressure is normal" {

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -505,6 +505,40 @@ EOF
     [[ "$output" == *"PASS"* ]]
 }
 
+@test "_clean_darwin_user_runtime_dir skips endpoint-security (EDR) agent caches" {
+    local runtime_home="$HOME/darwin-runtime-edr"
+    run env HOME="$runtime_home" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+mkdir -p "$HOME/runtime/C/com.crowdstrike.falcon.App" "$HOME/runtime/C/com.example.App"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+_darwin_user_runtime_dir_is_safe() { return 0; }
+# Isolate the loop's use of the guard from the predicate's real var/folders
+# anchoring (which is covered in core_safe_functions.bats): treat the Falcon
+# fixture as an EDR path regardless of the test sandbox location.
+is_endpoint_security_cache_path() { case "$1" in *com.crowdstrike.*) return 0 ;; *) return 1 ;; esac; }
+note_activity() { :; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+echo edr > "$HOME/runtime/C/com.crowdstrike.falcon.App/cache.bin"
+echo norm > "$HOME/runtime/C/com.example.App/cache.bin"
+touch -t 202301010000 "$HOME/runtime/C/com.crowdstrike.falcon.App/cache.bin" "$HOME/runtime/C/com.example.App/cache.bin"
+
+_clean_darwin_user_runtime_dir "$HOME/runtime/C" "cache" "Darwin user cache files"
+
+# The EDR agent's user-owned cache is never deleted (tamper protection)...
+[[ -e "$HOME/runtime/C/com.crowdstrike.falcon.App/cache.bin" ]]
+# ...while a normal app's old cache file still gets reclaimed.
+[[ ! -e "$HOME/runtime/C/com.example.App/cache.bin" ]]
+echo "PASS"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}
+
 @test "app_support_entry_count_capped stops at cap without failing under pipefail" {
     local support_home="$HOME/support-appsupport-cap"
     run env HOME="$support_home" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -376,13 +376,11 @@ SCRIPT
 }
 
 @test "safe_sudo_remove returns protected-path code for safety skips" {
-    local target_dir="$TEST_DIR/protected-sudo-target"
-    mkdir -p "$target_dir"
+    local target_dir="/private/var/folders/9d/abc/C/com.crowdstrike.falcon.App/com.apple.metalfe"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" bash --noprofile --norc <<'SCRIPT'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
-should_protect_path() { return 0; }
 
 safe_sudo_remove "$TARGET_DIR" && rc=0 || rc=$?
 echo "RC=$rc"

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -125,6 +125,17 @@ teardown() {
     [[ "$output" == *"critical system path"* ]]
 }
 
+@test "validate_path_for_deletion rejects endpoint-security agent var/folders caches" {
+    # Central chokepoint: every safe_remove / safe_sudo_remove caller is covered,
+    # not only the cleanup sweeps that pre-check the predicate.
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/private/var/folders/9d/abc/C/com.crowdstrike.falcon.App/com.apple.metalfe'"
+    [ "$status" -eq 1 ]
+
+    # A normal app's Darwin cache shard stays deletable.
+    run bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '/private/var/folders/9d/abc/C/com.example.App/com.apple.metalfe'"
+    [ "$status" -eq 0 ]
+}
+
 @test "should_protect_path applies high-risk cleanup denylist" {
     run bash -c "
         source '$PROJECT_ROOT/lib/core/common.sh'
@@ -137,6 +148,55 @@ teardown() {
         should_protect_data 'com.native-instruments.NativeAccess'
         ! should_protect_path '$HOME/Library/Application Support/Example/Cache/item'
     "
+    [ "$status" -eq 0 ]
+}
+
+@test "is_endpoint_security_cache_path matches only EDR agent var/folders caches" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+# Deleting anything an EDR agent owns under the per-user Darwin folder trips
+# sensor tamper detection (CrowdStrike MacFalconSensorTamper, MITRE T1562.001).
+# The matcher covers the vendor bundle id anywhere under var/folders: the C/
+# shader cache that triggered the real corporate alert, the X/ code-signature
+# clone, and T/ temp. Protection-only, so a wide match within var/folders is
+# intentional.
+is_endpoint_security_cache_path "/private/var/folders/9d/abc123/C/com.crowdstrike.falcon.App/com.apple.metalfe"
+is_endpoint_security_cache_path "/private/var/folders/9d/abc123/X/com.crowdstrike.falcon.App.code_sign_clone"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/T/com.crowdstrike.falcon.App/scratch"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/C/com.sentinelone.agent/com.apple.metal"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/C/com.jamf.management/com.apple.gpuarchiver"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/C/com.paloaltonetworks.GlobalProtect/com.apple.metalfe"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/C/com.eset.endpoint/com.apple.metal"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/C/com.sentinel-labs.agent/com.apple.metalfe"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/C/com.jamfsoftware.selfservice/com.apple.gpuarchiver"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/X/com.cisco.anyconnect.gui.code_sign_clone"
+is_endpoint_security_cache_path "/private/var/folders/aa/bb/X/com.cisco.secureclient.gui.code_sign_clone"
+# A normal third-party app's cache is not an EDR cache.
+! is_endpoint_security_cache_path "/private/var/folders/aa/bb/C/com.example.App/com.apple.metalfe"
+# Non-security Cisco products (e.g. Webex) are not matched; only the secure-access clients are.
+! is_endpoint_security_cache_path "/private/var/folders/aa/bb/X/com.cisco.webex.code_sign_clone"
+# Paths outside var/folders are out of scope for this predicate.
+! is_endpoint_security_cache_path "/Applications/Falcon.app"
+# A non-Darwin path that merely contains "var/folders" must NOT match (anchored).
+! is_endpoint_security_cache_path "/Users/me/project/var/folders/com.crowdstrike.fixture/cache"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "should_protect_path protects endpoint-security / EDR agent caches (CrowdStrike Falcon tamper)" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+# Matched by the dedicated EDR predicate before any bundle/filename fallback,
+# so the result is deterministic regardless of nounset/source order.
+should_protect_path "/private/var/folders/9d/abc123/C/com.crowdstrike.falcon.App/com.apple.metalfe"
+should_protect_path "/private/var/folders/aa/bb/C/com.sentinelone.agent/com.apple.metal"
+EOF
+
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

`mo clean` and `mo analyze` deleted rebuildable GPU/Metal shader caches, code-signature clones, and old user-owned files under every app's per-user Darwin folder (`/private/var/folders/.../C`, `.../X`, `.../T`). On a Mac managed with CrowdStrike Falcon this removed files inside the Falcon sensor's own cache container (`com.crowdstrike.falcon.App/com.apple.metalfe`), which tripped the sensor's tamper protection (IOA `MacFalconSensorTamper`, MITRE T1562.001) and was flagged as malware by the company's security team.

The fix follows the repo's data/logic split and protects every deletion path:

- `app_protection_data.sh`: new `ENDPOINT_SECURITY_BUNDLE_PREFIXES` array of endpoint-security / EDR / MDM vendor bundle ids (CrowdStrike, SentinelOne, ESET, Jamf, GlobalProtect, Cisco Secure Client), mirroring the vendors already in `OFFICIAL_UNINSTALLER_RULES`.
- `app_protection.sh`: `is_endpoint_security_cache_path()` iterates the array and matches a vendor id under `/private/var/folders` (or the `/var/folders` symlink form).
- **`file_ops.sh`: `validate_path_for_deletion()` rejects these paths before its `/private/var/folders` allowlist** — so every `safe_remove` / `safe_sudo_remove` caller is covered, not only the cleanup sweeps.
- `lib/clean/system.sh` (GPU-cache + `code_sign_clone` sweeps), `lib/clean/user.sh` (`_clean_darwin_user_runtime_dir`), and `should_protect_path()` also pre-check the predicate.
- **`cmd/analyze/delete.go`: `mo analyze` refuses to move these paths to Trash** (`validateTrashTarget` / `isProtectedAnalyzeDeletePath`), mirroring the shell predicate.

The match is protection-only: rebuildable caches for all other apps are still reclaimed.

## Safety Review

- Affects `clean` (system + user cleanup) and `analyze` (interactive Trash) deletion behavior.
- Affects protected-directory policy: it **adds** protection (skips deletions) for EDR/MDM agent paths under `var/folders`, enforced centrally in `validate_path_for_deletion()` so no future caller can regress. It does not broaden any deletion matcher, remove an existing protection, or change sudo / Trash / dry-run / operation-logging behavior.
- The predicate is anchored to `/private/var/folders/*` and `/var/folders/*` (an unrelated `.../var/folders/...` path cannot match) and is protection-only: the worst case is leaving a few MB of a security agent's rebuildable cache unreclaimed; it can never cause an unwanted deletion. Non-security products (e.g. `com.cisco.webex`) are not matched.

## Tests

- `./scripts/check.sh` (shfmt, shellcheck, go vet, syntax) and `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh` (full bats + Go): pass.
- `core_safe_functions.bats`: predicate matches every vendor across `C/` / `X/` / `T/`, rejects normal apps / `com.cisco.webex` / non-Darwin `.../var/folders/...` / non-`var/folders` paths; `validate_path_for_deletion` rejects the Falcon path but allows a normal Darwin cache shard.
- `clean_system_maintenance.bats`: GPU-cache and `code_sign_clone` sweeps skip EDR paths while reclaiming a normal app's cache.
- `clean_user_core.bats`: `_clean_darwin_user_runtime_dir` skips an EDR agent's user-owned cache while reclaiming a normal old cache file.
- `cmd/analyze/delete_test.go`: `validateTrashTarget` rejects EDR Darwin caches and allows a normal Darwin cache.

## Safety-related changes

- Adds `ENDPOINT_SECURITY_BUNDLE_PREFIXES` (data) + `is_endpoint_security_cache_path()` (shell) + a Go mirror, enforced at `validate_path_for_deletion()` (covers all shell deletion callers), the three `clean` sweeps, `should_protect_path()`, and `mo analyze`'s Trash validation. Protection-only: no new deletion surface, no change to sudo / Trash / dry-run / logging.
