### PR TITLE
fix(core): guard empty files_to_clean expansion in app_protection.sh

### DIFF
--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -1045,12 +1045,14 @@ find_app_files() {
             while IFS= read -r -d '' derived_path; do
                 mole_name_has_bundle_id_boundary "$derived_path" "$bundle_id" || continue
                 already_added=false
-                for existing_path in "${files_to_clean[@]}"; do
-                    if [[ "$existing_path" == "$derived_path" ]]; then
-                        already_added=true
-                        break
-                    fi
-                done
+                if [[ ${#files_to_clean[@]} -gt 0 ]]; then
+                    for existing_path in "${files_to_clean[@]}"; do
+                        if [[ "$existing_path" == "$derived_path" ]]; then
+                            already_added=true
+                            break
+                        fi
+                    done
+                fi
                 [[ "$already_added" == "true" ]] || files_to_clean+=("$derived_path")
             done < <(command find "$derived_root" -maxdepth 1 -type d -print0 2> /dev/null)
         done

--- a/tests/uninstall_naming_variants.bats
+++ b/tests/uninstall_naming_variants.bats
@@ -140,6 +140,22 @@ setup() {
     [[ ! "$result" =~ Library/Containers/com.tencent.otherapp.Helper ]]
 }
 
+@test "find_app_files handles the first derived bundle match under bash 3.2 set -u" {
+    mkdir -p "$HOME/Library/Containers/com.example.Widget.Helper"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/base.sh"
+source "$PROJECT_ROOT/lib/core/log.sh"
+source "$PROJECT_ROOT/lib/core/app_protection.sh"
+find_app_files "com.example.Widget" "Widget"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"Library/Containers/com.example.Widget.Helper"* ]] || return 1
+    [[ "$output" != *"unbound variable"* ]]
+}
+
 @test "find_app_files detects vendor-nested Application Support directories" {
     mkdir -p "$HOME/Library/Application Support/Avid/Sibelius"
     mkdir -p "$HOME/Library/Application Support/OtherVendor/Sibelius"


### PR DESCRIPTION
## Summary

- Guard `"${files_to_clean[@]}"` expansion with `${#files_to_clean[@]} -gt 0` check in `find_app_files` dedup loop (`lib/core/app_protection.sh` line 1048)
- On macOS built-in Bash 3.2 + `set -u`, expanding an empty array is fatal ("unbound variable"), causing `mo uninstall` to hang during file scan
- Uses the same guard pattern established in #792 / #867

Closes #1127

## Test plan

- [x] `bash -n lib/core/app_protection.sh` passes
- [x] `./scripts/check.sh --format` passes
- [x] `MOLE_TEST_NO_AUTH=1 bats tests/uninstall_safety.bats tests/uninstall_scan_bash32.bats` — 25/25 pass
- [ ] `mo uninstall` with an app that has no leftover files no longer triggers unbound variable error