### PR TITLE
fix(uninstall): keep side-by-side installs that share a bundle id

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -688,6 +688,9 @@ _scan_resolve_uncached() {
 
 # Phase 6: collapse duplicate bundle IDs discovered from backup volumes or
 # mirrored Applications folders. Keep the live app locations first.
+# The dedupe key includes the .app basename so distinct installs that share a
+# bundle ID (e.g. Xcode.app and Xcode-beta.app, both com.apple.dt.Xcode) are
+# kept, while true clones of the same bundle name in mirrored roots collapse.
 _scan_dedupe_bundle_ids() {
     [[ -s "$scan_raw_file" ]] || return 0
 
@@ -715,6 +718,10 @@ _scan_dedupe_bundle_ids() {
             }
             return 3
         }
+        function app_basename(path, n, parts) {
+            n = split(path, parts, "/")
+            return parts[n]
+        }
         {
             bundle_id = $3
             if (bundle_id == "" || bundle_id == "unknown") {
@@ -724,16 +731,17 @@ _scan_dedupe_bundle_ids() {
                 next
             }
 
+            key = bundle_id "|" app_basename($1)
             rank = path_rank($1)
-            if (!(bundle_id in rows)) {
-                rows[bundle_id] = $0
-                ranks[bundle_id] = rank
-                order[++count] = bundle_id
+            if (!(key in rows)) {
+                rows[key] = $0
+                ranks[key] = rank
+                order[++count] = key
                 next
             }
-            if (rank < ranks[bundle_id]) {
-                rows[bundle_id] = $0
-                ranks[bundle_id] = rank
+            if (rank < ranks[key]) {
+                rows[key] = $0
+                ranks[key] = rank
             }
         }
         END {

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1066,8 +1066,21 @@ find_app_files() {
     # tokens, AVD images, SDK installs, or other manually-curated data. Only
     # regenerable cache/derived paths belong here. If a toolchain dir is mixed
     # (config + cache), skip the whole tree rather than guess.
+    #
+    # MOLE_UNINSTALL_SIBLING_SURVIVES=1 skips the whole heuristic section
+    # below (through Raycast). The batch uninstall sibling guard sets it when
+    # another install sharing this bundle id stays on disk (Xcode.app vs
+    # Xcode-beta.app): these blocks match by regex substring, so the demoted
+    # bundle id alone does not stop them, and every path they collect is a
+    # toolchain cache the surviving install still uses.
+    local collect_toolchain_leftovers=true
+    if [[ "${MOLE_UNINSTALL_SIBLING_SURVIVES:-0}" == "1" ]]; then
+        collect_toolchain_leftovers=false
+    fi
+
     # 1. DevEco-Studio (Huawei)
-    if [[ "$app_name" =~ DevEco|deveco ]] || [[ "$bundle_id" =~ huawei.*deveco ]]; then
+    if [[ "$collect_toolchain_leftovers" == "true" ]] &&
+        { [[ "$app_name" =~ DevEco|deveco ]] || [[ "$bundle_id" =~ huawei.*deveco ]]; }; then
         # Skipped: ~/DevEcoStudioProjects, ~/HarmonyOS, ~/Huawei (project
         # source); ~/DevEco-Studio (IDE config + license state); ~/Library/
         # Application Support/Huawei, ~/Library/Huawei, ~/.huawei, ~/.ohos
@@ -1079,7 +1092,8 @@ find_app_files() {
     fi
 
     # 2. Android Studio (Google)
-    if [[ "$app_name" =~ Android.*Studio|android.*studio ]] || [[ "$bundle_id" =~ google.*android.*studio|jetbrains.*android ]]; then
+    if [[ "$collect_toolchain_leftovers" == "true" ]] &&
+        { [[ "$app_name" =~ Android.*Studio|android.*studio ]] || [[ "$bundle_id" =~ google.*android.*studio|jetbrains.*android ]]; }; then
         # Skipped: ~/AndroidStudioProjects (project source), ~/Library/Android
         # (SDK installs, multi-GB), ~/.android root (debug.keystore signing
         # key, adbkey device pairing, avd/ images). Only sweep regenerable
@@ -1091,7 +1105,8 @@ find_app_files() {
     fi
 
     # 3. Xcode (Apple)
-    if [[ "$app_name" =~ Xcode|xcode ]] || [[ "$bundle_id" =~ apple.*xcode ]]; then
+    if [[ "$collect_toolchain_leftovers" == "true" ]] &&
+        { [[ "$app_name" =~ Xcode|xcode ]] || [[ "$bundle_id" =~ apple.*xcode ]]; }; then
         # Skipped: ~/Library/Developer root (Toolchains, Archives, UserData,
         # CoreSimulator/Devices, provisioning profiles). Only sweep
         # regenerable build/device caches.
@@ -1109,16 +1124,19 @@ find_app_files() {
     fi
 
     # 4. JetBrains (IDE settings)
-    if [[ "$bundle_id" =~ jetbrains ]] || [[ "$app_name" =~ IntelliJ|PyCharm|WebStorm|GoLand|RubyMine|PhpStorm|CLion|DataGrip|Rider ]]; then
+    if [[ "$collect_toolchain_leftovers" == "true" ]] &&
+        { [[ "$bundle_id" =~ jetbrains ]] || [[ "$app_name" =~ IntelliJ|PyCharm|WebStorm|GoLand|RubyMine|PhpStorm|CLion|DataGrip|Rider ]]; }; then
         for base in ~/Library/Application\ Support/JetBrains ~/Library/Caches/JetBrains ~/Library/Logs/JetBrains; do
             [[ -d "$base" ]] && while IFS= read -r -d '' d; do files_to_clean+=("$d"); done < <(command find "$base" -maxdepth 1 -name "${app_name}*" -print0 2> /dev/null)
         done
     fi
 
     # 5. Unity / Unreal / Godot
-    [[ "$app_name" =~ Unity|unity ]] && [[ -d ~/Library/Unity ]] && files_to_clean+=("$HOME/Library/Unity")
-    [[ "$app_name" =~ Unreal|unreal ]] && [[ -d ~/Library/Application\ Support/Epic ]] && files_to_clean+=("$HOME/Library/Application Support/Epic")
-    [[ "$app_name" =~ Godot|godot ]] && [[ -d ~/Library/Application\ Support/Godot ]] && files_to_clean+=("$HOME/Library/Application Support/Godot")
+    if [[ "$collect_toolchain_leftovers" == "true" ]]; then
+        [[ "$app_name" =~ Unity|unity ]] && [[ -d ~/Library/Unity ]] && files_to_clean+=("$HOME/Library/Unity")
+        [[ "$app_name" =~ Unreal|unreal ]] && [[ -d ~/Library/Application\ Support/Epic ]] && files_to_clean+=("$HOME/Library/Application Support/Epic")
+        [[ "$app_name" =~ Godot|godot ]] && [[ -d ~/Library/Application\ Support/Godot ]] && files_to_clean+=("$HOME/Library/Application Support/Godot")
+    fi
 
     # 6. Tools
     # VS Code stores user data under folder names that don't match the app name
@@ -1141,14 +1159,15 @@ find_app_files() {
     # Docker: ~/.docker holds config.json (Docker Hub auth tokens), contexts/
     # (kubeconfig-style endpoints, possibly with credentials), and cli-plugins.
     # Only sweep regenerable cache subtrees, never the whole tree.
-    if [[ "$app_name" =~ Docker ]]; then
+    if [[ "$collect_toolchain_leftovers" == "true" ]] && [[ "$app_name" =~ Docker ]]; then
         for d in ~/.docker/buildx ~/.docker/scan; do
             [[ -d "$d" ]] && files_to_clean+=("$d")
         done
     fi
 
     # 6.1 Maestro Studio
-    if [[ "$bundle_id" == "com.maestro.studio" ]] || [[ "$lowercase_name" =~ maestro[[:space:]]*studio ]]; then
+    if [[ "$collect_toolchain_leftovers" == "true" ]] &&
+        { [[ "$bundle_id" == "com.maestro.studio" ]] || [[ "$lowercase_name" =~ maestro[[:space:]]*studio ]]; }; then
         [[ -d ~/.mobiledev ]] && files_to_clean+=("$HOME/.mobiledev")
     fi
 

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1173,7 +1173,8 @@ find_app_files() {
 
     # Anki's profile directory (Anki2) contains decks, media, and backups.
     # Only collect the launcher-managed support files here.
-    if [[ "$bundle_id" == "net.ankiweb.anki" ]] || [[ "$app_name" == "Anki" ]]; then
+    if [[ "$collect_toolchain_leftovers" == "true" ]] &&
+        { [[ "$bundle_id" == "net.ankiweb.anki" ]] || [[ "$app_name" == "Anki" ]]; }; then
         [[ -d "$HOME/Library/Application Support/AnkiProgramFiles" ]] && files_to_clean+=("$HOME/Library/Application Support/AnkiProgramFiles")
     fi
 

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -605,7 +605,17 @@ _batch_scan_app_details() {
             local survivor_name login_name_collides=false
             while IFS= read -r survivor_name; do
                 [[ -z "$survivor_name" ]] && continue
-                if [[ "$discovery_lower" == "$survivor_name" || "$discovery_base_lower" == "$survivor_name" ]]; then
+                # Equality catches the display-name collapse. The substring
+                # direction catches the inverse case: uninstalling "Foo.app"
+                # while "Foo-beta.app" survives. Downstream matchers are
+                # substring-based (the LaunchAgents scan globs
+                # "*<name>*.plist"), so a discovery name contained anywhere
+                # in a survivor identifier can still reach survivor data.
+                # Reverse containment (survivor inside discovery) stays
+                # allowed: patterns keyed on the longer "Foo-beta" cannot
+                # match the survivor's shorter "Foo"-keyed paths.
+                if [[ "$discovery_lower" == "$survivor_name" || "$discovery_base_lower" == "$survivor_name" ||
+                    "$survivor_name" == *"$discovery_lower"* || "$survivor_name" == *"$discovery_base_lower"* ]]; then
                     discovery_app_name=""
                 fi
                 # Login items are registered under the display name; when that
@@ -685,13 +695,21 @@ _batch_scan_app_details() {
             local sibling_survives=0
             [[ "$sibling_guard" != "none" ]] && sibling_survives=1
             related_files=$(MOLE_UNINSTALL_SIBLING_SURVIVES="$sibling_survives" find_app_files "$bundle_id" "$discovery_app_name" "$app_path" || true)
-            diag_user=$(get_diagnostic_report_paths_for_app "$app_path" "$discovery_app_name" "$HOME/Library/Logs/DiagnosticReports" || true)
-            [[ -n "$diag_user" ]] && related_files=$(
-                [[ -n "$related_files" ]] && echo "$related_files"
-                echo "$diag_user"
-            )
+            # Diagnostic-report discovery prefers CFBundleExecutable from the
+            # selected bundle, and same-bundle-id siblings ship the same
+            # executable name ("Xcode" for Xcode-beta.app), so under the
+            # guard it would collect the survivor's crash reports no matter
+            # which name is passed in. Leaving crash logs behind is the
+            # fail-safe direction.
+            if [[ "$sibling_guard" == "none" ]]; then
+                diag_user=$(get_diagnostic_report_paths_for_app "$app_path" "$discovery_app_name" "$HOME/Library/Logs/DiagnosticReports" || true)
+                [[ -n "$diag_user" ]] && related_files=$(
+                    [[ -n "$related_files" ]] && echo "$related_files"
+                    echo "$diag_user"
+                )
+                diag_system=$(get_diagnostic_report_paths_for_app "$app_path" "$discovery_app_name" "/Library/Logs/DiagnosticReports" || true)
+            fi
             system_files=$(find_app_system_files "$bundle_id" "$discovery_app_name" || true)
-            diag_system=$(get_diagnostic_report_paths_for_app "$app_path" "$discovery_app_name" "/Library/Logs/DiagnosticReports" || true)
         fi
         local related_size_kb=$(calculate_total_size "$related_files" || echo "0")
         local review_only_system_files="$system_files"
@@ -937,8 +955,17 @@ _batch_execute_removals() {
         # (the running process keeps using its mmap'd code), so a stuck app
         # process must NOT block the uninstall. Track it so we can surface a
         # warning at the end without scaring the user with a "failed" status.
-        if ! force_kill_app "$app_name" "$app_path"; then
-            running_at_uninstall_apps+=("$app_name")
+        # Skipped under the sibling guard: force_kill_app quits by bundle id
+        # and matches processes by CFBundleExecutable, and both identifiers
+        # can belong to the surviving install (Xcode-beta.app ships the
+        # executable "Xcode"), so the kill ladder could SIGKILL the
+        # survivor's running process instead.
+        if [[ "${sibling_guard:-none}" == "none" ]]; then
+            if ! force_kill_app "$app_name" "$app_path"; then
+                running_at_uninstall_apps+=("$app_name")
+            fi
+        else
+            debug_log "Skipping process termination for $app_name: identifiers are shared with a surviving install"
         fi
 
         # Keep the spinner alive through the heavy work. For large apps the
@@ -1124,7 +1151,15 @@ _batch_execute_removals() {
                 fi
             fi
 
-            bootout_login_item_helpers "$login_item_helpers"
+            # Login item helper ids are read from the selected bundle and are
+            # identical across same-bundle-id siblings, so booting them out
+            # under the guard would stop the surviving install's running
+            # helper.
+            if [[ "${sibling_guard:-none}" == "none" ]]; then
+                bootout_login_item_helpers "$login_item_helpers"
+            else
+                debug_log "Skipping login item helper bootout for $app_name: helper ids are shared with a surviving install"
+            fi
 
             # All per-app side effects done; tear the spinner down before
             # any echo so the success line does not collide with the spinner.

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -492,6 +492,66 @@ uninstall_bundle_id_has_surviving_sibling() {
     return 1
 }
 
+# Print the lowercased display names and .app basenames of every surviving
+# same-bundle sibling (same filter as uninstall_bundle_id_has_surviving_sibling),
+# one per line. Used to detect when the selected app's own names collide with
+# the survivor's, in which case name-derived cleanup must be suppressed too.
+uninstall_surviving_sibling_names() {
+    local bundle_id="$1"
+    local app_path="$2"
+
+    [[ -z "$bundle_id" || "$bundle_id" == "unknown" ]] && return 0
+
+    local row other_path other_name other_bundle
+    for row in "${apps_data[@]+"${apps_data[@]}"}"; do
+        IFS='|' read -r _ other_path other_name other_bundle _ _ _ <<< "$row"
+        [[ "$other_bundle" == "$bundle_id" ]] || continue
+        [[ "$other_path" == "$app_path" ]] && continue
+        [[ -d "$other_path" ]] || continue
+
+        local sel selected_path is_selected=false
+        for sel in "${selected_apps[@]+"${selected_apps[@]}"}"; do
+            IFS='|' read -r _ selected_path _ _ _ _ <<< "$sel"
+            if [[ "$selected_path" == "$other_path" ]]; then
+                is_selected=true
+                break
+            fi
+        done
+        [[ "$is_selected" == true ]] && continue
+
+        local other_base="${other_path##*/}"
+        other_base="${other_base%.app}"
+
+        # Emit each identifier plus its version-suffix-stripped base: a
+        # survivor named "Foo Beta.app" also claims "Foo"-keyed dirs via the
+        # stripper in find_app_files, so uninstalling "Foo.app" must treat
+        # "foo" as taken.
+        local candidate
+        for candidate in "$other_name" "$other_base"; do
+            [[ -z "$candidate" ]] && continue
+            printf '%s\n' "$candidate" | LC_ALL=C tr '[:upper:]' '[:lower:]'
+            uninstall_strip_version_suffix "$candidate" | LC_ALL=C tr '[:upper:]' '[:lower:]'
+        done
+    done
+
+    return 0
+}
+
+# Mirror of the version-suffix stripping inside find_app_files. Needed here
+# because find_app_files derives extra patterns from the stripped base name
+# ("Zed Nightly" also matches "Zed" paths), so a collision check against the
+# survivor must consider the stripped form as well.
+uninstall_strip_version_suffix() {
+    local name="$1"
+    local version_suffixes="Nightly|Beta|Alpha|Dev|Canary|Preview|Insider|Edge|Stable|Release|RC|LTS"
+    version_suffixes+="|Developer Edition|Technology Preview"
+    if [[ "$name" =~ ^(.+)[[:space:]]+(${version_suffixes})$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    else
+        printf '%s\n' "$name"
+    fi
+}
+
 # Internal helpers for batch_uninstall_applications. They read and write
 # locals declared in the orchestrator's scope via bash dynamic scoping; do
 # not call them outside batch_uninstall_applications.
@@ -521,10 +581,50 @@ _batch_scan_app_details() {
         # A surviving install sharing this bundle id (e.g. Xcode.app when
         # uninstalling Xcode-beta.app) still owns every bundle-id-keyed path.
         # Demote the bundle id to "unknown" so leftover discovery and the
-        # bundle-id-keyed removal steps all fall back to name/path matching,
-        # which is unique per install.
+        # bundle-id-keyed removal steps all fall back to name/path matching.
+        # Name matching gets the same treatment: discovery keys on the .app
+        # basename (unique even when both installs resolve to one display
+        # name, which happens when mdls has no index and CFBundleName says
+        # "Xcode" for the beta), and if even that collides with the survivor,
+        # or its version-suffix-stripped base does, name discovery is dropped
+        # entirely so the fallback can never be broader than the primary path.
+        local sibling_guard="none"
+        local discovery_app_name="$app_name"
         if uninstall_bundle_id_has_surviving_sibling "$bundle_id" "$app_path"; then
-            debug_log "Bundle id $bundle_id shared with a surviving install; restricting $app_name leftovers to name/path matches"
+            sibling_guard="guard"
+            discovery_app_name="${app_path##*/}"
+            discovery_app_name="${discovery_app_name%.app}"
+
+            local survivor_names
+            survivor_names=$(uninstall_surviving_sibling_names "$bundle_id" "$app_path")
+            local discovery_lower discovery_base_lower display_lower
+            discovery_lower=$(printf '%s' "$discovery_app_name" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+            discovery_base_lower=$(uninstall_strip_version_suffix "$discovery_app_name" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+            display_lower=$(printf '%s' "$app_name" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+
+            local survivor_name login_name_collides=false
+            while IFS= read -r survivor_name; do
+                [[ -z "$survivor_name" ]] && continue
+                if [[ "$discovery_lower" == "$survivor_name" || "$discovery_base_lower" == "$survivor_name" ]]; then
+                    discovery_app_name=""
+                fi
+                # Login items are registered under the display name; when that
+                # string also belongs to the survivor, deleting it by name
+                # would remove the survivor's login item.
+                if [[ "$display_lower" == "$survivor_name" ]]; then
+                    login_name_collides=true
+                fi
+            done <<< "$survivor_names"
+            if [[ -z "$discovery_app_name" ]]; then
+                login_name_collides=true
+            fi
+            [[ "$login_name_collides" == true ]] && sibling_guard="guard_login"
+
+            if [[ -n "$discovery_app_name" ]]; then
+                debug_log "Bundle id $bundle_id shared with a surviving install; restricting $app_name leftovers to name/path matches for '$discovery_app_name'"
+            else
+                debug_log "Bundle id $bundle_id shared with a surviving install and names collide; removing only the app bundle for $app_name"
+            fi
             bundle_id="unknown"
         fi
 
@@ -568,19 +668,32 @@ _batch_scan_app_details() {
         fi
 
         local app_size_kb=$(get_path_size_kb "$app_path" || echo "0")
-        local related_files=$(find_app_files "$bundle_id" "$app_name" "$app_path" || true)
-        local diag_user
-        diag_user=$(get_diagnostic_report_paths_for_app "$app_path" "$app_name" "$HOME/Library/Logs/DiagnosticReports" || true)
-        [[ -n "$diag_user" ]] && related_files=$(
-            [[ -n "$related_files" ]] && echo "$related_files"
-            echo "$diag_user"
-        )
-        local related_size_kb=$(calculate_total_size "$related_files" || echo "0")
+        local related_files="" diag_user="" diag_system=""
         # system_files is a newline-separated string, not an array.
         # shellcheck disable=SC2178,SC2128
-        local system_files=$(find_app_system_files "$bundle_id" "$app_name" || true)
-        local diag_system
-        diag_system=$(get_diagnostic_report_paths_for_app "$app_path" "$app_name" "/Library/Logs/DiagnosticReports" || true)
+        local system_files=""
+        # discovery_app_name is empty only in the sibling-guard name-collision
+        # case: every name-derived pattern would belong to the survivor, and
+        # find_app_system_files has no empty-name guard (it would emit root
+        # dirs like "/Library/Application Support/"). Skip discovery entirely
+        # and remove just the app bundle.
+        if [[ -n "$discovery_app_name" ]]; then
+            # Under the sibling guard, also disable the regex-keyed toolchain
+            # heuristics in find_app_files (DerivedData, DeviceSupport, ...):
+            # they match "Xcode-beta" by substring and would still queue
+            # caches the surviving install uses.
+            local sibling_survives=0
+            [[ "$sibling_guard" != "none" ]] && sibling_survives=1
+            related_files=$(MOLE_UNINSTALL_SIBLING_SURVIVES="$sibling_survives" find_app_files "$bundle_id" "$discovery_app_name" "$app_path" || true)
+            diag_user=$(get_diagnostic_report_paths_for_app "$app_path" "$discovery_app_name" "$HOME/Library/Logs/DiagnosticReports" || true)
+            [[ -n "$diag_user" ]] && related_files=$(
+                [[ -n "$related_files" ]] && echo "$related_files"
+                echo "$diag_user"
+            )
+            system_files=$(find_app_system_files "$bundle_id" "$discovery_app_name" || true)
+            diag_system=$(get_diagnostic_report_paths_for_app "$app_path" "$discovery_app_name" "/Library/Logs/DiagnosticReports" || true)
+        fi
+        local related_size_kb=$(calculate_total_size "$related_files" || echo "0")
         local review_only_system_files="$system_files"
         review_only_system_files=$(append_line "$review_only_system_files" "$diag_system")
         # System-level remnants are review-only in the CLI: shown in the preview
@@ -622,7 +735,7 @@ _batch_scan_app_details() {
         login_item_helpers=$(discover_login_item_helper_bundle_ids "$app_path" || true)
         local encoded_login_item_helpers
         encoded_login_item_helpers=$(printf '%s' "$login_item_helpers" | base64 | tr -d '\n' || echo "")
-        app_details+=("$app_name|$app_path|$bundle_id|$total_kb|$encoded_files|$encoded_system_files|$has_sensitive_data|$needs_sudo|$is_brew_cask|$cask_name|$encoded_diag_system|$has_local_network_usage|$encoded_review_system|$encoded_login_item_helpers")
+        app_details+=("$app_name|$app_path|$bundle_id|$total_kb|$encoded_files|$encoded_system_files|$has_sensitive_data|$needs_sudo|$is_brew_cask|$cask_name|$encoded_diag_system|$has_local_network_usage|$encoded_review_system|$encoded_login_item_helpers|$sibling_guard")
     done
     if [[ -t 1 ]]; then stop_inline_spinner; fi
 
@@ -648,18 +761,27 @@ _batch_preview_and_confirm() {
 
     echo -e "\n${PURPLE_BOLD}Files to be removed:${NC}"
 
-    # Warn if brew cask apps are present.
-    local has_brew_cask=false
-    [[ ${#brew_cask_apps[@]} -gt 0 ]] && has_brew_cask=true
+    # Warn if brew cask apps are present. The --zap wording only applies to
+    # casks that will actually zap; sibling-guarded casks run a plain
+    # uninstall so their shared configs and data stay.
+    local has_zap_cask=false
+    local zap_detail zap_is_brew zap_guard
+    for zap_detail in "${app_details[@]}"; do
+        IFS='|' read -r _ _ _ _ _ _ _ _ zap_is_brew _ _ _ _ _ zap_guard <<< "$zap_detail"
+        if [[ "$zap_is_brew" == "true" && "${zap_guard:-none}" == "none" ]]; then
+            has_zap_cask=true
+            break
+        fi
+    done
 
-    if [[ "$has_brew_cask" == "true" ]]; then
+    if [[ "$has_zap_cask" == "true" ]]; then
         echo -e "${GRAY}${ICON_WARNING} Homebrew apps will be fully cleaned, --zap removes configs and data${NC}"
     fi
 
     echo ""
 
     for detail in "${app_details[@]}"; do
-        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files has_sensitive_data needs_sudo_flag is_brew_cask cask_name encoded_diag_system has_local_network_usage encoded_review_system encoded_login_item_helpers <<< "$detail"
+        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files has_sensitive_data needs_sudo_flag is_brew_cask cask_name encoded_diag_system has_local_network_usage encoded_review_system encoded_login_item_helpers sibling_guard <<< "$detail"
         local app_size_display=$(bytes_to_human "$((total_kb * 1024))")
 
         local brew_tag=""
@@ -775,7 +897,7 @@ _batch_execute_removals() {
     local current_index=0
     for detail in "${app_details[@]}"; do
         current_index=$((current_index + 1))
-        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage encoded_review_system encoded_login_item_helpers <<< "$detail"
+        IFS='|' read -r app_name app_path bundle_id total_kb encoded_files encoded_system_files has_sensitive_data needs_sudo is_brew_cask cask_name encoded_diag_system has_local_network_usage encoded_review_system encoded_login_item_helpers sibling_guard <<< "$detail"
         local related_files=$(decode_file_list "$encoded_files" "$app_name")
         local system_files=$(decode_file_list "$encoded_system_files" "$app_name")
         local diag_system=$(decode_file_list "$encoded_diag_system" "$app_name")
@@ -801,8 +923,15 @@ _batch_execute_removals() {
         stop_launch_services "$bundle_id" "$has_system_files" "$app_path"
         unregister_app_bundle "$app_path"
 
-        # Remove from Login Items
-        remove_login_item "$app_name" "$bundle_id"
+        # Remove from Login Items. Skipped when the sibling guard flagged a
+        # name collision: login items are matched by display name only, and
+        # deleting "Xcode" by name would take out the surviving install's
+        # login item along with the beta's.
+        if [[ "${sibling_guard:-none}" != "guard_login" ]]; then
+            remove_login_item "$app_name" "$bundle_id"
+        else
+            debug_log "Skipping login item removal for $app_name: name is shared with a surviving install"
+        fi
 
         # Best-effort termination. macOS allows removing a running app bundle
         # (the running process keeps using its mmap'd code), so a stuck app
@@ -830,8 +959,13 @@ _batch_execute_removals() {
         local used_brew_successfully=false
         if [[ -z "$reason" ]]; then
             if [[ "$is_brew_cask" == "true" && -n "$cask_name" ]]; then
+                # Zap stanzas delete bundle-id-keyed prefs/caches. When the
+                # sibling guard is active those paths still belong to the
+                # surviving same-bundle install, so run a plain uninstall.
+                local cask_zap_mode="zap"
+                [[ "${sibling_guard:-none}" != "none" ]] && cask_zap_mode="nozap"
                 # Use brew_uninstall_cask helper (handles env vars, timeout, verification)
-                if brew_uninstall_cask "$cask_name" "$app_path"; then
+                if brew_uninstall_cask "$cask_name" "$app_path" "$cask_zap_mode"; then
                     used_brew_successfully=true
                 else
                     # Only fall back to manual app removal when Homebrew no longer
@@ -853,7 +987,11 @@ _batch_execute_removals() {
                         fi
                     elif [[ $cask_state -eq 0 ]]; then
                         reason="brew uninstall failed, package still installed"
-                        suggestion="Run brew uninstall --cask --zap $cask_name"
+                        if [[ "$cask_zap_mode" == "nozap" ]]; then
+                            suggestion="Run brew uninstall --cask $cask_name"
+                        else
+                            suggestion="Run brew uninstall --cask --zap $cask_name"
+                        fi
                     else
                         reason="brew uninstall failed, package state unknown"
                         suggestion="Run brew uninstall --cask --zap $cask_name"

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -452,6 +452,14 @@ remove_file_list() {
 # stays on disk and is not part of the current selection, bundle-id-derived
 # leftovers (caches, preferences, containers, launch services) still belong to
 # the surviving install and must not be touched by this uninstall.
+#
+# Siblings under /Volumes/* count on purpose. Exact mirror clones never reach
+# this check (the scan dedupe collapses same-basename rows and keeps the live
+# path), so a /Volumes row here means a same-bundle app the scan considers a
+# distinct install. Apps genuinely run from an external volume use the same
+# $HOME bundle-id data, and skipping that data is the safe failure mode: worst
+# case a few leftover files stay behind, versus deleting state a real install
+# still uses.
 # Reads apps_data and selected_apps from the caller's scope via dynamic
 # scoping; both may be unset when batch.sh is exercised standalone in tests.
 uninstall_bundle_id_has_surviving_sibling() {

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -151,7 +151,10 @@ append_line() {
 
 format_uninstall_preview_path() {
     local path="$1"
-    local display_path="${path/$HOME/~}"
+    # Replacement must come from a variable: bash 5.3+ tilde-expands a literal
+    # unquoted ~ in the patsub replacement, turning this into a no-op.
+    local tilde='~'
+    local display_path="${path/#$HOME/$tilde}"
     local size_kb
     size_kb=$(get_path_size_kb "$path" 2> /dev/null || echo "0")
 
@@ -444,6 +447,43 @@ remove_file_list() {
     echo "$count"
 }
 
+# Distinct installs can share one bundle id (Xcode.app and Xcode-beta.app are
+# both com.apple.dt.Xcode). When a sibling install with the same bundle id
+# stays on disk and is not part of the current selection, bundle-id-derived
+# leftovers (caches, preferences, containers, launch services) still belong to
+# the surviving install and must not be touched by this uninstall.
+# Reads apps_data and selected_apps from the caller's scope via dynamic
+# scoping; both may be unset when batch.sh is exercised standalone in tests.
+uninstall_bundle_id_has_surviving_sibling() {
+    local bundle_id="$1"
+    local app_path="$2"
+
+    [[ -z "$bundle_id" || "$bundle_id" == "unknown" ]] && return 1
+
+    local row other_path other_bundle
+    # shellcheck disable=SC2154 # apps_data is provided by bin/uninstall.sh via dynamic scope.
+    for row in "${apps_data[@]+"${apps_data[@]}"}"; do
+        IFS='|' read -r _ other_path _ other_bundle _ _ _ <<< "$row"
+        [[ "$other_bundle" == "$bundle_id" ]] || continue
+        [[ "$other_path" == "$app_path" ]] && continue
+        [[ -d "$other_path" ]] || continue
+
+        local sel selected_path is_selected=false
+        for sel in "${selected_apps[@]+"${selected_apps[@]}"}"; do
+            IFS='|' read -r _ selected_path _ _ _ _ <<< "$sel"
+            if [[ "$selected_path" == "$other_path" ]]; then
+                is_selected=true
+                break
+            fi
+        done
+        [[ "$is_selected" == true ]] && continue
+
+        return 0
+    done
+
+    return 1
+}
+
 # Internal helpers for batch_uninstall_applications. They read and write
 # locals declared in the orchestrator's scope via bash dynamic scoping; do
 # not call them outside batch_uninstall_applications.
@@ -468,6 +508,16 @@ _batch_scan_app_details() {
         if official_vendor=$(official_uninstaller_vendor "$bundle_id" "$app_name" "$app_path" 2> /dev/null); then
             blocked_apps+=("$app_name|$official_vendor")
             continue
+        fi
+
+        # A surviving install sharing this bundle id (e.g. Xcode.app when
+        # uninstalling Xcode-beta.app) still owns every bundle-id-keyed path.
+        # Demote the bundle id to "unknown" so leftover discovery and the
+        # bundle-id-keyed removal steps all fall back to name/path matching,
+        # which is unique per install.
+        if uninstall_bundle_id_has_surviving_sibling "$bundle_id" "$app_path"; then
+            debug_log "Bundle id $bundle_id shared with a surviving install; restricting $app_name leftovers to name/path matches"
+            bundle_id="unknown"
         fi
 
         # Check running app by bundle executable if available
@@ -711,6 +761,9 @@ _batch_preview_and_confirm() {
 #         total_size_freed, brew_apps_removed,
 #         files_cleaned, total_items (the latter two via dynamic scope)
 _batch_execute_removals() {
+    # See format_uninstall_preview_path: literal ~ in a patsub replacement is
+    # tilde-expanded by bash 5.3+, so route it through a variable.
+    local tilde_display='~'
     local current_index=0
     for detail in "${app_details[@]}"; do
         current_index=$((current_index + 1))
@@ -943,7 +996,7 @@ _batch_execute_removals() {
             # Warn about files that could not be removed and exclude them from freed total.
             if [[ ${#leftover_paths[@]} -gt 0 ]]; then
                 for _lpath in "${leftover_paths[@]}"; do
-                    echo -e "  ${YELLOW}${ICON_WARNING}${NC} Could not remove: ${_lpath/$HOME/~}"
+                    echo -e "  ${YELLOW}${ICON_WARNING}${NC} Could not remove: ${_lpath/#$HOME/$tilde_display}"
                 done
                 total_kb=$((total_kb - leftover_kb))
                 ((total_kb < 0)) && total_kb=0

--- a/lib/uninstall/brew.sh
+++ b/lib/uninstall/brew.sh
@@ -192,21 +192,31 @@ get_brew_cask_name() {
 }
 
 # Uninstall a Homebrew cask and verify removal
-# Args: $1 - cask_name, $2 - app_path (optional, for verification)
+# Args: $1 - cask_name, $2 - app_path (optional, for verification),
+#       $3 - zap mode: "nozap" runs a plain uninstall without --zap. Used when
+#            another install shares the cask's bundle id: zap stanzas delete
+#            bundle-id-keyed prefs/caches that the surviving install still
+#            uses (iterm2 and iterm2-beta both zap com.googlecode.iterm2).
 # Returns: 0 on success, 1 on failure
 brew_uninstall_cask() {
     local cask_name="$1"
     local app_path="${2:-}"
+    local zap_mode="${3:-zap}"
+
+    local -a uninstall_args=(uninstall --cask)
+    if [[ "$zap_mode" != "nozap" ]]; then
+        uninstall_args+=(--zap)
+    fi
 
     if [[ "${MOLE_DRY_RUN:-0}" == "1" ]]; then
-        debug_log "[DRY RUN] Would brew uninstall --cask --zap $cask_name"
+        debug_log "[DRY RUN] Would brew ${uninstall_args[*]} $cask_name"
         return 0
     fi
 
     is_homebrew_available || return 1
     [[ -z "$cask_name" ]] && return 1
 
-    debug_log "Attempting brew uninstall --cask --zap $cask_name"
+    debug_log "Attempting brew ${uninstall_args[*]} $cask_name"
 
     local uninstall_ok=false
     local brew_exit=0
@@ -227,13 +237,13 @@ brew_uninstall_cask() {
     if [[ -n "${SUDO_USER:-}" ]]; then
         if run_with_timeout "$timeout" sudo -u "$SUDO_USER" env \
             HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_AUTO_UPDATE=1 NONINTERACTIVE=1 \
-            brew uninstall --cask --zap "$cask_name" 2>&1; then
+            brew "${uninstall_args[@]}" "$cask_name" 2>&1; then
             uninstall_ok=true
         else
             brew_exit=$?
         fi
     elif HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_AUTO_UPDATE=1 NONINTERACTIVE=1 \
-        run_with_timeout "$timeout" brew uninstall --cask --zap "$cask_name" 2>&1; then
+        run_with_timeout "$timeout" brew "${uninstall_args[@]}" "$cask_name" 2>&1; then
         uninstall_ok=true
     else
         brew_exit=$?

--- a/tests/brew_uninstall.bats
+++ b/tests/brew_uninstall.bats
@@ -172,6 +172,75 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "batch_uninstall_applications drops --zap when a sibling install shares the cask bundle id" {
+    # iterm2 and iterm2-beta both zap com.googlecode.iterm2. When the stable
+    # install survives, uninstalling the beta cask must not run the zap
+    # stanza, or brew deletes the survivor's prefs/caches behind the guard.
+    mkdir -p "$HOME/Applications/BrewShared.app" "$HOME/Applications/BrewShared-beta.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+request_sudo_access() { return 0; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+get_file_owner() { whoami; }
+get_path_size_kb() { echo "100"; }
+bytes_to_human() { echo "$1"; }
+drain_pending_input() { :; }
+print_summary_block() { :; }
+remove_apps_from_dock() { :; }
+force_kill_app() { return 0; }
+run_with_timeout() { shift; "$@"; }
+export -f run_with_timeout
+ensure_sudo_session() { return 0; }
+
+brew() {
+    echo "brew call: $*" >> "$HOME/brew_shared_calls.log"
+    # Make the uninstall "work" so verification passes and no manual
+    # fallback path runs.
+    if [[ "$1" == "uninstall" ]]; then
+        rm -rf "$HOME/Applications/BrewShared-beta.app"
+    fi
+    return 0
+}
+export -f brew
+
+get_brew_cask_name() { echo "brewshared-beta"; return 0; }
+export -f get_brew_cask_name
+
+apps_data=(
+    "0|$HOME/Applications/BrewShared.app|BrewShared|com.example.brewshared|0|Never|0"
+    "0|$HOME/Applications/BrewShared-beta.app|BrewShared-beta|com.example.brewshared|0|Never|0"
+)
+selected_apps=("0|$HOME/Applications/BrewShared-beta.app|BrewShared-beta|com.example.brewshared|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+printf '\n' | batch_uninstall_applications > /dev/null 2>&1
+
+grep -q "uninstall --cask brewshared-beta" "$HOME/brew_shared_calls.log" || {
+    echo "WRONG: plain cask uninstall not invoked"
+    cat "$HOME/brew_shared_calls.log"
+    exit 1
+}
+if grep -q -- "--zap" "$HOME/brew_shared_calls.log"; then
+    echo "WRONG: --zap used despite surviving same-bundle sibling"
+    cat "$HOME/brew_shared_calls.log"
+    exit 1
+fi
+[[ -d "$HOME/Applications/BrewShared.app" ]] || {
+    echo "WRONG: surviving install removed"
+    exit 1
+}
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "batch_uninstall_applications pre-auths sudo for brew-only casks" {
     local app_bundle="$HOME/Applications/BrewPreAuth.app"
     mkdir -p "$app_bundle"

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -433,6 +433,98 @@ EOF
 	[ "$status" -eq 0 ]
 }
 
+@test "batch_uninstall_applications keeps name-keyed leftovers when sibling installs share a display name" {
+	# On unindexed volumes mdls returns (null) and CFBundleName collapses both
+	# installs to one display name ("Xcode" for Xcode-beta.app). Discovery must
+	# fall back to the .app basename; when even that collides with the
+	# survivor, name cleanup and login-item removal must be suppressed.
+	mkdir -p "$HOME/Applications/SharedName-beta.app" "$HOME/Applications/SharedName.app"
+	mkdir -p "$HOME/OtherApps/SharedName.app"
+	mkdir -p "$HOME/Library/Application Support/SharedName"
+	mkdir -p "$HOME/Library/Caches/SharedName"
+	mkdir -p "$HOME/Library/Preferences"
+	touch "$HOME/Library/Preferences/SharedName.plist"
+	mkdir -p "$HOME/Library/Caches/SharedName-beta"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+request_sudo_access() { return 0; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+enter_alt_screen() { :; }
+leave_alt_screen() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+remove_apps_from_dock() { :; }
+pgrep() { return 1; }
+pkill() { return 0; }
+sudo() { return 0; }
+remove_login_item() { printf 'LOGIN_ITEM:%s\n' "$1" >> "$HOME/login.log"; }
+
+# Case 1: display names collide ("SharedName" for both) but basenames differ.
+# Discovery must use the basename (SharedName-beta) so the survivor's
+# name-keyed dirs stay, and login-item removal must be skipped.
+apps_data=(
+	"0|$HOME/Applications/SharedName.app|SharedName|com.example.sharedname|0|Never|0"
+	"0|$HOME/Applications/SharedName-beta.app|SharedName|com.example.sharedname|0|Never|0"
+)
+selected_apps=("0|$HOME/Applications/SharedName-beta.app|SharedName|com.example.sharedname|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+printf '\n' | batch_uninstall_applications > /dev/null 2>&1
+
+[[ ! -d "$HOME/Applications/SharedName-beta.app" ]] || { echo "WRONG: beta bundle preserved"; exit 1; }
+[[ ! -d "$HOME/Library/Caches/SharedName-beta" ]] || { echo "WRONG: beta's own cache preserved"; exit 1; }
+[[ -d "$HOME/Applications/SharedName.app" ]] || { echo "WRONG: survivor removed"; exit 1; }
+[[ -d "$HOME/Library/Application Support/SharedName" ]] || { echo "WRONG: survivor app support removed"; exit 1; }
+[[ -d "$HOME/Library/Caches/SharedName" ]] || { echo "WRONG: survivor cache removed"; exit 1; }
+[[ -f "$HOME/Library/Preferences/SharedName.plist" ]] || { echo "WRONG: survivor prefs removed"; exit 1; }
+[[ ! -f "$HOME/login.log" ]] || { echo "WRONG: login item removed on colliding name"; cat "$HOME/login.log"; exit 1; }
+
+# Case 2: basenames collide too (same SharedName.app in two folders).
+# Name discovery must be suppressed entirely: only the bundle goes.
+apps_data=(
+	"0|$HOME/OtherApps/SharedName.app|SharedName|com.example.sharedname|0|Never|0"
+	"0|$HOME/Applications/SharedName.app|SharedName|com.example.sharedname|0|Never|0"
+)
+selected_apps=("0|$HOME/Applications/SharedName.app|SharedName|com.example.sharedname|0|Never")
+
+printf '\n' | batch_uninstall_applications > /dev/null 2>&1
+
+[[ ! -d "$HOME/Applications/SharedName.app" ]] || { echo "WRONG: selected bundle preserved"; exit 1; }
+[[ -d "$HOME/OtherApps/SharedName.app" ]] || { echo "WRONG: survivor removed (case 2)"; exit 1; }
+[[ -d "$HOME/Library/Application Support/SharedName" ]] || { echo "WRONG: shared-name app support removed (case 2)"; exit 1; }
+[[ -d "$HOME/Library/Caches/SharedName" ]] || { echo "WRONG: shared-name cache removed (case 2)"; exit 1; }
+[[ -f "$HOME/Library/Preferences/SharedName.plist" ]] || { echo "WRONG: shared-name prefs removed (case 2)"; exit 1; }
+[[ ! -f "$HOME/login.log" ]] || { echo "WRONG: login item removed on colliding name (case 2)"; exit 1; }
+
+# Case 3: the Xcode toolchain heuristic matches by regex substring, so even
+# a non-colliding basename ("XcodeClone-beta") would sweep DerivedData that
+# the surviving install still uses. The sibling guard must disable it.
+mkdir -p "$HOME/Applications/XcodeClone.app" "$HOME/Applications/XcodeClone-beta.app"
+mkdir -p "$HOME/Library/Developer/Xcode/DerivedData"
+
+apps_data=(
+	"0|$HOME/Applications/XcodeClone.app|XcodeClone|com.example.xcodeclone|0|Never|0"
+	"0|$HOME/Applications/XcodeClone-beta.app|XcodeClone|com.example.xcodeclone|0|Never|0"
+)
+selected_apps=("0|$HOME/Applications/XcodeClone-beta.app|XcodeClone|com.example.xcodeclone|0|Never")
+
+printf '\n' | batch_uninstall_applications > /dev/null 2>&1
+
+[[ ! -d "$HOME/Applications/XcodeClone-beta.app" ]] || { echo "WRONG: beta bundle preserved (case 3)"; exit 1; }
+[[ -d "$HOME/Applications/XcodeClone.app" ]] || { echo "WRONG: survivor removed (case 3)"; exit 1; }
+[[ -d "$HOME/Library/Developer/Xcode/DerivedData" ]] || { echo "WRONG: DerivedData swept despite surviving sibling (case 3)"; exit 1; }
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "batch_uninstall_applications blocks official-uninstaller apps" {
 	mkdir -p "$HOME/Applications/Falcon.app"
 

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -445,6 +445,13 @@ EOF
 	mkdir -p "$HOME/Library/Preferences"
 	touch "$HOME/Library/Preferences/SharedName.plist"
 	mkdir -p "$HOME/Library/Caches/SharedName-beta"
+	# Same-bundle siblings ship the same CFBundleExecutable (Xcode-beta.app
+	# ships "Xcode"); diagnostic-report discovery keys on it, so the beta's
+	# Info.plist points at the shared executable name.
+	mkdir -p "$HOME/Applications/SharedName-beta.app/Contents"
+	printf '%s' '<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict><key>CFBundleExecutable</key><string>SharedName</string></dict></plist>' > "$HOME/Applications/SharedName-beta.app/Contents/Info.plist"
+	mkdir -p "$HOME/Library/Logs/DiagnosticReports"
+	touch "$HOME/Library/Logs/DiagnosticReports/SharedName-2026-07-03-101010.ips"
 
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -463,6 +470,7 @@ pgrep() { return 1; }
 pkill() { return 0; }
 sudo() { return 0; }
 remove_login_item() { printf 'LOGIN_ITEM:%s\n' "$1" >> "$HOME/login.log"; }
+force_kill_app() { printf 'KILL:%s\n' "$1" >> "$HOME/kill.log"; return 0; }
 
 # Case 1: display names collide ("SharedName" for both) but basenames differ.
 # Discovery must use the basename (SharedName-beta) so the survivor's
@@ -485,6 +493,7 @@ printf '\n' | batch_uninstall_applications > /dev/null 2>&1
 [[ -d "$HOME/Library/Caches/SharedName" ]] || { echo "WRONG: survivor cache removed"; exit 1; }
 [[ -f "$HOME/Library/Preferences/SharedName.plist" ]] || { echo "WRONG: survivor prefs removed"; exit 1; }
 [[ ! -f "$HOME/login.log" ]] || { echo "WRONG: login item removed on colliding name"; cat "$HOME/login.log"; exit 1; }
+[[ -f "$HOME/Library/Logs/DiagnosticReports/SharedName-2026-07-03-101010.ips" ]] || { echo "WRONG: survivor crash reports deleted under sibling guard"; exit 1; }
 
 # Case 2: basenames collide too (same SharedName.app in two folders).
 # Name discovery must be suppressed entirely: only the bundle goes.
@@ -520,6 +529,49 @@ printf '\n' | batch_uninstall_applications > /dev/null 2>&1
 [[ ! -d "$HOME/Applications/XcodeClone-beta.app" ]] || { echo "WRONG: beta bundle preserved (case 3)"; exit 1; }
 [[ -d "$HOME/Applications/XcodeClone.app" ]] || { echo "WRONG: survivor removed (case 3)"; exit 1; }
 [[ -d "$HOME/Library/Developer/Xcode/DerivedData" ]] || { echo "WRONG: DerivedData swept despite surviving sibling (case 3)"; exit 1; }
+
+# Case 4: inverse direction: uninstalling the base-named install while the
+# hyphen-suffixed sibling survives. The discovery name ("RevBase") is
+# contained in the survivor's identifiers ("RevBase-beta"), and downstream
+# matchers are substring-based (the LaunchAgents scan globs "*<name>*.plist"),
+# so name discovery must be suppressed entirely.
+mkdir -p "$HOME/Applications/RevBase.app" "$HOME/Applications/RevBase-beta.app"
+mkdir -p "$HOME/Library/Application Support/RevBase"
+mkdir -p "$HOME/Library/LaunchAgents"
+touch "$HOME/Library/LaunchAgents/com.example.RevBase-beta.agent.plist"
+
+apps_data=(
+	"0|$HOME/Applications/RevBase.app|RevBase|com.example.revbase|0|Never|0"
+	"0|$HOME/Applications/RevBase-beta.app|RevBase-beta|com.example.revbase|0|Never|0"
+)
+selected_apps=("0|$HOME/Applications/RevBase.app|RevBase|com.example.revbase|0|Never")
+
+printf '\n' | batch_uninstall_applications > /dev/null 2>&1
+
+[[ ! -d "$HOME/Applications/RevBase.app" ]] || { echo "WRONG: selected base bundle preserved (case 4)"; exit 1; }
+[[ -d "$HOME/Applications/RevBase-beta.app" ]] || { echo "WRONG: suffixed survivor removed (case 4)"; exit 1; }
+[[ -f "$HOME/Library/LaunchAgents/com.example.RevBase-beta.agent.plist" ]] || { echo "WRONG: survivor launch agent removed (case 4)"; exit 1; }
+[[ -d "$HOME/Library/Application Support/RevBase" ]] || { echo "WRONG: shared app support removed (case 4)"; exit 1; }
+[[ ! -f "$HOME/login.log" ]] || { echo "WRONG: login item removed (case 4)"; exit 1; }
+
+# Across all four guard cases process termination must never run:
+# force_kill_app quits by bundle id and matches by CFBundleExecutable, and
+# both can belong to the surviving install.
+[[ ! -f "$HOME/kill.log" ]] || { echo "WRONG: process termination attempted under sibling guard"; cat "$HOME/kill.log"; exit 1; }
+
+# Case 5 (control): without a surviving sibling the termination and
+# diagnostic-report paths must still run, proving the negative assertions
+# above are not vacuous.
+mkdir -p "$HOME/Applications/SoloApp.app"
+touch "$HOME/Library/Logs/DiagnosticReports/SoloApp-2026-07-03-101010.ips"
+apps_data=("0|$HOME/Applications/SoloApp.app|SoloApp|com.example.soloapp|0|Never|0")
+selected_apps=("0|$HOME/Applications/SoloApp.app|SoloApp|com.example.soloapp|0|Never")
+
+printf '\n' | batch_uninstall_applications > /dev/null 2>&1
+
+[[ ! -d "$HOME/Applications/SoloApp.app" ]] || { echo "WRONG: solo bundle preserved (case 5)"; exit 1; }
+grep -q "KILL:SoloApp" "$HOME/kill.log" 2> /dev/null || { echo "WRONG: termination skipped without sibling guard (case 5)"; exit 1; }
+[[ ! -f "$HOME/Library/Logs/DiagnosticReports/SoloApp-2026-07-03-101010.ips" ]] || { echo "WRONG: diagnostic reports not collected without sibling guard (case 5)"; exit 1; }
 EOF
 
 	[ "$status" -eq 0 ]

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -342,6 +342,97 @@ EOF
 	[ "$status" -eq 0 ]
 }
 
+@test "uninstall_bundle_id_has_surviving_sibling detects unselected same-bundle install" {
+	mkdir -p "$HOME/Applications/Shared.app" "$HOME/Applications/Shared-beta.app"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+apps_data=(
+	"0|$HOME/Applications/Shared.app|Shared|com.example.Shared|0|Never|0"
+	"0|$HOME/Applications/Shared-beta.app|Shared-beta|com.example.Shared|0|Never|0"
+)
+
+# Only the beta variant is selected; the stable install survives.
+selected_apps=("0|$HOME/Applications/Shared-beta.app|Shared-beta|com.example.Shared|0|Never")
+uninstall_bundle_id_has_surviving_sibling "com.example.Shared" "$HOME/Applications/Shared-beta.app" || {
+	echo "WRONG: surviving sibling not detected"
+	exit 1
+}
+
+# Both variants selected: no survivor, bundle-id cleanup is safe.
+selected_apps=(
+	"0|$HOME/Applications/Shared.app|Shared|com.example.Shared|0|Never"
+	"0|$HOME/Applications/Shared-beta.app|Shared-beta|com.example.Shared|0|Never"
+)
+if uninstall_bundle_id_has_surviving_sibling "com.example.Shared" "$HOME/Applications/Shared-beta.app"; then
+	echo "WRONG: sibling reported although both installs are selected"
+	exit 1
+fi
+
+# Unknown bundle id never reports a sibling.
+if uninstall_bundle_id_has_surviving_sibling "unknown" "$HOME/Applications/Shared-beta.app"; then
+	echo "WRONG: unknown bundle id reported a sibling"
+	exit 1
+fi
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
+@test "batch_uninstall_applications keeps shared bundle-id leftovers when a sibling install survives" {
+	# Xcode.app and Xcode-beta.app both use com.apple.dt.Xcode. Uninstalling
+	# only the beta must not delete bundle-id-keyed files still owned by the
+	# surviving stable install.
+	mkdir -p "$HOME/Applications/Shared.app" "$HOME/Applications/Shared-beta.app"
+	mkdir -p "$HOME/Library/Caches/com.example.Shared"
+	mkdir -p "$HOME/Library/Preferences"
+	touch "$HOME/Library/Preferences/com.example.Shared.plist"
+	mkdir -p "$HOME/Library/Caches/Shared-beta"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+request_sudo_access() { return 0; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+enter_alt_screen() { :; }
+leave_alt_screen() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+remove_apps_from_dock() { :; }
+pgrep() { return 1; }
+pkill() { return 0; }
+sudo() { return 0; }
+
+apps_data=(
+	"0|$HOME/Applications/Shared.app|Shared|com.example.Shared|0|Never|0"
+	"0|$HOME/Applications/Shared-beta.app|Shared-beta|com.example.Shared|0|Never|0"
+)
+selected_apps=("0|$HOME/Applications/Shared-beta.app|Shared-beta|com.example.Shared|0|Never")
+files_cleaned=0
+total_items=0
+total_size_cleaned=0
+
+printf '\n' | batch_uninstall_applications
+
+# The selected bundle and its name-keyed leftovers are gone.
+[[ ! -d "$HOME/Applications/Shared-beta.app" ]] || { echo "WRONG: beta bundle preserved"; exit 1; }
+[[ ! -d "$HOME/Library/Caches/Shared-beta" ]] || { echo "WRONG: beta name cache preserved"; exit 1; }
+
+# The surviving install and every bundle-id-keyed path are untouched.
+[[ -d "$HOME/Applications/Shared.app" ]] || { echo "WRONG: surviving install removed"; exit 1; }
+[[ -d "$HOME/Library/Caches/com.example.Shared" ]] || { echo "WRONG: shared bundle-id cache removed"; exit 1; }
+[[ -f "$HOME/Library/Preferences/com.example.Shared.plist" ]] || { echo "WRONG: shared bundle-id prefs removed"; exit 1; }
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 @test "batch_uninstall_applications blocks official-uninstaller apps" {
 	mkdir -p "$HOME/Applications/Falcon.app"
 
@@ -1782,7 +1873,7 @@ read_key() {
 MOLE_SELECTION_RESULT=""
 unset MOLE_MENU_SORT_MODE MOLE_MENU_SORT_REVERSE MOLE_MENU_META_SIZEKB
 set +e
-MOLE_MENU_META_EPOCHS="100,200" paginated_multi_select "Test Menu" "Alpha" "Beta" > "$HOME/menu.out" 2> "$HOME/menu.err"
+MOLE_MENU_META_EPOCHS="100,200" paginated_multi_select "Test Menu" "Alpha" "Beta" > "$HOME/menu.out" 2> "$HOME/menu.err" < /dev/null
 rc=$?
 set -e
 echo "rc=$rc"
@@ -1818,7 +1909,7 @@ read_key() {
 
 MOLE_SELECTION_RESULT=""
 set +e
-MOLE_MENU_META_SIZEKB="1,100" MOLE_MENU_SORT_MODE=size MOLE_MENU_SORT_REVERSE=false paginated_multi_select "Test Menu" "Small" "Large" > "$HOME/menu-default.out" 2> "$HOME/menu-default.err"
+MOLE_MENU_META_SIZEKB="1,100" MOLE_MENU_SORT_MODE=size MOLE_MENU_SORT_REVERSE=false paginated_multi_select "Test Menu" "Small" "Large" > "$HOME/menu-default.out" 2> "$HOME/menu-default.err" < /dev/null
 default_rc=$?
 set -e
 echo "default=${MOLE_SELECTION_RESULT:-}"
@@ -1826,7 +1917,7 @@ echo "default=${MOLE_SELECTION_RESULT:-}"
 : > "$key_state"
 MOLE_SELECTION_RESULT=""
 set +e
-NEXT_KEY="CHAR:O" MOLE_MENU_META_SIZEKB="1,100" MOLE_MENU_SORT_MODE=size MOLE_MENU_SORT_REVERSE=false paginated_multi_select "Test Menu" "Small" "Large" > "$HOME/menu-reverse.out" 2> "$HOME/menu-reverse.err"
+NEXT_KEY="CHAR:O" MOLE_MENU_META_SIZEKB="1,100" MOLE_MENU_SORT_MODE=size MOLE_MENU_SORT_REVERSE=false paginated_multi_select "Test Menu" "Small" "Large" > "$HOME/menu-reverse.out" 2> "$HOME/menu-reverse.err" < /dev/null
 reverse_rc=$?
 set -e
 echo "default_rc=$default_rc"

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -296,6 +296,35 @@ EOF
 	[[ "$output" != *"|$backup_app|Dupe|com.example.Dupe|"* ]]
 }
 
+@test "scan_applications keeps distinct installs sharing a bundle id (Xcode vs Xcode-beta)" {
+	src="$HOME/uninstall_source.sh"
+	sourceable_uninstall_sh "$src"
+
+	apps_root="$HOME/Applications"
+	stable_app="$apps_root/Xcode.app"
+	beta_app="$apps_root/Xcode-beta.app"
+	create_test_app_bundle "$stable_app" "com.apple.dt.Xcode" "Xcode"
+	create_test_app_bundle "$beta_app" "com.apple.dt.Xcode" "Xcode"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+		MOLE_TEST_NO_AUTH=1 APPS_ROOT="$apps_root" SRC_PATH="$src" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$SRC_PATH"
+
+uninstall_print_app_search_dirs() { printf '%s\n' "$APPS_ROOT"; }
+
+apps_file=$(scan_applications)
+cat "$apps_file"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"|$stable_app|"* ]]
+	[[ "$output" == *"|$beta_app|"* ]]
+}
+
 @test "scan_applications keeps unique apps from backup Applications roots (#975)" {
 	src="$HOME/uninstall_source.sh"
 	sourceable_uninstall_sh "$src"


### PR DESCRIPTION
Fixes #1186

## Summary

Xcode.app and Xcode-beta.app both ship `com.apple.dt.Xcode` as their bundle ID. The backup-volume dedupe from #975 keys scan rows on bundle ID alone, so the beta was collapsed into the stable install and never showed up in `mo uninstall`.

- `_scan_dedupe_bundle_ids` now keys on bundle ID plus the `.app` basename. True clones on mirrored volumes (the #975 case) still collapse with the live location winning, while distinct installs stay visible.
- New guard in `lib/uninstall/batch.sh`: when an unselected install with the same bundle ID is still on disk, the selected app's bundle ID is demoted to `unknown` before leftover discovery. Without this, uninstalling only the beta would trash `~/Library/Caches/com.apple.dt.Xcode`, preferences, containers, and launch services that the surviving stable install still uses. Leftovers fall back to name and path matches, which are unique per install.
- Two small fixes that surfaced while testing on this machine: `${path/$HOME/~}` in the uninstall preview became a no-op under bash 5.3 (a literal `~` in the patsub replacement is now tilde-expanded, so the replacement equals the original), routed through a variable instead; and two paginated menu tests needed `< /dev/null` because the menu's `read -n1` was eating heredoc bytes.

Dry run on the affected machine, with both Xcodes installed:

```
$ mo uninstall --list | grep -i xcode
Xcode-beta   com.apple.dt.Xcode   Xcode-beta   9.12GB
Xcode        com.apple.dt.Xcode   Xcode        12.48GB

$ mo uninstall Xcode-beta --dry-run --debug
[DEBUG] Bundle id com.apple.dt.Xcode shared with a surviving install; restricting Xcode-beta leftovers to name/path matches
  ✓ /Applications/Xcode-beta.app , 9.12GB
  ✓ ~/Library/Developer/Xcode/DerivedData
  ✓ ~/Library/Developer/CoreSimulator/Caches
```

## Safety Review

- Affects uninstall scan and leftover collection.
- The dedupe change only widens what the scan keeps; it removes nothing new. Renamed clones in backup roots (`Xcode copy.app`) no longer collapse and will show as extra rows, which seems acceptable for a scan surface.
- The sibling guard narrows deletion: bundle-ID-keyed paths are skipped whenever another install with the same bundle ID survives outside the selection. Selecting both installs restores full bundle-ID cleanup. `should_protect_path` coverage is unchanged.
- The demoted bundle ID takes the existing `unknown` code paths (`stop_launch_services`, `remove_login_item`, defaults deletion, ByHost scan all already no-op on `unknown`).

## Tests

- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats` (66 pass, includes 2 new tests: sibling detection unit test, full batch flow asserting shared bundle-ID files survive)
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_scan_bash32.bats` (9 pass, includes new Xcode/Xcode-beta dedupe test; verified on /bin/bash 3.2)
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_safety.bats tests/uninstall_remove_file_list.bats tests/uninstall_naming_variants.bats` (36 pass)
- `./scripts/check.sh` (shellcheck, syntax, format all pass)
- Manual: `mo uninstall Xcode-beta --dry-run --debug` on macOS 27 beta with both installs present, output above

## Safety-related changes

- Leftover collection now skips bundle-ID-derived paths when a same-bundle-ID install survives the uninstall. This is a deliberate narrowing to avoid deleting live data of the surviving install.

Made with [Cursor](https://cursor.com)