### PR TITLE
fix(purge): include Terragrunt cache targets

### DIFF
--- a/lib/clean/purge_shared.sh
+++ b/lib/clean/purge_shared.sh
@@ -22,6 +22,7 @@ readonly MOLE_PURGE_TARGETS=(
     ".nox"          # Python (nox virtualenvs)
     ".ruff_cache"   # Python (ruff)
     ".gradle"       # Gradle local
+    ".terragrunt-cache" # Terragrunt downloaded modules/providers
     "__pycache__"   # Python
     ".next"         # Next.js
     ".nuxt"         # Nuxt.js
@@ -72,6 +73,8 @@ readonly MOLE_PURGE_PROJECT_INDICATORS=(
     "requirements.txt"
     "pom.xml"
     "build.gradle"
+    "*.tf"
+    "terragrunt.hcl"
     "Gemfile"
     "composer.json"
     "pubspec.yaml"

--- a/lib/clean/purge_shared.sh
+++ b/lib/clean/purge_shared.sh
@@ -11,39 +11,39 @@ readonly MOLE_PURGE_SHARED_LOADED=1
 # Canonical purge targets (heavy project build artifacts).
 readonly MOLE_PURGE_TARGETS=(
     "node_modules"
-    "target"        # Rust, Maven
-    "build"         # Gradle, various
-    "dist"          # JS builds
-    "venv"          # Python
-    ".venv"         # Python
-    ".pytest_cache" # Python (pytest)
-    ".mypy_cache"   # Python (mypy)
-    ".tox"          # Python (tox virtualenvs)
-    ".nox"          # Python (nox virtualenvs)
-    ".ruff_cache"   # Python (ruff)
-    ".gradle"       # Gradle local
+    "target"            # Rust, Maven
+    "build"             # Gradle, various
+    "dist"              # JS builds
+    "venv"              # Python
+    ".venv"             # Python
+    ".pytest_cache"     # Python (pytest)
+    ".mypy_cache"       # Python (mypy)
+    ".tox"              # Python (tox virtualenvs)
+    ".nox"              # Python (nox virtualenvs)
+    ".ruff_cache"       # Python (ruff)
+    ".gradle"           # Gradle local
     ".terragrunt-cache" # Terragrunt downloaded modules/providers
-    "__pycache__"   # Python
-    ".next"         # Next.js
-    ".nuxt"         # Nuxt.js
-    ".output"       # Nuxt.js
-    "vendor"        # PHP Composer
-    "bin"           # .NET build output (guarded; see is_protected_purge_artifact)
-    "obj"           # C# / Unity
-    ".turbo"        # Turborepo cache
-    ".parcel-cache" # Parcel bundler
-    ".dart_tool"    # Flutter/Dart build cache
-    ".zig-cache"    # Zig
-    "zig-out"       # Zig
-    ".angular"      # Angular
-    ".svelte-kit"   # SvelteKit
-    ".astro"        # Astro
-    "coverage"      # Code coverage reports
-    "DerivedData"   # Xcode
-    "Pods"          # CocoaPods
-    ".cxx"          # React Native Android NDK build cache
-    ".expo"         # Expo
-    ".build"        # Swift Package Manager
+    "__pycache__"       # Python
+    ".next"             # Next.js
+    ".nuxt"             # Nuxt.js
+    ".output"           # Nuxt.js
+    "vendor"            # PHP Composer
+    "bin"               # .NET build output (guarded; see is_protected_purge_artifact)
+    "obj"               # C# / Unity
+    ".turbo"            # Turborepo cache
+    ".parcel-cache"     # Parcel bundler
+    ".dart_tool"        # Flutter/Dart build cache
+    ".zig-cache"        # Zig
+    "zig-out"           # Zig
+    ".angular"          # Angular
+    ".svelte-kit"       # SvelteKit
+    ".astro"            # Astro
+    "coverage"          # Code coverage reports
+    "DerivedData"       # Xcode
+    "Pods"              # CocoaPods
+    ".cxx"              # React Native Android NDK build cache
+    ".expo"             # Expo
+    ".build"            # Swift Package Manager
 )
 
 readonly MOLE_PURGE_DEFAULT_SEARCH_PATHS=(
@@ -73,7 +73,6 @@ readonly MOLE_PURGE_PROJECT_INDICATORS=(
     "requirements.txt"
     "pom.xml"
     "build.gradle"
-    "*.tf"
     "terragrunt.hcl"
     "Gemfile"
     "composer.json"

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -619,6 +619,28 @@ EOF
 	[[ "$result" == "FOUND" ]]
 }
 
+@test "scan_purge_targets: includes Terragrunt cache in project root with find mode" {
+	mkdir -p "$HOME/terragrunt-project/.terragrunt-cache"
+	touch "$HOME/terragrunt-project/terragrunt.hcl"
+
+	local scan_output
+	scan_output="$(mktemp)"
+
+	result=$(bash -c "
+        source '$PROJECT_ROOT/lib/clean/project.sh'
+        MO_USE_FIND=1 scan_purge_targets '$HOME/terragrunt-project' '$scan_output'
+        if grep -q '$HOME/terragrunt-project/.terragrunt-cache' '$scan_output'; then
+            echo 'FOUND'
+        else
+            echo 'MISSING'
+        fi
+    ")
+
+	rm -f "$scan_output"
+
+	[[ "$result" == "FOUND" ]]
+}
+
 @test "scan_purge_targets: supports trailing slash search path in find mode" {
 	mkdir -p "$HOME/single-project/node_modules"
 	touch "$HOME/single-project/package.json"
@@ -771,6 +793,7 @@ EOF
     ")
 	[[ "$result" == *"node_modules"* ]]
 	[[ "$result" == *"target"* ]]
+	[[ "$result" == *".terragrunt-cache"* ]]
 }
 
 @test "get_dir_size_kb: calculates directory size" {


### PR DESCRIPTION
## Summary
- add `.terragrunt-cache` to the purge artifact target list
- treat Terraform/Terragrunt files as project indicators so a configured single-project purge root can safely include its direct-child Terragrunt cache
- add a purge regression test covering find-mode discovery from a Terragrunt project root

Fixes #1214.

## Verification
- `./scripts/check.sh`
- `./scripts/test.sh`
- manual bash probe confirming `PURGE_TARGETS` includes `.terragrunt-cache`, `terragrunt.hcl` marks the directory as a project root, and `MO_USE_FIND=1 scan_purge_targets` finds the cache directory

Note: this local machine does not have `bats`, `shellcheck`, `shfmt`, or Go installed, so the repo scripts skipped those tool-specific checks while still passing syntax, module loading, integration, and installation checks.
