### PR TITLE
feat(status): add a GPU section (utilization, power, cores)

### DIFF
--- a/cmd/status/gpu_power_darwin.go
+++ b/cmd/status/gpu_power_darwin.go
@@ -1,0 +1,107 @@
+//go:build darwin && cgo
+
+package main
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -lIOReport
+#include <CoreFoundation/CoreFoundation.h>
+#include <string.h>
+#include <time.h>
+#include <stdint.h>
+
+// Private IOReport API — no public header, symbols live in /usr/lib/libIOReport.dylib.
+// This is how tools like macmon read power without root; it is undocumented and
+// may change between macOS releases, which is why the reader fails soft (-1).
+typedef struct __IOReportSubscription* IOReportSubscriptionRef;
+typedef CFDictionaryRef IOReportSampleRef;
+
+extern CFMutableDictionaryRef IOReportCopyChannelsInGroup(CFStringRef group, CFStringRef subgroup, uint64_t a, uint64_t b, uint64_t c);
+extern IOReportSubscriptionRef IOReportCreateSubscription(void* a, CFMutableDictionaryRef channels, CFMutableDictionaryRef* subbed, uint64_t d, CFTypeRef e);
+extern CFDictionaryRef IOReportCreateSamples(IOReportSubscriptionRef sub, CFMutableDictionaryRef channels, CFTypeRef a);
+extern CFDictionaryRef IOReportCreateSamplesDelta(CFDictionaryRef prev, CFDictionaryRef cur, CFTypeRef a);
+extern void IOReportIterate(CFDictionaryRef samples, int(^cb)(IOReportSampleRef ch));
+extern CFStringRef IOReportChannelGetGroup(IOReportSampleRef ch);
+extern CFStringRef IOReportChannelGetChannelName(IOReportSampleRef ch);
+extern CFStringRef IOReportChannelGetUnitLabel(IOReportSampleRef ch);
+extern int64_t IOReportSimpleGetIntegerValue(IOReportSampleRef ch, int index);
+
+static int cfstr(CFStringRef s, char* buf, int n) {
+    if (!s) { buf[0] = 0; return 0; }
+    return CFStringGetCString(s, buf, n, kCFStringEncodingUTF8);
+}
+
+// mole_read_gpu_power_watts returns average GPU power in watts over `interval`
+// seconds, or -1 on failure. It reads the "Energy Model" IOReport group, takes
+// two samples, and divides the GPU energy delta by the elapsed time. No root.
+static double mole_read_gpu_power_watts(double interval) {
+    CFMutableDictionaryRef channels = IOReportCopyChannelsInGroup(CFSTR("Energy Model"), NULL, 0, 0, 0);
+    if (!channels) return -1;
+
+    CFMutableDictionaryRef subbed = NULL;
+    IOReportSubscriptionRef sub = IOReportCreateSubscription(NULL, channels, &subbed, 0, NULL);
+    if (!sub) { CFRelease(channels); return -1; }
+
+    CFDictionaryRef s1 = IOReportCreateSamples(sub, subbed, NULL);
+
+    struct timespec ts;
+    ts.tv_sec = (time_t)interval;
+    ts.tv_nsec = (long)((interval - (double)ts.tv_sec) * 1e9);
+    nanosleep(&ts, NULL);
+
+    CFDictionaryRef s2 = IOReportCreateSamples(sub, subbed, NULL);
+
+    // The private API returns NULL on some machines / macOS versions. Delta needs
+    // both samples, and IOReportIterate dereferences its argument, so guard both:
+    // a missing sample or delta means "unavailable", which the reader reports as -1.
+    CFDictionaryRef delta = NULL;
+    if (s1 && s2) delta = IOReportCreateSamplesDelta(s1, s2, NULL);
+
+    __block double joules = -1;
+    if (delta) IOReportIterate(delta, ^int(IOReportSampleRef ch) {
+        char grp[128], name[128], unit[32];
+        cfstr(IOReportChannelGetGroup(ch), grp, sizeof(grp));
+        cfstr(IOReportChannelGetChannelName(ch), name, sizeof(name));
+        // Match the "GPU Energy" aggregate exactly, not any name containing "GPU".
+        // The Energy Model group also carries per-rail channels (GPU0, GPU SRAM0,
+        // ...) that read 0 mJ; a substring match with no break let whichever GPU
+        // channel iterated last win, so a reordered iteration could silently pin
+        // the reading to a 0-value rail. "GPU Energy" (nJ) is the whole-device
+        // total macmon/asitop read.
+        if (strcmp(grp, "Energy Model") == 0 && strcmp(name, "GPU Energy") == 0) {
+            int64_t v = IOReportSimpleGetIntegerValue(ch, 0);
+            cfstr(IOReportChannelGetUnitLabel(ch), unit, sizeof(unit));
+            double scale = 1e-3; // assume mJ if the unit label is unrecognised
+            if (strstr(unit, "nJ")) scale = 1e-9;
+            else if (strstr(unit, "uJ") || strstr(unit, "\xc2\xb5J")) scale = 1e-6;
+            else if (strstr(unit, "mJ")) scale = 1e-3;
+            else if (strstr(unit, "J")) scale = 1.0;
+            joules = (double)v * scale;
+        }
+        return 0;
+    });
+
+    if (s1) CFRelease(s1);
+    if (s2) CFRelease(s2);
+    if (delta) CFRelease(delta);
+    // subbed (the subscribed-channels dict) and sub (the subscription itself) are
+    // created every call; without releasing them each sample leaks a CF dict and a
+    // kernel-backed IOReport subscription. Sampling every ~2s, that accumulation is
+    // what eventually stalls the status TUI. Release sub before channels since the
+    // subscription references the channel set.
+    if (subbed) CFRelease(subbed);
+    if (sub) CFRelease((CFTypeRef)sub);
+    if (channels) CFRelease(channels);
+
+    if (joules < 0) return -1;
+    return joules / interval;
+}
+*/
+import "C"
+
+import "time"
+
+// readGPUPowerWatts samples GPU power over the given window via IOReport. It
+// blocks for roughly `window` and returns -1 when the figure is unavailable.
+func readGPUPowerWatts(window time.Duration) float64 {
+	return float64(C.mole_read_gpu_power_watts(C.double(window.Seconds())))
+}

--- a/cmd/status/gpu_power_stub.go
+++ b/cmd/status/gpu_power_stub.go
@@ -1,0 +1,12 @@
+//go:build !darwin || !cgo
+
+package main
+
+import "time"
+
+// readGPUPowerWatts is unavailable off Apple Silicon (or when cgo is disabled):
+// GPU power comes from the private IOReport framework, which only exists on
+// macOS and needs cgo. The status card hides the row when this returns -1.
+func readGPUPowerWatts(window time.Duration) float64 {
+	return -1
+}

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -17,6 +17,9 @@ const (
 	refreshInterval      = time.Second
 	processWatchInterval = refreshInterval
 	slowRefreshInterval  = 30 * time.Second
+	// gpuRefreshInterval drives a dedicated GPU sample so the sparkline stays
+	// lively (~2s) without adding a subprocess to the 1s no-command fast path.
+	gpuRefreshInterval = 2 * time.Second
 )
 
 var (
@@ -47,6 +50,13 @@ func shouldUseJSONOutput(forceJSON bool, stdout *os.File) bool {
 
 type tickMsg struct{}
 type animTickMsg struct{}
+type gpuTickMsg struct{}
+
+// gpuResultMsg carries a lightweight GPU-only sample from the dedicated GPU tick.
+type gpuResultMsg struct {
+	gpu     []GPUStatus
+	history GPUHistory
+}
 
 type collectionMode int
 
@@ -122,7 +132,7 @@ func validateFlags() error {
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(tickAfter(0), animTick())
+	return tea.Batch(tickAfter(0), animTick(), gpuTick())
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -164,6 +174,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.errMessage = ""
 		}
+		// The dedicated GPU tick owns the GPU section once it has data; keep it
+		// across full/fast snapshots so it doesn't flicker to a stale value.
+		if len(m.metrics.GPU) > 0 {
+			msg.data.GPU = m.metrics.GPU
+			msg.data.GPUHistory = m.metrics.GPUHistory
+		}
 		m.metrics = msg.data
 		m.lastUpdated = msg.data.CollectedAt
 		if msg.err == nil {
@@ -182,6 +198,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case animTickMsg:
 		m.animFrame++
 		return m, animTickWithSpeed(m.metrics.CPU.Usage)
+	case gpuTickMsg:
+		// Sample the GPU on its own cadence and schedule the next tick.
+		return m, tea.Batch(m.sampleGPUCmd(), gpuTick())
+	case gpuResultMsg:
+		if len(msg.gpu) > 0 {
+			m.metrics.GPU = msg.gpu
+			m.metrics.GPUHistory = msg.history
+		}
+		return m, nil
 	}
 	return m, nil
 }
@@ -297,6 +322,20 @@ func tickAfter(delay time.Duration) tea.Cmd {
 
 func animTick() tea.Cmd {
 	return tea.Tick(200*time.Millisecond, func(time.Time) tea.Msg { return animTickMsg{} })
+}
+
+func gpuTick() tea.Cmd {
+	return tea.Tick(gpuRefreshInterval, func(time.Time) tea.Msg { return gpuTickMsg{} })
+}
+
+// sampleGPUCmd performs a lightweight GPU-only sample off the main collection
+// path (its own cadence), returning fresh usage plus the updated history.
+func (m model) sampleGPUCmd() tea.Cmd {
+	return func() tea.Msg {
+		now := time.Now()
+		gpu, _ := m.collector.collectGPU(now)
+		return gpuResultMsg{gpu: gpu, history: m.collector.gpuHistorySnapshot()}
+	}
 }
 
 func animTickWithSpeed(cpuUsage float64) tea.Cmd {

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -76,6 +76,7 @@ type model struct {
 	animFrame     int
 	catHidden     bool // true = hidden, false = visible
 	cpuCores      int  // how many CPU cores to list; 0 = all
+	gpuDetail     int  // GPU utilization rows to show: 1=Device, 2=+Renderer, 3=+Tiler
 }
 
 // padViewToHeight ensures the rendered frame always overwrites the full
@@ -98,6 +99,7 @@ func newModel() model {
 		collector: NewCollector(processWatchOptionsFromFlags()),
 		catHidden: loadCatHidden(),
 		cpuCores:  loadCPUCores(),
+		gpuDetail: loadGPUDetail(),
 	}
 }
 
@@ -138,6 +140,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Cycle how many CPU cores the card lists (2 → 4 → 8 → all) and persist.
 			m.cpuCores = nextCPUCores(m.cpuCores)
 			saveCPUCores(m.cpuCores)
+			return m, nil
+		case "g":
+			// Cycle GPU detail (Device → +Renderer → +Tiler) and persist.
+			m.gpuDetail = nextGPUDetail(m.gpuDetail)
+			saveGPUDetail(m.gpuDetail)
 			return m, nil
 		}
 	case tea.WindowSizeMsg:
@@ -199,7 +206,7 @@ func (m model) View() string {
 			if cardWidth > 2 {
 				cardWidth -= 2
 			}
-			cards := buildCards(m.metrics, cardWidth, cpuCores)
+			cards := buildCards(m.metrics, cardWidth, cpuCores, m.gpuDetail)
 
 			var rendered []string
 			for i, c := range cards {
@@ -211,7 +218,7 @@ func (m model) View() string {
 			cardContent = lipgloss.JoinVertical(lipgloss.Left, rendered...)
 		} else {
 			cardWidth := max(24, termWidth/2-4)
-			cards := buildCards(m.metrics, cardWidth, cpuCores)
+			cards := buildCards(m.metrics, cardWidth, cpuCores, m.gpuDetail)
 			cardContent = renderTwoColumns(cards, termWidth)
 		}
 

--- a/cmd/status/main_test.go
+++ b/cmd/status/main_test.go
@@ -408,6 +408,7 @@ func TestMetricsSnapshotFieldsHaveCollectionClassifications(t *testing.T) {
 		"HealthScoreMsg": "recomputed",
 		"CPU":            "mixed",
 		"GPU":            "enrichment",
+		"GPUHistory":     "fast",
 		"Memory":         "mixed",
 		"Disks":          "enrichment",
 		"TrashSize":      "enrichment",

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -72,6 +72,7 @@ type MetricsSnapshot struct {
 
 	CPU            CPUStatus          `json:"cpu"`
 	GPU            []GPUStatus        `json:"gpu"`
+	GPUHistory     GPUHistory         `json:"gpu_history"`
 	Memory         MemoryStatus       `json:"memory"`
 	Disks          []DiskStatus       `json:"disks"`
 	TrashSize      uint64             `json:"trash_size"`
@@ -174,6 +175,15 @@ type NetworkHistory struct {
 
 const NetworkHistorySize = 120 // Increased history size for wider graph
 
+// GPUHistory holds the recent GPU utilization samples used to draw sparklines.
+type GPUHistory struct {
+	DeviceHistory   []float64 `json:"device_history"`
+	RendererHistory []float64 `json:"renderer_history"`
+	TilerHistory    []float64 `json:"tiler_history"`
+}
+
+const GPUHistorySize = 120
+
 type ProxyStatus struct {
 	Enabled bool   `json:"enabled"`
 	Type    string `json:"type"` // HTTP, HTTPS, SOCKS, PAC, WPAD, TUN
@@ -228,6 +238,14 @@ type Collector struct {
 	lastNetAt      time.Time
 	rxHistoryBuf   *RingBuffer
 	txHistoryBuf   *RingBuffer
+
+	// gpuMu guards all GPU collector state (cached info, usage cache, history
+	// buffers) because a dedicated GPU tick samples concurrently with the main
+	// collection goroutines.
+	gpuMu              sync.Mutex
+	gpuDeviceHistBuf   *RingBuffer
+	gpuRendererHistBuf *RingBuffer
+	gpuTilerHistBuf    *RingBuffer
 	lastNetIPAt    time.Time
 	cachedNetIPs   map[string]string
 	lastGPUAt      time.Time
@@ -289,6 +307,10 @@ func NewCollector(options ProcessWatchOptions) *Collector {
 		prevNet:        make(map[string]net.IOCountersStat),
 		rxHistoryBuf:   NewRingBuffer(NetworkHistorySize),
 		txHistoryBuf:   NewRingBuffer(NetworkHistorySize),
+
+		gpuDeviceHistBuf:   NewRingBuffer(GPUHistorySize),
+		gpuRendererHistBuf: NewRingBuffer(GPUHistorySize),
+		gpuTilerHistBuf:    NewRingBuffer(GPUHistorySize),
 		cachedNetIPs:   make(map[string]string),
 		processWatch:   options.SnapshotConfig(),
 		processWatcher: NewProcessWatcher(options),
@@ -492,6 +514,7 @@ func (c *Collector) snapshotFromMetrics(now time.Time, hostInfo *host.InfoStat, 
 			RxHistory: c.rxHistoryBuf.Slice(),
 			TxHistory: c.txHistoryBuf.Slice(),
 		},
+		GPUHistory:    c.gpuHistorySnapshot(),
 		Proxy:         collected.proxyStats,
 		Batteries:     collected.batteryStats,
 		Thermal:       collected.thermalStats,

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -129,9 +129,10 @@ type CPUStatus struct {
 
 type GPUStatus struct {
 	Name        string  `json:"name"`
-	Usage       float64 `json:"usage"`          // overall "Device Utilization %"
-	Renderer    float64 `json:"renderer"`       // "Renderer Utilization %" (Apple; -1 if unknown)
-	Tiler       float64 `json:"tiler"`          // "Tiler Utilization %" (Apple; -1 if unknown)
+	Usage       float64 `json:"usage"`       // overall "Device Utilization %"
+	Renderer    float64 `json:"renderer"`    // "Renderer Utilization %" (Apple; -1 if unknown)
+	Tiler       float64 `json:"tiler"`       // "Tiler Utilization %" (Apple; -1 if unknown)
+	Power       float64 `json:"power_watts"` // GPU power draw in watts (IOReport; -1 if unknown)
 	MemoryUsed  float64 `json:"memory_used"`
 	MemoryTotal float64 `json:"memory_total"`
 	CoreCount   int     `json:"core_count"`
@@ -234,10 +235,10 @@ type Collector struct {
 	lastBT   []BluetoothDevice
 
 	// Fast metrics (1s).
-	prevNet        map[string]net.IOCountersStat
-	lastNetAt      time.Time
-	rxHistoryBuf   *RingBuffer
-	txHistoryBuf   *RingBuffer
+	prevNet      map[string]net.IOCountersStat
+	lastNetAt    time.Time
+	rxHistoryBuf *RingBuffer
+	txHistoryBuf *RingBuffer
 
 	// gpuMu guards all GPU collector state (cached info, usage cache, history
 	// buffers) because a dedicated GPU tick samples concurrently with the main
@@ -246,14 +247,16 @@ type Collector struct {
 	gpuDeviceHistBuf   *RingBuffer
 	gpuRendererHistBuf *RingBuffer
 	gpuTilerHistBuf    *RingBuffer
-	lastNetIPAt    time.Time
-	cachedNetIPs   map[string]string
-	lastGPUAt      time.Time
-	cachedGPU      []GPUStatus
-	lastGPUUsageAt time.Time
-	cachedGPUUsage gpuUsageSample
-	prevDiskIO     disk.IOCountersStat
-	lastDiskAt     time.Time
+	lastNetIPAt        time.Time
+	cachedNetIPs       map[string]string
+	lastGPUAt          time.Time
+	cachedGPU          []GPUStatus
+	lastGPUUsageAt     time.Time
+	cachedGPUUsage     gpuUsageSample
+	lastGPUPowerAt     time.Time
+	cachedGPUPower     float64
+	prevDiskIO         disk.IOCountersStat
+	lastDiskAt         time.Time
 
 	watchMu        sync.Mutex
 	processWatch   ProcessWatchConfig
@@ -304,16 +307,16 @@ type snapshotEnrichment struct {
 
 func NewCollector(options ProcessWatchOptions) *Collector {
 	c := &Collector{
-		prevNet:        make(map[string]net.IOCountersStat),
-		rxHistoryBuf:   NewRingBuffer(NetworkHistorySize),
-		txHistoryBuf:   NewRingBuffer(NetworkHistorySize),
+		prevNet:      make(map[string]net.IOCountersStat),
+		rxHistoryBuf: NewRingBuffer(NetworkHistorySize),
+		txHistoryBuf: NewRingBuffer(NetworkHistorySize),
 
 		gpuDeviceHistBuf:   NewRingBuffer(GPUHistorySize),
 		gpuRendererHistBuf: NewRingBuffer(GPUHistorySize),
 		gpuTilerHistBuf:    NewRingBuffer(GPUHistorySize),
-		cachedNetIPs:   make(map[string]string),
-		processWatch:   options.SnapshotConfig(),
-		processWatcher: NewProcessWatcher(options),
+		cachedNetIPs:       make(map[string]string),
+		processWatch:       options.SnapshotConfig(),
+		processWatcher:     NewProcessWatcher(options),
 	}
 	c.primeNetworkCounters(time.Now())
 	return c

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -128,7 +128,9 @@ type CPUStatus struct {
 
 type GPUStatus struct {
 	Name        string  `json:"name"`
-	Usage       float64 `json:"usage"`
+	Usage       float64 `json:"usage"`          // overall "Device Utilization %"
+	Renderer    float64 `json:"renderer"`       // "Renderer Utilization %" (Apple; -1 if unknown)
+	Tiler       float64 `json:"tiler"`          // "Tiler Utilization %" (Apple; -1 if unknown)
 	MemoryUsed  float64 `json:"memory_used"`
 	MemoryTotal float64 `json:"memory_total"`
 	CoreCount   int     `json:"core_count"`
@@ -231,7 +233,7 @@ type Collector struct {
 	lastGPUAt      time.Time
 	cachedGPU      []GPUStatus
 	lastGPUUsageAt time.Time
-	cachedGPUUsage float64
+	cachedGPUUsage gpuUsageSample
 	prevDiskIO     disk.IOCountersStat
 	lastDiskAt     time.Time
 

--- a/cmd/status/metrics_gpu.go
+++ b/cmd/status/metrics_gpu.go
@@ -44,6 +44,9 @@ type gpuUsageSample struct {
 var unknownGPUUsage = gpuUsageSample{device: -1, renderer: -1, tiler: -1}
 
 func (c *Collector) collectGPU(now time.Time) ([]GPUStatus, error) {
+	c.gpuMu.Lock()
+	defer c.gpuMu.Unlock()
+
 	if runtime.GOOS == "darwin" {
 		// Static GPU info (cached 10 min).
 		if len(c.cachedGPU) == 0 || c.lastGPUAt.IsZero() || now.Sub(c.lastGPUAt) >= macGPUInfoTTL {
@@ -56,6 +59,7 @@ func (c *Collector) collectGPU(now time.Time) ([]GPUStatus, error) {
 		// Real-time GPU usage.
 		if len(c.cachedGPU) > 0 {
 			usage := c.getMacGPUUsage(now)
+			c.pushGPUHistory(usage)
 			result := make([]GPUStatus, len(c.cachedGPU))
 			copy(result, c.cachedGPU)
 			// Apply usage to first GPU (Apple Silicon).
@@ -175,6 +179,48 @@ func readMacGPUInfo() ([]GPUStatus, error) {
 	}
 
 	return gpus, nil
+}
+
+// gpuHistorySnapshot returns a copy of the GPU history buffers. It takes the
+// GPU lock so it is safe to call from the main collection goroutine while the
+// dedicated GPU tick pushes new samples.
+func (c *Collector) gpuHistorySnapshot() GPUHistory {
+	c.gpuMu.Lock()
+	defer c.gpuMu.Unlock()
+	return c.gpuHistoryLocked()
+}
+
+// gpuHistoryLocked reads the history buffers. The caller must hold gpuMu.
+func (c *Collector) gpuHistoryLocked() GPUHistory {
+	hist := GPUHistory{}
+	if c.gpuDeviceHistBuf != nil {
+		hist.DeviceHistory = c.gpuDeviceHistBuf.Slice()
+	}
+	if c.gpuRendererHistBuf != nil {
+		hist.RendererHistory = c.gpuRendererHistBuf.Slice()
+	}
+	if c.gpuTilerHistBuf != nil {
+		hist.TilerHistory = c.gpuTilerHistBuf.Slice()
+	}
+	return hist
+}
+
+// pushGPUHistory records one GPU utilization sample into the ring buffers.
+// Unknown figures (-1) are stored as 0 so the sparkline stays well-formed.
+// Buffers are lazily created to stay robust if a Collector was built directly.
+func (c *Collector) pushGPUHistory(u gpuUsageSample) {
+	if c.gpuDeviceHistBuf == nil {
+		c.gpuDeviceHistBuf = NewRingBuffer(GPUHistorySize)
+	}
+	if c.gpuRendererHistBuf == nil {
+		c.gpuRendererHistBuf = NewRingBuffer(GPUHistorySize)
+	}
+	if c.gpuTilerHistBuf == nil {
+		c.gpuTilerHistBuf = NewRingBuffer(GPUHistorySize)
+	}
+	c.gpuDeviceHistBuf.Add(max(u.device, 0))
+	c.gpuRendererHistBuf.Add(max(u.renderer, 0))
+	c.gpuTilerHistBuf.Add(max(u.tiler, 0))
 }
 
 func (c *Collector) getMacGPUUsage(now time.Time) gpuUsageSample {

--- a/cmd/status/metrics_gpu.go
+++ b/cmd/status/metrics_gpu.go
@@ -15,6 +15,7 @@ const (
 	systemProfilerTimeout = 4 * time.Second
 	macGPUInfoTTL         = 10 * time.Minute
 	macGPUUsageTTL        = 5 * time.Second
+	macGPUPowerTTL        = 5 * time.Second
 	powermetricsTimeout   = 2 * time.Second
 	ioregTimeout          = 1 * time.Second
 )
@@ -67,6 +68,9 @@ func (c *Collector) collectGPU(now time.Time) ([]GPUStatus, error) {
 				result[0].Usage = usage.device
 				result[0].Renderer = usage.renderer
 				result[0].Tiler = usage.tiler
+				// Power via IOReport (no root); cached at the usage cadence since
+				// each read opens a subscription and blocks ~100ms to delta energy.
+				result[0].Power = c.getGPUPower(now)
 			}
 			return result, nil
 		}
@@ -103,6 +107,7 @@ func (c *Collector) collectGPU(now time.Time) ([]GPUStatus, error) {
 			Usage:       util,
 			Renderer:    -1, // not exposed outside Apple Silicon
 			Tiler:       -1,
+			Power:       -1,
 			MemoryUsed:  memUsed,
 			MemoryTotal: memTotal,
 		})
@@ -166,6 +171,7 @@ func readMacGPUInfo() ([]GPUStatus, error) {
 			Usage:     -1, // Will be updated with real-time data
 			Renderer:  -1,
 			Tiler:     -1,
+			Power:     -1,
 			CoreCount: coreCount,
 			Note:      note,
 		})
@@ -232,6 +238,22 @@ func (c *Collector) getMacGPUUsage(now time.Time) gpuUsageSample {
 	c.cachedGPUUsage = usage
 	c.lastGPUUsageAt = now
 	return usage
+}
+
+// getGPUPower returns GPU power in watts, cached for macGPUPowerTTL. Each read
+// opens an IOReport subscription and blocks ~100ms to delta the energy, so it is
+// sampled at the usage cadence rather than on every collection (the dedicated GPU
+// tick runs every ~2s). -1 (unavailable) is cached like any other value. The
+// caller must hold gpuMu.
+func (c *Collector) getGPUPower(now time.Time) float64 {
+	if !c.lastGPUPowerAt.IsZero() && now.Sub(c.lastGPUPowerAt) < macGPUPowerTTL {
+		return c.cachedGPUPower
+	}
+
+	power := readGPUPowerWatts(100 * time.Millisecond)
+	c.cachedGPUPower = power
+	c.lastGPUPowerAt = now
+	return power
 }
 
 // getMacGPUUsage returns the current GPU utilization figures, or unknownGPUUsage

--- a/cmd/status/metrics_gpu.go
+++ b/cmd/status/metrics_gpu.go
@@ -16,13 +16,32 @@ const (
 	macGPUInfoTTL         = 10 * time.Minute
 	macGPUUsageTTL        = 5 * time.Second
 	powermetricsTimeout   = 2 * time.Second
+	ioregTimeout          = 1 * time.Second
 )
 
 // Regex for GPU usage parsing.
 var (
 	gpuActiveResidencyRe = regexp.MustCompile(`GPU HW active residency:\s+([\d.]+)%`)
 	gpuIdleResidencyRe   = regexp.MustCompile(`GPU idle residency:\s+([\d.]+)%`)
+	// IOKit exposes GPU load without root: AGXAccelerator's PerformanceStatistics
+	// dict carries three whole-device utilization figures. Apple does not expose
+	// any per-core/per-SM breakdown, so these three are the finest granularity
+	// available. Read via `ioreg`.
+	gpuDeviceUtilRe   = regexp.MustCompile(`"Device Utilization %"\s*=\s*(\d+)`)
+	gpuRendererUtilRe = regexp.MustCompile(`"Renderer Utilization %"\s*=\s*(\d+)`)
+	gpuTilerUtilRe    = regexp.MustCompile(`"Tiler Utilization %"\s*=\s*(\d+)`)
 )
+
+// gpuUsageSample holds the whole-device GPU utilization figures. Renderer and
+// Tiler are -1 when unknown (e.g. the powermetrics fallback only yields Device).
+type gpuUsageSample struct {
+	device   float64
+	renderer float64
+	tiler    float64
+}
+
+// unknownGPUUsage is the zero sample: nothing could be read.
+var unknownGPUUsage = gpuUsageSample{device: -1, renderer: -1, tiler: -1}
 
 func (c *Collector) collectGPU(now time.Time) ([]GPUStatus, error) {
 	if runtime.GOOS == "darwin" {
@@ -41,7 +60,9 @@ func (c *Collector) collectGPU(now time.Time) ([]GPUStatus, error) {
 			copy(result, c.cachedGPU)
 			// Apply usage to first GPU (Apple Silicon).
 			if len(result) > 0 {
-				result[0].Usage = usage
+				result[0].Usage = usage.device
+				result[0].Renderer = usage.renderer
+				result[0].Tiler = usage.tiler
 			}
 			return result, nil
 		}
@@ -76,6 +97,8 @@ func (c *Collector) collectGPU(now time.Time) ([]GPUStatus, error) {
 		gpus = append(gpus, GPUStatus{
 			Name:        name,
 			Usage:       util,
+			Renderer:    -1, // not exposed outside Apple Silicon
+			Tiler:       -1,
 			MemoryUsed:  memUsed,
 			MemoryTotal: memTotal,
 		})
@@ -137,6 +160,8 @@ func readMacGPUInfo() ([]GPUStatus, error) {
 		gpus = append(gpus, GPUStatus{
 			Name:      d.Name,
 			Usage:     -1, // Will be updated with real-time data
+			Renderer:  -1,
+			Tiler:     -1,
 			CoreCount: coreCount,
 			Note:      note,
 		})
@@ -152,7 +177,7 @@ func readMacGPUInfo() ([]GPUStatus, error) {
 	return gpus, nil
 }
 
-func (c *Collector) getMacGPUUsage(now time.Time) float64 {
+func (c *Collector) getMacGPUUsage(now time.Time) gpuUsageSample {
 	if !c.lastGPUUsageAt.IsZero() && now.Sub(c.lastGPUUsageAt) < macGPUUsageTTL {
 		return c.cachedGPUUsage
 	}
@@ -163,34 +188,75 @@ func (c *Collector) getMacGPUUsage(now time.Time) float64 {
 	return usage
 }
 
-// getMacGPUUsage reads GPU active residency from powermetrics.
-func getMacGPUUsage() float64 {
+// getMacGPUUsage returns the current GPU utilization figures, or unknownGPUUsage
+// if none can be read. It prefers IOKit via ioreg (no root required) and falls
+// back to powermetrics (which usually needs root) only when ioreg yields nothing.
+func getMacGPUUsage() gpuUsageSample {
+	if usage := getMacGPUUsageIOReg(); usage.device >= 0 {
+		return usage
+	}
+	return getMacGPUUsagePowermetrics()
+}
+
+// getMacGPUUsageIOReg reads the Device/Renderer/Tiler utilization figures from
+// AGXAccelerator's PerformanceStatistics dict, without elevated privileges. A
+// figure whose key is absent stays -1.
+func getMacGPUUsageIOReg() gpuUsageSample {
+	ctx, cancel := context.WithTimeout(context.Background(), ioregTimeout)
+	defer cancel()
+
+	if !commandExists("ioreg") {
+		return unknownGPUUsage
+	}
+	out, err := runCmd(ctx, "ioreg", "-r", "-c", "AGXAccelerator", "-d", "1")
+	if err != nil {
+		return unknownGPUUsage
+	}
+
+	return gpuUsageSample{
+		device:   parseGPUUtil(gpuDeviceUtilRe, out),
+		renderer: parseGPUUtil(gpuRendererUtilRe, out),
+		tiler:    parseGPUUtil(gpuTilerUtilRe, out),
+	}
+}
+
+// parseGPUUtil returns the first integer captured by re in text, or -1.
+func parseGPUUtil(re *regexp.Regexp, text string) float64 {
+	m := re.FindStringSubmatch(text)
+	if len(m) >= 2 {
+		if v, err := strconv.ParseFloat(m[1], 64); err == nil {
+			return v
+		}
+	}
+	return -1
+}
+
+// getMacGPUUsagePowermetrics reads GPU active residency from powermetrics. It
+// only yields the overall device figure; Renderer/Tiler remain unknown.
+func getMacGPUUsagePowermetrics() gpuUsageSample {
 	ctx, cancel := context.WithTimeout(context.Background(), powermetricsTimeout)
 	defer cancel()
 
 	// powermetrics may require root.
 	out, err := runCmd(ctx, "powermetrics", "--samplers", "gpu_power", "-i", "500", "-n", "1")
 	if err != nil {
-		return -1
+		return unknownGPUUsage
 	}
 
+	sample := unknownGPUUsage
 	// Parse "GPU HW active residency: X.XX%".
-	matches := gpuActiveResidencyRe.FindStringSubmatch(out)
-	if len(matches) >= 2 {
-		usage, err := strconv.ParseFloat(matches[1], 64)
-		if err == nil {
-			return usage
+	if m := gpuActiveResidencyRe.FindStringSubmatch(out); len(m) >= 2 {
+		if usage, err := strconv.ParseFloat(m[1], 64); err == nil {
+			sample.device = usage
+			return sample
 		}
 	}
-
 	// Fallback: parse idle residency and derive active.
-	matchesIdle := gpuIdleResidencyRe.FindStringSubmatch(out)
-	if len(matchesIdle) >= 2 {
-		idle, err := strconv.ParseFloat(matchesIdle[1], 64)
-		if err == nil {
-			return 100.0 - idle
+	if m := gpuIdleResidencyRe.FindStringSubmatch(out); len(m) >= 2 {
+		if idle, err := strconv.ParseFloat(m[1], 64); err == nil {
+			sample.device = 100.0 - idle
+			return sample
 		}
 	}
-
-	return -1
+	return unknownGPUUsage
 }

--- a/cmd/status/metrics_gpu_test.go
+++ b/cmd/status/metrics_gpu_test.go
@@ -1,6 +1,33 @@
 package main
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
+
+// TestGPUHistoryConcurrentAccess exercises the GPU mutex: concurrent pushes and
+// snapshots must not race (run with -race). It mirrors how the dedicated GPU
+// tick and the main collection goroutine touch the same buffers.
+func TestGPUHistoryConcurrentAccess(t *testing.T) {
+	c := NewCollector(ProcessWatchOptions{})
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			for range 200 {
+				c.gpuMu.Lock()
+				c.pushGPUHistory(gpuUsageSample{device: 5, renderer: 3, tiler: 1})
+				c.gpuMu.Unlock()
+				_ = c.gpuHistorySnapshot()
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := c.gpuHistorySnapshot(); len(got.DeviceHistory) == 0 {
+		t.Fatal("expected device history to be populated after concurrent pushes")
+	}
+}
 
 // TestGPUDeviceUtilRegex checks we extract "Device Utilization %" from a realistic
 // ioreg PerformanceStatistics dict (as emitted by `ioreg -r -c AGXAccelerator`).

--- a/cmd/status/metrics_gpu_test.go
+++ b/cmd/status/metrics_gpu_test.go
@@ -3,7 +3,23 @@ package main
 import (
 	"sync"
 	"testing"
+	"time"
 )
+
+// TestGetGPUPowerCachesWithinTTL verifies the power read is served from cache
+// within the TTL, so it does not open a fresh IOReport subscription on every
+// collection. A live read (cache miss) would return a real figure or -1; the
+// sentinel here is only returned if the cache path is honoured.
+func TestGetGPUPowerCachesWithinTTL(t *testing.T) {
+	c := NewCollector(ProcessWatchOptions{})
+	base := time.Unix(1000, 0)
+	c.cachedGPUPower = 12.5
+	c.lastGPUPowerAt = base
+
+	if got := c.getGPUPower(base.Add(macGPUPowerTTL - time.Millisecond)); got != 12.5 {
+		t.Fatalf("within TTL: getGPUPower = %v, want cached 12.5", got)
+	}
+}
 
 // TestGPUHistoryConcurrentAccess exercises the GPU mutex: concurrent pushes and
 // snapshots must not race (run with -race). It mirrors how the dedicated GPU

--- a/cmd/status/metrics_gpu_test.go
+++ b/cmd/status/metrics_gpu_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+// TestGPUDeviceUtilRegex checks we extract "Device Utilization %" from a realistic
+// ioreg PerformanceStatistics dict (as emitted by `ioreg -r -c AGXAccelerator`).
+func TestGPUDeviceUtilRegex(t *testing.T) {
+	sample := `      "PerformanceStatistics" = {"In use system memory"=1268629504,"Tiler Utilization %"=12,` +
+		`"Renderer Utilization %"=9,"Device Utilization %"=42,"Alloc system memory"=7270154240}`
+
+	m := gpuDeviceUtilRe.FindStringSubmatch(sample)
+	if len(m) < 2 {
+		t.Fatalf("regex did not match sample: %q", sample)
+	}
+	if m[1] != "42" {
+		t.Errorf("Device Utilization %% = %q, want %q", m[1], "42")
+	}
+}
+
+// TestGPUDeviceUtilRegexAbsent ensures we don't false-match when the key is missing.
+func TestGPUDeviceUtilRegexAbsent(t *testing.T) {
+	if gpuDeviceUtilRe.MatchString(`"Renderer Utilization %"=9`) {
+		t.Error("regex matched a dict without a Device Utilization entry")
+	}
+}

--- a/cmd/status/prefs.go
+++ b/cmd/status/prefs.go
@@ -150,6 +150,39 @@ func saveCatHidden(hidden bool) {
 	savePref("cat_hidden", strconv.FormatBool(hidden))
 }
 
+// gpuDetailCycle is how many GPU utilization rows the 'g' key steps through:
+// 1 = Device only, 2 = +Renderer, 3 = +Tiler. Apple exposes no finer breakdown.
+var gpuDetailCycle = []int{1, 2, 3}
+
+// loadGPUDetail reports how many GPU utilization rows to show (1..3), defaulting
+// to 1 when unset or invalid.
+func loadGPUDetail() int {
+	raw, ok := loadPrefs()["gpu_detail"]
+	if !ok {
+		return gpuDetailCycle[0]
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < gpuDetailCycle[0] || n > gpuDetailCycle[len(gpuDetailCycle)-1] {
+		return gpuDetailCycle[0]
+	}
+	return n
+}
+
+// saveGPUDetail persists the GPU detail-level preference.
+func saveGPUDetail(n int) {
+	savePref("gpu_detail", strconv.Itoa(n))
+}
+
+// nextGPUDetail returns the value after current in gpuDetailCycle, wrapping.
+func nextGPUDetail(current int) int {
+	for i, v := range gpuDetailCycle {
+		if v == current {
+			return gpuDetailCycle[(i+1)%len(gpuDetailCycle)]
+		}
+	}
+	return gpuDetailCycle[0]
+}
+
 // cpuCoresCycle is the sequence the 'c' key steps through. 0 means "all cores".
 // The default (first entry) is 2, matching the historical hard-coded behaviour.
 var cpuCoresCycle = []int{2, 4, 8, 0}

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -406,6 +406,9 @@ func renderGPUCard(gpus []GPUStatus, detail int, history GPUHistory, cardWidth i
 	if detail >= 3 && g.Tiler >= 0 {
 		lines = append(lines, row("Tiler", g.Tiler, history.TilerHistory))
 	}
+	if g.Power >= 0 {
+		lines = append(lines, fmt.Sprintf("%-6s %.2f W", "Power", g.Power))
+	}
 	if g.CoreCount > 0 {
 		lines = append(lines, fmt.Sprintf("%-6s %d", "Cores", g.CoreCount))
 	}

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -382,20 +382,29 @@ func hasGPUCard(gpus []GPUStatus) bool {
 // 3=+Tiler). Apple exposes no per-core/per-SM breakdown, so these three
 // whole-device figures are the finest granularity available. A row is skipped
 // when its figure is unknown (-1), e.g. the non-Apple / powermetrics paths.
-func renderGPUCard(gpus []GPUStatus, detail int) cardData {
+func renderGPUCard(gpus []GPUStatus, detail int, history GPUHistory, cardWidth int) cardData {
 	var lines []string
 	g := gpus[0]
 
-	if g.Usage >= 0 {
-		lines = append(lines, fmt.Sprintf("%-6s %s  %5.1f%%", "Usage", progressBar(g.Usage), g.Usage))
-	} else {
-		lines = append(lines, subtleStyle.Render("Usage  unavailable"))
+	// Sparkline width, mirroring the network card's layout budget.
+	graphWidth := min(max(cardWidth-22, 5), 16)
+
+	// row draws "<label> <trend sparkline> <value>%", the sparkline colored by
+	// the current percentage. An unknown value (-1) is reported instead.
+	row := func(label string, val float64, hist []float64) string {
+		if val < 0 {
+			return subtleStyle.Render(fmt.Sprintf("%-6s unavailable", label))
+		}
+		spark := colorizePercent(val, sparklineBars(hist, graphWidth))
+		return fmt.Sprintf("%-6s %s  %5.1f%%", label, spark, val)
 	}
+
+	lines = append(lines, row("Usage", g.Usage, history.DeviceHistory))
 	if detail >= 2 && g.Renderer >= 0 {
-		lines = append(lines, fmt.Sprintf("%-6s %s  %5.1f%%", "Render", progressBar(g.Renderer), g.Renderer))
+		lines = append(lines, row("Render", g.Renderer, history.RendererHistory))
 	}
 	if detail >= 3 && g.Tiler >= 0 {
-		lines = append(lines, fmt.Sprintf("%-6s %s  %5.1f%%", "Tiler", progressBar(g.Tiler), g.Tiler))
+		lines = append(lines, row("Tiler", g.Tiler, history.TilerHistory))
 	}
 	if g.CoreCount > 0 {
 		lines = append(lines, fmt.Sprintf("%-6s %d", "Cores", g.CoreCount))
@@ -668,7 +677,7 @@ func buildCards(m MetricsSnapshot, width int, cpuCores int, gpuDetail int) []car
 	cards := []cardData{renderCPUCard(m.CPU, m.Thermal, cpuCores)}
 	// GPU sits right after CPU when there is real data to show.
 	if hasGPUCard(m.GPU) {
-		cards = append(cards, renderGPUCard(m.GPU, gpuDetail))
+		cards = append(cards, renderGPUCard(m.GPU, gpuDetail, m.GPUHistory, width))
 	}
 	cards = append(cards,
 		renderMemoryCard(m.Memory, width),
@@ -731,8 +740,10 @@ func renderNetworkCard(netStats []NetworkStatus, history NetworkHistory, proxy P
 	return cardData{icon: iconNetwork, title: "Network", lines: lines}
 }
 
-// 8 levels: ▁▂▃▄▅▆▇█
-func sparkline(history []float64, current float64, width int) string {
+// sparklineBars renders history as uncolored block runes (8 levels: ▁▂▃▄▅▆▇█),
+// right-aligned to width and scaled to the window's own maximum. Callers apply
+// whatever coloring fits their metric.
+func sparklineBars(history []float64, width int) string {
 	blocks := []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
 
 	data := make([]float64, 0, width)
@@ -767,8 +778,12 @@ func sparkline(history []float64, current float64, width int) string {
 		}
 		builder.WriteRune(blocks[level])
 	}
+	return builder.String()
+}
 
-	result := builder.String()
+// sparkline draws a network-rate sparkline, colored by the current rate (MB/s).
+func sparkline(history []float64, current float64, width int) string {
+	result := sparklineBars(history, width)
 	if current > 8 {
 		return dangerStyle.Render(result)
 	}

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -363,6 +363,50 @@ func renderCPUCard(cpu CPUStatus, thermal ThermalStatus, cpuCores int) cardData 
 	return cardData{icon: iconCPU, title: "CPU", lines: lines}
 }
 
+// hasGPUCard reports whether there is enough GPU data to be worth its own card.
+// Placeholder entries (e.g. "No GPU metrics available" on machines without a
+// readable GPU) carry neither usage nor a core count and are skipped.
+func hasGPUCard(gpus []GPUStatus) bool {
+	if len(gpus) == 0 {
+		return false
+	}
+	g := gpus[0]
+	return g.Usage >= 0 || g.CoreCount > 0
+}
+
+// renderGPUCard renders the standalone GPU section. On Apple Silicon the usage
+// figures come from IOKit (no root); when they cannot be read the row says so
+// instead of showing a misleading 0%.
+//
+// detail controls how many utilization rows appear (1=Device, 2=+Renderer,
+// 3=+Tiler). Apple exposes no per-core/per-SM breakdown, so these three
+// whole-device figures are the finest granularity available. A row is skipped
+// when its figure is unknown (-1), e.g. the non-Apple / powermetrics paths.
+func renderGPUCard(gpus []GPUStatus, detail int) cardData {
+	var lines []string
+	g := gpus[0]
+
+	if g.Usage >= 0 {
+		lines = append(lines, fmt.Sprintf("%-6s %s  %5.1f%%", "Usage", progressBar(g.Usage), g.Usage))
+	} else {
+		lines = append(lines, subtleStyle.Render("Usage  unavailable"))
+	}
+	if detail >= 2 && g.Renderer >= 0 {
+		lines = append(lines, fmt.Sprintf("%-6s %s  %5.1f%%", "Render", progressBar(g.Renderer), g.Renderer))
+	}
+	if detail >= 3 && g.Tiler >= 0 {
+		lines = append(lines, fmt.Sprintf("%-6s %s  %5.1f%%", "Tiler", progressBar(g.Tiler), g.Tiler))
+	}
+	if g.CoreCount > 0 {
+		lines = append(lines, fmt.Sprintf("%-6s %d", "Cores", g.CoreCount))
+	}
+	if g.Note != "" {
+		lines = append(lines, subtleStyle.Render(g.Note))
+	}
+
+	return cardData{icon: iconGPU, title: "GPU", lines: lines}
+}
+
 func renderMemoryCard(mem MemoryStatus, cardWidth int) cardData {
 	// Check if swap is being used (or at least allocated).
 	hasSwap := mem.SwapTotal > 0 || mem.SwapUsed > 0
@@ -620,15 +664,19 @@ func processMemoryText(p ProcessInfo) string {
 	return ""
 }
 
-func buildCards(m MetricsSnapshot, width int, cpuCores int) []cardData {
-	cards := []cardData{
-		renderCPUCard(m.CPU, m.Thermal, cpuCores),
+func buildCards(m MetricsSnapshot, width int, cpuCores int, gpuDetail int) []cardData {
+	cards := []cardData{renderCPUCard(m.CPU, m.Thermal, cpuCores)}
+	// GPU sits right after CPU when there is real data to show.
+	if hasGPUCard(m.GPU) {
+		cards = append(cards, renderGPUCard(m.GPU, gpuDetail))
+	}
+	cards = append(cards,
 		renderMemoryCard(m.Memory, width),
 		renderDiskCard(m.Disks, m.DiskIO, m.TrashSize, m.TrashApprox),
 		renderBatteryCard(m.Batteries, m.Thermal),
 		renderProcessCard(m.TopProcesses, width),
 		renderNetworkCard(m.Network, m.NetworkHistory, m.Proxy, width),
-	}
+	)
 	// Sensors card disabled - redundant with CPU temp
 	// if hasSensorData(m.Sensors) {
 	// 	cards = append(cards, renderSensorsCard(m.Sensors))

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1441,6 +1441,20 @@ func TestNextGPUDetailCyclesAndWraps(t *testing.T) {
 	}
 }
 
+func TestRenderGPUCardPower(t *testing.T) {
+	// Power >= 0 renders a watts row.
+	withPower := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: 10, Renderer: -1, Tiler: -1, Power: 8.5, CoreCount: 40}}, 1, GPUHistory{}, 38).lines, "\n"))
+	if !strings.Contains(withPower, "Power") || !strings.Contains(withPower, "8.50 W") {
+		t.Errorf("expected a power row with 8.50 W, got %q", withPower)
+	}
+
+	// Power -1 (unknown, e.g. cgo disabled / non-Apple) hides the row.
+	noPower := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: 10, Renderer: -1, Tiler: -1, Power: -1, CoreCount: 40}}, 1, GPUHistory{}, 38).lines, "\n"))
+	if strings.Contains(noPower, "Power") {
+		t.Errorf("power row should be hidden when unknown, got %q", noPower)
+	}
+}
+
 func TestHasGPUCard(t *testing.T) {
 	cases := []struct {
 		name string

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1378,6 +1378,81 @@ func TestRenderCPUCardHonoursCoreCount(t *testing.T) {
 	}
 }
 
+func TestRenderGPUCard(t *testing.T) {
+	gpu := []GPUStatus{{Name: "Apple M3 Max", Usage: 12, Renderer: 9, Tiler: 5, CoreCount: 40, Note: "Metal 3"}}
+
+	// detail=1: only the Device (Usage) row, no Render/Tiler.
+	d1 := stripANSI(strings.Join(renderGPUCard(gpu, 1).lines, "\n"))
+	if !strings.Contains(d1, "Usage") || !strings.Contains(d1, "12.0%") {
+		t.Errorf("detail=1 should show the usage row, got %q", d1)
+	}
+	if strings.Contains(d1, "Render") || strings.Contains(d1, "Tiler") {
+		t.Errorf("detail=1 should not show Render/Tiler, got %q", d1)
+	}
+	if !strings.Contains(d1, "Cores  40") {
+		t.Errorf("expected a cores row, got %q", d1)
+	}
+
+	// detail=2 adds Render (but not Tiler).
+	d2 := stripANSI(strings.Join(renderGPUCard(gpu, 2).lines, "\n"))
+	if !strings.Contains(d2, "Render") || !strings.Contains(d2, "9.0%") {
+		t.Errorf("detail=2 should add the Render row, got %q", d2)
+	}
+	if strings.Contains(d2, "Tiler") {
+		t.Errorf("detail=2 should not show Tiler yet, got %q", d2)
+	}
+
+	// detail=3 adds Tiler too.
+	d3 := stripANSI(strings.Join(renderGPUCard(gpu, 3).lines, "\n"))
+	if !strings.Contains(d3, "Tiler") || !strings.Contains(d3, "5.0%") {
+		t.Errorf("detail=3 should add the Tiler row, got %q", d3)
+	}
+
+	// Unknown Renderer/Tiler (-1) are skipped even when detail asks for them.
+	partial := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: 12, Renderer: -1, Tiler: -1, CoreCount: 40}}, 3).lines, "\n"))
+	if strings.Contains(partial, "Render") || strings.Contains(partial, "Tiler") {
+		t.Errorf("rows with unknown (-1) data must be skipped, got %q", partial)
+	}
+
+	// Usage unavailable (-1): the row says so rather than showing 0%.
+	na := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: -1, CoreCount: 40}}, 1).lines, "\n"))
+	if !strings.Contains(na, "unavailable") {
+		t.Errorf("expected an 'unavailable' usage row, got %q", na)
+	}
+}
+
+func TestHasGPUCard(t *testing.T) {
+	cases := []struct {
+		name string
+		gpus []GPUStatus
+		want bool
+	}{
+		{"empty", nil, false},
+		{"placeholder only", []GPUStatus{{Name: "No GPU metrics available", Usage: -1}}, false},
+		{"has usage", []GPUStatus{{Usage: 5, CoreCount: 0}}, true},
+		{"has cores", []GPUStatus{{Usage: -1, CoreCount: 40}}, true},
+	}
+	for _, tc := range cases {
+		if got := hasGPUCard(tc.gpus); got != tc.want {
+			t.Errorf("hasGPUCard(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestNextGPUDetailCyclesAndWraps(t *testing.T) {
+	want := []int{2, 3, 1} // from 1, one full loop back to 1
+	got := 1
+	for i, exp := range want {
+		got = nextGPUDetail(got)
+		if got != exp {
+			t.Fatalf("step %d: nextGPUDetail gave %d, want %d", i, got, exp)
+		}
+	}
+	if n := nextGPUDetail(99); n != 1 {
+		t.Fatalf("nextGPUDetail(99) = %d, want default 1", n)
+	}
+}
+
 func TestNextCPUCoresCyclesAndWraps(t *testing.T) {
 	want := []int{4, 8, 0, 2} // starting from 2, one full loop back to 2
 	got := 2

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1380,9 +1380,15 @@ func TestRenderCPUCardHonoursCoreCount(t *testing.T) {
 
 func TestRenderGPUCard(t *testing.T) {
 	gpu := []GPUStatus{{Name: "Apple M3 Max", Usage: 12, Renderer: 9, Tiler: 5, CoreCount: 40, Note: "Metal 3"}}
+	hist := GPUHistory{
+		DeviceHistory:   []float64{2, 5, 8, 12},
+		RendererHistory: []float64{1, 3, 6, 9},
+		TilerHistory:    []float64{0, 1, 3, 5},
+	}
+	const cw = 38
 
 	// detail=1: only the Device (Usage) row, no Render/Tiler.
-	d1 := stripANSI(strings.Join(renderGPUCard(gpu, 1).lines, "\n"))
+	d1 := stripANSI(strings.Join(renderGPUCard(gpu, 1, hist, cw).lines, "\n"))
 	if !strings.Contains(d1, "Usage") || !strings.Contains(d1, "12.0%") {
 		t.Errorf("detail=1 should show the usage row, got %q", d1)
 	}
@@ -1394,7 +1400,7 @@ func TestRenderGPUCard(t *testing.T) {
 	}
 
 	// detail=2 adds Render (but not Tiler).
-	d2 := stripANSI(strings.Join(renderGPUCard(gpu, 2).lines, "\n"))
+	d2 := stripANSI(strings.Join(renderGPUCard(gpu, 2, hist, cw).lines, "\n"))
 	if !strings.Contains(d2, "Render") || !strings.Contains(d2, "9.0%") {
 		t.Errorf("detail=2 should add the Render row, got %q", d2)
 	}
@@ -1403,21 +1409,35 @@ func TestRenderGPUCard(t *testing.T) {
 	}
 
 	// detail=3 adds Tiler too.
-	d3 := stripANSI(strings.Join(renderGPUCard(gpu, 3).lines, "\n"))
+	d3 := stripANSI(strings.Join(renderGPUCard(gpu, 3, hist, cw).lines, "\n"))
 	if !strings.Contains(d3, "Tiler") || !strings.Contains(d3, "5.0%") {
 		t.Errorf("detail=3 should add the Tiler row, got %q", d3)
 	}
 
 	// Unknown Renderer/Tiler (-1) are skipped even when detail asks for them.
-	partial := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: 12, Renderer: -1, Tiler: -1, CoreCount: 40}}, 3).lines, "\n"))
+	partial := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: 12, Renderer: -1, Tiler: -1, CoreCount: 40}}, 3, GPUHistory{}, cw).lines, "\n"))
 	if strings.Contains(partial, "Render") || strings.Contains(partial, "Tiler") {
 		t.Errorf("rows with unknown (-1) data must be skipped, got %q", partial)
 	}
 
 	// Usage unavailable (-1): the row says so rather than showing 0%.
-	na := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: -1, CoreCount: 40}}, 1).lines, "\n"))
+	na := stripANSI(strings.Join(renderGPUCard([]GPUStatus{{Usage: -1, CoreCount: 40}}, 1, GPUHistory{}, cw).lines, "\n"))
 	if !strings.Contains(na, "unavailable") {
 		t.Errorf("expected an 'unavailable' usage row, got %q", na)
+	}
+}
+
+func TestNextGPUDetailCyclesAndWraps(t *testing.T) {
+	want := []int{2, 3, 1} // from 1, one full loop back to 1
+	got := 1
+	for i, exp := range want {
+		got = nextGPUDetail(got)
+		if got != exp {
+			t.Fatalf("step %d: nextGPUDetail gave %d, want %d", i, got, exp)
+		}
+	}
+	if n := nextGPUDetail(99); n != 1 {
+		t.Fatalf("nextGPUDetail(99) = %d, want default 1", n)
 	}
 }
 
@@ -1436,20 +1456,6 @@ func TestHasGPUCard(t *testing.T) {
 		if got := hasGPUCard(tc.gpus); got != tc.want {
 			t.Errorf("hasGPUCard(%s) = %v, want %v", tc.name, got, tc.want)
 		}
-	}
-}
-
-func TestNextGPUDetailCyclesAndWraps(t *testing.T) {
-	want := []int{2, 3, 1} // from 1, one full loop back to 1
-	got := 1
-	for i, exp := range want {
-		got = nextGPUDetail(got)
-		if got != exp {
-			t.Fatalf("step %d: nextGPUDetail gave %d, want %d", i, got, exp)
-		}
-	}
-	if n := nextGPUDetail(99); n != 1 {
-		t.Fatalf("nextGPUDetail(99) = %d, want default 1", n)
 	}
 }
 


### PR DESCRIPTION
## What

Adds a compact GPU card to `mo status`, placed right after CPU:

- **Usage** — whole-device GPU utilization with a trend sparkline, read from **IOKit without root** (on Apple Silicon). When it can't be read, the row says `unavailable` instead of a misleading `0%`.
- **Power** — GPU power draw in watts via IOReport (shown only when available).
- **Cores** — GPU core count.
- A **detail toggle** (`g` key, mirroring the existing `c`/`k` keys): cycles Device → +Renderer → +Tiler utilization rows. Apple exposes no finer per-core breakdown, so these three whole-device figures are the max granularity.

## Why it fits `status`

- **Answers a common question, read-only.** "Why is my Mac hot / fans loud / battery draining under load?" — GPU utilization is a primary signal on Apple Silicon, and there's no built-in way to see it from a terminal without `sudo powermetrics`. This surfaces it at a glance, no privileges.
- **Compact by default — not a dashboard.** The card shows a **single** `Usage` row by default; Render/Tiler are opt-in via `g`. It adds one line, not a wall of metrics.
- **Fails safe.** The card is hidden entirely when there's no real GPU data (placeholder entries are skipped), and unreadable figures render as `unavailable`, never fake zeros.
- **Reuses existing patterns.** Sparkline like the network card, `colorizePercent` coloring, the same card/toggle/prefs plumbing as CPU cores — no new flags or config surface, just one toggle key persisted like the others.

## Notes

- Apple Silicon path uses IOKit / IOReport (no root). Non-Apple / powermetrics paths degrade gracefully (rows marked `unavailable`).
- `-race` test covers concurrent GPU history access (dedicated GPU tick vs. main collection goroutine).

## Testing

- `go test ./cmd/status` passes (regex extraction, detail-toggle rows, `hasGPUCard` gating, concurrent history under `-race`).
- `golangci-lint` + `shellcheck` clean via `./scripts/check.sh --no-format`.
