### PR TITLE
fix(uninstall): avoid SIGTTIN at confirm prompt from background tty handoff (#1222)

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -345,7 +345,14 @@ start_uninstall_metadata_refresh() {
         uninstall_release_metadata_lock "$MOLE_UNINSTALL_META_CACHE_LOCK"
         rm -f "$updates_file" "$refresh_merged_file"
         rm -f "$refresh_file" 2> /dev/null || true
-    ) > /dev/null 2>&1 &
+        # Redirect stdin from /dev/null so the perl timeout fallback does not see
+        # a tty on stdin and hand the controlling terminal to its timed child.
+        # This background refresh (and its nested workers, which inherit this
+        # stdin) never needs the terminal; leaving stdin as the tty lets a worker
+        # steal the foreground process group and stop the foreground prompt with
+        # SIGTTIN (issue #1222). The interactive sudo handoff (#1201) is on
+        # non-background call sites and is unaffected.
+    ) > /dev/null 2>&1 < /dev/null &
     disown "$!" 2> /dev/null || true
 
 }
@@ -708,7 +715,10 @@ _scan_resolve_uncached() {
     if ((total_apps > 0)); then
         for app_data_tuple in "${app_data_tuples[@]}"; do
             ((app_count++))
-            process_app_metadata "$app_data_tuple" "$scan_raw_file" &
+            # Redirect stdin from /dev/null so the perl timeout fallback used by
+            # process_app_metadata does not hand the controlling terminal to its
+            # timed mdls/du child from this background worker (issue #1222).
+            process_app_metadata "$app_data_tuple" "$scan_raw_file" < /dev/null &
             pids+=($!)
             update_scan_status "Scanning applications..." "$app_count" "$total_apps"
 

--- a/tests/core_timeout.bats
+++ b/tests/core_timeout.bats
@@ -260,6 +260,67 @@ setup() {
 	[[ "$output" == *"READ-AFTER:typed-after"* ]]
 }
 
+# Issue #1222: the perl fallback hands the controlling terminal to its timed
+# child whenever stdin is a tty (the #1201 behaviour). When it is invoked from a
+# background metadata/scan worker in bin/uninstall.sh that still has the tty on
+# stdin, that handoff steals the foreground process group from the foreground
+# script, which then stops with SIGTTIN at the confirmation prompt. Redirecting
+# the worker's stdin from /dev/null makes -t STDIN false and skips the handoff.
+# These two tests pin both halves of the contract: the handoff still happens for
+# interactive (tty) callers, and never happens once stdin is /dev/null.
+_tty_bg_field() {
+	# Extract NAME=<digits> from the fixture output (single line each).
+	printf '%s\n' "$2" | sed -n "s/.*${1}=\\([0-9][0-9]*\\).*/\\1/p" | head -1
+}
+
+@test "run_with_timeout: perl fallback hands tty to child when stdin is a tty (#1201/#1222)" {
+	if [[ "$(uname -s)" != "Darwin" || ! -x /usr/bin/expect || ! -x /usr/bin/perl ]]; then
+		skip "macOS expect/perl required"
+	fi
+
+	run /usr/bin/expect "$PROJECT_ROOT/tests/timeout_tty_background.exp" "$PROJECT_ROOT" tty
+
+	[ "$status" -eq 0 ] || return 1
+	local child fg caller
+	child=$(_tty_bg_field CHILD_PGRP "$output")
+	fg=$(_tty_bg_field FG "$output")
+	caller=$(_tty_bg_field CALLER_PGRP "$output")
+	[[ -n "$child" && -n "$fg" && -n "$caller" ]] || return 1
+	# The timed child captured the terminal's foreground process group.
+	[ "$fg" = "$child" ] || return 1
+	[ "$fg" != "$caller" ] || return 1
+}
+
+@test "run_with_timeout: perl fallback keeps tty with caller when stdin is /dev/null (#1222)" {
+	if [[ "$(uname -s)" != "Darwin" || ! -x /usr/bin/expect || ! -x /usr/bin/perl ]]; then
+		skip "macOS expect/perl required"
+	fi
+
+	run /usr/bin/expect "$PROJECT_ROOT/tests/timeout_tty_background.exp" "$PROJECT_ROOT" devnull
+
+	[ "$status" -eq 0 ] || return 1
+	local child fg caller
+	child=$(_tty_bg_field CHILD_PGRP "$output")
+	fg=$(_tty_bg_field FG "$output")
+	caller=$(_tty_bg_field CALLER_PGRP "$output")
+	[[ -n "$child" && -n "$fg" && -n "$caller" ]] || return 1
+	# No handoff: the terminal's foreground group stayed with the caller.
+	[ "$fg" = "$caller" ] || return 1
+	[ "$fg" != "$child" ] || return 1
+}
+
+# Guard the actual call sites: the background metadata refresh and scan workers
+# in bin/uninstall.sh must redirect stdin from /dev/null. Without it the perl
+# timeout fallback can steal the terminal from a background worker (#1222).
+@test "uninstall.sh: background metadata/scan workers redirect stdin (#1222)" {
+	# Disowned metadata-refresh subshell close.
+	run grep -nE '^[[:space:]]*\)[[:space:]]*>[[:space:]]*/dev/null[[:space:]]+2>&1[[:space:]]+<[[:space:]]*/dev/null[[:space:]]*&[[:space:]]*$' "$PROJECT_ROOT/bin/uninstall.sh"
+	[ "$status" -eq 0 ] || return 1
+	# Parallel scan workers.
+	run grep -nE 'process_app_metadata[[:space:]].*<[[:space:]]*/dev/null[[:space:]]*&[[:space:]]*$' "$PROJECT_ROOT/bin/uninstall.sh"
+	[ "$status" -eq 0 ] || return 1
+}
+
 @test "run_with_timeout: shell fallback preserves caller INT trap" {
     result=$(bash -c "
         set -euo pipefail

--- a/tests/timeout_tty_background.exp
+++ b/tests/timeout_tty_background.exp
@@ -1,0 +1,22 @@
+#!/usr/bin/expect -f
+# Runs tests/timeout_tty_background_fixture.sh under a real pty (issue #1222) so
+# the perl timeout fallback has a controlling terminal to hand off. Prints the
+# fixture output for the bats caller to assert on.
+#
+# Args: PROJECT_ROOT MODE   (MODE = tty | devnull)
+
+set timeout 8
+set project_root [lindex $argv 0]
+set mode [lindex $argv 1]
+
+spawn /bin/bash "$project_root/tests/timeout_tty_background_fixture.sh" "$project_root" "$mode"
+
+expect {
+    -re {CALLER_PGRP=[0-9]+\r?\n} {}
+    timeout { exit 124 }
+    eof {}
+}
+
+expect eof
+set result [wait]
+exit [lindex $result 3]

--- a/tests/timeout_tty_background_fixture.sh
+++ b/tests/timeout_tty_background_fixture.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Regression fixture for issue #1222.
+#
+# The perl timeout fallback hands the controlling terminal to its timed child
+# whenever stdin is a tty, so nested sudo inside the child can prompt (#1201).
+# bin/uninstall.sh, however, calls run_with_timeout from background metadata and
+# scan workers that have no use for the terminal. When such a worker inherits
+# the tty on stdin, this handoff steals the terminal's foreground process group
+# from the foreground script, which then stops with SIGTTIN at its confirmation
+# prompt before anything is uninstalled.
+#
+# This fixture reports whether the timed child captured the controlling
+# terminal's foreground process group:
+#   MODE=tty      - stdin is the tty; the handoff must happen (#1201 preserved)
+#   MODE=devnull  - stdin is /dev/null; the handoff must be skipped (#1222 fix)
+#
+# The child reads the foreground pgrp via /dev/tty (the controlling terminal),
+# so the probe works even when its own stdin is /dev/null.
+
+set -uo pipefail
+
+PROJECT_ROOT="$1"
+MODE="${2:-devnull}"
+
+# shellcheck source=lib/core/timeout.sh
+source "$PROJECT_ROOT/lib/core/timeout.sh"
+
+# Force the perl fallback: this is the path that performs the tty handoff.
+MO_TIMEOUT_BIN=""
+MO_TIMEOUT_PERL_BIN="/usr/bin/perl"
+
+caller_pgrp=$(ps -o pgid= -p $$ | tr -d ' ')
+
+# shellcheck disable=SC2016  # Perl source; $pgrp/$tty/$fg are Perl variables.
+child_probe='
+    use POSIX qw(tcgetpgrp);
+    my $pgrp = getpgrp();
+    open(my $tty, "<", "/dev/tty") or exit 3;
+    my $fg = tcgetpgrp(fileno($tty));
+    print "CHILD_PGRP=$pgrp FG=$fg\n";
+'
+
+if [[ "$MODE" == "tty" ]]; then
+    run_with_timeout 3 /usr/bin/perl -e "$child_probe"
+else
+    run_with_timeout 3 /usr/bin/perl -e "$child_probe" < /dev/null
+fi
+
+echo "CALLER_PGRP=$caller_pgrp"


### PR DESCRIPTION
## Summary

Fixes #1222. `mo uninstall <app>` was suspended with `SIGTTIN` at the **pre-uninstall confirmation prompt** — before anything was removed — on machines **without coreutils** (`gtimeout`/`timeout` absent, so the Perl timeout fallback is active).

## Root cause

The Perl timeout fallback in `lib/core/timeout.sh` deliberately hands the controlling terminal's foreground process group to its timed child whenever stdin is a tty, so nested `sudo` inside brew cask uninstall scripts can prompt (the #1201 fix). But `bin/uninstall.sh` calls `run_with_timeout` from **background** workers that never need the terminal:

- the disowned metadata-refresh subshell and its nested per-app workers (`mdls` / `du`);
- the parallel scan workers (`process_app_metadata` → `mdls`).

Those blocks redirected stdout/stderr but not **stdin**, so when a worker still had the tty on stdin, the Perl helper's `-t STDIN` check was true and it performed the `tcsetpgrp` handoff — stealing the foreground process group. While the main script sat at the `read` confirmation prompt, it was now a background process reading the tty → `SIGTTIN` → `zsh: suspended (tty input)`.

This is distinct from #1218 / PR #1213 (which guards the *post*-removal countdown): the confirm-prompt `read` has no such guard, and the handoff here isn't *failing* — it *succeeds* from a context that should never touch the terminal.

Full credit to @oichtental for the precise diagnosis and the suggested fix.

## Fix

Redirect stdin from `/dev/null` on the two background call sites so `-t STDIN` is false and the handoff is skipped:

- the disowned metadata-refresh subshell (its nested workers inherit the redirected stdin);
- the parallel scan workers.

The interactive sudo handoff (#1201) lives on **non-background** call sites (`lib/uninstall/brew.sh`) that keep the tty on stdin and are untouched, so it is unaffected.

## Tests

New coverage in `tests/core_timeout.bats` (with an `expect` pty harness), verifying both halves of the contract:

- the Perl fallback **still** hands the tty to its child when stdin is a tty (#1201 preserved);
- the Perl fallback **never** hands off when stdin is `/dev/null` (#1222 fixed);
- a source guard that both background call sites in `bin/uninstall.sh` redirect stdin.

The source guard was confirmed to fail on the pre-fix tree and pass after.

## Verification

```
MOLE_TEST_NO_AUTH=1 bats tests/core_timeout.bats           # 27 passed
MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats tests/uninstall_scan_bash32.bats  # 82 passed
./scripts/check.sh --format                                 # clean (shfmt + shellcheck)
```
