### PR TITLE
fix(installer): keep incomplete-cleanup summary reachable under errexit

### DIFF
--- a/bin/installer.sh
+++ b/bin/installer.sh
@@ -834,8 +834,11 @@ main() {
     fi
 
     hide_cursor
-    perform_installers
-    local exit_code=$?
+    # Capture the status without tripping errexit: a bare call under set -e
+    # would exit the script before the case handler below could report
+    # incomplete cleanup.
+    local exit_code=0
+    perform_installers || exit_code=$?
     show_cursor
 
     case $exit_code in

--- a/tests/installer.bats
+++ b/tests/installer.bats
@@ -438,3 +438,41 @@ setup() {
 	[[ "$output" == *"rc=1"* ]] || return 1
 	[[ "$output" == *"removed=yes"* ]]
 }
+
+@test "main reports incomplete cleanup under errexit" {
+	local removable="$HOME/Downloads/ErrexitGood.dmg"
+	printf 'good' > "$removable"
+
+	# Production runs installer.sh with set -euo pipefail active, so main must
+	# not let a nonzero perform_installers status trip errexit before the
+	# incomplete-cleanup summary is printed.
+	# shellcheck disable=SC2016
+	run env HOME="$HOME" TERM="$TERM" /bin/bash -euo pipefail -c '
+        export MOLE_TEST_MODE=1
+        export MOLE_TEST_NO_AUTH=1
+        export MOLE_DELETE_LOG="$HOME/deletions.log"
+        source "$1"
+        test_removable="$2"
+
+        collect_installers() {
+            local system_size
+            system_size=$(get_file_size "/System")
+            INSTALLER_PATHS=("$test_removable" "/System")
+            INSTALLER_SIZES=(4 "$system_size")
+            DISPLAY_NAMES=("ErrexitGood.dmg" "System")
+            return 0
+        }
+
+        show_installer_menu() {
+            MOLE_SELECTION_RESULT="0,1"
+            return 0
+        }
+
+        main < <(printf "\n")
+    ' bash "$PROJECT_ROOT/bin/installer.sh" "$removable"
+
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"Installer cleanup incomplete"* ]] || return 1
+	[[ "$output" == *"Failed to remove"* ]] || return 1
+	[[ ! -e "$removable" ]]
+}


### PR DESCRIPTION
## Summary

- `bin/installer.sh` runs under `set -euo pipefail`, and `main()` called `perform_installers` bare before capturing `$?`. Any nonzero return — most commonly `INSTALLER_EXIT_INCOMPLETE` (3), when the selection includes files that path validation refuses to delete — aborted the script at that line with raw exit 3.
- The `case $exit_code` handler below was therefore unreachable for every nonzero status: the "Installer cleanup incomplete / Failed to remove N installers" summary added in #990 never rendered, and the terminal showed nothing after the confirmation — just an unexplained failed command. The cancel path was affected too: quitting the menu exited 1 instead of the designed 0.
- Capture the status with `perform_installers || exit_code=$?`, the same idiom `delete_selected_installers` already uses, so incomplete cleanup prints its report and exits 1 as designed. This follows the Pipefail Safety guidance in CONTRIBUTING.md.
- Add a regression test that invokes `main()` with errexit active, matching production invocation.

Observed on a real run: 46 installers selected, 41 removed, 5 rejected by app protection — the deletion audit log recorded everything, but the terminal output stopped after the file list and the command exited 3.

## Reproduction

The failure branch only triggers when a selected file is refused at delete time. Deletion normally succeeds for every selected file, which is why this path is rarely exercised. The easiest organic trigger is an installer whose filename matches the proxy-tool protection patterns in `lib/core/app_protection_data.sh`: the scan lists it as a candidate, then `validate_path_for_deletion` refuses it at delete time.

```bash
dd if=/dev/zero of=~/Downloads/ClashX-repro.dmg bs=1k count=4
mo installer --dry-run   # select it, Enter, then Enter to confirm
```

Without this fix: output stops after the "Files to be removed:" list, no summary, exit code 3. With this fix: "Dry run complete / Failed to remove 1 installer (delete failed)", exit code 1.

The new bats test reproduces the same shape hermetically by planning `/System` as a protected entry, so CI does not depend on any local files.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
  - Installer reporting only. Deletion routing, plan validation, and protection checks are unchanged; the fix only captures the status of `perform_installers` without tripping errexit so the existing summary and exit-code handler can run.
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
  - No.

## Tests

- `MOLE_TEST_NO_AUTH=1 bats tests/installer.bats tests/installer_fd.bats tests/installer_zip.bats` — 42/42, including the new regression test, which fails against `main` without this fix
- `./scripts/check.sh` — shfmt, shellcheck, and syntax checks pass
- Manual: scripted-PTY run of `./mole installer --dry-run` with a selection containing protected installers. Before: exit 3, no output after the file list. After: full summary ("Failed to remove 10 installers" with per-file reasons), exit 1. Cancelling the menu now exits 0 instead of 1.

## Safety-related changes

- None.
