### PR TITLE
feat(clean): show category totals

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -187,6 +187,7 @@ fi
 total_items=0
 TRACK_SECTION=0
 SECTION_ACTIVITY=0
+SECTION_START_SIZE_KB=0
 files_cleaned=0
 total_size_cleaned=0
 whitelist_skipped_count=0
@@ -367,6 +368,7 @@ flush_idle_section_slot() {
 start_section() {
     TRACK_SECTION=1
     SECTION_ACTIVITY=0
+    SECTION_START_SIZE_KB=${total_size_cleaned:-0}
     CURRENT_SECTION="$1"
     if [[ "${IDLE_SECTION_PENDING:-0}" == "1" ]]; then
         # Overwrite the previous idle section's header line in place (the
@@ -401,6 +403,9 @@ end_section() {
         fi
     else
         IDLE_SECTION_PENDING=0
+        local section_size_kb=$((total_size_cleaned - SECTION_START_SIZE_KB))
+        [[ $section_size_kb -ge 0 ]] || section_size_kb=0
+        echo -e "  ${GRAY}${ICON_SUBLIST} Category total${NC} · $(colorize_human_size "$(bytes_to_human_kb "$section_size_kb")")"
     fi
     TRACK_SECTION=0
 }

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -368,7 +368,7 @@ flush_idle_section_slot() {
 start_section() {
     TRACK_SECTION=1
     SECTION_ACTIVITY=0
-    SECTION_START_SIZE_KB=${total_size_cleaned:-0}
+    SECTION_START_SIZE_KB="${total_size_cleaned:-0}"
     CURRENT_SECTION="$1"
     if [[ "${IDLE_SECTION_PENDING:-0}" == "1" ]]; then
         # Overwrite the previous idle section's header line in place (the
@@ -404,7 +404,7 @@ end_section() {
     else
         IDLE_SECTION_PENDING=0
         local section_size_kb=$((total_size_cleaned - SECTION_START_SIZE_KB))
-        [[ $section_size_kb -ge 0 ]] || section_size_kb=0
+        [[ "$section_size_kb" -ge 0 ]] || section_size_kb=0
         echo -e "  ${GRAY}${ICON_SUBLIST} Category total${NC} · $(colorize_human_size "$(bytes_to_human_kb "$section_size_kb")")"
     fi
     TRACK_SECTION=0

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -403,9 +403,15 @@ end_section() {
         fi
     else
         IDLE_SECTION_PENDING=0
+        # Report-only sections (Large files, System Data clues, Project
+        # artifacts, hint-only App leftovers) mark activity without reclaiming
+        # anything, so a footer there would read "Category total · 0B" directly
+        # under a row quoting a 100GB directory. Only sections that actually
+        # moved the tracked total get one.
         local section_size_kb=$((total_size_cleaned - SECTION_START_SIZE_KB))
-        [[ "$section_size_kb" -ge 0 ]] || section_size_kb=0
-        echo -e "  ${GRAY}${ICON_SUBLIST} Category total${NC} · $(colorize_human_size "$(bytes_to_human_kb "$section_size_kb")")"
+        if [[ "$section_size_kb" -gt 0 ]]; then
+            echo -e "  ${GRAY}${ICON_SUBLIST} Category total${NC} · $(colorize_human_size "$(bytes_to_human_kb "$section_size_kb")")"
+        fi
     fi
     TRACK_SECTION=0
 }

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -763,9 +763,9 @@ EOF
             note_activity
             end_section
         '
-    [ "$status" -eq 0 ] || return 1
+    [[ "$status" -eq 0 ]] || return 1
     [[ "$output" == *"First"*"Category total"*"3.1MB"*"Second"*"Category total"*"2.0MB"* ]] || return 1
-    [ "$(printf '%s\n' "$output" | grep -c "Category total")" -eq 2 ] || return 1
+    [[ "$(printf '%s\n' "$output" | grep -c "Category total")" -eq 2 ]] || return 1
 }
 
 @test "active clean sections report a zero category total when size is untracked" {
@@ -777,7 +777,7 @@ EOF
             log_success "System logs"
             end_section
         '
-    [ "$status" -eq 0 ] || return 1
+    [[ "$status" -eq 0 ]] || return 1
     [[ "$output" == *"System logs"*"Category total"*"0B"* ]] || return 1
 }
 

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -749,6 +749,38 @@ EOF
     [[ "$list_content" != *"com.example.ocr"* ]] || return 1
 }
 
+@test "active clean sections report isolated category totals" {
+    # shellcheck disable=SC2016  # inner bash expands these from its environment
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_NO_AUTH=1 \
+        bash --noprofile --norc -c '
+            source "$PROJECT_ROOT/bin/clean.sh"
+            start_section "First"
+            total_size_cleaned=$((total_size_cleaned + 3000))
+            note_activity
+            end_section
+            start_section "Second"
+            total_size_cleaned=$((total_size_cleaned + 2000))
+            note_activity
+            end_section
+        '
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"First"*"Category total"*"3.1MB"*"Second"*"Category total"*"2.0MB"* ]] || return 1
+    [ "$(printf '%s\n' "$output" | grep -c "Category total")" -eq 2 ] || return 1
+}
+
+@test "active clean sections report a zero category total when size is untracked" {
+    # shellcheck disable=SC2016  # inner bash expands these from its environment
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_NO_AUTH=1 \
+        bash --noprofile --norc -c '
+            source "$PROJECT_ROOT/bin/clean.sh"
+            start_section "System"
+            log_success "System logs"
+            end_section
+        '
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"System logs"*"Category total"*"0B"* ]] || return 1
+}
+
 @test "log rows do not trigger purge's export-only note_activity override" {
     export_file="$HOME/purge-log-activity.txt"
     # shellcheck disable=SC2016  # inner bash expands these from its environment
@@ -803,4 +835,5 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Idle Alpha"* ]] || return 1
     [[ "$output" == *"Nothing to clean"* ]] || return 1
+    [[ "$output" != *"Category total"* ]] || return 1
 }

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -768,17 +768,20 @@ EOF
     [[ "$(printf '%s\n' "$output" | grep -c "Category total")" -eq 2 ]] || return 1
 }
 
-@test "active clean sections report a zero category total when size is untracked" {
+@test "report-only clean sections omit the category total" {
     # shellcheck disable=SC2016  # inner bash expands these from its environment
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_NO_AUTH=1 \
         bash --noprofile --norc -c '
             source "$PROJECT_ROOT/bin/clean.sh"
-            start_section "System"
-            log_success "System logs"
+            start_section "Large files"
+            log_success "iOS backups"
             end_section
         '
     [[ "$status" -eq 0 ]] || return 1
-    [[ "$output" == *"System logs"*"Category total"*"0B"* ]] || return 1
+    [[ "$output" == *"iOS backups"* ]] || return 1
+    # A hint row is activity but reclaims nothing: a "0B" footer under a row
+    # quoting a huge directory reads as a bug, so there must be no footer.
+    [[ "$output" != *"Category total"* ]] || return 1
 }
 
 @test "log rows do not trigger purge's export-only note_activity override" {


### PR DESCRIPTION
## Summary

Track how much data is being removed while cleaning by showing category totals as they complete.

- snapshot the tracked cleanup size when each `mo clean` category starts
- render the category's size delta as a compact `Category total` footer
- preserve the existing idle-category collapse and piped `Nothing to clean` behavior
- cover isolated, zero-size, and idle category totals with regression tests

## Example

```text
➤ User essentials
  ✓ User app cache · 90 items, 26.02GB
  ✓ User app logs · 30 items, 42.8MB
  ✓ Darwin user temp files · 128 old items, 2.42GB
  ✓ Darwin user cache files · 281 old items, 75.0MB
  ✓ Trash · already empty
  ↳ Category total · 28.56GB
```

<img width="497" height="385" alt="Screenshot 2026-07-21 at 11 21 44 AM" src="https://github.com/user-attachments/assets/1d50d038-fce6-487e-9fbb-f1379afbb7bc" />

## Verification

Automated format / checks pass as per CONTRIBUTING.md. Tested by installing / running locally.
