### PR TITLE
feat(clean): JianyingPro (CapCut CN) generated cache cleanup

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -397,8 +397,15 @@ clean_jianying_pro_generated_caches() {
     #   local_models, AigcMaterailCache, agencycache); plaintext draft configs
     #   reference effect 8000+ times, so anything not on this list is preserved.
     #
+    # image/ and importcache3/ are deliberately excluded: both hold copies of
+    # material the user imported, draft_info.json is encrypted so no plaintext
+    # reference check can prove they are unreferenced, and mo clean deletes
+    # permanently. If the user has since moved or deleted the source file, the
+    # cached copy is the only remaining one. Revisit only with evidence that
+    # the editor re-imports from the original on demand.
+    #
     # Verified on a real machine (macOS 15.7 Intel, JianyingPro 11.1.0):
-    # removing this set reclaimed ~76GB, 2025-era projects reopened cleanly, and
+    # removing this set reclaimed ~70GB, 2025-era projects reopened cleanly, and
     # the app recreated the scratch directories on next launch.
     local -a regenerable_subdirs=(
         recognize
@@ -406,12 +413,10 @@ clean_jianying_pro_generated_caches() {
         audioWave
         AlgorithmCache
         ILASDKDB
-        image
         RemuxCache
         prerender
         segmentPrerenderCache
         MotionBlurCache
-        importcache3
         ttsTemp
         tmp
     )

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -359,6 +359,77 @@ clean_final_cut_pro_generated_caches() {
     safe_clean "${fcp_cache_targets[@]}" "Final Cut Pro generated cache"
 }
 
+jianying_pro_is_running() {
+    command -v pgrep > /dev/null 2>&1 || return 1
+
+    # Match the main editor process only. Narrow the -f pattern to the primary
+    # executable path so the always-resident menu-bar agent
+    # (.../Frameworks/VideoFusion-macOSTrayHelper.app/.../VideoFusion-macOSTrayHelper)
+    # does not read as "editor running" and permanently skip cleanup.
+    pgrep -x "VideoFusion-macOS" > /dev/null 2>&1 && return 0
+    pgrep -f "/VideoFusion-macOS.app/Contents/MacOS/VideoFusion-macOS" > /dev/null 2>&1 && return 0
+    return 1
+}
+
+clean_jianying_pro_generated_caches() {
+    local cache_root="$HOME/Movies/JianyingPro/User Data/Cache"
+    [[ -d "$cache_root" && ! -L "$cache_root" ]] || return 0
+
+    if jianying_pro_is_running; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} JianyingPro generated caches · skipped (JianyingPro running)"
+        note_activity
+        return 0
+    fi
+
+    # JianyingPro (剪映专业版 / CapCut CN, com.lemon.lvpro) generated cache
+    # cleanup (issue #1277). Same shape as Final Cut Pro (#843): the editor
+    # keeps heavy generated caches under ~/Movies/JianyingPro/User Data/Cache/
+    # instead of ~/Library/Caches, so standard cleanup never reaches them.
+    #
+    # Safety scope for the first pass:
+    # - only the default cache root under ~/Movies; never User Data/Projects
+    #   (the user's editable drafts) or any sibling of Cache;
+    # - only remove an explicit whitelist of regenerable subdirectories:
+    #   subtitle-recognition PCM scratch, frame thumbnails, audio waveforms,
+    #   algorithm scratch, and prerender/remux temp;
+    # - never touch draft-referenced or downloaded assets (effect,
+    #   onlineMaterial, artistEffect, music, AITextTemplate, template,
+    #   local_models, AigcMaterailCache, agencycache); plaintext draft configs
+    #   reference effect 8000+ times, so anything not on this list is preserved.
+    #
+    # Verified on a real machine (macOS 15.7 Intel, JianyingPro 11.1.0):
+    # removing this set reclaimed ~76GB, 2025-era projects reopened cleanly, and
+    # the app recreated the scratch directories on next launch.
+    local -a regenerable_subdirs=(
+        recognize
+        frameThumbnail
+        audioWave
+        AlgorithmCache
+        ILASDKDB
+        image
+        RemuxCache
+        prerender
+        segmentPrerenderCache
+        MotionBlurCache
+        importcache3
+        ttsTemp
+        tmp
+    )
+
+    local -a targets=()
+    local subdir path
+    for subdir in "${regenerable_subdirs[@]}"; do
+        path="$cache_root/$subdir"
+        if [[ -d "$path" && ! -L "$path" ]]; then
+            targets+=("$path")
+        fi
+    done
+
+    [[ ${#targets[@]} -gt 0 ]] || return 0
+
+    safe_clean "${targets[@]}" "JianyingPro generated cache"
+}
+
 clean_video_tools() {
     safe_clean ~/Library/Caches/net.telestream.screenflow10/* "ScreenFlow cache"
     safe_clean ~/Library/Caches/com.apple.FinalCut/* "Final Cut Pro cache"
@@ -366,6 +437,7 @@ clean_video_tools() {
     safe_clean ~/Library/Caches/com.blackmagic-design.DaVinciResolve/* "DaVinci Resolve cache"
     safe_clean ~/Movies/CacheClip/* "DaVinci Resolve CacheClip"
     safe_clean ~/Library/Caches/com.adobe.PremierePro.*/* "Premiere Pro cache"
+    clean_jianying_pro_generated_caches
 }
 # 3D and CAD tools.
 clean_3d_tools() {

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -172,6 +172,138 @@ EOF
     [[ "$output" != *"unexpected safe_clean"* ]]
 }
 
+@test "clean_jianying_pro_generated_caches targets only whitelisted regenerable subdirs" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+cache_root="$HOME/Movies/JianyingPro/User Data/Cache"
+# Regenerable (should be cleaned)
+mkdir -p "$cache_root/recognize"
+mkdir -p "$cache_root/frameThumbnail"
+mkdir -p "$cache_root/audioWave"
+mkdir -p "$cache_root/AlgorithmCache"
+# Draft-referenced / downloaded assets (must be preserved)
+mkdir -p "$cache_root/effect"
+mkdir -p "$cache_root/music"
+mkdir -p "$cache_root/AigcMaterailCache"
+mkdir -p "$cache_root/agencycache"
+# The user's editable drafts (must never be touched)
+mkdir -p "$HOME/Movies/JianyingPro/User Data/Projects/com.lveditor.draft/my-project"
+
+pgrep() { return 1; }
+safe_clean() {
+    local arg
+    for arg in "$@"; do
+        printf 'CLEAN:%s\n' "$arg"
+    done
+}
+
+clean_jianying_pro_generated_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CLEAN:$HOME/Movies/JianyingPro/User Data/Cache/recognize"* ]] || return 1
+    [[ "$output" == *"CLEAN:$HOME/Movies/JianyingPro/User Data/Cache/frameThumbnail"* ]] || return 1
+    [[ "$output" == *"CLEAN:$HOME/Movies/JianyingPro/User Data/Cache/audioWave"* ]] || return 1
+    [[ "$output" == *"CLEAN:$HOME/Movies/JianyingPro/User Data/Cache/AlgorithmCache"* ]] || return 1
+    [[ "$output" == *"CLEAN:JianyingPro generated cache"* ]] || return 1
+    [[ "$output" != *"Cache/effect"* ]] || return 1
+    [[ "$output" != *"Cache/music"* ]] || return 1
+    [[ "$output" != *"AigcMaterailCache"* ]] || return 1
+    [[ "$output" != *"agencycache"* ]] || return 1
+    [[ "$output" != *"Projects"* ]] || return 1
+}
+
+@test "jianying_pro_is_running ignores the resident menu-bar tray helper" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+# Faithful pgrep mock for a process table that contains ONLY the always-on
+# tray helper: -x compares the pattern against the process name exactly,
+# and -f substring-matches the pattern against the command line, like real
+# pgrep does.
+helper_name="VideoFusion-macOSTrayHelper"
+helper_cmdline="/Applications/VideoFusion-macOS.app/Contents/Frameworks/VideoFusion-macOSTrayHelper.app/Contents/MacOS/VideoFusion-macOSTrayHelper"
+pgrep() {
+    local mode="$1"
+    local pattern="${!#}"
+    if [[ "$mode" == "-x" ]]; then
+        [[ "$helper_name" == "$pattern" ]] && return 0
+        return 1
+    fi
+    case "$helper_cmdline" in
+        *"$pattern"*) return 0 ;;
+    esac
+    return 1
+}
+
+# Mock fidelity check: the historical broad probe DOES match the helper's
+# command line. Without this, a lazy mock would pass even if the production
+# probe were widened back to "/VideoFusion-macOS.app/".
+if pgrep -f "/VideoFusion-macOS.app/" > /dev/null 2>&1; then
+    echo "MOCK-FAITHFUL: broad pattern matches helper"
+fi
+
+if jianying_pro_is_running; then
+    echo "WRONG: reported running"
+else
+    echo "OK: not running"
+fi
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"MOCK-FAITHFUL: broad pattern matches helper"* ]] || return 1
+    [[ "$output" == *"OK: not running"* ]] || return 1
+    [[ "$output" != *"WRONG"* ]] || return 1
+}
+
+@test "clean_jianying_pro_generated_caches skips while JianyingPro is running" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+mkdir -p "$HOME/Movies/JianyingPro/User Data/Cache/recognize"
+pgrep() { return 0; }
+safe_clean() {
+    echo "unexpected safe_clean"
+    return 1
+}
+
+clean_jianying_pro_generated_caches
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"JianyingPro generated caches · skipped (JianyingPro running)"* ]] || return 1
+    [[ "$output" != *"unexpected safe_clean"* ]] || return 1
+}
+
+@test "clean_jianying_pro_generated_caches is a no-op when cache root is absent" {
+    local empty_home
+    empty_home="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-app-caches.XXXXXX")"
+    run env HOME="$empty_home" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+pgrep() { return 1; }
+safe_clean() {
+    echo "unexpected safe_clean"
+    return 1
+}
+
+clean_jianying_pro_generated_caches
+EOF
+    rm -rf "$empty_home"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"unexpected safe_clean"* ]] || return 1
+}
+
 @test "is_final_cut_pro_generated_cache_target rejects protected sibling paths" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -173,7 +173,7 @@ EOF
 }
 
 @test "clean_jianying_pro_generated_caches targets only whitelisted regenerable subdirs" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
@@ -189,6 +189,9 @@ mkdir -p "$cache_root/effect"
 mkdir -p "$cache_root/music"
 mkdir -p "$cache_root/AigcMaterailCache"
 mkdir -p "$cache_root/agencycache"
+# Copies of user-imported material (must be preserved, see the exclusion note)
+mkdir -p "$cache_root/image"
+mkdir -p "$cache_root/importcache3"
 # The user's editable drafts (must never be touched)
 mkdir -p "$HOME/Movies/JianyingPro/User Data/Projects/com.lveditor.draft/my-project"
 
@@ -211,13 +214,15 @@ EOF
     [[ "$output" == *"CLEAN:JianyingPro generated cache"* ]] || return 1
     [[ "$output" != *"Cache/effect"* ]] || return 1
     [[ "$output" != *"Cache/music"* ]] || return 1
+    [[ "$output" != *"Cache/image"* ]] || return 1
+    [[ "$output" != *"importcache3"* ]] || return 1
     [[ "$output" != *"AigcMaterailCache"* ]] || return 1
     [[ "$output" != *"agencycache"* ]] || return 1
     [[ "$output" != *"Projects"* ]] || return 1
 }
 
 @test "jianying_pro_is_running ignores the resident menu-bar tray helper" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
@@ -262,7 +267,7 @@ EOF
 }
 
 @test "clean_jianying_pro_generated_caches skips while JianyingPro is running" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
@@ -285,7 +290,7 @@ EOF
 @test "clean_jianying_pro_generated_caches is a no-op when cache root is absent" {
     local empty_home
     empty_home="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-app-caches.XXXXXX")"
-    run env HOME="$empty_home" PROJECT_ROOT="$PROJECT_ROOT" bash --noprofile --norc << 'EOF'
+    run env HOME="$empty_home" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"


### PR DESCRIPTION
## Summary

- Adds `clean_jianying_pro_generated_caches()` to `mo clean`, covering JianyingPro (剪映专业版 / CapCut CN, `com.lemon.lvpro`), which stores heavy generated caches under `~/Movies/JianyingPro/User Data/Cache/` instead of `~/Library/Caches` — the same problem class as Final Cut Pro (#843).
- Field data (issue #1277): on a real machine this cache reached **83 GB** (vs. 37 GB of actual drafts), dominated by 54 GB of uncompressed subtitle-recognition PCM scratch that the editor never cleans up after use.
- Implements the conservative pattern from `clean_final_cut_pro_generated_caches`, registered in `clean_video_tools()`.

Closes #1277.

## Safety Review

- Affects cleanup behavior (new `mo clean` target). Boundaries, chosen to be strictly narrower than the FCP precedent:
  - **Fixed default root only**: `~/Movies/JianyingPro/User Data/Cache`; no `find` recursion, no globbing outside the root; symlinked root/subdirs are rejected (`-d && ! -L`).
  - **Explicit whitelist of regenerable subdirs only** (recognize / frameThumbnail / audioWave / AlgorithmCache / ILASDKDB / image / prerender & remux temp). Anything not on the list is preserved by construction — including draft-referenced or downloaded assets (`effect` — referenced 8,000+ times by plaintext draft configs — `onlineMaterial`, `artistEffect`, `music`, `AITextTemplate`, `template`, `local_models`, `AigcMaterailCache`, `agencycache`).
  - **Never touches `User Data/Projects`** (user drafts) or any sibling of `Cache`.
  - **Skips while the editor is running.** The running check is narrowed to the main executable path because JianyingPro ships an always-resident menu-bar agent (`VideoFusion-macOSTrayHelper`) inside the app bundle; a broad `-f "/VideoFusion-macOS.app/"` match would read the helper as "editor running" and permanently skip cleanup (caught during on-machine verification, covered by a regression test).
  - All deletions route through `safe_clean` (whitelist honor, protected-path checks, dry-run, op-log).
- On-machine verification (macOS 15.7 Intel, JianyingPro 11.1.0): removing the whitelist set reclaimed ~76 GB; projects from 2025-03 reopened cleanly; the app recreated scratch dirs on next launch. `should_protect_path` / `validate_path_for_deletion` both pass for the new targets.

## Tests

- `MOLE_TEST_NO_AUTH=1 bats tests/clean_app_caches.bats` — 46/46 pass, including 4 new tests:
  - whitelist targets cleaned; excluded assets (`effect`, `music`, `AigcMaterailCache`, `agencycache`) and `Projects` never referenced
  - tray-helper-only process table does not read as "running" (regression for the narrowed pgrep)
  - skips while the editor is running
  - no-op when the cache root is absent
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_core.bats tests/clean_apps.bats` — pass (66/66 on clean_apps).
- `./scripts/check.sh --format` clean; `shellcheck -x lib/clean/app_caches.sh` clean; `bash -n` across `bin lib` clean.
- Manual: sourced the function against the real cache with a print-only `safe_clean` stub — emits exactly the whitelisted existing subdirs, nothing else.

## Safety-related changes

- New cleanup target as described above; strictly whitelist-based, no recursive discovery, no new sudo/osascript/launchctl usage.
