### PR TITLE
fix privileged helper detection for Clash Verge

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -426,6 +426,27 @@ clean_orphaned_app_data() {
     rm -f "$installed_bundles"
 }
 
+_privileged_helper_bundle_id_from_binary() {
+    local binary="$1"
+    local helper_bundle_id=""
+
+    case "$binary" in
+        /Library/PrivilegedHelperTools/*.bundle/Contents/MacOS/*)
+            local helper_bundle_dir info_plist
+            helper_bundle_dir="${binary%/Contents/MacOS/*}"
+            info_plist="$helper_bundle_dir/Contents/Info.plist"
+            helper_bundle_id=$(plutil -extract CFBundleIdentifier raw "$info_plist" 2> /dev/null || true)
+            [[ -n "$helper_bundle_id" ]] || helper_bundle_id=$(basename "$helper_bundle_dir" .bundle)
+            ;;
+        *)
+            helper_bundle_id=$(basename "$binary")
+            helper_bundle_id="${helper_bundle_id%.plist}"
+            ;;
+    esac
+
+    printf '%s\n' "$helper_bundle_id"
+}
+
 # Clean orphaned system-level services (LaunchDaemons, LaunchAgents, PrivilegedHelperTools)
 # These are left behind when apps are uninstalled but their system services remain
 clean_orphaned_system_services() {
@@ -589,8 +610,7 @@ clean_orphaned_system_services() {
         if [[ -e "$binary" ]]; then
             if [[ "$binary" == /Library/PrivilegedHelperTools/* ]]; then
                 local helper_bundle_id
-                helper_bundle_id=$(basename "$binary")
-                helper_bundle_id="${helper_bundle_id%.plist}"
+                helper_bundle_id=$(_privileged_helper_bundle_id_from_binary "$binary")
                 if bundle_has_installed_app "$helper_bundle_id"; then
                     return 1 # Parent app still installed, plist is healthy
                 fi

--- a/lib/core/bundle_resolver.sh
+++ b/lib/core/bundle_resolver.sh
@@ -57,7 +57,7 @@ bundle_has_installed_app() {
     #     ARMDC helpers shipped inside Adobe Acrobat DC.app) -- issue #733
     local parent_id=""
     local suffix
-    for suffix in ".helper" ".daemon" ".agent" ".xpc"; do
+    for suffix in ".helper" ".daemon" ".agent" ".xpc" ".service"; do
         if [[ "$bundle_id" == *"$suffix" ]]; then
             parent_id="${bundle_id%"$suffix"}"
             break

--- a/tests/bundle_resolver.bats
+++ b/tests/bundle_resolver.bats
@@ -154,6 +154,17 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "bundle_has_installed_app finds parent app via .service suffix" {
+    make_app "$FAKE_APPS/Clash Verge.app" "io.github.clash-verge-rev.clash-verge-rev"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "io.github.clash-verge-rev.clash-verge-rev.service"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "bundle_has_installed_app returns non-zero for .helper when parent app absent" {
     make_app "$FAKE_APPS/Other.app" "com.example.other"
 

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -768,13 +768,18 @@ EOF
     [[ "$output" != *"unexpected-launchctl"* ]]
 }
 
-@test "_privileged_helper_bundle_id_from_binary prefers the bundle ID over the executable name" {
+@test "_privileged_helper_bundle_id_from_binary prefers Info.plist bundle ID over directory and executable names" {
     run env PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/apps.sh"
 
-result=$(_privileged_helper_bundle_id_from_binary "/Library/PrivilegedHelperTools/io.github.clash-verge-rev.clash-verge-rev.service.bundle/Contents/MacOS/clash-verge-service")
+plutil() {
+  [[ "$*" == *"/Library/PrivilegedHelperTools/com.example.directory.bundle/Contents/Info.plist"* ]] || return 1
+  printf '%s\n' "io.github.clash-verge-rev.clash-verge-rev.service"
+}
+
+result=$(_privileged_helper_bundle_id_from_binary "/Library/PrivilegedHelperTools/com.example.directory.bundle/Contents/MacOS/clash-verge-service")
 printf '%s\n' "$result"
 EOF
 

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -768,6 +768,20 @@ EOF
     [[ "$output" != *"unexpected-launchctl"* ]]
 }
 
+@test "_privileged_helper_bundle_id_from_binary prefers the bundle ID over the executable name" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+result=$(_privileged_helper_bundle_id_from_binary "/Library/PrivilegedHelperTools/io.github.clash-verge-rev.clash-verge-rev.service.bundle/Contents/MacOS/clash-verge-service")
+printf '%s\n' "$result"
+EOF
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "io.github.clash-verge-rev.clash-verge-rev.service" ]
+}
+
 @test "clean_orphaned_system_services removes orphaned helper despite data protection (#1082)" {
     # The Docker leftover in #1082 survived because should_protect_data matches
     # com.docker.* and blocked cleanup. com.getpostman.* hits the exact same


### PR DESCRIPTION
## Summary

- Fix `mo clean` orphaned system-service detection for bundle-wrapped privileged helpers.
- Resolve helper bundle IDs from `/Library/PrivilegedHelperTools/*.bundle/Contents/MacOS/*` instead of treating the executable name as the bundle ID.
- Add `.service` parent bundle resolution in `bundle_has_installed_app()`.
- Add regression coverage for helper bundle ID extraction and `.service` suffix resolution.
- Fixes #1155

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
  - Yes. It affects `mo clean` orphaned system-service detection under the cleanup path.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
  - It affects sudo cleanup boundaries indirectly by narrowing which system services are classified as orphaned before `launchctl unload` / removal is attempted.
- If yes, describe the new boundary or risk change clearly.
  - Before this change, Mole could misclassify bundle-wrapped helpers such as Clash Verge because it passed the executable filename (for example `clash-verge-service`) into `bundle_has_installed_app()` instead of the helper bundle ID.
  - After this change, Mole first resolves the helper bundle ID from the helper bundle `Info.plist`, then falls back to the `.bundle` directory name when needed.
  - The resolver also recognizes `.service` as a parent-app suffix, reducing false orphan detection when Spotlight is unavailable or incomplete.

## Tests

- List the automated tests you ran.
  - `bash -n lib/clean/apps.sh lib/core/bundle_resolver.sh tests/clean_apps.bats tests/bundle_resolver.bats`
- List any manual checks for high-risk paths or destructive flows.
  - Verified `_privileged_helper_bundle_id_from_binary` returns `io.github.clash-verge-rev.clash-verge-rev.service` for the Clash Verge helper binary path.
  - Verified `bundle_has_installed_app "io.github.clash-verge-rev.clash-verge-rev.service"` resolves successfully with a fake parent app bundle.
  - Verified source-tree dry-run service scan on the affected machine dropped Clash Verge from the orphan list, reducing the reported set from 9 entries to 8.
  - Verified `MOLE_DRY_RUN=1 ./mole clean --dry-run` no longer reports `/Library/LaunchDaemons/io.github.clash-verge-rev.clash-verge-rev.service.plist` as orphaned on the affected machine.

## Safety-related changes

- Narrowed orphaned-service detection for bundle-wrapped privileged helpers so installed services are less likely to be misclassified and unloaded.
