### PR TITLE
fix(status): keep health score monotonic past CPU and memory high thresholds

### DIFF
--- a/cmd/status/metrics_health.go
+++ b/cmd/status/metrics_health.go
@@ -62,7 +62,11 @@ func calculateHealthScore(cpu CPUStatus, mem MemoryStatus, disks []DiskStatus, d
 	cpuPenalty := 0.0
 	if cpu.Usage > cpuNormalThreshold {
 		if cpu.Usage > cpuHighThreshold {
-			cpuPenalty = healthCPUWeight * (cpu.Usage - cpuNormalThreshold) / cpuHighThreshold
+			// Scale across the remaining range up to 100% so the penalty keeps
+			// growing with usage (matches the disk branch). Dividing by the raw
+			// high threshold instead made the penalty drop past 85%, letting the
+			// score rise as CPU load got worse.
+			cpuPenalty = healthCPUWeight * (cpu.Usage - cpuNormalThreshold) / (100 - cpuNormalThreshold)
 		} else {
 			cpuPenalty = (healthCPUWeight / 2) * (cpu.Usage - cpuNormalThreshold) / (cpuHighThreshold - cpuNormalThreshold)
 		}
@@ -76,7 +80,11 @@ func calculateHealthScore(cpu CPUStatus, mem MemoryStatus, disks []DiskStatus, d
 	memPenalty := 0.0
 	if mem.UsedPercent > memNormalThreshold {
 		if mem.UsedPercent > memHighThreshold {
-			memPenalty = healthMemWeight * (mem.UsedPercent - memNormalThreshold) / memNormalThreshold
+			// Scale across the remaining range up to 100% so the penalty keeps
+			// growing with usage (matches the disk branch). Dividing by the raw
+			// normal threshold instead made the penalty drop past 88%, letting
+			// the score rise as memory pressure got worse.
+			memPenalty = healthMemWeight * (mem.UsedPercent - memNormalThreshold) / (100 - memNormalThreshold)
 		} else {
 			memPenalty = (healthMemWeight / 2) * (mem.UsedPercent - memNormalThreshold) / (memHighThreshold - memNormalThreshold)
 		}

--- a/cmd/status/metrics_health_test.go
+++ b/cmd/status/metrics_health_test.go
@@ -47,6 +47,46 @@ func TestCalculateHealthScoreDetectsIssues(t *testing.T) {
 	}
 }
 
+func TestCalculateHealthScoreMonotonicInCPU(t *testing.T) {
+	// Rising CPU usage must never improve (raise) the health score, including
+	// across the high-usage threshold at 85%.
+	prev := 101
+	for usage := 40.0; usage <= 100.0; usage += 0.5 {
+		score, _ := calculateHealthScore(
+			CPUStatus{Usage: usage},
+			MemoryStatus{UsedPercent: 20, Pressure: "normal"},
+			[]DiskStatus{{UsedPercent: 30}},
+			DiskIOStatus{ReadRate: 5, WriteRate: 5},
+			ThermalStatus{CPUTemp: 40},
+			nil, 0,
+		)
+		if score > prev {
+			t.Fatalf("health score rose from %d to %d as CPU usage increased to %.1f%%", prev, score, usage)
+		}
+		prev = score
+	}
+}
+
+func TestCalculateHealthScoreMonotonicInMemory(t *testing.T) {
+	// Rising memory usage must never improve (raise) the health score, including
+	// across the high-usage threshold at 88%.
+	prev := 101
+	for usage := 60.0; usage <= 100.0; usage += 0.5 {
+		score, _ := calculateHealthScore(
+			CPUStatus{Usage: 10},
+			MemoryStatus{UsedPercent: usage, Pressure: "normal"},
+			[]DiskStatus{{UsedPercent: 30}},
+			DiskIOStatus{ReadRate: 5, WriteRate: 5},
+			ThermalStatus{CPUTemp: 40},
+			nil, 0,
+		)
+		if score > prev {
+			t.Fatalf("health score rose from %d to %d as memory usage increased to %.1f%%", prev, score, usage)
+		}
+		prev = score
+	}
+}
+
 func TestFormatUptime(t *testing.T) {
 	if got := formatUptime(65); got != "1m" {
 		t.Fatalf("expected 1m, got %s", got)


### PR DESCRIPTION
## Summary

- Fixes #1226. The `mo status` health score rises as CPU usage climbs past 85% (and memory past 88%), so a more loaded Mac can score *better* than a less loaded one.
- The high-usage branches in `calculateHealthScore` divided by the raw threshold constant (`cpuHighThreshold` / `memNormalThreshold`) instead of the remaining range to 100%. The lower branch reaches `weight/2` at the threshold, but the upper branch restarted below that, so the penalty dropped at the boundary:
  - CPU at 85.0% → penalty 15.0; at 85.5% → ≈12.5 (score goes up).
  - Memory at 88.0% → penalty 12.5; at 88.5% → ≈6.6 (score jumps up ~6).
- Divide by `(100 - normalThreshold)` in both branches, matching the disk penalty right below (`diskPenalty` already uses `(100 - diskWarnThreshold)`). The penalty now grows monotonically with usage and reaches the full weight at 100%.

## Safety Review

- No. Display-only scoring math in the `mo status` TUI; no cleanup, uninstall, optimize, path validation, sudo, or install behavior is affected.

## Tests

- `go test ./cmd/status/` — added `TestCalculateHealthScoreMonotonicInCPU` and `TestCalculateHealthScoreMonotonicInMemory`, which sweep usage across the thresholds and assert the score never rises. Both fail before the fix (score rises 85→87 at 85.5% CPU; 87→93 at 88.5% memory) and pass after.
- Full `go build ./...`, `go vet ./...`, and `go test ./...` pass (382 tests). The existing `TestCalculateHealthScoreDetectsIssues` still holds.

## Safety-related changes

- None.