### PR TITLE
fix(uninstall): keep Raycast v2 data when uninstalling Raycast v1

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1186,18 +1186,12 @@ find_app_files() {
             "$HOME/Library/Application Scripts"
             "$HOME/Library/Containers"
         )
+        # Raycast v2 ships as a separate app (bundle id com.raycast-x.macos);
+        # exclude its directories from every v1 "*raycast*" sweep (#1202).
         for dir in "${raycast_dirs[@]}"; do
             [[ -d "$dir" ]] && while IFS= read -r -d '' p; do
-                shopt -s nocasematch
-                case "$(basename "$p")" in
-                    *raycast-x*)
-                        shopt -u nocasematch
-                        continue
-                        ;;
-                esac
-                shopt -u nocasematch
                 files_to_clean+=("$p")
-            done < <(command find "$dir" -maxdepth 1 -type d -iname "*raycast*" -print0 2> /dev/null)
+            done < <(command find "$dir" -maxdepth 1 -type d -iname "*raycast*" ! -iname "*raycast-x*" -print0 2> /dev/null)
         done
 
         # Explicit Raycast container directories (hardcoded leftovers)
@@ -1206,22 +1200,14 @@ find_app_files() {
 
         # Cache (deeper search)
         [[ -d "$HOME/Library/Caches" ]] && while IFS= read -r -d '' p; do
-            shopt -s nocasematch
-            case "$(basename "$p")" in
-                *raycast-x*)
-                    shopt -u nocasematch
-                    continue
-                    ;;
-            esac
-            shopt -u nocasematch
             files_to_clean+=("$p")
-        done < <(command find "$HOME/Library/Caches" -maxdepth 2 -type d -iname "*raycast*" -print0 2> /dev/null)
+        done < <(command find "$HOME/Library/Caches" -maxdepth 2 -type d -iname "*raycast*" ! -iname "*raycast-x*" -print0 2> /dev/null)
 
         # VSCode extension storage
         local vscode_global="$HOME/Library/Application Support/Code/User/globalStorage"
         [[ -d "$vscode_global" ]] && while IFS= read -r -d '' p; do
             files_to_clean+=("$p")
-        done < <(command find "$vscode_global" -maxdepth 1 -type d -iname "*raycast*" -print0 2> /dev/null)
+        done < <(command find "$vscode_global" -maxdepth 1 -type d -iname "*raycast*" ! -iname "*raycast-x*" -print0 2> /dev/null)
     fi
 
     # CrashReporter plists: named AppName_UUID.plist (not subdirectories)
@@ -1465,19 +1451,11 @@ find_app_system_files() {
         done < <(command find /Library/PrivilegedHelperTools -maxdepth 1 -print0 2> /dev/null)
     fi
 
-    # Raycast system-level files
+    # Raycast system-level files (v2 dirs excluded, see find_app_files)
     if [[ "$bundle_id" == "com.raycast.macos" ]]; then
         [[ -d "/Library/Application Support" ]] && while IFS= read -r -d '' p; do
-            shopt -s nocasematch
-            case "$(basename "$p")" in
-                *raycast-x*)
-                    shopt -u nocasematch
-                    continue
-                    ;;
-            esac
-            shopt -u nocasematch
             system_files+=("$p")
-        done < <(command find "/Library/Application Support" -maxdepth 1 -type d -iname "*raycast*" -print0 2> /dev/null)
+        done < <(command find "/Library/Application Support" -maxdepth 1 -type d -iname "*raycast*" ! -iname "*raycast-x*" -print0 2> /dev/null)
     fi
 
     local receipt_files=""

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1188,6 +1188,14 @@ find_app_files() {
         )
         for dir in "${raycast_dirs[@]}"; do
             [[ -d "$dir" ]] && while IFS= read -r -d '' p; do
+                shopt -s nocasematch
+                case "$(basename "$p")" in
+                    *raycast-x*)
+                        shopt -u nocasematch
+                        continue
+                        ;;
+                esac
+                shopt -u nocasematch
                 files_to_clean+=("$p")
             done < <(command find "$dir" -maxdepth 1 -type d -iname "*raycast*" -print0 2> /dev/null)
         done
@@ -1198,6 +1206,14 @@ find_app_files() {
 
         # Cache (deeper search)
         [[ -d "$HOME/Library/Caches" ]] && while IFS= read -r -d '' p; do
+            shopt -s nocasematch
+            case "$(basename "$p")" in
+                *raycast-x*)
+                    shopt -u nocasematch
+                    continue
+                    ;;
+            esac
+            shopt -u nocasematch
             files_to_clean+=("$p")
         done < <(command find "$HOME/Library/Caches" -maxdepth 2 -type d -iname "*raycast*" -print0 2> /dev/null)
 
@@ -1452,6 +1468,14 @@ find_app_system_files() {
     # Raycast system-level files
     if [[ "$bundle_id" == "com.raycast.macos" ]]; then
         [[ -d "/Library/Application Support" ]] && while IFS= read -r -d '' p; do
+            shopt -s nocasematch
+            case "$(basename "$p")" in
+                *raycast-x*)
+                    shopt -u nocasematch
+                    continue
+                    ;;
+            esac
+            shopt -u nocasematch
             system_files+=("$p")
         done < <(command find "/Library/Application Support" -maxdepth 1 -type d -iname "*raycast*" -print0 2> /dev/null)
     fi

--- a/lib/core/app_protection_data.sh
+++ b/lib/core/app_protection_data.sh
@@ -395,6 +395,7 @@ readonly DATA_PROTECTED_BUNDLES=(
     # Launcher & Automation
     "com.runningwithcrayons.Alfred"
     "com.raycast.*"
+    "com.raycast-x.*"
     "com.blacktree.Quicksilver"
     "com.stairways.keyboardmaestro.*"
     "com.manytricks.Butler"

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -418,7 +418,7 @@ EOF
 }
 
 @test "should_protect_data covers Raycast wildcard variants" {
-    for id in com.raycast.macos com.raycast.shared com.raycast.macos.BrowserExtension; do
+    for id in com.raycast.macos com.raycast.shared com.raycast.macos.BrowserExtension com.raycast-x.macos; do
         result=$(HOME="$HOME" bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; should_protect_data '$id' && echo 'protected' || echo 'not-protected'")
         [ "$result" = "protected" ]
     done

--- a/tests/uninstall_naming_variants.bats
+++ b/tests/uninstall_naming_variants.bats
@@ -269,3 +269,24 @@ find_app_files 'invalid_bundle' ''"
 
     [[ "$result" == *".config/zed"* ]] || [[ "$result" == *".local/share/zed"* ]]
 }
+
+@test "find_app_files keeps Raycast v2 data when uninstalling Raycast v1 (#1202)" {
+    # Raycast v2 is a separate app (com.raycast-x.macos); the v1 "*raycast*"
+    # sweeps must not collect any of its directories.
+    mkdir -p "$HOME/Library/Application Support/com.raycast.macos"
+    mkdir -p "$HOME/Library/Application Support/com.raycast-x.macos"
+    mkdir -p "$HOME/Library/Containers/com.raycast.macos"
+    mkdir -p "$HOME/Library/Containers/com.raycast-x.macos"
+    mkdir -p "$HOME/Library/Caches/com.raycast.macos"
+    mkdir -p "$HOME/Library/Caches/Raycast-X"
+    mkdir -p "$HOME/Library/Application Support/Code/User/globalStorage/raycast-x.raycast"
+
+    result=$(find_app_files "com.raycast.macos" "Raycast")
+
+    [[ "$result" == *"Application Support/com.raycast.macos"* ]] || return 1
+    [[ "$result" == *"Containers/com.raycast.macos"* ]] || return 1
+    [[ "$result" == *"Caches/com.raycast.macos"* ]] || return 1
+    [[ "$result" != *"com.raycast-x.macos"* ]] || return 1
+    [[ "$result" != *"Caches/Raycast-X"* ]] || return 1
+    [[ "$result" != *"raycast-x.raycast"* ]] || return 1
+}


### PR DESCRIPTION
When uninstalling Raycast v1 (`com.raycast.macos`), Mole is also deleting [Raycast v2](https://www.raycast.com/new) data (`com.raycast-x.macos`).
This is a consequence of #404, which implemented sweeping everything matching \*raycast\*. 

## Summary

The fix skips any basename matching *raycast-x* in each of the Raycast collection loops.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
Yes, uninstall
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
No
- If yes, describe the new boundary or risk change clearly.
 Raycast v1 uninstall no longer touches `com.raycast-x.macos.*` directories which match Raycast v2 bundle ID.

## Tests

- `bash -n lib/core/app_protection.sh and ./scripts/check.sh --format` pass
- Verified against real directories in ~/Library/Application Support, ~/Library/Caches, ~/Library/Containers: the Raycast V2 entries are excluded while V1 entries remain

## Safety-related changes

Narrows Raycast v1 uninstall to stop deleting the separate `com.raycast-x.macos.*`
