### PR TITLE
fix(uninstall): allow Karabiner-Elements to be uninstalled

### DIFF
--- a/lib/core/app_protection_data.sh
+++ b/lib/core/app_protection_data.sh
@@ -121,7 +121,6 @@ readonly SYSTEM_CRITICAL_BUNDLES=(
     "KeyLayout*"
     "GlobalPreferences"
     ".GlobalPreferences"
-    "org.pqrs.Karabiner*"
 )
 
 # Apple apps that CAN be uninstalled (from App Store or developer.apple.com)

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -416,6 +416,16 @@ EOF
     [ "$result" = "protected" ]
 }
 
+@test "Karabiner-Elements is protected during cleanup but allowed for uninstall" {
+    # Keyboard config and preferences stay protected during clean
+    result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data 'org.pqrs.Karabiner-Elements.Settings' && echo 'protected' || echo 'not-protected'")
+    [ "$result" = "protected" ]
+
+    # But the app itself is a third-party app, not a system component, so it can be uninstalled
+    result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_from_uninstall 'org.pqrs.Karabiner-Elements.Settings' && echo 'protected' || echo 'not-protected'")
+    [ "$result" = "not-protected" ]
+}
+
 @test "Apple apps from App Store can be uninstalled (Issue #386)" {
     # Xcode should NOT be protected from uninstall
     result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_from_uninstall 'com.apple.dt.Xcode' && echo 'protected' || echo 'not-protected'")


### PR DESCRIPTION
## Summary

`mo uninstall` cannot see or remove Karabiner-Elements. It never appears in `mo uninstall --list`, and `mo uninstall karabiner` finds nothing.

The cause is in `lib/core/app_protection_data.sh`. `SYSTEM_CRITICAL_BUNDLES` contained the pattern `org.pqrs.Karabiner*`, placed right after the keyboard and input-source preference entries. That array gates uninstall through `should_protect_from_uninstall`, so the match made Mole treat Karabiner as a macOS system component and filter it out entirely.

Karabiner is a third-party app, not a system component. Its preferences are already protected during `mo clean` in two other places:

- `should_protect_data` has an `org.pqrs.Karabiner*` case (`app_protection.sh`)
- `DATA_PROTECTED_BUNDLES` lists `org.pqrs.Karabiner-Elements`, whose own comment says these apps are "protected during cleanup but removable"

So the `SYSTEM_CRITICAL` entry duplicated the data protection in the wrong list and contradicted the removable classification. Removing that one pattern lets `mo uninstall` find and remove Karabiner while its keyboard config stays protected during cleanup.

## Safety Review

- Affects uninstall: yes. It narrows the protected set by one third-party app, so Karabiner becomes uninstallable. It does not touch any deletion sink, path validation, wildcard matcher, or sudo boundary.
- Data protection during `mo clean` is unchanged. Karabiner preferences stay protected through `should_protect_data` and `DATA_PROTECTED_BUNDLES`.
- No change to `find_app_files`, `mole_delete`, `remove_file_list`, or any glob expansion.

## Tests

- `MOLE_TEST_NO_AUTH=1 bats tests/core_common.bats tests/uninstall_safety.bats tests/uninstall_naming_variants.bats tests/bundle_resolver.bats`, all pass (79 in core_common including the new case).
- Added a regression test asserting Karabiner is data-protected during cleanup but not protected from uninstall, mirroring the existing input-method test.
- `./scripts/check.sh --format` clean.
- Manual check on macOS 27, Mole 1.44.1: with the line removed, `mo uninstall --list` shows Karabiner-Elements and `mo uninstall --dry-run karabiner-elements` matches it. With the line present it shows nothing.

## Safety-related changes

- Narrows uninstall protection by one third-party app. Cleanup data protection unchanged.