### PR TITLE
fix(status): preserve published battery health

### DIFF
--- a/cmd/status/metrics_battery.go
+++ b/cmd/status/metrics_battery.go
@@ -230,13 +230,20 @@ func getAppleSmartBatteryHealthData() (cycles int, capacity int) {
 }
 
 func parseAppleSmartBatteryHealth(out string) (cycles int, capacity int) {
-	var design, nominal, rawMax int
+	var normalizedCapacity, design, nominal, rawMax int
 	for line := range strings.Lines(out) {
 		line = strings.TrimSpace(line)
 		if cycles == 0 {
 			if raw, found := ioRegValueForKey(line, "CycleCount"); found {
 				if value, err := strconv.Atoi(raw); err == nil && value > 0 && value < 100000 {
 					cycles = value
+				}
+			}
+		}
+		if normalizedCapacity == 0 {
+			if raw, found := ioRegValueForKey(line, "MaxCapacity"); found {
+				if value, err := strconv.Atoi(raw); err == nil && value > 0 && value <= 100 {
+					normalizedCapacity = value
 				}
 			}
 		}
@@ -262,13 +269,16 @@ func parseAppleSmartBatteryHealth(out string) (cycles int, capacity int) {
 			}
 		}
 	}
+	if normalizedCapacity > 0 {
+		return cycles, normalizedCapacity
+	}
 	return cycles, batteryHealthPercent(design, nominal, rawMax)
 }
 
-// batteryHealthPercent mirrors the algorithm used by the Mole Mac app
-// (SystemMetricsCollector.batteryHealthPercent): NominalChargeCapacity is
-// preferred over AppleRawMaxCapacity, the ratio is rounded half-away-from-zero,
-// and the result is clamped to [0, 100].
+// batteryHealthPercent is the fallback estimate when ioreg does not expose a
+// normalized MaxCapacity percentage. NominalChargeCapacity is preferred over
+// AppleRawMaxCapacity, the ratio is rounded half-away-from-zero, and the result
+// is clamped to [0, 100].
 func batteryHealthPercent(design, nominal, rawMax int) int {
 	if design <= 0 {
 		return 0

--- a/cmd/status/metrics_battery.go
+++ b/cmd/status/metrics_battery.go
@@ -149,7 +149,9 @@ func mergeBatteryHealthData(health string, cycles int, capacity int, ioregCycles
 	if ioregCycles > 0 {
 		cycles = ioregCycles
 	}
-	if ioregCapacity > 0 {
+	// system_profiler publishes the same Maximum Capacity value users see in
+	// macOS. IORegistry ratios are estimates and only fill a missing value.
+	if capacity <= 0 && ioregCapacity > 0 {
 		capacity = ioregCapacity
 	}
 	return health, cycles, capacity
@@ -230,20 +232,13 @@ func getAppleSmartBatteryHealthData() (cycles int, capacity int) {
 }
 
 func parseAppleSmartBatteryHealth(out string) (cycles int, capacity int) {
-	var normalizedCapacity, design, nominal, rawMax int
+	var design, nominal, rawMax int
 	for line := range strings.Lines(out) {
 		line = strings.TrimSpace(line)
 		if cycles == 0 {
 			if raw, found := ioRegValueForKey(line, "CycleCount"); found {
 				if value, err := strconv.Atoi(raw); err == nil && value > 0 && value < 100000 {
 					cycles = value
-				}
-			}
-		}
-		if normalizedCapacity == 0 {
-			if raw, found := ioRegValueForKey(line, "MaxCapacity"); found {
-				if value, err := strconv.Atoi(raw); err == nil && value > 0 && value <= 100 {
-					normalizedCapacity = value
 				}
 			}
 		}
@@ -269,23 +264,21 @@ func parseAppleSmartBatteryHealth(out string) (cycles int, capacity int) {
 			}
 		}
 	}
-	if normalizedCapacity > 0 {
-		return cycles, normalizedCapacity
-	}
 	return cycles, batteryHealthPercent(design, nominal, rawMax)
 }
 
-// batteryHealthPercent is the fallback estimate when ioreg does not expose a
-// normalized MaxCapacity percentage. NominalChargeCapacity is preferred over
-// AppleRawMaxCapacity, the ratio is rounded half-away-from-zero, and the result
-// is clamped to [0, 100].
+// batteryHealthPercent estimates health only when system_profiler does not
+// publish Maximum Capacity. AppleRawMaxCapacity is preferred because
+// NominalChargeCapacity includes a buffer and can read high. MaxCapacity is
+// intentionally ignored: on Apple Silicon it is the denominator of the current
+// charge percentage and is normally 100, not a battery-health measurement.
 func batteryHealthPercent(design, nominal, rawMax int) int {
 	if design <= 0 {
 		return 0
 	}
-	capacity := nominal
+	capacity := rawMax
 	if capacity == 0 {
-		capacity = rawMax
+		capacity = nominal
 	}
 	if capacity <= 0 {
 		return 0

--- a/cmd/status/metrics_battery_test.go
+++ b/cmd/status/metrics_battery_test.go
@@ -62,8 +62,8 @@ func TestParseSystemPowerText(t *testing.T) {
 	}
 }
 
-func TestMergeBatteryHealthDataPrefersAppleSmartBatteryCapacity(t *testing.T) {
-	health, cycles, capacity := mergeBatteryHealthData("Good", 12, 97, 13, 100)
+func TestMergeBatteryHealthDataPrefersPublishedCapacity(t *testing.T) {
+	health, cycles, capacity := mergeBatteryHealthData("Good", 12, 100, 13, 96)
 
 	if health != "Good" {
 		t.Fatalf("health = %q, want Good", health)
@@ -72,11 +72,22 @@ func TestMergeBatteryHealthDataPrefersAppleSmartBatteryCapacity(t *testing.T) {
 		t.Fatalf("cycles = %d, want 13", cycles)
 	}
 	if capacity != 100 {
-		t.Fatalf("capacity = %d, want 100", capacity)
+		t.Fatalf("capacity = %d, want published 100", capacity)
 	}
 }
 
-func TestParseAppleSmartBatteryHealthPrefersNormalizedMaxCapacity(t *testing.T) {
+func TestMergeBatteryHealthDataFallsBackToAppleSmartBatteryCapacity(t *testing.T) {
+	_, cycles, capacity := mergeBatteryHealthData("Good", 12, 0, 13, 96)
+
+	if cycles != 13 {
+		t.Fatalf("cycles = %d, want 13", cycles)
+	}
+	if capacity != 96 {
+		t.Fatalf("capacity = %d, want fallback 96", capacity)
+	}
+}
+
+func TestParseAppleSmartBatteryHealthNeverTreatsMaxCapacityAsHealth(t *testing.T) {
 	out := `
   | |   "BatteryData" = {"MaxCapacity"=100,"DesignCapacity"=6075,"BatteryHealthMetric"=0}
   | |   "NominalChargeCapacity" = 6008
@@ -91,12 +102,12 @@ func TestParseAppleSmartBatteryHealthPrefersNormalizedMaxCapacity(t *testing.T) 
 	if cycles != 48 {
 		t.Fatalf("cycles = %d, want 48", cycles)
 	}
-	if capacity != 100 {
-		t.Fatalf("capacity = %d, want 100", capacity)
+	if capacity != 96 {
+		t.Fatalf("capacity = %d, want raw fallback 96", capacity)
 	}
 }
 
-func TestParseAppleSmartBatteryHealthIgnoresUnnormalizedMaxCapacity(t *testing.T) {
+func TestParseAppleSmartBatteryHealthFallsBackToNominalWhenRawUnavailable(t *testing.T) {
 	out := `
   | |   "MaxCapacity" = 7745
   | |   "DesignCapacity" = 8579
@@ -114,7 +125,7 @@ func TestParseAppleSmartBatteryHealthIgnoresUnnormalizedMaxCapacity(t *testing.T
 	}
 }
 
-func TestParseAppleSmartBatteryHealthPrefersNominalCharge(t *testing.T) {
+func TestParseAppleSmartBatteryHealthPrefersRawMaxCapacity(t *testing.T) {
 	out := `
   | |   "DesignCapacity" = 10000
   | |   "AppleRawMaxCapacity" = 7800
@@ -127,8 +138,8 @@ func TestParseAppleSmartBatteryHealthPrefersNominalCharge(t *testing.T) {
 	if cycles != 250 {
 		t.Fatalf("cycles = %d, want 250", cycles)
 	}
-	if capacity != 83 {
-		t.Fatalf("capacity = %d, want 83", capacity)
+	if capacity != 78 {
+		t.Fatalf("capacity = %d, want 78", capacity)
 	}
 }
 

--- a/cmd/status/metrics_battery_test.go
+++ b/cmd/status/metrics_battery_test.go
@@ -76,6 +76,44 @@ func TestMergeBatteryHealthDataPrefersAppleSmartBatteryCapacity(t *testing.T) {
 	}
 }
 
+func TestParseAppleSmartBatteryHealthPrefersNormalizedMaxCapacity(t *testing.T) {
+	out := `
+  | |   "BatteryData" = {"MaxCapacity"=100,"DesignCapacity"=6075,"BatteryHealthMetric"=0}
+  | |   "NominalChargeCapacity" = 6008
+  | |   "MaxCapacity" = 100
+  | |   "DesignCapacity" = 6075
+  | |   "AppleRawMaxCapacity" = 5858
+  | |   "CycleCount" = 48
+`
+
+	cycles, capacity := parseAppleSmartBatteryHealth(out)
+
+	if cycles != 48 {
+		t.Fatalf("cycles = %d, want 48", cycles)
+	}
+	if capacity != 100 {
+		t.Fatalf("capacity = %d, want 100", capacity)
+	}
+}
+
+func TestParseAppleSmartBatteryHealthIgnoresUnnormalizedMaxCapacity(t *testing.T) {
+	out := `
+  | |   "MaxCapacity" = 7745
+  | |   "DesignCapacity" = 8579
+  | |   "NominalChargeCapacity" = 7989
+  | |   "CycleCount" = 12
+`
+
+	cycles, capacity := parseAppleSmartBatteryHealth(out)
+
+	if cycles != 12 {
+		t.Fatalf("cycles = %d, want 12", cycles)
+	}
+	if capacity != 93 {
+		t.Fatalf("capacity = %d, want 93", capacity)
+	}
+}
+
 func TestParseAppleSmartBatteryHealthPrefersNominalCharge(t *testing.T) {
 	out := `
   | |   "DesignCapacity" = 10000


### PR DESCRIPTION
## Summary

- Keep the Maximum Capacity published by `system_profiler` authoritative.
- Use the IORegistry capacity ratio only when the published value is unavailable.
- Prefer `AppleRawMaxCapacity` over the buffered `NominalChargeCapacity` for that fallback.
- Never interpret AppleSmartBattery `MaxCapacity` as battery health. On Apple Silicon it is the denominator used with `CurrentCapacity` for the current charge percentage and is normally 100.

## Safety Review

- This only changes read-only status parsing.
- It does not affect cleanup, deletion, path validation, sudo boundaries, or install integrity.
- No new metric, field, command, setting, or data source is introduced.

## Verification

- Red-green regression run against the original PR behavior.
- `./scripts/check.sh --no-format`
- `go test -count=1 ./...`
- `make build`
- Clean integration with the current `main` passed the same checks.
- Local JSON smoke reported `capacity=100`, `percent=100`, `cycle_count=38`, and `health=Good`.
