### PR TITLE
fix(clean): report the cleaned item count instead of the raw target count

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -977,10 +977,13 @@ safe_clean() {
         size_human=$(bytes_to_human "$((total_size_kb * 1024))")
 
         # Multi-target cleanups report the item count as part of the detail
-        # column, keeping the label clean: "npm logs · 2 items, 2KB".
+        # column, keeping the label clean: "npm logs · 2 items, 2KB". Use the
+        # actually-cleaned count (total_count), not the raw target count, so it
+        # stays consistent with the reported size after protected, whitelisted,
+        # missing, and deduplicated targets have been dropped.
         local count_note=""
-        if [[ ${#targets[@]} -gt 1 ]]; then
-            count_note="${#targets[@]} items, "
+        if [[ $total_count -gt 1 ]]; then
+            count_note="$total_count items, "
         fi
 
         if [[ "$DRY_RUN" == "true" ]]; then

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -100,13 +100,15 @@ safe_remove() { /bin/rm -rf "\$1"; return 0; }
 safe_clean "$base/a" "$base/b" "$base/keep" "Test cache"
 EOF
 
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 0 ] || return 1
     # Two items were removed, so the detail column must say "2 items", not "3".
-    [[ "$output" == *"2 items"* ]]
-    [[ "$output" != *"3 items"* ]]
-    [[ ! -e "$base/a" ]]
-    [[ ! -e "$base/b" ]]
-    [[ -e "$base/keep" ]]
+    # Every assertion ends with || return 1: bare [[ ]] failures mid-test can be
+    # swallowed and let the test pass vacuously (same shape as #886).
+    [[ "$output" == *"2 items"* ]] || return 1
+    [[ "$output" != *"3 items"* ]] || return 1
+    [[ ! -e "$base/a" ]] || return 1
+    [[ ! -e "$base/b" ]] || return 1
+    [[ -e "$base/keep" ]] || return 1
 
     rm -rf "$base"
 }

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -74,6 +74,43 @@ run_clean_dry_run() {
         "$PROJECT_ROOT/mole" clean --dry-run
 }
 
+@test "safe_clean item count reflects cleaned items, not raw target count" {
+    local base="$HOME/safe_clean_count"
+    mkdir -p "$base"
+    printf 'xxxx' > "$base/a"
+    printf 'xxxx' > "$base/b"
+    printf 'xxxx' > "$base/keep"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 bash --noprofile --norc <<EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+note_activity() { :; }
+# One of the three targets is whitelisted, so only two are actually cleaned.
+is_path_whitelisted() { [[ "\$1" == "$base/keep" ]]; }
+safe_remove() { /bin/rm -rf "\$1"; return 0; }
+safe_clean "$base/a" "$base/b" "$base/keep" "Test cache"
+EOF
+
+    [ "$status" -eq 0 ]
+    # Two items were removed, so the detail column must say "2 items", not "3".
+    [[ "$output" == *"2 items"* ]]
+    [[ "$output" != *"3 items"* ]]
+    [[ ! -e "$base/a" ]]
+    [[ ! -e "$base/b" ]]
+    [[ -e "$base/keep" ]]
+
+    rm -rf "$base"
+}
+
 @test "mo clean --dry-run skips system cleanup in non-interactive mode" {
     set_mock_sudo_uncached
     run_clean_dry_run


### PR DESCRIPTION
## Summary

- Fixes #1230. A multi-target `mo clean` row printed `N items` from the raw `targets` array, so the count could exceed what was actually cleaned and stop matching the size beside it.
- Between `targets` and the deletion, `existing_paths` is reduced by protected paths, whitelisted paths, and nested-path deduplication (`normalize_paths_for_cleanup`). The real count is `total_count`, incremented per successful removal together with `total_size_kb`, and it is already what the aggregate `files_cleaned` uses.
- Build the `N items` note from `total_count` instead of `${#targets[@]}`. `count_note` is assembled after the deletion loop, so `total_count` is final at that point, and it is guaranteed `>= 1` inside the `removed_any` block.

## Safety Review

- No. Display-only change to the cleanup summary count; the scan, protection, whitelist, dedup, and removal logic are untouched.

## Tests

- `bats tests/clean_core.bats` — added `safe_clean item count reflects cleaned items, not raw target count`, which runs the real `safe_clean` with three targets where one is whitelisted and asserts the row says `2 items` (not `3`), the two others are removed, and the whitelisted one survives. It fails before the fix and passes after.
- `shellcheck bin/clean.sh` and `shfmt -i 4 -ci -sr -d bin/clean.sh` are clean.

## Safety-related changes

- None.