### PR TITLE
feat(status): let the CPU card show a configurable number of cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Proxy   HTTP · 192.168.1.100             Terminal   ▮▯▯▯▯  12.5%
 
 Health score is based on CPU, memory, disk, temperature, and I/O load, with color-coded ranges.
 
-Shortcuts: In `mo status`, press `k` to toggle the cat and save the preference, and `q` to quit.
+Shortcuts: In `mo status`, press `k` to toggle the cat, `c` to cycle how many CPU cores the card lists (2, 4, 8, all), and `q` to quit. Both preferences are saved.
 
 When enabled, `mo status` shows a read-only alert banner for processes that stay above the configured CPU threshold for a sustained window. Use `--proc-cpu-threshold`, `--proc-cpu-window`, or `--proc-cpu-alerts=false` to tune or disable it.
 

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -91,46 +90,6 @@ func padViewToHeight(view string, height int) string {
 	}
 
 	return view + strings.Repeat("\n", height-contentHeight)
-}
-
-// getConfigPath returns the path to the status preferences file.
-func getConfigPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".config", "mole", "status_prefs")
-}
-
-// loadCatHidden loads the cat hidden preference from config file.
-func loadCatHidden() bool {
-	path := getConfigPath()
-	if path == "" {
-		return false
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(data)) == "cat_hidden=true"
-}
-
-// saveCatHidden saves the cat hidden preference to config file.
-func saveCatHidden(hidden bool) {
-	path := getConfigPath()
-	if path == "" {
-		return
-	}
-	// Ensure directory exists
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return
-	}
-	value := "cat_hidden=false"
-	if hidden {
-		value = "cat_hidden=true"
-	}
-	_ = os.WriteFile(path, []byte(value+"\n"), 0644)
 }
 
 func newModel() model {

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -192,38 +192,51 @@ func (m model) View() string {
 	header, mole := renderHeader(m.metrics, m.errMessage, m.animFrame, termWidth, m.catHidden)
 	alertBar := renderProcessAlertBar(m.metrics.ProcessAlerts, termWidth)
 
-	var cardContent string
-	if termWidth <= 80 {
-		cardWidth := termWidth
-		if cardWidth > 2 {
-			cardWidth -= 2
-		}
-		cards := buildCards(m.metrics, cardWidth, m.cpuCores)
-
-		var rendered []string
-		for i, c := range cards {
-			if i > 0 {
-				rendered = append(rendered, "")
+	renderFrame := func(cpuCores int) string {
+		var cardContent string
+		if termWidth <= 80 {
+			cardWidth := termWidth
+			if cardWidth > 2 {
+				cardWidth -= 2
 			}
-			rendered = append(rendered, renderCard(c, cardWidth, 0))
+			cards := buildCards(m.metrics, cardWidth, cpuCores)
+
+			var rendered []string
+			for i, c := range cards {
+				if i > 0 {
+					rendered = append(rendered, "")
+				}
+				rendered = append(rendered, renderCard(c, cardWidth, 0))
+			}
+			cardContent = lipgloss.JoinVertical(lipgloss.Left, rendered...)
+		} else {
+			cardWidth := max(24, termWidth/2-4)
+			cards := buildCards(m.metrics, cardWidth, cpuCores)
+			cardContent = renderTwoColumns(cards, termWidth)
 		}
-		cardContent = lipgloss.JoinVertical(lipgloss.Left, rendered...)
-	} else {
-		cardWidth := max(24, termWidth/2-4)
-		cards := buildCards(m.metrics, cardWidth, m.cpuCores)
-		cardContent = renderTwoColumns(cards, termWidth)
+
+		// Combine header, mole, and cards with consistent spacing
+		parts := []string{header}
+		if alertBar != "" {
+			parts = append(parts, alertBar)
+		}
+		if mole != "" {
+			parts = append(parts, mole)
+		}
+		parts = append(parts, cardContent)
+		return lipgloss.JoinVertical(lipgloss.Left, parts...)
 	}
 
-	// Combine header, mole, and cards with consistent spacing
-	parts := []string{header}
-	if alertBar != "" {
-		parts = append(parts, alertBar)
+	// Every extra core is another card row, and the frame has no scrollback: on
+	// a 20-core Mac "all" adds ~18 lines and pushes the lower cards off a short
+	// window. Step the preference back down until the frame fits; the stored
+	// preference is untouched, so a taller window gets it back.
+	cpuCores := m.cpuCores
+	output := renderFrame(cpuCores)
+	for m.height > 0 && lipgloss.Height(output) > m.height && cpuCores != cpuCoresCycle[0] {
+		cpuCores = smallerCPUCores(cpuCores)
+		output = renderFrame(cpuCores)
 	}
-	if mole != "" {
-		parts = append(parts, mole)
-	}
-	parts = append(parts, cardContent)
-	output := lipgloss.JoinVertical(lipgloss.Left, parts...)
 	return padViewToHeight(output, m.height)
 }
 

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -75,6 +75,7 @@ type model struct {
 	collecting    bool
 	animFrame     int
 	catHidden     bool // true = hidden, false = visible
+	cpuCores      int  // how many CPU cores to list; 0 = all
 }
 
 // padViewToHeight ensures the rendered frame always overwrites the full
@@ -96,6 +97,7 @@ func newModel() model {
 	return model{
 		collector: NewCollector(processWatchOptionsFromFlags()),
 		catHidden: loadCatHidden(),
+		cpuCores:  loadCPUCores(),
 	}
 }
 
@@ -131,6 +133,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Toggle cat visibility and persist preference
 			m.catHidden = !m.catHidden
 			saveCatHidden(m.catHidden)
+			return m, nil
+		case "c":
+			// Cycle how many CPU cores the card lists (2 → 4 → 8 → all) and persist.
+			m.cpuCores = nextCPUCores(m.cpuCores)
+			saveCPUCores(m.cpuCores)
 			return m, nil
 		}
 	case tea.WindowSizeMsg:
@@ -191,7 +198,7 @@ func (m model) View() string {
 		if cardWidth > 2 {
 			cardWidth -= 2
 		}
-		cards := buildCards(m.metrics, cardWidth)
+		cards := buildCards(m.metrics, cardWidth, m.cpuCores)
 
 		var rendered []string
 		for i, c := range cards {
@@ -203,7 +210,7 @@ func (m model) View() string {
 		cardContent = lipgloss.JoinVertical(lipgloss.Left, rendered...)
 	} else {
 		cardWidth := max(24, termWidth/2-4)
-		cards := buildCards(m.metrics, cardWidth)
+		cards := buildCards(m.metrics, cardWidth, m.cpuCores)
 		cardContent = renderTwoColumns(cards, termWidth)
 	}
 

--- a/cmd/status/prefs.go
+++ b/cmd/status/prefs.go
@@ -1,0 +1,102 @@
+// Package main — status preferences store.
+//
+// Persisted preferences live in a tiny `key=value` file (one pair per line) at
+// ~/.config/mole/status_prefs. This file replaces the previous single-value
+// implementation, which compared the whole file against one exact string and so
+// could only ever hold a single preference. The map-based store below lets any
+// number of preferences coexist: writing one key preserves all the others.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// getConfigPath returns the path to the status preferences file, or "" if the
+// user's home directory cannot be resolved.
+func getConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "mole", "status_prefs")
+}
+
+// loadPrefs reads the preferences file into a map. A missing or unreadable file
+// yields an empty (never nil) map, so callers can index it safely. Blank lines
+// and lines starting with '#' are ignored, so the file stays hand-editable.
+func loadPrefs() map[string]string {
+	prefs := map[string]string{}
+
+	path := getConfigPath()
+	if path == "" {
+		return prefs
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return prefs
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue // no '=' on the line — skip it rather than guess
+		}
+		prefs[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return prefs
+}
+
+// savePref sets a single preference and rewrites the file, preserving every
+// other key already stored. Failures are silently ignored: a preference that
+// cannot be persisted must never crash the status TUI.
+func savePref(key, value string) {
+	path := getConfigPath()
+	if path == "" {
+		return
+	}
+
+	prefs := loadPrefs()
+	prefs[key] = value
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+
+	// Sort keys so the file is deterministic: stable on disk, clean diffs,
+	// and testable (map iteration order is randomized in Go).
+	keys := make([]string, 0, len(prefs))
+	for k := range prefs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(prefs[k])
+		b.WriteByte('\n')
+	}
+	_ = os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+// Typed accessors — the rest of the code speaks in bools/ints, not raw strings.
+
+// loadCatHidden reports whether the ASCII cat should be hidden.
+func loadCatHidden() bool {
+	return loadPrefs()["cat_hidden"] == "true"
+}
+
+// saveCatHidden persists the cat visibility preference.
+func saveCatHidden(hidden bool) {
+	savePref("cat_hidden", strconv.FormatBool(hidden))
+}

--- a/cmd/status/prefs.go
+++ b/cmd/status/prefs.go
@@ -100,3 +100,38 @@ func loadCatHidden() bool {
 func saveCatHidden(hidden bool) {
 	savePref("cat_hidden", strconv.FormatBool(hidden))
 }
+
+// cpuCoresCycle is the sequence the 'c' key steps through. 0 means "all cores".
+// The default (first entry) is 2, matching the historical hard-coded behaviour.
+var cpuCoresCycle = []int{2, 4, 8, 0}
+
+// loadCPUCores reports how many CPU cores the status card should list. 0 means
+// "all". It falls back to the default (2) when unset or invalid, so a corrupt
+// pref never breaks the display.
+func loadCPUCores() int {
+	raw, ok := loadPrefs()["cpu_cores"]
+	if !ok {
+		return cpuCoresCycle[0]
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return cpuCoresCycle[0]
+	}
+	return n
+}
+
+// saveCPUCores persists the CPU core count preference (0 = all).
+func saveCPUCores(n int) {
+	savePref("cpu_cores", strconv.Itoa(n))
+}
+
+// nextCPUCores returns the value after current in cpuCoresCycle, wrapping around.
+// An unrecognised current value restarts the cycle at its first entry.
+func nextCPUCores(current int) int {
+	for i, v := range cpuCoresCycle {
+		if v == current {
+			return cpuCoresCycle[(i+1)%len(cpuCoresCycle)]
+		}
+	}
+	return cpuCoresCycle[0]
+}

--- a/cmd/status/prefs.go
+++ b/cmd/status/prefs.go
@@ -40,7 +40,7 @@ func loadPrefs() map[string]string {
 		return prefs
 	}
 
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -131,6 +131,21 @@ func nextCPUCores(current int) int {
 	for i, v := range cpuCoresCycle {
 		if v == current {
 			return cpuCoresCycle[(i+1)%len(cpuCoresCycle)]
+		}
+	}
+	return cpuCoresCycle[0]
+}
+
+// smallerCPUCores returns the entry before current in cpuCoresCycle, without
+// wrapping: the first entry is the floor. Used by the view to shrink the CPU
+// card when the rendered frame does not fit the window.
+func smallerCPUCores(current int) int {
+	for i, v := range cpuCoresCycle {
+		if v == current {
+			if i == 0 {
+				return cpuCoresCycle[0]
+			}
+			return cpuCoresCycle[i-1]
 		}
 	}
 	return cpuCoresCycle[0]

--- a/cmd/status/prefs_test.go
+++ b/cmd/status/prefs_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+// TestSavePrefPreservesOtherKeys is the whole point of the refactor: writing one
+// preference must not clobber another. The previous single-string store failed
+// exactly this scenario. t.Setenv redirects HOME to a temp dir so getConfigPath
+// resolves inside it and the test never touches the user's real config.
+func TestSavePrefPreservesOtherKeys(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	savePref("cat_hidden", "true")
+	savePref("cpu_cores", "8")
+
+	prefs := loadPrefs()
+	if got := prefs["cat_hidden"]; got != "true" {
+		t.Errorf("cat_hidden = %q, want %q (clobbered by the second write)", got, "true")
+	}
+	if got := prefs["cpu_cores"]; got != "8" {
+		t.Errorf("cpu_cores = %q, want %q", got, "8")
+	}
+}
+
+// TestCatHiddenRoundTrip checks the typed accessors still behave like before.
+func TestCatHiddenRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if loadCatHidden() {
+		t.Fatal("cat_hidden should default to false when no file exists")
+	}
+	saveCatHidden(true)
+	if !loadCatHidden() {
+		t.Error("cat_hidden should be true after saveCatHidden(true)")
+	}
+	saveCatHidden(false)
+	if loadCatHidden() {
+		t.Error("cat_hidden should be false after saveCatHidden(false)")
+	}
+}
+
+// TestLoadPrefsIgnoresBlanksAndComments keeps the file hand-editable.
+func TestLoadPrefsIgnoresBlanksAndComments(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Seed a file with a comment, a blank line, and a malformed line.
+	savePref("cat_hidden", "true")
+	prefs := loadPrefs()
+	if len(prefs) != 1 || prefs["cat_hidden"] != "true" {
+		t.Fatalf("unexpected prefs after seed: %#v", prefs)
+	}
+}

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -313,7 +313,7 @@ func renderBanner(style lipgloss.Style, text string, width int) string {
 	return style.Render(text)
 }
 
-func renderCPUCard(cpu CPUStatus, thermal ThermalStatus) cardData {
+func renderCPUCard(cpu CPUStatus, thermal ThermalStatus, cpuCores int) cardData {
 	var lines []string
 
 	// Line 1: Usage + Temp (Format: 15% @ 30.4°C)
@@ -339,7 +339,12 @@ func renderCPUCard(cpu CPUStatus, thermal ThermalStatus) cardData {
 		}
 		sort.Slice(cores, func(i, j int) bool { return cores[i].val > cores[j].val })
 
-		maxCores := min(len(cores), 2)
+		// cpuCores selects how many of the busiest cores to list; 0 (or any
+		// value >= the core count) means "all". Set via the 'c' key, persisted.
+		maxCores := len(cores)
+		if cpuCores > 0 {
+			maxCores = min(len(cores), cpuCores)
+		}
 		for i := range maxCores {
 			c := cores[i]
 			lines = append(lines, fmt.Sprintf("Core%-2d %s  %5.1f%%", c.idx+1, progressBar(c.val), c.val))
@@ -562,9 +567,9 @@ func processMemoryText(p ProcessInfo) string {
 	return ""
 }
 
-func buildCards(m MetricsSnapshot, width int) []cardData {
+func buildCards(m MetricsSnapshot, width int, cpuCores int) []cardData {
 	cards := []cardData{
-		renderCPUCard(m.CPU, m.Thermal),
+		renderCPUCard(m.CPU, m.Thermal, cpuCores),
 		renderMemoryCard(m.Memory, width),
 		renderDiskCard(m.Disks, m.DiskIO, m.TrashSize, m.TrashApprox),
 		renderBatteryCard(m.Batteries, m.Thermal),

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1336,6 +1336,46 @@ func TestNextCPUCoresCyclesAndWraps(t *testing.T) {
 	}
 }
 
+func TestSmallerCPUCoresStepsDownAndFloors(t *testing.T) {
+	for _, tc := range []struct{ from, want int }{
+		{0, 8}, {8, 4}, {4, 2}, {2, 2}, {7, 2},
+	} {
+		if got := smallerCPUCores(tc.from); got != tc.want {
+			t.Errorf("smallerCPUCores(%d) = %d, want %d", tc.from, got, tc.want)
+		}
+	}
+}
+
+// A tall CPU card must never push the frame past the window: the view steps the
+// core count back down until it fits, so the lower cards stay on screen.
+func TestViewShrinksCPUCardToFitHeight(t *testing.T) {
+	cpu := CPUStatus{Usage: 6.1, LogicalCPU: 20}
+	for i := range 20 {
+		cpu.PerCore = append(cpu.PerCore, float64(i))
+	}
+	m := model{
+		ready:    true,
+		width:    120,
+		metrics:  MetricsSnapshot{CPU: cpu},
+		cpuCores: 0, // "all"
+	}
+
+	tall := m
+	tall.height = 200
+	if got := lipgloss.Height(tall.View()); got != 200 {
+		t.Fatalf("tall window should render all cores and pad to 200, got %d", got)
+	}
+
+	short := m
+	short.height = 20
+	if got := lipgloss.Height(short.View()); got > 20 {
+		t.Fatalf("frame overflows a 20-line window: %d lines", got)
+	}
+	if strings.Count(stripANSI(short.View()), "Core") > 8 {
+		t.Error("short window should have stepped the core count down")
+	}
+}
+
 func TestRenderTwoColumnsInsertsRowGap(t *testing.T) {
 	cards := []cardData{
 		{icon: iconCPU, title: "CPU", lines: []string{"Total  ok"}},

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1281,7 +1281,7 @@ func TestRenderCPUCardKeepsOnlyTwoHotCores(t *testing.T) {
 		Load5:      2.27,
 		Load15:     2.16,
 		LogicalCPU: 4,
-	}, ThermalStatus{})
+	}, ThermalStatus{}, 2)
 
 	plain := stripANSI(strings.Join(card.lines, "\n"))
 	if len(card.lines) != 4 {
@@ -1292,6 +1292,47 @@ func TestRenderCPUCardKeepsOnlyTwoHotCores(t *testing.T) {
 	}
 	if !strings.Contains(plain, "Core2") || !strings.Contains(plain, "Core3") {
 		t.Fatalf("renderCPUCard() should keep the two hottest cores, got %q", plain)
+	}
+}
+
+func TestRenderCPUCardHonoursCoreCount(t *testing.T) {
+	cpu := CPUStatus{
+		Usage:      6.1,
+		PerCore:    []float64{8.0, 27.9, 18.9, 16.8},
+		LogicalCPU: 4,
+	}
+
+	// cpuCores = 0 means "all": every core gets a row.
+	all := stripANSI(strings.Join(renderCPUCard(cpu, ThermalStatus{}, 0).lines, "\n"))
+	if got := strings.Count(all, "Core"); got != 4 {
+		t.Fatalf("cpuCores=0 should render all 4 cores, got %d rows: %q", got, all)
+	}
+
+	// A custom count lists exactly that many of the hottest cores.
+	three := stripANSI(strings.Join(renderCPUCard(cpu, ThermalStatus{}, 3).lines, "\n"))
+	if got := strings.Count(three, "Core"); got != 3 {
+		t.Fatalf("cpuCores=3 should render 3 cores, got %d rows: %q", got, three)
+	}
+
+	// A count larger than the core total is clamped, not padded.
+	many := stripANSI(strings.Join(renderCPUCard(cpu, ThermalStatus{}, 99).lines, "\n"))
+	if got := strings.Count(many, "Core"); got != 4 {
+		t.Fatalf("cpuCores=99 should clamp to 4 cores, got %d rows: %q", got, many)
+	}
+}
+
+func TestNextCPUCoresCyclesAndWraps(t *testing.T) {
+	want := []int{4, 8, 0, 2} // starting from 2, one full loop back to 2
+	got := 2
+	for i, exp := range want {
+		got = nextCPUCores(got)
+		if got != exp {
+			t.Fatalf("step %d: nextCPUCores gave %d, want %d", i, got, exp)
+		}
+	}
+	// An unknown value restarts the cycle at the default.
+	if n := nextCPUCores(7); n != 2 {
+		t.Fatalf("nextCPUCores(7) = %d, want default 2", n)
 	}
 }
 


### PR DESCRIPTION
## What

The CPU card hard-codes `min(len(cores), 2)`, so `mo status` only ever lists the
two busiest cores regardless of how many the machine has. This makes the count
configurable:

- Press **`c`** to cycle how many cores the card lists: **2 → 4 → 8 → all**.
- The choice is persisted in `~/.config/mole/status_prefs`, so it survives restarts.
- The default stays **2**, so existing users see no change.
- Per-core data was already collected — this only changes rendering.

## Two commits, and why

1. **`refactor(status): multi-key preferences store`** — the preferences file was
   read with a single whole-file string comparison (`cat_hidden=true`), so it could
   only ever hold one preference: writing a second key would clobber the first.
   This refactors it into a small `key=value` map store (`loadPrefs`/`savePref`)
   that preserves other keys on write and sorts output for a stable file. The
   existing cat toggle behaves exactly as before.
2. **`feat(status): let the CPU card show a configurable number of cores`** — adds
   the `cpu_cores` preference (0 = all) and the `c` key on top of that store.

Splitting it this way keeps the store refactor reusable for any future preference.

## Testing

- `./scripts/check.sh` passes (gofmt + go vet + syntax).
- `go test ./cmd/status/` green, including new tests for: prefs round-trip &
  key-preservation, the core-count rendering (top-N / all / clamp), and the `c`
  cycle wrap-around.

No new dependencies; the macOS/Linux build is unaffected.
