### PR TITLE
fix(uninstall): detach post-cleanup jobs from tty

### DIFF
--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -1603,10 +1603,13 @@ batch_uninstall_applications() {
 
     # Run brew autoremove silently in background to avoid interrupting UX.
     if [[ $brew_apps_removed -gt 0 && "${MOLE_DRY_RUN:-0}" != "1" ]]; then
+        # This background job never needs terminal input. Keeping its stdin
+        # attached lets the Perl timeout fallback hand off the controlling tty
+        # and suspend the foreground uninstall prompt with SIGTTIN.
         (
             HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_AUTO_UPDATE=1 NONINTERACTIVE=1 \
                 run_with_timeout "$MOLE_TIMEOUT_DISK_VERIFY_SEC" brew autoremove > /dev/null 2>&1 || true
-        ) &
+        ) > /dev/null 2>&1 < /dev/null &
         disown $! 2> /dev/null || true
     fi
 
@@ -1615,10 +1618,12 @@ batch_uninstall_applications() {
         if is_uninstall_dry_run; then
             log_info "[DRY RUN] Would refresh LaunchServices and update Dock entries"
         else
+            # LaunchServices refresh uses run_with_timeout. It is best-effort
+            # background work, so it must never own the tty.
             (
                 remove_apps_from_dock "${success_dock_targets[@]}" > /dev/null 2>&1 || true
                 refresh_launch_services_after_uninstall > /dev/null 2>&1 || true
-            ) &
+            ) > /dev/null 2>&1 < /dev/null &
             disown $! 2> /dev/null || true
         fi
     fi

--- a/tests/core_timeout.bats
+++ b/tests/core_timeout.bats
@@ -309,16 +309,20 @@ _tty_bg_field() {
 	[ "$fg" != "$child" ] || return 1
 }
 
-# Guard the actual call sites: the background metadata refresh and scan workers
-# in bin/uninstall.sh must redirect stdin from /dev/null. Without it the perl
-# timeout fallback can steal the terminal from a background worker (#1222).
-@test "uninstall.sh: background metadata/scan workers redirect stdin (#1222)" {
+# Guard the actual call sites: background uninstall workers must redirect stdin
+# from /dev/null. Without it the Perl timeout fallback can steal the terminal
+# from a background worker and suspend the foreground prompt with SIGTTIN.
+@test "uninstall: background timeout workers redirect stdin (#1222)" {
 	# Disowned metadata-refresh subshell close.
 	run grep -nE '^[[:space:]]*\)[[:space:]]*>[[:space:]]*/dev/null[[:space:]]+2>&1[[:space:]]+<[[:space:]]*/dev/null[[:space:]]*&[[:space:]]*$' "$PROJECT_ROOT/bin/uninstall.sh"
 	[ "$status" -eq 0 ] || return 1
 	# Parallel scan workers.
 	run grep -nE 'process_app_metadata[[:space:]].*<[[:space:]]*/dev/null[[:space:]]*&[[:space:]]*$' "$PROJECT_ROOT/bin/uninstall.sh"
 	[ "$status" -eq 0 ] || return 1
+	# Post-uninstall work: Homebrew autoremove and LaunchServices/Dock refresh.
+	run grep -cE '^[[:space:]]*\)[[:space:]]*>[[:space:]]*/dev/null[[:space:]]+2>&1[[:space:]]+<[[:space:]]*/dev/null[[:space:]]*&[[:space:]]*$' "$PROJECT_ROOT/lib/uninstall/batch.sh"
+	[ "$status" -eq 0 ] || return 1
+	[ "$output" -eq 2 ] || return 1
 }
 
 @test "run_with_timeout: shell fallback preserves caller INT trap" {

--- a/tests/core_timeout.bats
+++ b/tests/core_timeout.bats
@@ -322,7 +322,7 @@ _tty_bg_field() {
 	# Post-uninstall work: Homebrew autoremove and LaunchServices/Dock refresh.
 	run grep -cE '^[[:space:]]*\)[[:space:]]*>[[:space:]]*/dev/null[[:space:]]+2>&1[[:space:]]+<[[:space:]]*/dev/null[[:space:]]*&[[:space:]]*$' "$PROJECT_ROOT/lib/uninstall/batch.sh"
 	[ "$status" -eq 0 ] || return 1
-	[ "$output" -eq 2 ] || return 1
+	[ "$output" -ge 2 ] || return 1
 }
 
 @test "run_with_timeout: shell fallback preserves caller INT trap" {


### PR DESCRIPTION
## Summary

- Detach the background Homebrew autoremove job from the controlling terminal.
- Detach the post-uninstall LaunchServices and Dock refresh job from the controlling terminal.
- Extend the timeout regression guard to cover both post-uninstall workers.

## Root cause

When coreutils timeout is unavailable, Mole uses its Perl timeout fallback. The post-uninstall LaunchServices refresh ran in the background but inherited standard input. The fallback could then hand the foreground TTY to `lsregister`; the final prompt caused `mo` to stop with `SIGTTIN` (exit 149).

## Reproduction

Environment observed in the report:

- macOS Sequoia on Apple Silicon with Mole installed through Homebrew.
- Mole upgraded to `1.47.1` with `brew upgrade mole`.
- `gtimeout` is unavailable, so `run_with_timeout` uses Mole's Perl fallback.

Steps:

1. Run `mo`.
2. Choose `2. Uninstall`.
3. Select an app, for example `TeamViewer`.
4. Confirm removal.
5. After the uninstall completes, wait at the final prompt or press Enter to return to the app list.

Observed result:

```text
Uninstall complete
Removed 1 app, freed 477.6MB: TeamViewer
Press Enter to return to the app list, press q to exit (5) [2]  + 80478 suspended (tty input)  mo
FAIL: 149
```

The uninstall itself succeeds, but the foreground `mo` process is suspended with `SIGTTIN` (`149 = 128 + 21`) immediately after the background post-cleanup path runs.

Expected result:

`mo` should stay in the foreground and return to the app list or exit normally after a successful uninstall.

## Validation

- `./scripts/check.sh --format`
- `MOLE_TEST_NO_AUTH=1 bats tests/core_timeout.bats tests/brew_uninstall.bats tests/uninstall.bats tests/uninstall_remove_file_list.bats`

I also started `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh`. Its lint phase passed, but the suite cannot complete in this environment: a Go toolchain download lands in the temporary HOME used by `clean_core.bats`, and its protected files make that test sandbox cleanup fail. The targeted suites above cover this change and passed.
