### PR TITLE
spike: add machine-readable CLI previews for agent workflows

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -10,6 +10,7 @@ export LANG=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/core/common.sh"
+source "$SCRIPT_DIR/../lib/core/history.sh"
 
 source "$SCRIPT_DIR/../lib/core/sudo.sh"
 source "$SCRIPT_DIR/../lib/clean/brew.sh"
@@ -26,6 +27,8 @@ SYSTEM_CLEAN=false
 DRY_RUN=false
 PROTECT_FINDER_METADATA=false
 EXTERNAL_VOLUME_TARGET=""
+CLEAN_JSON=false
+CLEAN_JSON_CANDIDATE_FILE=""
 IS_M_SERIES=$([[ "$(uname -m)" == "arm64" ]] && echo "true" || echo "false")
 
 # Whitelist and preview belong to the invoking user even when the whole
@@ -1046,6 +1049,7 @@ safe_clean() {
                     else
                         echo "$display_path  # $size_human" >> "$EXPORT_LIST_FILE"
                     fi
+                    record_clean_json_candidate "$display_path" "$total_size"
                 done
             fi
         else
@@ -1530,6 +1534,63 @@ run_cloud_and_office_cleanup() {
     clean_office_applications
 }
 
+record_clean_json_candidate() {
+    local path="$1"
+    local size_kb="${2:-0}"
+    [[ -n "${MOLE_CLEAN_JSON_CANDIDATE_FILE:-}" ]] || return 0
+    [[ "$size_kb" =~ ^[0-9]+$ ]] || size_kb=0
+    printf '%s\0%s\0' "$size_kb" "$path" >> "$MOLE_CLEAN_JSON_CANDIDATE_FILE"
+}
+
+emit_clean_preview_json() {
+    local candidate_count=0
+    local size_kb path
+    while IFS= read -r -d '' size_kb && IFS= read -r -d '' path; do
+        candidate_count=$((candidate_count + 1))
+    done < "$CLEAN_JSON_CANDIDATE_FILE"
+    local system_included=false
+    [[ "$SYSTEM_CLEAN" == "true" ]] && system_included=true
+    local potential_bytes=$((total_size_cleaned * 1024))
+
+    printf '{'
+    printf '"schema_version":1,'
+    printf '"command":"clean",'
+    printf '"mode":"preview",'
+    printf '"dry_run":true,'
+    printf '"apply_supported":false,'
+    printf '"scope":{"system_included":%s,' "$system_included"
+    printf '"external_path":'
+    if [[ -n "$EXTERNAL_VOLUME_TARGET" ]]; then
+        history_json_string "$EXTERNAL_VOLUME_TARGET"
+    else
+        printf 'null'
+    fi
+    printf '},'
+    printf '"summary":{"status":"complete","candidate_groups":%d,"items":%d,"potential_bytes":%d},' \
+        "$candidate_count" "$files_cleaned" "$potential_bytes"
+    printf '"warnings":['
+    if [[ "$SYSTEM_CLEAN" != "true" ]]; then
+        printf '{"code":"system_scope_excluded","message":"System-level candidates require a pre-authorized sudo session and were not scanned."}'
+    fi
+    printf '],'
+    printf '"candidates":['
+
+    local first=true
+    while IFS= read -r -d '' size_kb && IFS= read -r -d '' path; do
+        if [[ "$first" == "true" ]]; then
+            first=false
+        else
+            printf ','
+        fi
+        printf '{"path":'
+        history_json_string "$path"
+        printf ',"action":"remove","recoverability":"permanent","safety":"eligible_after_runtime_validation","size_bytes":%d}' \
+            "$((size_kb * 1024))"
+    done < "$CLEAN_JSON_CANDIDATE_FILE"
+
+    printf ']}\n'
+}
+
 main() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -1543,6 +1604,9 @@ main() {
             "--dry-run" | "-n")
                 DRY_RUN=true
                 export MOLE_DRY_RUN=1
+                ;;
+            "--json")
+                CLEAN_JSON=true
                 ;;
             "--external")
                 shift
@@ -1575,6 +1639,22 @@ main() {
         esac
         shift
     done
+
+    if [[ "$CLEAN_JSON" == "true" && "$DRY_RUN" != "true" ]]; then
+        echo "mo clean --json requires --dry-run" >&2
+        exit 2
+    fi
+
+    if [[ "$CLEAN_JSON" == "true" ]]; then
+        CLEAN_JSON_CANDIDATE_FILE=$(create_temp_file)
+        export MOLE_CLEAN_JSON_CANDIDATE_FILE="$CLEAN_JSON_CANDIDATE_FILE"
+        start_cleanup >&2
+        hide_cursor >&2
+        perform_cleanup >&2
+        show_cursor >&2
+        emit_clean_preview_json
+        exit 0
+    fi
 
     start_cleanup
     hide_cursor

--- a/bin/completion.sh
+++ b/bin/completion.sh
@@ -11,10 +11,10 @@ for entry in "${MOLE_COMMANDS[@]}"; do
     command_names+=("${entry%%:*}")
 done
 command_words="${command_names[*]}"
-clean_option_words="--dry-run -n --external --whitelist --debug --help -h"
-analyze_option_words="--json --help -h"
+clean_option_words="--dry-run -n --json --external --whitelist --debug --help -h"
+analyze_option_words="--json --limit --compact --help -h"
 history_option_words="--json --limit --help -h"
-purge_option_words="--paths --dry-run -n --include-empty --debug --help -h"
+purge_option_words="--paths --dry-run -n --json --include-empty --debug --help -h"
 
 emit_zsh_subcommands() {
     for entry in "${MOLE_COMMANDS[@]}"; do
@@ -32,18 +32,22 @@ emit_fish_completions() {
 
     printf '\n'
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from clean" -l dry-run -s n -d "Preview cleanup without making changes"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from clean" -l json -d "Output a machine-readable dry-run preview"\n' "$cmd"
     printf 'complete -c %s -n "__fish_seen_subcommand_from clean" -l external -r -a "(__fish_complete_directories)" -d "Clean OS metadata from an external volume"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from clean" -l whitelist -d "Manage protected paths"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from clean" -l debug -d "Show detailed logs"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from clean" -l help -s h -d "Show help"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from analyze analyse" -l json -d "Output analysis as JSON"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from analyze analyse" -l limit -r -d "Limit JSON top-level entries"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from analyze analyse" -l compact -d "Emit compact JSON"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from analyze analyse" -l help -s h -d "Show help"\n' "$cmd"
-    printf 'complete -c %s -n "__fish_seen_subcommand_from analyze analyse; and not __fish_seen_argument -l json -l help -s h" -a "(__fish_complete_directories)" -d "Path to analyze"\n' "$cmd"
+    printf 'complete -c %s -n "__fish_seen_subcommand_from analyze analyse; and not __fish_seen_argument -l json -l limit -l compact -l help -s h" -a "(__fish_complete_directories)" -d "Path to analyze"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from history" -l json -d "Output history as JSON"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from history" -l limit -r -d "Limit recent entries"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from history" -l help -s h -d "Show help"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l paths -d "Edit custom scan directories"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l dry-run -s n -d "Preview purge actions without making changes"\n' "$cmd"
+    printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l json -d "Output a machine-readable dry-run preview"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l include-empty -d "Show zero-size project artifact directories"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l debug -d "Show detailed logs"\n' "$cmd"
     printf 'complete -f -c %s -n "__fish_seen_subcommand_from purge" -l help -s h -d "Show help"\n' "$cmd"
@@ -374,6 +378,7 @@ EOF
         printf '            _arguments \\\n'
         printf "                '--dry-run[Preview cleanup without making changes]' \\\\\n"
         printf "                '-n[Preview cleanup without making changes]' \\\\\n"
+        printf "                '--json[Output a machine-readable dry-run preview]' \\\\\n"
         printf "                '--external[Clean OS metadata from an external volume]:path:_files -/' \\\\\n"
         printf "                '--whitelist[Manage protected paths]' \\\\\n"
         printf "                '--debug[Show detailed logs]' \\\\\n"
@@ -382,6 +387,8 @@ EOF
         printf '        analyze|analyse)\n'
         printf '            _arguments \\\n'
         printf "                '--json[Output analysis as JSON]' \\\\\n"
+        printf "                '--limit[Limit JSON top-level entries]:limit:' \\\\\n"
+        printf "                '--compact[Emit compact JSON]' \\\\\n"
         printf "                '(-h --help)'{-h,--help}'[Show help]' \\\\\n"
         printf "                '*:path:_files'\n"
         printf '            ;;\n'
@@ -396,6 +403,7 @@ EOF
         printf "                '--paths[Edit custom scan directories]' \\\\\n"
         printf "                '--dry-run[Preview purge actions without making changes]' \\\\\n"
         printf "                '-n[Preview purge actions without making changes]' \\\\\n"
+        printf "                '--json[Output a machine-readable dry-run preview]' \\\\\n"
         printf "                '--include-empty[Show zero-size project artifact directories]' \\\\\n"
         printf "                '--debug[Show detailed logs]' \\\\\n"
         printf "                '(-h --help)'{-h,--help}'[Show help]'\n"

--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -12,6 +12,7 @@ export LANG=C
 # Get script directory and source common functions
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/core/common.sh"
+source "$SCRIPT_DIR/../lib/core/history.sh"
 
 # Restores cursor and clears temp files even when set -e aborts (#915).
 cleanup() {
@@ -25,6 +26,8 @@ source "$SCRIPT_DIR/../lib/clean/project.sh"
 
 # Configuration
 CURRENT_SECTION=""
+PURGE_JSON=false
+PURGE_JSON_CANDIDATE_FILE=""
 
 # IMPORTANT: This file overrides start_section / end_section / note_activity
 # from lib/core/base.sh by virtue of being sourced after it. The purge variant
@@ -48,6 +51,57 @@ note_activity() {
     if [[ -n "$CURRENT_SECTION" ]]; then
         printf '%s\n' "$CURRENT_SECTION" >> "$EXPORT_LIST_FILE"
     fi
+}
+
+emit_purge_preview_json() {
+    local candidate_count=0
+    local potential_bytes=0
+    local size_kb path
+
+    while IFS= read -r -d '' size_kb && IFS= read -r -d '' path; do
+        candidate_count=$((candidate_count + 1))
+        potential_bytes=$((potential_bytes + (size_kb * 1024)))
+    done < "$PURGE_JSON_CANDIDATE_FILE"
+
+    printf '{'
+    printf '"schema_version":1,'
+    printf '"command":"purge",'
+    printf '"mode":"preview",'
+    printf '"dry_run":true,'
+    printf '"apply_supported":false,'
+    printf '"scope":{"search_roots":['
+    local first=true
+    local search_root
+    if [[ ${#PURGE_SEARCH_PATHS[@]} -gt 0 ]]; then
+        for search_root in "${PURGE_SEARCH_PATHS[@]}"; do
+            if [[ "$first" == "true" ]]; then
+                first=false
+            else
+                printf ','
+            fi
+            history_json_string "$search_root"
+        done
+    fi
+    printf ']},'
+    printf '"summary":{"status":"complete","candidate_groups":%d,"items":%d,"potential_bytes":%d},' \
+        "$candidate_count" "$candidate_count" "$potential_bytes"
+    printf '"warnings":[],'
+    printf '"candidates":['
+
+    first=true
+    while IFS= read -r -d '' size_kb && IFS= read -r -d '' path; do
+        if [[ "$first" == "true" ]]; then
+            first=false
+        else
+            printf ','
+        fi
+        printf '{"path":'
+        history_json_string "$path"
+        printf ',"action":"remove","recoverability":"rebuild","safety":"validated_project_artifact","size_bytes":%d}' \
+            "$((size_kb * 1024))"
+    done < "$PURGE_JSON_CANDIDATE_FILE"
+
+    printf ']}\n'
 }
 
 # Keep the most specific tail of a long purge path visible on the live scan line.
@@ -292,6 +346,7 @@ show_help() {
     echo -e "${YELLOW}Options:${NC}"
     echo "  --paths         Edit custom scan directories"
     echo "  --dry-run       Preview purge actions without making changes"
+    echo "  --json          Output a machine-readable preview (requires --dry-run)"
     echo "  --include-empty Show zero-size project artifact directories"
     echo "  --debug         Enable debug logging"
     echo "  --help          Show this help message"
@@ -322,6 +377,9 @@ main() {
             "--dry-run" | "-n")
                 export MOLE_DRY_RUN=1
                 ;;
+            "--json")
+                PURGE_JSON=true
+                ;;
             "--include-empty")
                 export MOLE_PURGE_INCLUDE_EMPTY=1
                 ;;
@@ -332,6 +390,23 @@ main() {
                 ;;
         esac
     done
+
+    if [[ "$PURGE_JSON" == "true" && "${MOLE_DRY_RUN:-0}" != "1" ]]; then
+        echo "mo purge --json requires --dry-run" >&2
+        exit 2
+    fi
+
+    if [[ "$PURGE_JSON" == "true" ]]; then
+        PURGE_JSON_CANDIDATE_FILE=$(create_temp_file)
+        export MOLE_PURGE_JSON_CANDIDATE_FILE="$PURGE_JSON_CANDIDATE_FILE"
+        start_purge >&2
+        echo -e "${YELLOW}${ICON_DRY_RUN} DRY RUN MODE${NC}, No project artifacts will be removed" >&2
+        printf '\n' >&2
+        hide_cursor >&2
+        perform_purge >&2
+        emit_purge_preview_json
+        return 0
+    fi
 
     start_purge
     if [[ "${MOLE_DRY_RUN:-0}" == "1" ]]; then

--- a/cmd/analyze/json.go
+++ b/cmd/analyze/json.go
@@ -5,6 +5,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"sync"
@@ -13,12 +14,16 @@ import (
 )
 
 type jsonOutput struct {
-	Path       string          `json:"path"`
-	Overview   bool            `json:"overview"`
-	Entries    []jsonEntry     `json:"entries"`
-	LargeFiles []jsonFileEntry `json:"large_files,omitempty"`
-	TotalSize  int64           `json:"total_size"`
-	TotalFiles int64           `json:"total_files,omitempty"`
+	SchemaVersion    int             `json:"schema_version"`
+	Path             string          `json:"path"`
+	Overview         bool            `json:"overview"`
+	Entries          []jsonEntry     `json:"entries"`
+	EntriesTotal     int             `json:"entries_total"`
+	EntriesReturned  int             `json:"entries_returned"`
+	EntriesTruncated bool            `json:"entries_truncated"`
+	LargeFiles       []jsonFileEntry `json:"large_files,omitempty"`
+	TotalSize        int64           `json:"total_size"`
+	TotalFiles       int64           `json:"total_files,omitempty"`
 }
 
 type jsonEntry struct {
@@ -37,15 +42,22 @@ type jsonFileEntry struct {
 	Size int64  `json:"size"`
 }
 
-func runJSONMode(path string, isOverview bool) {
+func runJSONMode(path string, isOverview bool, limit int, compact bool) {
 	result := performScanForJSON(path, isOverview)
+	result = limitJSONEntries(result, limit)
 
-	encoder := json.NewEncoder(os.Stdout)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(result); err != nil {
+	if err := writeJSONOutput(os.Stdout, result, compact); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to encode JSON: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func writeJSONOutput(w io.Writer, result jsonOutput, compact bool) error {
+	encoder := json.NewEncoder(w)
+	if !compact {
+		encoder.SetIndent("", "  ")
+	}
+	return encoder.Encode(result)
 }
 
 func performScanForJSON(path string, isOverview bool) jsonOutput {
@@ -66,13 +78,17 @@ func performDirectoryScanForJSON(path string) jsonOutput {
 		os.Exit(1)
 	}
 
+	entries := jsonEntriesFromDirEntries(result.Entries, false, nil)
 	return jsonOutput{
-		Path:       path,
-		Overview:   false,
-		Entries:    jsonEntriesFromDirEntries(result.Entries, false, nil),
-		LargeFiles: jsonFileEntriesFromFileEntries(result.LargeFiles),
-		TotalSize:  result.TotalSize,
-		TotalFiles: result.TotalFiles,
+		SchemaVersion:   1,
+		Path:            path,
+		Overview:        false,
+		Entries:         entries,
+		EntriesTotal:    len(entries),
+		EntriesReturned: len(entries),
+		LargeFiles:      jsonFileEntriesFromFileEntries(result.LargeFiles),
+		TotalSize:       result.TotalSize,
+		TotalFiles:      result.TotalFiles,
 	}
 }
 
@@ -99,12 +115,27 @@ func performOverviewScanForJSON(path string) jsonOutput {
 		return entries[i].Size > entries[j].Size
 	})
 
+	jsonEntries := jsonEntriesFromDirEntries(entries, true, insightPaths)
 	return jsonOutput{
-		Path:      path,
-		Overview:  true,
-		Entries:   jsonEntriesFromDirEntries(entries, true, insightPaths),
-		TotalSize: totalSize,
+		SchemaVersion:   1,
+		Path:            path,
+		Overview:        true,
+		Entries:         jsonEntries,
+		EntriesTotal:    len(jsonEntries),
+		EntriesReturned: len(jsonEntries),
+		TotalSize:       totalSize,
 	}
+}
+
+func limitJSONEntries(result jsonOutput, limit int) jsonOutput {
+	if limit <= 0 || len(result.Entries) <= limit {
+		return result
+	}
+
+	result.Entries = result.Entries[:limit]
+	result.EntriesReturned = len(result.Entries)
+	result.EntriesTruncated = true
+	return result
 }
 
 func measureOverviewEntriesForJSON(overviewEntries []dirEntry, insightPaths map[string]bool) []dirEntry {

--- a/cmd/analyze/json_test.go
+++ b/cmd/analyze/json_test.go
@@ -3,9 +3,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -34,6 +37,13 @@ func TestPerformScanForJSONIncludesAllEntriesAndLargeFiles(t *testing.T) {
 	if got := len(result.Entries); got != totalFiles {
 		t.Fatalf("expected %d entries, got %d", totalFiles, got)
 	}
+	if result.SchemaVersion != 1 {
+		t.Fatalf("expected schema version 1, got %d", result.SchemaVersion)
+	}
+	if result.EntriesTotal != totalFiles || result.EntriesReturned != totalFiles || result.EntriesTruncated {
+		t.Fatalf("unexpected entry metadata: total=%d returned=%d truncated=%t",
+			result.EntriesTotal, result.EntriesReturned, result.EntriesTruncated)
+	}
 	if result.TotalFiles != int64(totalFiles) {
 		t.Fatalf("expected %d total files, got %d", totalFiles, result.TotalFiles)
 	}
@@ -50,6 +60,64 @@ func TestPerformScanForJSONIncludesAllEntriesAndLargeFiles(t *testing.T) {
 	}
 	if !foundHuge {
 		t.Fatalf("expected huge.bin in large_files, got %#v", result.LargeFiles)
+	}
+}
+
+func TestLimitJSONEntriesPreservesTotalsAndLargestEntries(t *testing.T) {
+	result := jsonOutput{
+		SchemaVersion:   1,
+		Entries:         []jsonEntry{{Name: "large", Size: 300}, {Name: "medium", Size: 200}, {Name: "small", Size: 100}},
+		EntriesTotal:    3,
+		EntriesReturned: 3,
+		TotalSize:       600,
+		TotalFiles:      9,
+	}
+
+	limited := limitJSONEntries(result, 2)
+
+	if len(limited.Entries) != 2 || limited.Entries[0].Name != "large" || limited.Entries[1].Name != "medium" {
+		t.Fatalf("unexpected limited entries: %#v", limited.Entries)
+	}
+	if limited.EntriesTotal != 3 || limited.EntriesReturned != 2 || !limited.EntriesTruncated {
+		t.Fatalf("unexpected entry metadata: total=%d returned=%d truncated=%t",
+			limited.EntriesTotal, limited.EntriesReturned, limited.EntriesTruncated)
+	}
+	if limited.TotalSize != 600 || limited.TotalFiles != 9 {
+		t.Fatalf("scan totals changed: size=%d files=%d", limited.TotalSize, limited.TotalFiles)
+	}
+}
+
+func TestWriteJSONOutputCompactPreservesDocument(t *testing.T) {
+	result := jsonOutput{
+		SchemaVersion:   1,
+		Path:            "/tmp/example",
+		Entries:         []jsonEntry{{Name: "cache", Path: "/tmp/example/cache", Size: 42, IsDir: true}},
+		EntriesTotal:    1,
+		EntriesReturned: 1,
+		TotalSize:       42,
+	}
+
+	var indented bytes.Buffer
+	if err := writeJSONOutput(&indented, result, false); err != nil {
+		t.Fatalf("write indented JSON: %v", err)
+	}
+	var compact bytes.Buffer
+	if err := writeJSONOutput(&compact, result, true); err != nil {
+		t.Fatalf("write compact JSON: %v", err)
+	}
+
+	var indentedDoc, compactDoc map[string]any
+	if err := json.Unmarshal(indented.Bytes(), &indentedDoc); err != nil {
+		t.Fatalf("decode indented JSON: %v", err)
+	}
+	if err := json.Unmarshal(compact.Bytes(), &compactDoc); err != nil {
+		t.Fatalf("decode compact JSON: %v", err)
+	}
+	if !reflect.DeepEqual(indentedDoc, compactDoc) {
+		t.Fatalf("documents differ: indented=%#v compact=%#v", indentedDoc, compactDoc)
+	}
+	if compact.Len() >= indented.Len() || bytes.Count(compact.Bytes(), []byte("\n")) != 1 {
+		t.Fatalf("compact output was not compact: indented=%d compact=%d", indented.Len(), compact.Len())
 	}
 }
 

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -17,11 +17,33 @@ import (
 )
 
 var (
-	jsonMode = flag.Bool("json", false, "output analysis as JSON instead of TUI")
+	jsonMode    = flag.Bool("json", false, "output analysis as JSON instead of TUI")
+	jsonLimit   = flag.Int("limit", 0, "limit JSON output to the largest N top-level entries (0 = all)")
+	jsonCompact = flag.Bool("compact", false, "emit compact JSON without indentation")
 )
 
 func main() {
 	flag.Parse()
+
+	limitSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "limit" {
+			limitSet = true
+		}
+	})
+
+	if *jsonLimit < 0 {
+		fmt.Fprintln(os.Stderr, "analyze: --limit must be 0 or greater")
+		os.Exit(2)
+	}
+	if limitSet && !*jsonMode {
+		fmt.Fprintln(os.Stderr, "analyze: --limit requires --json")
+		os.Exit(2)
+	}
+	if *jsonCompact && !*jsonMode {
+		fmt.Fprintln(os.Stderr, "analyze: --compact requires --json")
+		os.Exit(2)
+	}
 
 	target := os.Getenv("MO_ANALYZE_PATH")
 	if target == "" && len(flag.Args()) > 0 {
@@ -46,7 +68,7 @@ func main() {
 
 	go pruneAnalyzerCache()
 	if *jsonMode {
-		runJSONMode(abs, isOverview)
+		runJSONMode(abs, isOverview, *jsonLimit, *jsonCompact)
 	} else {
 		runTUIMode(abs, isOverview)
 	}

--- a/docs/spikes/agent-cli-protocol.md
+++ b/docs/spikes/agent-cli-protocol.md
@@ -1,0 +1,243 @@
+# Agent CLI protocol spike
+
+Status: five iterations and final proof complete. This is an experiment log,
+not a shipped interface specification.
+
+## Baseline
+
+- `mo analyze --json [path]` emits one indented JSON document after the scan.
+- `mo status --watch` emits unversioned metric snapshots as NDJSON.
+- `mo history --json` emits one JSON document.
+- Destructive commands support dry-run, but their preview output is human text;
+  `clean` additionally writes a path list outside stdout.
+- The human TUI and existing human-readable output are compatibility surfaces
+  and remain unchanged by this spike.
+
+The initial read-only sample against a large local repository tree completed in
+0.57s. It returned 69 top-level entries and 20 large-file records: 14,969 bytes
+indented, or 11,280 bytes compacted. This is small enough that scan latency does
+not yet justify streaming, but large enough that explicit result bounding may
+materially reduce agent context.
+
+## Current proposed contract
+
+The current analysis proposal is additive:
+
+`mo analyze --json [--limit N] [--compact] [path]`
+
+- scan totals continue to describe the complete scope;
+- `entries` contains at most the largest `N` top-level entries;
+- `schema_version`, `entries_total`, `entries_returned`, and
+  `entries_truncated` make the bounded response explicit;
+- `large_files` retains its existing independently bounded semantics;
+- omitting `--limit` preserves the existing entry set;
+- the flag is rejected outside JSON mode.
+- `--compact` changes encoding only; the decoded document is identical.
+
+No run ID, durable storage, or apply path is proposed.
+
+The current preview proposal covers:
+
+`mo clean --dry-run --json`
+
+`mo purge --dry-run --json`
+
+```json
+{
+  "schema_version": 1,
+  "command": "clean",
+  "mode": "preview",
+  "dry_run": true,
+  "apply_supported": false,
+  "scope": {"system_included": false, "external_path": null},
+  "summary": {
+    "status": "complete",
+    "candidate_groups": 2,
+    "items": 37,
+    "potential_bytes": 5120
+  },
+  "warnings": [
+    {
+      "code": "system_scope_excluded",
+      "message": "System-level candidates require a pre-authorized sudo session and were not scanned."
+    }
+  ],
+  "candidates": [
+    {
+      "path": "<absolute path>",
+      "action": "remove",
+      "recoverability": "permanent",
+      "safety": "eligible_after_runtime_validation"
+    }
+  ]
+}
+```
+
+Structured preview data is stdout-only; the existing human dry-run rendering is
+sent to stderr. JSON without `--dry-run` is rejected before cleanup starts.
+
+## Iterations
+
+| Iteration | Hypothesis and acceptance check | Evidence | Decision / next hypothesis |
+| --- | --- | --- | --- |
+| 1 | A JSON-only `--limit N` can reduce response volume without hiding full-scan totals. Accept if focused tests prove stable metadata and top-N ordering, the TUI is untouched, and the real sample is materially smaller. | Focused JSON tests passed. The real `--limit 10` sample returned 10/69 entries with unchanged totals in 0.50s and shrank from 14,969 to 5,362 bytes (64%). Using `--limit` without `--json` exited 2 with a direct diagnostic. | Keep the limit and explicit truncation metadata. Next test whether native compact encoding removes avoidable whitespace without changing the document contract. |
+| 2 | Native `--compact` JSON can remove avoidable formatting tokens while preserving the exact schema and human TUI. Accept if compact and indented documents decode identically, invalid non-JSON use is rejected, completions expose the option, and the real bounded sample shrinks materially. | Focused Go tests and all 19 completion tests passed. Canonicalized real documents matched. Compact output reduced the bounded sample from 5,362 to 4,215 bytes (21%); non-JSON use exited 2. | Keep the opt-in encoder to preserve default formatting. Further analyzer controls are lower value than the missing machine-readable preview contract. |
+| 3 | A versioned `clean --dry-run --json` document can expose the authoritative preview list on stdout without terminal scraping. Accept if JSON is impossible without dry-run, stdout is parseable and prose-free, diagnostics stay on stderr, candidates carry stable path/action/safety fields, tests prove no fixture is removed, and a temp-HOME CLI probe exercises the real command. | Two focused Bats tests and all completion tests passed. A normal temp-HOME dry-run emitted one 596-byte JSON line on stdout and 107 human-diagnostic lines on stderr, reported 2 candidate groups/37 items, and preserved the cache fixture. The non-dry-run negative control exited 2 with empty stdout. | Keep the stdout/stderr split and fail-closed flag dependency. Next test whether the same envelope generalizes to `purge` without erasing its rebuildable-artifact semantics. |
+| 4 | The preview envelope can cover `purge --dry-run --json` with shared top-level fields but command-specific recoverability and scope. Accept if a temp project fixture yields parseable stdout-only JSON, candidate paths come from the immutable purge selection, recoverability is `rebuild`, non-dry-run JSON is rejected, and focused tests prove the artifact remains. | Two focused Bats tests and all completion tests passed. A temp-project dry-run emitted one 455-byte JSON line plus 11 stderr lines, reported one 4 KiB validated artifact, and preserved it. The non-dry-run negative control exited 2. The real bounded analysis sample remained 4,215 bytes in iterations 3 and 4. | Keep the shared envelope and command-specific recoverability. NUL-delimited internal capture avoids corrupting unusual candidate paths. Next determine whether a plan ID provides real correlation without implying apply authority. |
+| 5 | Observation rejected a content-derived `plan_id`: hashing is portable, but without stored plans, status lookup, or apply receipts the ID would be decorative and could imply authority it does not have. The refined hypothesis is that structured safety warnings add more value. Accept if both preview commands expose a stable `warnings` array, excluded clean system scope has a machine code, purge can return an empty array, tests cover both shapes, and stale/cancel/failure semantics are documented without adding storage or apply. | Focused clean and purge JSON tests passed. Clean returns coded `system_scope_excluded` when sudo scope is absent; purge returns an empty stable array. The iteration-5 real analysis sample remained 4,215 bytes. | Keep structured warnings. Reject plan/run IDs, NDJSON streaming, durable state, and apply semantics in this spike. Use each final JSON document plus process exit as the complete receipt. |
+
+## Commands and compact evidence
+
+### Baseline
+
+```text
+./mole --help
+./mole analyze --help
+./mole clean --help
+./mole purge --help
+./mole installer --help
+./mole optimize --help
+./mole analyze --json <large-local-tree>
+MOLE_TEST_NO_AUTH=1 go test ./cmd/analyze -run 'JSON|Limit' -count=1
+make build
+./mole analyze --json --limit 10 <large-local-tree>
+./mole analyze --limit 2 <temporary-directory>
+MOLE_TEST_NO_AUTH=1 go test ./cmd/analyze -run 'JSON|Limit|Compact' -count=1
+MOLE_TEST_NO_AUTH=1 bats tests/completion.bats
+./mole analyze --json --limit 10 --compact <large-local-tree>
+MOLE_TEST_NO_AUTH=1 bats --filter 'clean.*json' tests/clean_core.bats
+MOLE_TEST_NO_AUTH=1 bats --filter 'purge.*json' tests/purge.bats
+./mole analyze --json --limit 10 --compact <large-local-tree>
+./mole analyze --compact <temporary-directory>
+MOLE_TEST_NO_AUTH=1 bats --filter 'clean.*json' tests/clean_core.bats
+HOME=<temporary-home> MOLE_TEST_NO_AUTH=1 MOLE_TEST_MODE=0 \
+  ./mole clean --dry-run --json
+HOME=<temporary-home> MOLE_TEST_NO_AUTH=1 ./mole clean --json
+MOLE_TEST_NO_AUTH=1 bats --filter 'purge.*json' tests/purge.bats
+HOME=<temporary-home> MOLE_TEST_NO_AUTH=1 \
+  ./mole purge --dry-run --json < /dev/null
+./mole analyze --json --limit 10 --compact <large-local-tree>
+```
+
+The real analysis was redirected to a temporary proof directory before being
+summarized. No repository inventory was printed or written to this document.
+
+## Token-volume observations
+
+- Indented JSON adds about 33% over the compact byte count in the initial
+  sample.
+- Top-level entries, rather than summary fields, dominate the response.
+- The existing 20-record `large_files` list is already bounded internally but
+  does not disclose that policy in the command contract.
+- `--limit 10` reduced the indented real sample by 9,607 bytes (64%) while
+  preserving complete scan totals and the independently bounded large-file list.
+- Compact encoding removed another 1,147 bytes (21%) from the bounded sample
+  without changing its decoded document.
+
+## Safety findings
+
+- Read-only analysis does not modify the sampled repository tree.
+- A limit must affect presentation only, never scan accounting or deletion
+  selection.
+- A result bound must state that truncation occurred; silently slicing paths
+  would be unsafe for follow-up cleanup decisions.
+- Machine JSON is accepted only with dry-run; a format flag cannot activate a
+  removal path.
+- Clean candidates use `recoverability: "permanent"` because the normal clean
+  deletion funnel is not recoverable through Trash.
+- The preview path list groups some underlying files by parent. The document
+  therefore distinguishes `candidate_groups` from `items`.
+- Purge candidates are captured only after the configured-root safety
+  revalidation and use NUL-delimited internal records, so whitespace in a path
+  does not become a candidate boundary.
+- `recoverability` is command-specific: `clean` is `permanent`; `purge` is
+  `rebuild`.
+- No destructive Mole command has been executed.
+
+## Rejected or deferred ideas
+
+- An `mo agent` subsystem: outside product direction and unnecessary.
+- Streaming analysis/events: rejected for this spike. All five real samples
+  completed quickly enough that a bounded final document was simpler, and
+  stdout-only receipts eliminate polling without a progress protocol.
+- Plan/run IDs: rejected. A hash is technically portable, but without durable
+  plan storage, lookup, or an apply receipt it adds no follow-up capability and
+  risks implying authorization.
+- Apply commands: rejected. Preview identifiers and documents never authorize
+  deletion.
+- Replacing stderr diagnostics with structured progress: deferred. The 107-line
+  temp-HOME clean trace is noisy, but stdout already remains parseable and the
+  scan completed without polling.
+
+## Remaining limitations
+
+- Installer, uninstall, and optimize previews remain human-oriented; this spike
+  covers only clean and purge.
+- Analyze JSON remains indented by default for compatibility; agents must opt
+  into `--compact`.
+- Analysis has no minimum-size filter or pagination.
+- Cancellation and failures are process-level behavior, not structured events.
+- Preview documents are snapshots, not stored plans. They become stale as soon
+  as the filesystem changes; consumers must rerun the dry-run before any
+  separately authorized destructive invocation.
+- Cancellation exits 130 and may produce no final JSON receipt. Other failures
+  exit nonzero with diagnostics on stderr; consumers must not treat partial or
+  absent stdout as a plan.
+- There is no follow-up status lookup because there is no durable run state.
+
+## Final proof and readiness
+
+Fresh final proof:
+
+```text
+./scripts/check.sh --format
+env -u NO_COLOR MOLE_TEST_NO_AUTH=1 bats \
+  tests/clean_core.bats tests/clean_apps.bats \
+  tests/clean_system_caches.bats tests/purge.bats \
+  tests/purge_config_paths.bats tests/completion.bats tests/cli.bats
+env -u NO_COLOR MOLE_SKIP_FINDER_TESTS=1 MOLE_TEST_NO_AUTH=1 make verify
+HOME=<temporary-home> MOLE_TEST_NO_AUTH=1 MOLE_TEST_MODE=0 \
+  ./mole clean --dry-run --json
+HOME=<temporary-home> MOLE_TEST_NO_AUTH=1 \
+  ./mole purge --dry-run --json < /dev/null
+./mole analyze --json --limit 10 --compact <large-local-tree>
+git diff --check
+git status --short
+```
+
+- Formatting completed cleanly.
+- All 232 touched-surface Bats tests passed. `NO_COLOR` was removed because two
+  existing tests intentionally assert ANSI-colored glyphs.
+- `make verify` passed ShellCheck, shell syntax, golangci-lint, and all Go
+  packages. Finder-dependent Trash tests used their documented skip flag; this
+  spike does not change deletion behavior.
+- The final temp-HOME clean receipt was one 803-byte JSON line with two
+  candidates and a structured excluded-system warning. A path containing the
+  human preview delimiter round-tripped exactly through the separate
+  NUL-delimited machine stream. The fixture remained.
+- The final temp-HOME purge receipt was one 483-byte JSON line with one
+  validated rebuildable candidate. The fixture remained.
+- The final real analysis completed in 0.49s and emitted 4,215 bytes, returning
+  10 of 69 entries with complete totals for 465,251 files.
+
+Readiness: **implementation-ready as a spike**, confidence **8/10**. The branch
+has clean local proof and real safe CLI evidence. Confidence is below 10
+because only `clean` and `purge` exercise the shared preview shape; a
+pre-authorized system-scope clean was intentionally not run; Finder deletion
+integration was skipped as unrelated and unsafe; and the streaming decision is
+based on one real repository tree rather than a deliberately slow volume.
+
+Recommendation: **narrowly promote**, not broadly standardize yet. Keep the
+analysis bounds and the common clean/purge preview envelope, then review the
+schema before extending it to installer, uninstall, or optimize. Do not add
+run IDs, durable plan storage, status lookup, or apply semantics without a
+separate product decision and safety design.
+
+## Proof caveats
+
+- Two attempts at the broad `go test ./cmd/analyze` suite, including the
+  required `MOLE_TEST_NO_AUTH=1` environment, hit existing 30/60-second Finder
+  Trash timeouts in `TestDeletePathWithProgress`, `TestTrashPathWithProgress`,
+  and `TestDeleteMultiplePathsCmdHandlesParentChild`. These runs are not cited
+  as iteration proof and no expectations were changed. The touched JSON surface
+  was rerun cleanly with a focused test selection.

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -820,6 +820,9 @@ clean_orphaned_system_services() {
                     orphan_size_kb=$(run_with_timeout "$MOLE_TIMEOUT_DISK_VERIFY_SEC" sudo -n du -skP "$orphan_file" 2> /dev/null | awk '{print $1}' || echo "0")
                     [[ -n "$orphan_size_kb" ]] || orphan_size_kb=0
                     echo "$orphan_file  # $(bytes_to_human "$((orphan_size_kb * 1024))")" >> "$EXPORT_LIST_FILE"
+                    if [[ -n "${MOLE_CLEAN_JSON_CANDIDATE_FILE:-}" ]] && command -v record_clean_json_candidate > /dev/null 2>&1; then
+                        record_clean_json_candidate "$orphan_file" "$orphan_size_kb"
+                    fi
                 fi
             else
                 local file_size_kb

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -438,6 +438,9 @@ clean_python_bytecode_cache_group() {
                 local path_size_human
                 path_size_human=$(bytes_to_human "$((path_size_kb * 1024))")
                 echo "${path}  # ${path_size_human}" >> "$EXPORT_LIST_FILE"
+                if [[ -n "${MOLE_CLEAN_JSON_CANDIDATE_FILE:-}" ]] && command -v record_clean_json_candidate > /dev/null 2>&1; then
+                    record_clean_json_candidate "$path" "$path_size_kb"
+                fi
             done
         fi
 

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1676,6 +1676,9 @@ clean_project_artifacts() {
         fi
         local removal_recorded=false
         if [[ -e "$item_path" ]]; then
+            if [[ -n "${MOLE_PURGE_JSON_CANDIDATE_FILE:-}" ]]; then
+                printf '%s\0%s\0' "$size_kb" "$item_path" >> "$MOLE_PURGE_JSON_CANDIDATE_FILE"
+            fi
             if safe_remove "$item_path" true; then
                 if [[ "$dry_run_mode" == "1" || ! -e "$item_path" ]]; then
                     local current_total

--- a/lib/core/help.sh
+++ b/lib/core/help.sh
@@ -7,6 +7,7 @@ show_clean_help() {
     echo ""
     echo "Options:"
     echo "  --dry-run, -n     Preview cleanup without making changes"
+    echo "  --json            Output a machine-readable preview (requires --dry-run)"
     echo "  --external PATH   Clean OS metadata from a mounted external volume"
     echo "  --whitelist       Manage protected paths"
     echo "  --debug           Show detailed operation logs"

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -369,6 +369,53 @@ EOF
     [ -f "$HOME/Library/Caches/TestApp/cache.tmp" ]
 }
 
+@test "mo clean --dry-run --json emits a safe machine preview on stdout" {
+    local cache_path="$HOME/Library/Caches/Test  # App"
+    mkdir -p "$cache_path"
+    printf 'cache data\n' > "$cache_path/cache.tmp"
+
+    local stdout_file="$HOME/clean-preview.json"
+    local stderr_file="$HOME/clean-preview.stderr"
+    env HOME="$HOME" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=1 \
+        "$PROJECT_ROOT/mole" clean --dry-run --json > "$stdout_file" 2> "$stderr_file"
+
+    python3 - "$stdout_file" "$cache_path" <<'PY'
+import json
+import pathlib
+import sys
+
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert data["schema_version"] == 1
+assert data["command"] == "clean"
+assert data["mode"] == "preview"
+assert data["dry_run"] is True
+assert data["apply_supported"] is False
+assert data["summary"]["status"] == "complete"
+assert isinstance(data["candidates"], list)
+assert data["warnings"] == [{
+    "code": "system_scope_excluded",
+    "message": "System-level candidates require a pre-authorized sudo session and were not scanned.",
+}]
+assert any(item["path"] == sys.argv[2] for item in data["candidates"])
+assert all(item["action"] == "remove" for item in data["candidates"])
+assert all(item["safety"] == "eligible_after_runtime_validation" for item in data["candidates"])
+PY
+    [[ "$(wc -l < "$stdout_file")" -eq 1 ]] || return 1
+    [[ "$(cat "$stderr_file")" == *"Dry Run Mode"* ]] || return 1
+    [[ -f "$cache_path/cache.tmp" ]] || return 1
+}
+
+@test "mo clean --json refuses to run without dry-run" {
+    mkdir -p "$HOME/Library/Caches/TestApp"
+    printf 'keep\n' > "$HOME/Library/Caches/TestApp/cache.tmp"
+
+    run env HOME="$HOME" MOLE_TEST_NO_AUTH=1 "$PROJECT_ROOT/mole" clean --json
+
+    [ "$status" -eq 2 ] || return 1
+    [[ "$output" == *"requires --dry-run"* ]] || return 1
+    [[ -f "$HOME/Library/Caches/TestApp/cache.tmp" ]] || return 1
+}
+
 @test "mo clean --dry-run reports stale login item without deleting it" {
     mkdir -p "$HOME/Library/LaunchAgents"
     cat > "$HOME/Library/LaunchAgents/com.example.stale.plist" <<'PLIST'

--- a/tests/completion.bats
+++ b/tests/completion.bats
@@ -89,10 +89,10 @@ setup() {
 @test "completion bash includes current clean, analyze, history, and purge options only" {
 	run "$PROJECT_ROOT/bin/completion.sh" bash
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"--dry-run -n --external --whitelist --debug --help -h"* ]]
-	[[ "$output" == *"--json --help -h"* ]]
+	[[ "$output" == *"--dry-run -n --json --external --whitelist --debug --help -h"* ]]
+	[[ "$output" == *"--json --limit --compact --help -h"* ]]
 	[[ "$output" == *"--json --limit --help -h"* ]]
-	[[ "$output" == *"--paths --dry-run -n --include-empty --debug --help -h"* ]]
+	[[ "$output" == *"--paths --dry-run -n --json --include-empty --debug --help -h"* ]]
 	[[ "$output" != *"--select"* ]]
 	[[ "$output" != *"--categories"* ]]
 	[[ "$output" != *"--exclude-paths"* ]]

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1086,6 +1086,53 @@ EOF
 	[[ "$output" == *"DRY RUN MODE"* ]] || [[ "$output" == *"Dry run complete"* ]]
 }
 
+@test "mo purge --dry-run --json emits rebuildable candidates without removal" {
+	mkdir -p "$HOME/www/agent-spike/build" "$HOME/.config/mole"
+	printf '{}\n' > "$HOME/www/agent-spike/package.json"
+	printf 'rebuildable artifact\n' > "$HOME/www/agent-spike/build/output.bin"
+	touch -t 202001010000 "$HOME/www/agent-spike/build" "$HOME/www/agent-spike/build/output.bin"
+	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"
+
+	local stdout_file="$HOME/purge-preview.json"
+	local stderr_file="$HOME/purge-preview.stderr"
+	env HOME="$HOME" MOLE_TEST_NO_AUTH=1 \
+		"$PROJECT_ROOT/mole" purge --dry-run --json \
+		> "$stdout_file" 2> "$stderr_file" < /dev/null
+
+	python3 - "$stdout_file" "$HOME/www/agent-spike/build" <<'PY'
+import json
+import pathlib
+import sys
+
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert data["schema_version"] == 1
+assert data["command"] == "purge"
+assert data["mode"] == "preview"
+assert data["dry_run"] is True
+assert data["apply_supported"] is False
+assert data["summary"]["status"] == "complete"
+assert data["warnings"] == []
+candidate = next(item for item in data["candidates"] if item["path"] == sys.argv[2])
+assert candidate["action"] == "remove"
+assert candidate["recoverability"] == "rebuild"
+assert candidate["safety"] == "validated_project_artifact"
+PY
+	[[ "$(wc -l < "$stdout_file")" -eq 1 ]] || return 1
+	[[ "$(cat "$stderr_file")" == *"DRY RUN MODE"* ]] || return 1
+	[[ -f "$HOME/www/agent-spike/build/output.bin" ]] || return 1
+}
+
+@test "mo purge --json refuses to run without dry-run" {
+	mkdir -p "$HOME/www/agent-spike/build"
+	printf 'keep\n' > "$HOME/www/agent-spike/build/output.bin"
+
+	run env HOME="$HOME" MOLE_TEST_NO_AUTH=1 "$PROJECT_ROOT/mole" purge --json
+
+	[ "$status" -eq 2 ] || return 1
+	[[ "$output" == *"requires --dry-run"* ]] || return 1
+	[[ -f "$HOME/www/agent-spike/build/output.bin" ]] || return 1
+}
+
 @test "mo purge: accepts --include-empty flag" {
 	if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
 		skip "gtimeout/timeout not available"


### PR DESCRIPTION
## Feedback requested

This is intentionally a draft spike. Let me know if this is the right direction and, especially, whether the proposed machine contract is small enough for Mole.
This is coming from a personal need to having agents clean up local dev environment with build artifacts and other generated data

## What was the problem

Mole already has good read-only JSON surfaces for `analyze`, `status`, and `history`, but agent consumers still hit two practical gaps:

- `analyze --json` always returns the complete indented result, even when an agent only needs the largest few entries.
- destructive commands have safe dry-run behavior, but their preview formats are human-oriented and inconsistent. An agent must scrape terminal prose or, for `clean`, read a separate path-list file.

That makes automated use more verbose and less reliable than the existing safety model deserves.

## Why this is important

Coding agents can generate large, rebuildable artifacts during long sessions. They need to inspect disk usage and preview cleanup without consuming unnecessary context or accidentally turning a formatting option into an authorization path.

A small structured preview contract makes the safety state explicit: whether the command is a dry-run, which scope was scanned, whether candidates are permanent or rebuildable, whether warnings were raised, and whether the result was truncated.

## What is the solution

This spike extends existing commands rather than adding an `mo agent` subsystem:

- `mo analyze --json --limit N [path]` returns the largest `N` top-level entries while preserving complete scan totals and explicit truncation metadata.
- `mo analyze --json --compact [path]` removes optional indentation without changing the decoded document.
- `mo clean --dry-run --json` and `mo purge --dry-run --json` emit a versioned preview receipt on stdout while keeping human diagnostics on stderr.
- Preview receipts include command, mode, scope, summary, warnings, candidates, action, safety classification, and command-specific recoverability.
- `--json` is rejected unless `--dry-run` is also present. Receipts explicitly set `apply_supported: false`.
- Machine candidate records use an internal NUL-delimited stream so unusual whitespace or human preview comment delimiters cannot corrupt paths.
- Shell completions, focused tests, and a durable spike log are included.

The human TUI and existing human-readable output remain unchanged.

## The things we tried and why this is a good initial approach

The spike was developed through five evidence-driven iterations:

1. Added top-N analysis output. On a representative large repository tree, `--limit 10` reduced the response from 14,969 to 5,362 bytes while preserving full totals.
2. Added opt-in compact encoding, reducing the bounded response to 4,215 bytes without changing the decoded JSON.
3. Proved the preview schema first on `clean`, which already had an authoritative dry-run candidate list.
4. Extended the same envelope to `purge`, while retaining its different `rebuild` recoverability semantics and configured-root validation.
5. Added structured safety warnings and deliberately rejected extra machinery that did not earn its complexity.

We considered bounded NDJSON progress streaming, but the observed scans completed in roughly half a second and a final bounded document was simpler. We also considered plan/run IDs, but rejected them because Mole has no durable plan store, status lookup, or apply receipt; an ID would be decorative and could imply authority it does not have.

This seems like a useful initial boundary because it is additive, preview-only, uses existing command concepts, and does not add storage, background state, a new subsystem, or an apply path. The full experiment record and rejected ideas are in `docs/spikes/agent-cli-protocol.md`.

## Safety review

- This changes cleanup and purge preview output only; it does not add or broaden a deletion path.
- JSON preview fails closed unless dry-run is active.
- Purge candidates are recorded only after configured-root safety revalidation.
- Clean and purge fixtures were verified to remain present after real CLI dry-runs.
- No path validation, protected-directory policy, sudo boundary, deletion funnel, or confirmation behavior was weakened.
- No real destructive Mole command was run during development or verification.

## Tests

- `./scripts/check.sh --format`
- 232 touched-surface Bats tests across clean, app cleanup, project caches, purge, completion, and CLI behavior
- `MOLE_SKIP_FINDER_TESTS=1 MOLE_TEST_NO_AUTH=1 make verify`
  - ShellCheck
  - shell syntax
  - golangci-lint
  - all Go packages
- Fresh temporary-HOME `clean --dry-run --json` and `purge --dry-run --json` probes with fixture-preservation checks
- Fresh read-only `analyze --json --limit 10 --compact` probe against a representative large repository tree
- Negative controls proving JSON preview without dry-run exits nonzero without removing fixtures

Finder-dependent Trash integration tests used their documented skip flag because this spike does not change analyze deletion behavior.

## Feedback areas

I would especially appreciate feedback on:

- whether `--limit` and `--compact` fit the existing `analyze` command;
- whether the shared top-level preview fields are named appropriately;
- whether `clean` and `purge` are the right first two preview surfaces;
- whether this should be narrowed further before promotion; and
- whether any part of this belongs in documentation rather than the CLI.
