### PR TITLE
feat(analyze): add opt-in --deep scan for root-owned System Data (/private/var/folders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Select a location to explore:
 ↑↓→ | Enter | R Refresh | O Open | P Preview | F File | Esc/Q Quit
 ```
 
-> Deep scan: `mo analyze --deep` additionally measures root-owned system areas such as `/private/var/folders`, where background daemons (for example `com.apple.idleassetsd` aerial-wallpaper downloads) can silently accumulate tens of gigabytes that macOS hides inside the opaque "System Data" bucket. It is opt-in because it authenticates with `sudo` once, up front, and then reads without ever blocking the interface on a password prompt; if authentication is declined, `analyze` falls back to the normal, unprivileged view.
+> Note: `mo analyze --deep` also measures root-owned areas such as `/private/var/folders`, which macOS hides inside "System Data". It asks for `sudo` once up front and falls back to the normal view if you decline. These areas are read-only in analyze: they are shown so you can see what is filling the disk, not deleted from here.
 
 ### Live System Status
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Select a location to explore:
 ↑↓→ | Enter | R Refresh | O Open | P Preview | F File | Esc/Q Quit
 ```
 
+> Deep scan: `mo analyze --deep` additionally measures root-owned system areas such as `/private/var/folders`, where background daemons (for example `com.apple.idleassetsd` aerial-wallpaper downloads) can silently accumulate tens of gigabytes that macOS hides inside the opaque "System Data" bucket. It is opt-in because it authenticates with `sudo` once, up front, and then reads without ever blocking the interface on a password prompt; if authentication is declined, `analyze` falls back to the normal, unprivileged view.
+
 ### Live System Status
 
 Real-time dashboard with health score, hardware info, and performance metrics.

--- a/cmd/analyze/deep_scan.go
+++ b/cmd/analyze/deep_scan.go
@@ -12,36 +12,43 @@ import (
 	"time"
 )
 
-// Deep scan surfaces root-owned system areas — most notably
-// /private/var/folders, where daemons such as com.apple.idleassetsd can
-// silently accumulate hundreds of gigabytes of aborted temporary downloads —
-// that the normal, unprivileged analyze overview cannot measure. macOS folds
-// these bytes into the opaque "System Data" bucket and the Finder never shows
-// them, so a plain `du` run as the user hits "permission denied" on the
-// root-owned trees and reports almost nothing.
+// Deep scan surfaces root-owned system areas that the normal, unprivileged
+// analyze overview cannot measure, most notably /private/var/folders, where
+// daemons such as com.apple.idleassetsd can silently accumulate hundreds of
+// gigabytes of aborted temporary downloads. macOS folds these bytes into the
+// opaque "System Data" bucket and the Finder never shows them, so a plain `du`
+// run as the user hits "permission denied" on the root-owned trees and reports
+// almost nothing.
 //
 // Deep scan is strictly opt-in via the --deep flag (or MO_ANALYZE_DEEP=1)
 // because it requires sudo to read directories owned by root. Authentication is
 // primed once, up front, before the TUI starts, and every later read uses
-// `sudo -n` so the interface never blocks on a password prompt. Under the test
-// no-auth guard it degrades to unprivileged du and never touches sudo.
+// `sudo -n` so the interface never blocks on a password prompt. A keepalive
+// goroutine refreshes the sudo timestamp for the life of the process, because a
+// TUI session easily outlives sudo's default 5-minute window and an expired
+// timestamp would silently turn elevated reads back into the misleading
+// permission-denied measurements deep mode exists to fix. Under the test guards
+// it degrades to unprivileged du and never touches sudo.
 
 // deepScanEnabled reports whether the opt-in deep system scan is active.
 func deepScanEnabled() bool {
 	return os.Getenv("MO_ANALYZE_DEEP") == "1"
 }
 
+// deepScanAuthSuppressed reports whether the test guards forbid touching sudo.
+// Mirrors has_sudo_session() in lib/core/sudo.sh, which honours both flags.
+func deepScanAuthSuppressed() bool {
+	return os.Getenv("MOLE_TEST_NO_AUTH") == "1" || os.Getenv("MOLE_TEST_MODE") == "1"
+}
+
 // deepScanUsesSudo reports whether du should be elevated with `sudo -n` to read
-// root-owned trees. It stays false under the test no-auth guard so tests and CI
-// never trigger a real authentication prompt.
+// root-owned trees. It stays false under the test guards so tests and CI never
+// trigger a real authentication prompt.
 func deepScanUsesSudo() bool {
 	if !deepScanEnabled() {
 		return false
 	}
-	if os.Getenv("MOLE_TEST_NO_AUTH") == "1" {
-		return false
-	}
-	return true
+	return !deepScanAuthSuppressed()
 }
 
 // isDeepSystemPath reports whether target lives under /private, i.e. a
@@ -95,31 +102,90 @@ func deepSystemInsightPaths() []struct {
 	}
 }
 
+// deepScanRequiresElevation reports whether measuring path depends on an
+// elevated read succeeding. Callers must surface a failure for these paths
+// instead of falling back to an unprivileged walk: the fallback is exactly the
+// permission-denied undercount that makes root-owned trees look empty, and
+// reporting it as a real size is worse than reporting nothing.
+func deepScanRequiresElevation(path string) bool {
+	return deepScanUsesSudo() && isDeepSystemPath(path)
+}
+
+// disableDeepScan turns deep mode off for the rest of the process so the
+// overview falls back to its normal, unprivileged entries.
+func disableDeepScan(reason string) {
+	fmt.Fprintln(os.Stderr, "Deep scan: "+reason+"; continuing without elevated system folders.")
+	_ = os.Unsetenv("MO_ANALYZE_DEEP")
+}
+
 // primeSudoForDeepScan authenticates once, up front and outside the TUI's alt
 // screen, so later `sudo -n du` calls succeed without ever blocking the
 // interface on a password prompt. If authentication fails or is declined, deep
 // mode is disabled and analyze continues with normal, unprivileged output. It
 // is a no-op unless deep mode is enabled, and always a no-op under the test
-// no-auth guard.
-func primeSudoForDeepScan() {
+// guards.
+//
+// allowPrompt is false for --json, the automation surface: a password prompt
+// there would hang any script that captures the output, so JSON runs only get
+// deep mode when a sudo timestamp is already cached.
+func primeSudoForDeepScan(allowPrompt bool) {
 	if !deepScanEnabled() {
 		return
 	}
-	if os.Getenv("MOLE_TEST_NO_AUTH") == "1" {
+	if deepScanAuthSuppressed() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if !allowPrompt {
+		if err := exec.CommandContext(ctx, "sudo", "-n", "-v").Run(); err != nil {
+			disableDeepScan("--json cannot prompt for administrator access")
+			return
+		}
+		startSudoKeepalive()
 		return
 	}
 
 	fmt.Fprintln(os.Stderr, "Deep scan needs administrator access to measure root-owned system folders (e.g. /private/var/folders).")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sudo", "-v")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		fmt.Fprintln(os.Stderr, "Deep scan: administrator access unavailable; continuing without elevated system folders.")
-		_ = os.Unsetenv("MO_ANALYZE_DEEP")
+		disableDeepScan("administrator access unavailable")
+		return
 	}
+
+	startSudoKeepalive()
+}
+
+// startSudoKeepalive refreshes the sudo timestamp in the background for the life
+// of the process. Without it the timestamp expires (5 minutes by default) part
+// way through a TUI session and every later `sudo -n du` starts failing, which
+// would quietly reintroduce the undercount deep mode exists to fix. Mirrors
+// _start_sudo_keepalive() in lib/core/sudo.sh, including its behaviour of
+// giving up after three consecutive refresh failures.
+func startSudoKeepalive() {
+	go func() {
+		// Let the sudo cache settle after authentication so the first refresh
+		// does not immediately re-trigger Touch ID.
+		time.Sleep(2 * time.Second)
+
+		failures := 0
+		for {
+			if err := exec.Command("sudo", "-n", "-v").Run(); err != nil {
+				failures++
+				if failures >= 3 {
+					return
+				}
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			failures = 0
+			time.Sleep(30 * time.Second)
+		}
+	}()
 }

--- a/cmd/analyze/deep_scan.go
+++ b/cmd/analyze/deep_scan.go
@@ -1,0 +1,125 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Deep scan surfaces root-owned system areas — most notably
+// /private/var/folders, where daemons such as com.apple.idleassetsd can
+// silently accumulate hundreds of gigabytes of aborted temporary downloads —
+// that the normal, unprivileged analyze overview cannot measure. macOS folds
+// these bytes into the opaque "System Data" bucket and the Finder never shows
+// them, so a plain `du` run as the user hits "permission denied" on the
+// root-owned trees and reports almost nothing.
+//
+// Deep scan is strictly opt-in via the --deep flag (or MO_ANALYZE_DEEP=1)
+// because it requires sudo to read directories owned by root. Authentication is
+// primed once, up front, before the TUI starts, and every later read uses
+// `sudo -n` so the interface never blocks on a password prompt. Under the test
+// no-auth guard it degrades to unprivileged du and never touches sudo.
+
+// deepScanEnabled reports whether the opt-in deep system scan is active.
+func deepScanEnabled() bool {
+	return os.Getenv("MO_ANALYZE_DEEP") == "1"
+}
+
+// deepScanUsesSudo reports whether du should be elevated with `sudo -n` to read
+// root-owned trees. It stays false under the test no-auth guard so tests and CI
+// never trigger a real authentication prompt.
+func deepScanUsesSudo() bool {
+	if !deepScanEnabled() {
+		return false
+	}
+	if os.Getenv("MOLE_TEST_NO_AUTH") == "1" {
+		return false
+	}
+	return true
+}
+
+// isDeepSystemPath reports whether target lives under /private, i.e. a
+// root-owned system area that only deep mode is allowed to elevate reads for.
+// User paths (Home, ~/Library, /Applications, ...) are never elevated, so a
+// deep scan runs sudo strictly against the system trees it exists to reveal.
+func isDeepSystemPath(target string) bool {
+	if target == "" {
+		return false
+	}
+	clean := filepath.Clean(target)
+	return clean == "/private" || strings.HasPrefix(clean, "/private"+string(filepath.Separator))
+}
+
+// duCommandFor returns the executable name and leading arguments for a du
+// invocation against target. In deep mode, reads of root-owned system paths are
+// elevated with `sudo -n` (non-interactive; relies on credentials primed before
+// the TUI starts and never blocks on a password prompt). Everything else runs
+// du unprivileged, exactly as before.
+func duCommandFor(target string) (name string, leadingArgs []string) {
+	if deepScanUsesSudo() && isDeepSystemPath(target) {
+		return "sudo", []string{"-n", "du"}
+	}
+	return "du", nil
+}
+
+// deepDuCommand builds a du *exec.Cmd for target, transparently prefixing
+// `sudo -n` when deep mode should elevate the read. duArgs are the du arguments
+// (flags and the target path) exactly as they would be passed to a plain du.
+func deepDuCommand(ctx context.Context, target string, duArgs ...string) *exec.Cmd {
+	name, leading := duCommandFor(target)
+	full := make([]string, 0, len(leading)+len(duArgs))
+	full = append(full, leading...)
+	full = append(full, duArgs...)
+	return exec.CommandContext(ctx, name, full...)
+}
+
+// deepSystemInsightPaths lists the root-owned system areas surfaced only when
+// deep mode is active. These are the locations macOS folds into "System Data"
+// and that the Finder never shows.
+func deepSystemInsightPaths() []struct {
+	name string
+	path string
+} {
+	return []struct {
+		name string
+		path string
+	}{
+		{"System Temp (var/folders)", "/private/var/folders"},
+		{"System VM / Swap", "/private/var/vm"},
+	}
+}
+
+// primeSudoForDeepScan authenticates once, up front and outside the TUI's alt
+// screen, so later `sudo -n du` calls succeed without ever blocking the
+// interface on a password prompt. If authentication fails or is declined, deep
+// mode is disabled and analyze continues with normal, unprivileged output. It
+// is a no-op unless deep mode is enabled, and always a no-op under the test
+// no-auth guard.
+func primeSudoForDeepScan() {
+	if !deepScanEnabled() {
+		return
+	}
+	if os.Getenv("MOLE_TEST_NO_AUTH") == "1" {
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "Deep scan needs administrator access to measure root-owned system folders (e.g. /private/var/folders).")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sudo", "-v")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "Deep scan: administrator access unavailable; continuing without elevated system folders.")
+		_ = os.Unsetenv("MO_ANALYZE_DEEP")
+	}
+}

--- a/cmd/analyze/deep_scan_test.go
+++ b/cmd/analyze/deep_scan_test.go
@@ -1,0 +1,138 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestIsDeepSystemPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/private", true},
+		{"/private/var/folders", true},
+		{"/private/var/folders/zz/abc/T/com.apple.idleassetsd", true},
+		{"/private/var/vm", true},
+		{"/private/../private/var", true}, // cleaned to /private/var
+		{"", false},
+		{"/Users/someone", false},
+		{"/Applications", false},
+		{"/Library", false},
+		{"/privatex/y", false}, // must not match by raw prefix
+		{"/var/folders/zz", false},
+	}
+	for _, c := range cases {
+		if got := isDeepSystemPath(c.path); got != c.want {
+			t.Errorf("isDeepSystemPath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestDeepScanEnabledAndSudoGuards(t *testing.T) {
+	// Disabled by default.
+	t.Setenv("MO_ANALYZE_DEEP", "")
+	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	if deepScanEnabled() {
+		t.Fatal("deepScanEnabled() should be false when MO_ANALYZE_DEEP is unset")
+	}
+	if deepScanUsesSudo() {
+		t.Fatal("deepScanUsesSudo() should be false when deep is disabled")
+	}
+
+	// Enabled, no test guard -> elevates.
+	t.Setenv("MO_ANALYZE_DEEP", "1")
+	if !deepScanEnabled() {
+		t.Fatal("deepScanEnabled() should be true when MO_ANALYZE_DEEP=1")
+	}
+	if !deepScanUsesSudo() {
+		t.Fatal("deepScanUsesSudo() should be true when deep is enabled and not under the test guard")
+	}
+
+	// Test no-auth guard must suppress sudo even when deep is enabled.
+	t.Setenv("MOLE_TEST_NO_AUTH", "1")
+	if deepScanUsesSudo() {
+		t.Fatal("deepScanUsesSudo() must be false under MOLE_TEST_NO_AUTH=1")
+	}
+}
+
+func TestDuCommandFor(t *testing.T) {
+	// Not deep: always plain du, no matter the path.
+	t.Setenv("MO_ANALYZE_DEEP", "")
+	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	if name, lead := duCommandFor("/private/var/folders"); name != "du" || lead != nil {
+		t.Fatalf("non-deep du for system path = (%q, %v), want (du, nil)", name, lead)
+	}
+
+	// Deep + system path (no test guard): elevate with sudo -n.
+	t.Setenv("MO_ANALYZE_DEEP", "1")
+	name, lead := duCommandFor("/private/var/folders")
+	if name != "sudo" || !reflect.DeepEqual(lead, []string{"-n", "du"}) {
+		t.Fatalf("deep du for system path = (%q, %v), want (sudo, [-n du])", name, lead)
+	}
+
+	// Deep + user path: never elevated.
+	if name, lead := duCommandFor("/Users/someone/Downloads"); name != "du" || lead != nil {
+		t.Fatalf("deep du for user path = (%q, %v), want (du, nil)", name, lead)
+	}
+
+	// Deep + system path but under the test guard: no sudo.
+	t.Setenv("MOLE_TEST_NO_AUTH", "1")
+	if name, lead := duCommandFor("/private/var/folders"); name != "du" || lead != nil {
+		t.Fatalf("guarded deep du for system path = (%q, %v), want (du, nil)", name, lead)
+	}
+}
+
+func TestDeepDuCommandArgs(t *testing.T) {
+	ctx := context.Background()
+
+	// Non-deep: exactly the plain du argv.
+	t.Setenv("MO_ANALYZE_DEEP", "")
+	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	cmd := deepDuCommand(ctx, "/tmp/x", "-sk", "/tmp/x")
+	want := []string{"du", "-sk", "/tmp/x"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("non-deep argv = %v, want %v", cmd.Args, want)
+	}
+
+	// Deep + system path: sudo -n is prepended, du flags/target preserved.
+	t.Setenv("MO_ANALYZE_DEEP", "1")
+	cmd = deepDuCommand(ctx, "/private/var/folders", "-skPx", "/private/var/folders")
+	want = []string{"sudo", "-n", "du", "-skPx", "/private/var/folders"}
+	if !reflect.DeepEqual(cmd.Args, want) {
+		t.Fatalf("deep argv = %v, want %v", cmd.Args, want)
+	}
+}
+
+func TestCreateInsightEntriesDeepGating(t *testing.T) {
+	// /private/var/folders exists on every macOS host; use it as the probe.
+	const probe = "/private/var/folders"
+	if info, err := os.Stat(probe); err != nil || !info.IsDir() {
+		t.Skipf("%s not available on this host", probe)
+	}
+
+	hasProbe := func(entries []dirEntry) bool {
+		for _, e := range entries {
+			if e.Path == probe {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Deep disabled: system temp must not appear.
+	t.Setenv("MO_ANALYZE_DEEP", "")
+	if hasProbe(createInsightEntries()) {
+		t.Fatal("deep-only insight leaked into the default overview")
+	}
+
+	// Deep enabled: system temp must appear.
+	t.Setenv("MO_ANALYZE_DEEP", "1")
+	if !hasProbe(createInsightEntries()) {
+		t.Fatalf("deep insight for %s missing when deep mode is enabled", probe)
+	}
+}

--- a/cmd/analyze/deep_scan_test.go
+++ b/cmd/analyze/deep_scan_test.go
@@ -37,6 +37,7 @@ func TestDeepScanEnabledAndSudoGuards(t *testing.T) {
 	// Disabled by default.
 	t.Setenv("MO_ANALYZE_DEEP", "")
 	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	t.Setenv("MOLE_TEST_MODE", "")
 	if deepScanEnabled() {
 		t.Fatal("deepScanEnabled() should be false when MO_ANALYZE_DEEP is unset")
 	}
@@ -58,12 +59,45 @@ func TestDeepScanEnabledAndSudoGuards(t *testing.T) {
 	if deepScanUsesSudo() {
 		t.Fatal("deepScanUsesSudo() must be false under MOLE_TEST_NO_AUTH=1")
 	}
+
+	// MOLE_TEST_MODE is the other project-wide auth guard and must suppress
+	// sudo on its own, matching has_sudo_session() in lib/core/sudo.sh.
+	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	t.Setenv("MOLE_TEST_MODE", "1")
+	if deepScanUsesSudo() {
+		t.Fatal("deepScanUsesSudo() must be false under MOLE_TEST_MODE=1")
+	}
+}
+
+func TestDeepScanRequiresElevation(t *testing.T) {
+	// Elevation is only required for system paths in an active deep scan;
+	// everywhere else measureOverviewSize keeps its unprivileged fallbacks.
+	t.Setenv("MO_ANALYZE_DEEP", "")
+	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	t.Setenv("MOLE_TEST_MODE", "")
+	if deepScanRequiresElevation("/private/var/folders") {
+		t.Fatal("non-deep system path must not require elevation")
+	}
+
+	t.Setenv("MO_ANALYZE_DEEP", "1")
+	if !deepScanRequiresElevation("/private/var/folders") {
+		t.Fatal("deep system path must require elevation")
+	}
+	if deepScanRequiresElevation("/Users/someone") {
+		t.Fatal("user path must never require elevation")
+	}
+
+	t.Setenv("MOLE_TEST_NO_AUTH", "1")
+	if deepScanRequiresElevation("/private/var/folders") {
+		t.Fatal("guarded deep system path must not require elevation")
+	}
 }
 
 func TestDuCommandFor(t *testing.T) {
 	// Not deep: always plain du, no matter the path.
 	t.Setenv("MO_ANALYZE_DEEP", "")
 	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	t.Setenv("MOLE_TEST_MODE", "")
 	if name, lead := duCommandFor("/private/var/folders"); name != "du" || lead != nil {
 		t.Fatalf("non-deep du for system path = (%q, %v), want (du, nil)", name, lead)
 	}
@@ -93,6 +127,7 @@ func TestDeepDuCommandArgs(t *testing.T) {
 	// Non-deep: exactly the plain du argv.
 	t.Setenv("MO_ANALYZE_DEEP", "")
 	t.Setenv("MOLE_TEST_NO_AUTH", "")
+	t.Setenv("MOLE_TEST_MODE", "")
 	cmd := deepDuCommand(ctx, "/tmp/x", "-sk", "/tmp/x")
 	want := []string{"du", "-sk", "/tmp/x"}
 	if !reflect.DeepEqual(cmd.Args, want) {

--- a/cmd/analyze/insights.go
+++ b/cmd/analyze/insights.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -89,6 +88,22 @@ func createInsightEntries() []dirEntry {
 		}
 	}
 
+	// Deep mode only: root-owned system areas that macOS hides inside the
+	// "System Data" bucket. Sizing these requires sudo (primed before the TUI),
+	// so they are omitted from the default, unprivileged overview.
+	if deepScanEnabled() {
+		for _, d := range deepSystemInsightPaths() {
+			if info, err := os.Stat(d.path); err == nil && info.IsDir() {
+				entries = append(entries, dirEntry{
+					Name:  d.name,
+					Path:  d.path,
+					IsDir: true,
+					Size:  -1,
+				})
+			}
+		}
+	}
+
 	return entries
 }
 
@@ -146,7 +161,7 @@ func getDirSizeFast(path string) (int64, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "du", "-sk", path)
+	cmd := deepDuCommand(ctx, path, "-sk", path)
 	output, err := cmd.Output()
 	if err != nil {
 		return 0, err

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -47,11 +47,12 @@ func main() {
 
 	// Deep scan is opt-in. Enable it, then prime sudo once before the TUI starts
 	// so later root-owned reads use `sudo -n` and never block the interface on a
-	// password prompt. Priming may disable deep mode if auth is declined.
+	// password prompt. Priming may disable deep mode if auth is declined, and
+	// never prompts in --json so automation cannot hang on it.
 	if *deepMode {
 		_ = os.Setenv("MO_ANALYZE_DEEP", "1")
 	}
-	primeSudoForDeepScan()
+	primeSudoForDeepScan(!*jsonMode)
 
 	go pruneAnalyzerCache()
 	if *jsonMode {

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	jsonMode = flag.Bool("json", false, "output analysis as JSON instead of TUI")
+	deepMode = flag.Bool("deep", false, "include root-owned system areas (e.g. /private/var/folders) using sudo")
 )
 
 func main() {
@@ -43,6 +44,14 @@ func main() {
 		}
 		isOverview = false
 	}
+
+	// Deep scan is opt-in. Enable it, then prime sudo once before the TUI starts
+	// so later root-owned reads use `sudo -n` and never block the interface on a
+	// password prompt. Priming may disable deep mode if auth is declined.
+	if *deepMode {
+		_ = os.Setenv("MO_ANALYZE_DEEP", "1")
+	}
+	primeSudoForDeepScan()
 
 	go pruneAnalyzerCache()
 	if *jsonMode {

--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -851,7 +851,9 @@ func getDirectorySizeFromDuWithExcludeAndIgnores(path string, excludePath string
 			args = append(args, "-I", ignoreName)
 		}
 		args = append(args, target)
-		cmd := exec.CommandContext(ctx, "du", args...)
+		// In deep mode, reads of root-owned system paths (/private/...) are
+		// elevated with `sudo -n`; every other target runs du unprivileged.
+		cmd := deepDuCommand(ctx, target, args...)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr

--- a/cmd/analyze/scanner.go
+++ b/cmd/analyze/scanner.go
@@ -796,9 +796,18 @@ func measureOverviewSize(path string) (int64, error) {
 		excludePath = filepath.Join(home, "Library")
 	}
 
-	if duSize, err := getDirectorySizeFromDuWithExcludeAndIgnores(path, excludePath, overviewIgnoreNamesForPath(path)); err == nil {
+	duSize, duErr := getDirectorySizeFromDuWithExcludeAndIgnores(path, excludePath, overviewIgnoreNamesForPath(path))
+	if duErr == nil {
 		_ = storeOverviewSize(path, duSize)
 		return duSize, nil
+	}
+
+	// Root-owned trees are only measurable through the elevated du. Every
+	// fallback below runs unprivileged and would report a permission-denied
+	// undercount as if it were the real size, which is the exact failure deep
+	// mode exists to fix. Surface the error instead.
+	if deepScanRequiresElevation(path) {
+		return 0, fmt.Errorf("elevated measurement failed, sudo may have expired: %v", duErr)
 	}
 
 	if logicalSize, err := getDirectoryLogicalSizeWithExclude(path, excludePath); err == nil {


### PR DESCRIPTION
Closes #1253

## Summary
`mo analyze`'s overview runs fully unprivileged, so it cannot measure root-owned
trees. The biggest offender is `/private/var/folders`, where background daemons —
notably `com.apple.idleassetsd` (Aerial screensaver / dynamic wallpaper) — leak
hundreds of GB of aborted `CFNetworkDownload_*.tmp` files. macOS buries this in
the opaque "System Data" bucket and the Finder never shows it, so users see a
full disk with nothing to delete. A plain `du` as the user hits "permission
denied" on the root folder and reports ~0 — actively misleading.

## What this adds
An **opt-in** `--deep` flag (also `MO_ANALYZE_DEEP=1`) that:
- Surfaces `/private/var/folders` and `/private/var/vm` as hidden-space insights.
- Elevates `du` reads of `/private` paths with `sudo -n`.
- Primes sudo **once, up front, before the TUI starts**, so the interface never
  blocks on a password prompt. Declining auth falls back to the normal view.

## Safety
- Opt-in only; default behavior is byte-for-byte unchanged.
- Read-only: no deletion paths changed. Root-owned files remain non-deletable
  (analyze never deletes with sudo).
- `sudo` is used only for `/private` targets and only in deep mode. User paths
  (Home, ~/Library, /Applications) are never elevated.
- The `MOLE_TEST_NO_AUTH` guard suppresses sudo, so tests/CI never prompt.

## Product-decision-filter
1. Belongs to `analyze` (disk explorer). ✔
2. Safe by default, opt-in, testable without real auth, explainable in one line. ✔
3. Read-only — nothing is changed, only measured. ✔
4. N/A (visualization only; no removal). ✔
5. Not better as docs/warning — the value is making invisible System Data
   visible inside the existing explorer. ✔

## Known limitation
Overview sizing and folded-dir sizing of root-owned trees go through `du` and are
elevated. A pure Go-walk fallback still can't expand a `700`/root subtree
file-by-file, so some deep subtrees show a correct total but limited drill-down.
Flagged as a follow-up.

## Tests
- New `cmd/analyze/deep_scan_test.go` (path gating, sudo guards, argv building,
  deep-only insight gating). The unit tests never invoke real sudo.
- `go test ./...` → all pass. `gofmt` clean.
- Manual: `mo analyze --deep --json` lists the new insights;
  without `--deep` they are absent.
