### PR TITLE
fix(status): collect processes under comma-decimal locales

### DIFF
--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -574,11 +576,29 @@ func (e snapshotEnrichment) apply(snapshot *MetricsSnapshot, preserveLiveProcess
 
 var runCmd = func(ctx context.Context, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = cLocaleEnv()
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 	return string(output), nil
+}
+
+// cLocaleEnv forces the C locale on every metric subprocess. ps and uptime
+// localize their decimal separator, so under ru_RU.UTF-8 they emit "8,0" and
+// every strconv.ParseFloat in the collectors fails (#1267). The shell commands
+// in bin/ already export LC_ALL=C; status-go is exec'd directly and did not.
+func cLocaleEnv() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		key, _, found := strings.Cut(kv, "=")
+		if found && (key == "LC_ALL" || key == "LANG" || strings.HasPrefix(key, "LC_")) {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return append(filtered, "LC_ALL=C")
 }
 
 var commandExists = func(name string) bool {

--- a/cmd/status/metrics_process.go
+++ b/cmd/status/metrics_process.go
@@ -20,20 +20,15 @@ func collectProcesses() ([]ProcessInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	out, err := runPS(ctx, "-Aceo", "pid=,ppid=,pcpu=,pmem=,rss=,comm=", "-r")
+	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,pcpu=,pmem=,rss=,comm=", "-r")
 	if err != nil {
-		out, err = runPS(ctx, "aux")
+		out, err = runCmd(ctx, "ps", "aux")
 		if err != nil {
 			return nil, err
 		}
 		return parsePsAuxOutput(out), nil
 	}
 	return parseProcessOutput(out), nil
-}
-
-func runPS(ctx context.Context, args ...string) (string, error) {
-	// ps localizes percentage columns, but the parser expects dot decimals.
-	return runCmd(ctx, "env", append([]string{"LC_ALL=C", "ps"}, args...)...)
 }
 
 func parseProcessOutput(raw string) []ProcessInfo {

--- a/cmd/status/metrics_process.go
+++ b/cmd/status/metrics_process.go
@@ -20,15 +20,20 @@ func collectProcesses() ([]ProcessInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,pcpu=,pmem=,rss=,comm=", "-r")
+	out, err := runPS(ctx, "-Aceo", "pid=,ppid=,pcpu=,pmem=,rss=,comm=", "-r")
 	if err != nil {
-		out, err = runCmd(ctx, "ps", "aux")
+		out, err = runPS(ctx, "aux")
 		if err != nil {
 			return nil, err
 		}
 		return parsePsAuxOutput(out), nil
 	}
 	return parseProcessOutput(out), nil
+}
+
+func runPS(ctx context.Context, args ...string) (string, error) {
+	// ps localizes percentage columns, but the parser expects dot decimals.
+	return runCmd(ctx, "env", append([]string{"LC_ALL=C", "ps"}, args...)...)
 }
 
 func parseProcessOutput(raw string) []ProcessInfo {

--- a/cmd/status/process_watch_test.go
+++ b/cmd/status/process_watch_test.go
@@ -3,35 +3,44 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"slices"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
 
-func TestRunPSForcesCLocale(t *testing.T) {
-	originalRunCmd := runCmd
-	t.Cleanup(func() {
-		runCmd = originalRunCmd
-	})
+// Guards #1267: ps and uptime emit comma decimals under locales like
+// ru_RU.UTF-8, which made every ParseFloat in the collectors fail.
+func TestRunCmdForcesCLocale(t *testing.T) {
+	t.Setenv("LC_ALL", "ru_RU.UTF-8")
+	t.Setenv("LC_NUMERIC", "ru_RU.UTF-8")
+	t.Setenv("LANG", "ru_RU.UTF-8")
 
-	var gotName string
-	var gotArgs []string
-	runCmd = func(_ context.Context, name string, args ...string) (string, error) {
-		gotName = name
-		gotArgs = slices.Clone(args)
-		return "", nil
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	if _, err := runPS(context.Background(), "aux"); err != nil {
-		t.Fatalf("runPS() error = %v", err)
+	out, err := runCmd(ctx, "sh", "-c", "printf '%s|%s|%s' \"$LC_ALL\" \"$LC_NUMERIC\" \"$LANG\"")
+	if err != nil {
+		t.Fatalf("runCmd() error = %v", err)
 	}
-	if gotName != "env" {
-		t.Fatalf("runPS() command = %q, want env", gotName)
+	if out != "C||" {
+		t.Fatalf("runCmd() subprocess locale = %q, want %q", out, "C||")
 	}
-	wantArgs := []string{"LC_ALL=C", "ps", "aux"}
-	if !slices.Equal(gotArgs, wantArgs) {
-		t.Fatalf("runPS() args = %q, want %q", gotArgs, wantArgs)
+}
+
+func TestCollectProcessesUnderCommaLocale(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("ps output format is darwin-specific")
+	}
+	t.Setenv("LC_ALL", "ru_RU.UTF-8")
+	t.Setenv("LC_NUMERIC", "ru_RU.UTF-8")
+
+	procs, err := collectProcesses()
+	if err != nil {
+		t.Fatalf("collectProcesses() error = %v", err)
+	}
+	if len(procs) == 0 {
+		t.Fatal("collectProcesses() returned no processes under a comma-decimal locale")
 	}
 }
 

--- a/cmd/status/process_watch_test.go
+++ b/cmd/status/process_watch_test.go
@@ -1,11 +1,39 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestRunPSForcesCLocale(t *testing.T) {
+	originalRunCmd := runCmd
+	t.Cleanup(func() {
+		runCmd = originalRunCmd
+	})
+
+	var gotName string
+	var gotArgs []string
+	runCmd = func(_ context.Context, name string, args ...string) (string, error) {
+		gotName = name
+		gotArgs = slices.Clone(args)
+		return "", nil
+	}
+
+	if _, err := runPS(context.Background(), "aux"); err != nil {
+		t.Fatalf("runPS() error = %v", err)
+	}
+	if gotName != "env" {
+		t.Fatalf("runPS() command = %q, want env", gotName)
+	}
+	wantArgs := []string{"LC_ALL=C", "ps", "aux"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Fatalf("runPS() args = %q, want %q", gotArgs, wantArgs)
+	}
+}
 
 func TestParseProcessOutput(t *testing.T) {
 	raw := strings.Join([]string{


### PR DESCRIPTION
## Summary

- Run both process-collection `ps` paths with `LC_ALL=C` so CPU and memory percentages always use dot decimals.
- Add a regression test for the command environment.
- Fixes #1267

Prepared with Codex assistance and reviewed against the repository's safety rules.

## Safety Review

No. This only changes the environment of read-only `ps` collection. It does not affect cleanup, uninstall, optimize, installer, deletion, path validation, authorization, update, or install behavior.

## Tests

- `go test ./...`
- `./scripts/check.sh --no-format`
- Manual locale check. `ru_RU.UTF-8` produced `112,8`; the C locale produced `112.8`.

## Safety-related changes

- None.
