### PR TITLE
fix(uninstall): avoid SIGTTIN after completed removal

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -1704,6 +1704,15 @@ main() {
 
         batch_uninstall_applications
 
+        # A nested command may have returned the controlling terminal to the
+        # parent shell. Reading while Mole is no longer the foreground process
+        # group would suspend the completed uninstall with SIGTTIN. The removal
+        # is already finished, so exit cleanly instead of touching terminal input.
+        if ! mole_tty_is_foreground; then
+            show_cursor
+            return 0
+        fi
+
         local _countdown=5
         local _key=""
         local _pressed=false

--- a/lib/core/timeout.sh
+++ b/lib/core/timeout.sh
@@ -89,6 +89,28 @@ _mole_cleanup_timeout_killer() {
     wait "$killer_pid" 2> /dev/null || true
 }
 
+# Return success when Mole's process group still owns the controlling terminal.
+# Checking this before a prompt avoids SIGTTIN if a nested interactive command
+# returned the tty to Mole's parent shell instead of restoring it to Mole.
+mole_tty_is_foreground() {
+    # Non-terminal input cannot trigger SIGTTIN; preserve scripted/test flows.
+    [[ -t 0 ]] || return 0
+
+    local perl_bin="${MO_TIMEOUT_PERL_BIN:-}"
+    if [[ -z "$perl_bin" || ! -x "$perl_bin" ]]; then
+        perl_bin=$(command -v perl 2> /dev/null || true)
+    fi
+    [[ -n "$perl_bin" && -x "$perl_bin" ]] || return 0
+
+    # shellcheck disable=SC2016 # Embedded Perl variables are intentionally single-quoted.
+    "$perl_bin" -MPOSIX=tcgetpgrp -e '
+        my $foreground_pgrp = tcgetpgrp(fileno(STDIN));
+        my $current_pgrp = getpgrp();
+        exit((defined($foreground_pgrp) && $foreground_pgrp >= 0 &&
+            $foreground_pgrp == $current_pgrp) ? 0 : 1);
+    ' 2> /dev/null
+}
+
 # Run command with timeout
 # Uses gtimeout/timeout if available, falls back to shell-based implementation
 #

--- a/tests/uninstall_tty_foreground.bats
+++ b/tests/uninstall_tty_foreground.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup_file() {
+	PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+	export PROJECT_ROOT
+}
+
+@test "tty ownership helper distinguishes foreground and background processes" {
+	if [[ "$(uname -s)" != "Darwin" || ! -x /usr/bin/expect || ! -x /usr/bin/perl ]]; then
+		skip "macOS expect/perl required"
+	fi
+
+	run /usr/bin/expect "$PROJECT_ROOT/tests/uninstall_tty_foreground.exp" "$PROJECT_ROOT"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"TTY-STATE:foreground"* ]]
+	[[ "$output" == *"TTY-STATE:background"* ]]
+}
+
+@test "completed uninstall checks tty ownership before countdown input" {
+	run grep -n 'if ! mole_tty_is_foreground; then' "$PROJECT_ROOT/bin/uninstall.sh"
+
+	[ "$status" -eq 0 ]
+}
+
+@test "tty ownership helper permits non-terminal input" {
+	run /bin/bash -c '
+        set -euo pipefail
+        source "$1/lib/core/timeout.sh"
+        mole_tty_is_foreground
+    ' _ "$PROJECT_ROOT"
+
+	[ "$status" -eq 0 ]
+}

--- a/tests/uninstall_tty_foreground.exp
+++ b/tests/uninstall_tty_foreground.exp
@@ -1,0 +1,40 @@
+#!/usr/bin/expect -f
+
+set timeout 4
+set project_root [lindex $argv 0]
+
+spawn env "PS1=PROMPT> " /bin/zsh -df
+expect {
+    -re {PROMPT> } {}
+    timeout { exit 124 }
+    eof { exit 1 }
+}
+
+send -- "/bin/bash '$project_root/tests/uninstall_tty_foreground_fixture.sh' '$project_root'\r"
+expect {
+    -re {TTY-STATE:foreground\r?\n} {}
+    timeout { exit 124 }
+    eof { exit 1 }
+}
+expect {
+    -re {PROMPT> } {}
+    timeout { exit 124 }
+    eof { exit 1 }
+}
+
+send -- "/bin/bash '$project_root/tests/uninstall_tty_foreground_fixture.sh' '$project_root' &\r"
+
+expect {
+    -re {TTY-STATE:background\r?\n} {}
+    timeout { exit 124 }
+    eof { exit 1 }
+}
+
+expect {
+    -re {PROMPT> } {}
+    timeout { exit 124 }
+    eof { exit 1 }
+}
+
+send -- "exit\r"
+expect eof

--- a/tests/uninstall_tty_foreground_fixture.sh
+++ b/tests/uninstall_tty_foreground_fixture.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROJECT_ROOT="$1"
+
+# shellcheck source=lib/core/timeout.sh
+source "$PROJECT_ROOT/lib/core/timeout.sh"
+
+if mole_tty_is_foreground; then
+    printf 'TTY-STATE:foreground\n'
+else
+    printf 'TTY-STATE:background\n'
+fi


### PR DESCRIPTION
Fixes #1218

## Summary

Prevent `mo uninstall` from being suspended with `SIGTTIN` after an application has already been removed successfully.

This change:

- verifies that Mole still owns the controlling terminal before the post-uninstall countdown reads input;
- exits cleanly when terminal ownership has already returned to the parent shell;
- validates and retries `tcsetpgrp` when the Perl timeout fallback hands off or restores the terminal; and
- adds pseudo-terminal regression coverage for foreground, background, and non-TTY execution.

## Original report

The issue occurred while uninstalling **Adobe Downloader** with `mole uninstall`. The removal itself completed successfully:

```text
======================================================================
Uninstall complete
Removed 1 app, freed 16.6MB: Adobe Downloader
======================================================================

Press Enter to return to the app list, press q to exit (5) [1]  + 9008 suspended (tty input)  mole uninstall
```

The process was not launched with `&`, and the user did not intentionally suspend or background it. zsh reported `TTIN` immediately when the completed-uninstall screen attempted to read the next key.

Two privileged helper remnants were displayed as review-only, as expected:

```text
/Library/LaunchDaemons/com.x1a0he.macOS.Adobe-Downloader.helper.plist
/Library/PrivilegedHelperTools/com.x1a0he.macOS.Adobe-Downloader.helper
```

They are unrelated to the removal result: the app and user-level data were already removed before the suspension.

## Reporter environment

```text
Mole:        1.46.0
Install:     Homebrew
macOS:       26.5.2
Kernel:      25.5.0
Architecture: arm64
SIP:         Enabled
Shell:       /bin/zsh
Terminal:    Ghostty
Disk free:   396.32 GB
```

Command resolution was also checked to rule out aliases and wrapper functions:

```text
mole is /opt/homebrew/bin/mole
mo is /opt/homebrew/bin/mo
TERM_PROGRAM=ghostty
```

## Investigation and attempted mitigations

1. Confirmed that the uninstall operation completed before the error. The failure is limited to the final interactive return/exit prompt.
2. Confirmed this is `SIGTTIN`: a process attempted to read its controlling TTY while its process group was no longer foreground.
3. Verified that the reporter is already on 1.46.0, so upgrading does not resolve this instance.
4. Ruled out an alias/function wrapper and the documented iTerm2 compatibility concern; both commands resolve directly to the Homebrew installation and the terminal is Ghostty.
5. Verified that `fg` can resume the suspended process, confirming that Mole is stopped rather than crashed.
6. Reviewed the existing #1201 fix (`bfada7f3`), which correctly hands the TTY to interactive timeout children and restores it afterward. The remaining edge case is that `tcsetpgrp` restoration was attempted once without validating success, while the completed-uninstall countdown immediately performs a raw `read`.
7. Built an Expect-based pseudo-terminal fixture that runs the same helper in foreground and background zsh process groups. It verifies the exact ownership distinction before input is attempted.

Because Adobe Downloader was already removed, I did not repeat a destructive real-app uninstall solely to reproduce the final prompt.

## Root cause

The 1.46.0 timeout fallback can temporarily transfer the controlling terminal to a nested child process group. If terminal restoration fails or races with the parent shell reclaiming the terminal, `bin/uninstall.sh` still proceeds directly to:

```bash
read -r -s -n1 -t 1 _key
```

macOS then sends `SIGTTIN` because Mole is no longer the foreground process group. The app removal has already completed, so suspending the entire command at this point leaves a misleading failed-looking result and a stopped shell job.

## Fix

- Add `mole_tty_is_foreground`, using `tcgetpgrp(STDIN)` and `getpgrp()` to check terminal ownership without reading from the terminal.
- Preserve piped/scripted behavior: non-TTY input is allowed because it cannot raise terminal `SIGTTIN`.
- Before the post-uninstall countdown, exit successfully when Mole no longer owns the terminal. This does not steal the TTY back from another foreground job.
- Wrap `tcsetpgrp` in a small validated retry helper for both child handoff and parent restoration. Undefined/error results are no longer treated as successful handoffs.

## Validation

Passed:

```text
./scripts/check.sh --format
./scripts/check.sh
MOLE_TEST_NO_AUTH=1 bats \
  tests/core_timeout.bats \
  tests/uninstall.bats \
  tests/uninstall_remove_file_list.bats \
  tests/uninstall_tty_foreground.bats
```

The targeted run reported **102/102 tests passing** (with the existing `gtimeout/timeout not available` skip).

The new pseudo-terminal test was also repeated 20 times locally, and the existing #1201 foreground-read and timeout-restoration Expect tests were repeated five times each.

An additional complete `scripts/test.sh` run reached 1038/1038 test cases. It had two unrelated environment-sensitive failures:

- `clean_project_caches skips stalled root scans`
- `opt_spotlight_index_optimize skips when search is fast`

All timeout, TTY, and uninstall tests—including the three new tests—passed in that run. Go checks were skipped because Go is not installed locally; this PR does not change Go code.
