### PR TITLE
fix(ui): restore gg jump-to-top on macOS default bash 3.2

### DIFF
--- a/lib/core/ui.sh
+++ b/lib/core/ui.sh
@@ -12,6 +12,17 @@ readonly MOLE_UI_LOADED=1
 _MOLE_CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [[ -z "${MOLE_BASE_LOADED:-}" ]] && source "$_MOLE_CORE_DIR/base.sh"
 
+# Timeout for the second key of a multi-key sequence (e.g. gg -> jump to top).
+# Bash 4.0+ accepts fractional `read -t` values; macOS default Bash 3.2 rejects
+# them ("invalid timeout specification") and the read fails instantly, which
+# silently disabled the gg shortcut. Use a snappy sub-second wait where it is
+# supported and fall back to a 1s integer timeout on Bash 3.2.
+if [[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]]; then
+    readonly MOLE_KEY_SEQ_TIMEOUT="0.3"
+else
+    readonly MOLE_KEY_SEQ_TIMEOUT="1"
+fi
+
 # Cursor control
 clear_screen() { printf '\033[2J\033[H'; }
 hide_cursor() { [[ -t 1 ]] && printf '\033[?25l' >&2 || true; }
@@ -233,7 +244,7 @@ read_key() {
         'l' | 'L') echo "RIGHT" ;;
         'G') echo "BOTTOM" ;;
         'g')
-            if IFS= read -r -s -n 1 -t 0.3 rest 2> /dev/null; then
+            if IFS= read -r -s -n 1 -t "$MOLE_KEY_SEQ_TIMEOUT" rest 2> /dev/null; then
                 if [[ "$rest" == "g" ]]; then
                     echo "TOP"
                 else

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -631,6 +631,27 @@ EOF
     [ "$output" = "UP" ]
 }
 
+@test "read_key maps gg to TOP and a lone g to OTHER" {
+    run bash -c "export MOLE_BASE_LOADED=1; source '$PROJECT_ROOT/lib/core/ui.sh'; printf 'gg' | read_key"
+    [ "$output" = "TOP" ]
+
+    run bash -c "export MOLE_BASE_LOADED=1; source '$PROJECT_ROOT/lib/core/ui.sh'; printf 'g' | read_key"
+    [ "$output" = "OTHER" ]
+}
+
+@test "read_key gg works on macOS default Bash 3.2 (fractional read -t rejected)" {
+    # macOS ships /bin/bash 3.2.57, which rejects fractional `read -t` timeouts.
+    # Exercise the shortcut under that exact interpreter when present so the
+    # portability regression is caught on macOS even if bats runs under bash 4+.
+    [[ -x /bin/bash ]] || skip "/bin/bash not available"
+    local major
+    major=$(/bin/bash -c 'echo "${BASH_VERSINFO[0]}"' 2> /dev/null || echo 99)
+    [[ "$major" -lt 4 ]] || skip "/bin/bash is not a 3.x build"
+
+    run /bin/bash -c "export MOLE_BASE_LOADED=1; source '$PROJECT_ROOT/lib/core/ui.sh'; printf 'gg' | read_key"
+    [ "$output" = "TOP" ]
+}
+
 @test "read_key respects MOLE_READ_KEY_FORCE_CHAR" {
     run bash -c "export MOLE_BASE_LOADED=1; export MOLE_READ_KEY_FORCE_CHAR=1; source '$PROJECT_ROOT/lib/core/ui.sh'; echo -n 'j' | read_key"
     [ "$output" = "CHAR:j" ]


### PR DESCRIPTION
## Summary

- Fixes #1224. In the interactive paginated list (`mo uninstall`'s app selector), `G` jumps to the bottom but `gg` never jumps to the top on stock macOS.
- `read_key` waited for the second `g` with a fractional `read -t 0.3`. The `read` builtin only accepts fractional `-t` values from bash 4.0 on; macOS default `/bin/bash` 3.2.57 rejects `0.3` with `invalid timeout specification`, the read fails instantly, and the branch falls through to `OTHER`, so the shortcut is silently dead on every stock Mac.

  ```console
  $ /bin/bash -c 'IFS= read -r -s -n 1 -t 0.3 x; echo $?'
  bash: read: 0.3: invalid timeout specification
  1
  ```

- Pick the sequence timeout once at load time: keep the snappy `0.3s` on bash 4.0+, fall back to an integer `1s` on bash 3.2 (the only timeout it accepts). This matches the `BASH_VERSINFO` version-gate the repo already uses for `wait -n` in `lib/clean/project.sh`. The escape-sequence reads nearby already use integer `-t 1`, so no other path needed changing.

## Safety Review

- No. This only affects interactive key handling for cursor navigation; no cleanup, uninstall, optimize, path validation, sudo, or install behavior is touched.

## Tests

- `bats tests/core_common.bats` — added `read_key maps gg to TOP and a lone g to OTHER` (behavioral) and `read_key gg works on macOS default Bash 3.2` (runs under `/bin/bash` when it is a 3.x build, so macOS CI exercises the exact regression; skips elsewhere). Both pass; the rest of the suite is unchanged.
- Verified red/green against a local bash 3.2.57 build: `printf 'gg' | read_key` returns `OTHER` before the fix and `TOP` after, while a lone `g` stays `OTHER`.
- `shellcheck lib/core/ui.sh` and `shfmt -i 4 -ci -sr -d lib/core/ui.sh` are clean.

## Safety-related changes

- None.