### PR TITLE
fix(clean): report sub-megabyte Service Worker cleanups in KB

### DIFF
--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -89,17 +89,21 @@ clean_service_worker_cache() {
             stop_inline_spinner
             spinner_was_running=true
         fi
-        local cleaned_mb=$((cleaned_size / 1024))
+        # cleaned_size is in KB. Hand-rolled KB/1024 truncation reported any
+        # sub-megabyte cleanup as "0MB"; use the shared formatter like every
+        # other cleaner so amounts under 1MB render as KB.
+        local cleaned_human
+        cleaned_human=$(bytes_to_human "$((cleaned_size * 1024))")
         local line_color
         line_color=$(cleanup_result_color_kb "$cleaned_size")
         if [[ "$DRY_RUN" != "true" ]]; then
             if [[ $protected_count -gt 0 ]]; then
-                echo -e "  ${line_color}${ICON_SUCCESS}${NC} $browser_name Service Worker${NC} · ${line_color}${cleaned_mb}MB${NC}, ${protected_count} protected"
+                echo -e "  ${line_color}${ICON_SUCCESS}${NC} $browser_name Service Worker${NC} · ${line_color}${cleaned_human}${NC}, ${protected_count} protected"
             else
-                echo -e "  ${line_color}${ICON_SUCCESS}${NC} $browser_name Service Worker${NC} · ${line_color}${cleaned_mb}MB${NC}"
+                echo -e "  ${line_color}${ICON_SUCCESS}${NC} $browser_name Service Worker${NC} · ${line_color}${cleaned_human}${NC}"
             fi
         else
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $browser_name Service Worker, would clean $(colorize_human_size "${cleaned_mb}MB"), ${protected_count} protected"
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} $browser_name Service Worker, would clean $(colorize_human_size "$cleaned_human"), ${protected_count} protected"
         fi
         note_activity
         if [[ "$spinner_was_running" == "true" ]]; then

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -235,10 +235,12 @@ run_with_timeout() {
 clean_service_worker_cache 'TestBrowser' '$test_cache'
 EOF
 
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"TestBrowser Service Worker"* ]]
-    [[ "$output" == *"KB"* ]]
-    [[ "$output" != *"0MB"* ]]
+    # Every assertion ends with || return 1: bare [[ ]] failures mid-test can
+    # be swallowed and let the trailing rm -rf pass the test vacuously (#886).
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"TestBrowser Service Worker"* ]] || return 1
+    [[ "$output" == *"KB"* ]] || return 1
+    [[ "$output" != *"0MB"* ]] || return 1
 
     rm -rf "$test_cache"
 }

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -201,7 +201,44 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"TestBrowser Service Worker"* ]]
-    [[ "$output" == *$'\033[0;32m1MB\033[0m'* ]]
+    [[ "$output" == *$'\033[0;32m1.0MB\033[0m'* ]]
+
+    rm -rf "$test_cache"
+}
+
+@test "clean_service_worker_cache reports sub-megabyte cleanups as KB, not 0MB" {
+    local test_cache="$HOME/test_sw_cache_submb"
+    mkdir -p "$test_cache/abc123_https_example.com_0"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc <<EOF
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+DRY_RUN=false
+declare -a PROTECTED_SW_DOMAINS=("capcut.com")
+safe_remove() { return 0; }
+note_activity() { :; }
+run_with_timeout() {
+    local timeout="\$1"
+    shift
+    if [[ "\$1" == "sh" ]]; then
+        printf '%s\n' "$test_cache/abc123_https_example.com_0"
+        return 0
+    fi
+    if [[ "\$1" == "du" ]]; then
+        # 900 KB: under 1MB, so the old KB/1024 truncation printed "0MB".
+        printf '900\t%s\n' "$test_cache/abc123_https_example.com_0"
+        return 0
+    fi
+    "\$@"
+}
+clean_service_worker_cache 'TestBrowser' '$test_cache'
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TestBrowser Service Worker"* ]]
+    [[ "$output" == *"KB"* ]]
+    [[ "$output" != *"0MB"* ]]
 
     rm -rf "$test_cache"
 }


### PR DESCRIPTION
## Summary

- Fixes #1228. `clean_service_worker_cache` reported any cleanup under 1 MB as `0MB`.
- It tracked the cleaned amount in KB and formatted it with a hand-rolled `cleaned_size / 1024` integer division, which truncates anything below 1024 KB to `0`. Service Worker `CacheStorage` folders are per-origin and often only a few hundred KB, so this was easy to hit.
- Switch to the shared `bytes_to_human` formatter — the same one every other cleaner uses — so sub-MB amounts render as KB (e.g. `922KB`). MB amounts now carry the standard one-decimal format used elsewhere (e.g. `5.2MB` instead of `5MB`), making this row consistent with the rest of Mole's output.

## Safety Review

- No. This only changes how the freed size is formatted for display; the scan, protection, whitelist, and removal logic are untouched.

## Tests

- `bats tests/clean_system_caches.bats` — added `clean_service_worker_cache reports sub-megabyte cleanups as KB, not 0MB` (feeds a 900 KB cleanup and asserts the row shows `KB`, never `0MB`). Updated the existing color test's expectation from `1MB` to `1.0MB` to match the shared formatter. The rest of the Service Worker tests pass unchanged.
- `shellcheck lib/clean/caches.sh` and `shfmt -i 4 -ci -sr -d lib/clean/caches.sh` are clean.

## Safety-related changes

- None.