### PR TITLE
fix(clean): cover Zed bundled npm cache

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -171,8 +171,10 @@ clean_code_editors() {
     safe_clean ~/Library/Application\ Support/Code/WebStorage/*/CacheStorage/* "VS Code webview cache"
     safe_clean ~/Library/Caches/com.sublimetext.*/* "Sublime Text cache"
     safe_clean ~/Library/Caches/Zed/* "Zed cache"
-    # Zed stores its bundled npm cache here; keep editor state under db/ untouched.
+    # Zed npm caches: node/cache (system-node scratch) and node/node-v*/cache
+    # (per-version managed runtime, see #88); keep editor state under db/ untouched.
     safe_clean ~/Library/Application\ Support/Zed/node/cache/* "Zed npm cache"
+    safe_clean ~/Library/Application\ Support/Zed/node/node-v*/cache/* "Zed npm cache"
     safe_clean ~/Library/Logs/Zed/* "Zed logs"
     clean_editor_obsolete_extensions
     # CodeBuddy Extension (VS Code fork, Electron)

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -171,6 +171,8 @@ clean_code_editors() {
     safe_clean ~/Library/Application\ Support/Code/WebStorage/*/CacheStorage/* "VS Code webview cache"
     safe_clean ~/Library/Caches/com.sublimetext.*/* "Sublime Text cache"
     safe_clean ~/Library/Caches/Zed/* "Zed cache"
+    # Zed stores its bundled npm cache here; keep editor state under db/ untouched.
+    safe_clean ~/Library/Application\ Support/Zed/node/cache/* "Zed npm cache"
     safe_clean ~/Library/Logs/Zed/* "Zed logs"
     clean_editor_obsolete_extensions
     # CodeBuddy Extension (VS Code fork, Electron)

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -365,6 +365,8 @@ EOF
 
 @test "clean_code_editors includes Zed caches" {
     mkdir -p "$HOME/Library/Application Support/Zed/node/cache/_cacache"
+    mkdir -p "$HOME/Library/Application Support/Zed/node/node-v24.11.0-darwin-arm64/cache/_cacache"
+    mkdir -p "$HOME/Library/Application Support/Zed/node/node-v24.11.0-darwin-arm64/bin"
     mkdir -p "$HOME/Library/Application Support/Zed/db"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
@@ -378,7 +380,9 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Zed cache"* ]] || return 1
     [[ "$output" == *"CLEAN:$HOME/Library/Application Support/Zed/node/cache/_cacache|Zed npm cache"* ]] || return 1
+    [[ "$output" == *"CLEAN:$HOME/Library/Application Support/Zed/node/node-v24.11.0-darwin-arm64/cache/_cacache|Zed npm cache"* ]] || return 1
     [[ "$output" != *"$HOME/Library/Application Support/Zed/db"* ]] || return 1
+    [[ "$output" != *"node-v24.11.0-darwin-arm64/bin"* ]] || return 1
     [[ "$output" == *"Zed logs"* ]] || return 1
 }
 

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -364,17 +364,22 @@ EOF
 }
 
 @test "clean_code_editors includes Zed caches" {
+    mkdir -p "$HOME/Library/Application Support/Zed/node/cache/_cacache"
+    mkdir -p "$HOME/Library/Application Support/Zed/db"
+
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
-safe_clean() { echo "$2"; }
+safe_clean() { echo "CLEAN:$1|$2"; }
 clean_code_editors
 EOF
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Zed cache"* ]]
-    [[ "$output" == *"Zed logs"* ]]
+    [[ "$output" == *"Zed cache"* ]] || return 1
+    [[ "$output" == *"CLEAN:$HOME/Library/Application Support/Zed/node/cache/_cacache|Zed npm cache"* ]] || return 1
+    [[ "$output" != *"$HOME/Library/Application Support/Zed/db"* ]] || return 1
+    [[ "$output" == *"Zed logs"* ]] || return 1
 }
 
 @test "clean_code_editors includes VS Code WebStorage CacheStorage only" {


### PR DESCRIPTION
## Summary

Zed now keeps its bundled npm cache at `~/Library/Application Support/Zed/node/cache`. Mole only cleaned `~/Library/Caches/Zed`, so the npm cache was left behind. On my Mac, the current path had grown to 5.0 GB and contained the usual npm `_cacache` and `_npx` directories.

This change cleans only the contents of `node/cache` through `safe_clean`. It does not touch Zed's `db` directory or other editor state. The existing Zed test now checks the exact cache path and verifies that the `db` sibling stays outside the cleanup target.

Refs #88, which reported an earlier versioned form of the same Zed npm cache path.

## Safety Review

- This affects `mo clean` by adding one exact, user-owned cache path.
- Deletion still goes through `safe_clean`, so dry-run, whitelist, path validation, and operation logging keep their existing behavior.
- No path validation, protected-directory, symlink, sudo, install, or release boundaries change.
- This PR does not change System Data detection or clean any other `Application Support` data.

## Tests

- `MOLE_TEST_NO_AUTH=1 bats --filter 'clean_code_editors includes Zed caches' tests/clean_app_caches.bats`
- `./scripts/check.sh --no-format`
- `git diff --check`
- Full `tests/clean_app_caches.bats`: 41 passed, 1 existing Xcode assertion failed. The same failure reproduces on an unmodified `upstream/main` worktree.

## Safety-related changes

- Adds `~/Library/Application Support/Zed/node/cache/*` to `clean_code_editors()`.
- Keeps `~/Library/Application Support/Zed/db` untouched and covered by a regression assertion.
