### PR TITLE
fix(optimize): render system health under comma-decimal locales

### DIFF
--- a/bin/optimize.sh
+++ b/bin/optimize.sh
@@ -156,7 +156,15 @@ show_system_health() {
     disk_percent=${disk_percent:-0}
     uptime=${uptime:-0}
 
-    printf "${ICON_ADMIN} System  %.0f/%.0f GB RAM | %.0f/%.0f GB Disk | Uptime %.0fd\n" \
+    # printf parses float arguments with the locale's decimal separator, so
+    # comma-decimal locales reject dot values like "5.70" (#1220). Round in
+    # C-locale awk and print plain strings to avoid float parsing entirely.
+    local rounded
+    rounded=$(LC_ALL=C awk -v mu="$mem_used" -v mt="$mem_total" -v du="$disk_used" -v dt="$disk_total" -v ut="$uptime" \
+        'BEGIN { printf "%.0f %.0f %.0f %.0f %.0f", mu, mt, du, dt, ut }' 2> /dev/null || echo "0 0 0 0 0")
+    read -r mem_used mem_total disk_used disk_total uptime <<< "$rounded"
+
+    printf "${ICON_ADMIN} System  %s/%s GB RAM | %s/%s GB Disk | Uptime %sd\n" \
         "$mem_used" "$mem_total" "$disk_used" "$disk_total" "$uptime"
 }
 

--- a/tests/optimize.bats
+++ b/tests/optimize.bats
@@ -1089,6 +1089,32 @@ EOF
 	[[ "$output" == *"ordered"* ]]
 }
 
+@test "show_system_health formats floats under comma-decimal locales (#1220)" {
+	# Find an installed locale whose decimal separator is a comma.
+	local comma_locale="" candidate
+	for candidate in fr_FR.UTF-8 de_DE.UTF-8 pt_BR.UTF-8 es_ES.UTF-8 it_IT.UTF-8 nl_NL.UTF-8; do
+		if [[ "$(LC_ALL="$candidate" bash -c 'printf "%.1f" 1' 2> /dev/null)" == "1,0" ]]; then
+			comma_locale="$candidate"
+			break
+		fi
+	done
+	[[ -n "$comma_locale" ]] || skip "no comma-decimal locale installed"
+
+	run env LC_ALL="$comma_locale" LANG="$comma_locale" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
+set -euo pipefail
+eval "$(sed -n '/^json_get_value()/,/^}$/p' "$PROJECT_ROOT/bin/optimize.sh")"
+eval "$(sed -n '/^show_system_health()/,/^}$/p' "$PROJECT_ROOT/bin/optimize.sh")"
+ICON_ADMIN="*"
+health_json='{"memory_used_gb": 5.70, "memory_total_gb": 8.00, "disk_used_gb": 287.86, "disk_total_gb": 351.19, "uptime_days": 6.1}'
+show_system_health "$health_json"
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"6/8 GB RAM"* ]]
+	[[ "$output" == *"288/351 GB Disk"* ]]
+	[[ "$output" == *"Uptime 6d"* ]]
+}
+
 @test "optimize whitelist items include task ids" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Fixes #1220. On machines whose numeric locale uses a comma as the decimal separator, `mo optimize` prints `printf: 5.70: invalid number` for every value on the system health line.
- `generate_health_json` always emits dot-decimal values (it formats through `LC_ALL=C awk`), but `show_system_health` handed them to the bash `printf` builtin as `%.0f`, and the builtin parses float arguments with the locale's decimal separator. The mismatch reproduces on bash 3.2.57 and 5.x alike:

  ```
  $ env -i LANG=pt_BR.UTF-8 bash -c 'printf "%.0f\n" 5.70'
  bash: printf: 5.70: invalid number
  ```

- Round the five values in C-locale awk (the same pattern the JSON generator already uses) and print them with `%s`, so the printf builtin never parses floats no matter which locale or bash build is in effect. This follows the direction @gspannu suggested in the issue, with a single awk call and the existing output format kept intact.

## Safety Review

- No. Display-only change to the optimize health summary; no cleanup, uninstall, optimize task execution, path validation, or install behavior is affected.

## Tests

- `bats tests/optimize.bats` — includes a new regression test, `show_system_health formats floats under comma-decimal locales (#1220)`, which fails before the fix and passes after. It picks the first installed comma-decimal locale and skips if none is available.
- `shellcheck bin/optimize.sh` and `shfmt -i 4 -ci -sr -d bin/optimize.sh` are clean.

## Safety-related changes

- None.