### PR TITLE
fix(clean): keep sudo app scans running

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -338,8 +338,20 @@ clean_orphaned_app_data() {
         return 0
     fi
     start_section_spinner "Scanning installed apps..."
-    local installed_bundles=$(create_temp_file)
-    scan_installed_apps "$installed_bundles"
+    local installed_bundles=""
+    local scan_status=0
+    installed_bundles=$(create_temp_file)
+    scan_status=$?
+    if [[ $scan_status -eq 0 && -n "$installed_bundles" ]]; then
+        scan_installed_apps "$installed_bundles"
+        scan_status=$?
+    fi
+    if [[ $scan_status -ne 0 || -z "$installed_bundles" ]]; then
+        stop_section_spinner
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Skipped: Unable to scan installed applications"
+        note_activity
+        return 0
+    fi
     stop_section_spinner
     local app_count=$(wc -l < "$installed_bundles" 2> /dev/null | tr -d ' ')
     debug_log "Found $app_count active/installed apps"

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -102,8 +102,13 @@ scan_installed_apps() {
         # Setapp applications
         "$HOME/Library/Application Support/Setapp/Applications"
     )
-    # Temp dir avoids write contention across parallel scans.
-    local scan_tmp_dir=$(create_temp_dir)
+    # Temp dir avoids write contention across parallel scans. The temp registry
+    # owns cleanup because safe_remove intentionally rejects root's private tree.
+    local scan_tmp_dir
+    if ! scan_tmp_dir=$(create_temp_dir); then
+        debug_log "Failed to create installed application scan temp directory"
+        return 1
+    fi
     local pids=()
     local dir_idx=0
     for app_dir in "${app_dirs[@]}"; do
@@ -154,7 +159,6 @@ scan_installed_apps() {
     fi
     debug_log "All background processes completed"
     cat "$scan_tmp_dir"/*.txt >> "$installed_bundles" 2> /dev/null || true
-    safe_remove "$scan_tmp_dir" true
     sort -u "$installed_bundles" -o "$installed_bundles"
     ensure_user_dir "$(dirname "$cache_file")"
     cp "$installed_bundles" "$cache_file" 2> /dev/null || true

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -109,27 +109,27 @@ scan_installed_apps() {
         debug_log "Failed to create installed application scan temp directory"
         return 1
     fi
-    local pids=()
+    local app_scan_pids=()
+    local auxiliary_pids=()
     local dir_idx=0
     for app_dir in "${app_dirs[@]}"; do
         [[ -d "$app_dir" ]] || continue
         (
-            local -a app_paths=()
+            local app_paths
+            if ! app_paths=$(command find "$app_dir" -maxdepth 3 -type d -name '*.app' 2> /dev/null); then
+                exit 1
+            fi
             while IFS= read -r app_path; do
-                [[ -n "$app_path" ]] && app_paths+=("$app_path")
-            done < <(command find "$app_dir" -maxdepth 3 -type d -name '*.app' 2> /dev/null)
-            local count=0
-            for app_path in "${app_paths[@]:-}"; do
+                [[ -n "$app_path" ]] || continue
                 local plist_path="$app_path/Contents/Info.plist"
                 [[ ! -f "$plist_path" ]] && continue
                 local bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist_path" 2> /dev/null || echo "")
                 if [[ -n "$bundle_id" && "$bundle_id" != "missing value" ]]; then
                     echo "$bundle_id"
-                    count=$((count + 1))
                 fi
-            done
+            done <<< "$app_paths"
         ) > "$scan_tmp_dir/apps_${dir_idx}.txt" &
-        pids+=($!)
+        app_scan_pids+=($!)
         dir_idx=$((dir_idx + 1))
     done
     # Collect running apps and LaunchAgents to avoid false orphan cleanup.
@@ -144,20 +144,32 @@ scan_installed_apps() {
             run_with_timeout "$MOLE_TIMEOUT_SHORT_QUERY_SEC" lsappinfo list 2> /dev/null | grep -o '"CFBundleIdentifier"="[^"]*"' | cut -d'"' -f4 >> "$scan_tmp_dir/running.txt" 2> /dev/null || true
         fi
     ) < /dev/null &
-    pids+=($!)
+    auxiliary_pids+=($!)
     (
         run_with_timeout "$MOLE_TIMEOUT_MEDIUM_PROBE_SEC" find ~/Library/LaunchAgents /Library/LaunchAgents \
             -name "*.plist" -type f 2> /dev/null |
             xargs -I {} basename {} .plist > "$scan_tmp_dir/agents.txt" 2> /dev/null || true
     ) < /dev/null &
-    pids+=($!)
-    debug_log "Waiting for ${#pids[@]} background processes: ${pids[*]}"
-    if [[ ${#pids[@]} -gt 0 ]]; then
-        for pid in "${pids[@]}"; do
+    auxiliary_pids+=($!)
+    debug_log "Waiting for $((${#app_scan_pids[@]} + ${#auxiliary_pids[@]})) background processes"
+    local app_scan_failed=0
+    if [[ ${#app_scan_pids[@]} -gt 0 ]]; then
+        for pid in "${app_scan_pids[@]}"; do
+            if ! wait "$pid" 2> /dev/null; then
+                app_scan_failed=1
+            fi
+        done
+    fi
+    if [[ ${#auxiliary_pids[@]} -gt 0 ]]; then
+        for pid in "${auxiliary_pids[@]}"; do
             wait "$pid" 2> /dev/null || true
         done
     fi
     debug_log "All background processes completed"
+    if [[ $app_scan_failed -ne 0 ]]; then
+        debug_log "Failed to scan one or more installed application directories"
+        return 1
+    fi
     cat "$scan_tmp_dir"/*.txt >> "$installed_bundles" 2> /dev/null || true
     sort -u "$installed_bundles" -o "$installed_bundles"
     ensure_user_dir "$(dirname "$cache_file")"

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -282,6 +282,78 @@ EOF
     [[ "$output" == *"SCAN_FAILURE_CLOSED"* ]]
 }
 
+@test "clean_orphaned_app_data fails closed when an app directory find fails" {
+    local scan_home="$HOME/find-failure-scan"
+    rm -rf "$scan_home"
+    mkdir -p "$scan_home"
+
+    run env HOME="$scan_home" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+mkdir -p "$HOME/Applications/LiveApp.app" \
+    "$HOME/Applications/Partial.app/Contents" \
+    "$HOME/Library/Caches/com.example.LiveApp"
+touch -t "$(date -v-31d +%Y%m%d%H%M.%S)" "$HOME/Library/Caches/com.example.LiveApp"
+rm -f "$HOME/.cache/mole/installed_apps_cache"
+
+cat > "$HOME/Applications/Partial.app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.Partial</string>
+</dict>
+</plist>
+PLIST
+
+stub_dir="$HOME/stub-bin-find-failure"
+mkdir -p "$stub_dir"
+cat > "$stub_dir/find" <<'SH'
+#!/bin/sh
+if [ "${1:-}" = "$HOME/Applications" ]; then
+    exit 64
+fi
+if [ "${1:-}" = "/Applications" ]; then
+    printf '%s\n' "$HOME/Applications/Partial.app"
+fi
+exit 0
+SH
+cat > "$stub_dir/lsappinfo" <<'SH'
+#!/bin/sh
+exit 0
+SH
+chmod +x "$stub_dir/find" "$stub_dir/lsappinfo"
+export PATH="$stub_dir:$PATH"
+
+mdfind() { return 0; }
+run_with_timeout() { shift; "$@"; }
+get_path_size_kb() { printf '1\n'; }
+safe_clean() {
+    : > "$HOME/safe-clean-called"
+    return 0
+}
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+
+set +e
+clean_orphaned_app_data
+rc=$?
+set -e
+
+[[ $rc -eq 0 ]] || exit 1
+[[ ! -e "$HOME/safe-clean-called" ]] || exit 1
+[[ ! -e "$HOME/.cache/mole/installed_apps_cache" ]] || exit 1
+printf 'APP_DIRECTORY_SCAN_FAILURE_CLOSED\n'
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipped: Unable to scan installed applications"* ]] || return 1
+    [[ "$output" == *"APP_DIRECTORY_SCAN_FAILURE_CLOSED"* ]]
+}
+
 @test "is_bundle_orphaned returns true for old uninstalled bundle" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" ORPHAN_AGE_THRESHOLD=30 /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -244,6 +244,44 @@ EOF
     [[ "$output" == *"REGISTRY_CLEANUP_OK"* ]] || return 1
 }
 
+@test "clean_orphaned_app_data fails closed when the installed app scan fails" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+mkdir -p "$HOME/Library/Caches/com.example.LiveApp"
+touch -t "$(date -v-31d +%Y%m%d%H%M.%S)" "$HOME/Library/Caches/com.example.LiveApp"
+
+scan_installed_apps() {
+    : > "$1"
+    return 1
+}
+mdfind() { return 0; }
+run_with_timeout() { shift; "$@"; }
+get_path_size_kb() { printf '1\n'; }
+safe_clean() {
+    : > "$HOME/safe-clean-called"
+    return 0
+}
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+
+set +e
+clean_orphaned_app_data
+rc=$?
+set -e
+
+[[ $rc -eq 0 ]] || exit 1
+[[ ! -e "$HOME/safe-clean-called" ]] || exit 1
+printf 'SCAN_FAILURE_CLOSED\n'
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipped: Unable to scan installed applications"* ]] || return 1
+    [[ "$output" == *"SCAN_FAILURE_CLOSED"* ]]
+}
+
 @test "is_bundle_orphaned returns true for old uninstalled bundle" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" ORPHAN_AGE_THRESHOLD=30 /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -184,6 +184,66 @@ EOF
     [[ "$output" == *"com.example.Ordered"* ]]
 }
 
+@test "scan_installed_apps leaves tracked scratch cleanup to the temp registry (#1313)" {
+    local scan_home="$HOME/registry-scan"
+    rm -rf "$scan_home"
+    mkdir -p "$scan_home"
+
+    run env HOME="$scan_home" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+
+mkdir -p "$HOME/mole-tmp"
+export TMPDIR="$HOME/mole-tmp"
+
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+rm -f "$HOME/.cache/mole/installed_apps_cache"
+
+stub_dir="$HOME/stub-bin-registry"
+mkdir -p "$stub_dir"
+cat > "$stub_dir/find" <<'SH'
+#!/bin/sh
+exit 0
+SH
+cat > "$stub_dir/lsappinfo" <<'SH'
+#!/bin/sh
+exit 0
+SH
+chmod +x "$stub_dir/find" "$stub_dir/lsappinfo"
+export PATH="$stub_dir:$PATH"
+
+remove_calls="$HOME/safe-remove-calls"
+: > "$remove_calls"
+safe_remove() {
+    printf '%s\n' "$1" >> "$remove_calls"
+    return 1
+}
+debug_log() {
+    printf 'DEBUG:%s\n' "$*"
+}
+
+scan_installed_apps "$HOME/installed.txt"
+
+[[ -s "$MOLE_TEMP_REGISTRY_FILE" ]] || exit 1
+scan_tmp_dir=$(head -n 1 "$MOLE_TEMP_REGISTRY_FILE")
+[[ -d "$scan_tmp_dir" ]] || exit 1
+[[ ! -s "$remove_calls" ]] || exit 1
+
+outside_file="$HOME/outside-temp-root"
+touch "$outside_file"
+cleanup_temp_files
+
+[[ ! -e "$scan_tmp_dir" ]] || exit 1
+[[ -e "$outside_file" ]] || exit 1
+printf 'REGISTRY_CLEANUP_OK\n'
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"DEBUG:Scanned 0 unique applications"* ]] || return 1
+    [[ "$output" == *"REGISTRY_CLEANUP_OK"* ]] || return 1
+}
+
 @test "is_bundle_orphaned returns true for old uninstalled bundle" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" ORPHAN_AGE_THRESHOLD=30 /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Keep app-leftover discovery running under whole-command `sudo` by leaving Mole-created scan scratch to the existing tracked-temp cleanup instead of routing it through the user-data deletion validator.
- Return an explicit failure if the scan scratch directory cannot be created.
- Add regression coverage for both reaching the completed scan path and removing only the registered scratch directory.

Fixes #1313.

## Safety Review

- This affects the app-leftover scan's internal temporary-directory lifecycle; it does not add or broaden any cleanup target.
- The protected `/private/var/root` boundary is unchanged. Under `sudo mo`, the scan scratch remains under Mole's root-owned temp tree and is removed by the existing registry cleanup constrained to `MOLE_RESOLVED_TMPDIR`.
- The regression test makes `safe_remove` fail if called, verifies the scan still completes, verifies registered scratch is cleaned, and verifies an unrelated path outside the temp root remains untouched.

## Tests

- Red/green: the new #1313 test failed against the old immediate-`safe_remove` path and passes with this change.
- `env -u NO_COLOR MOLE_TEST_NO_AUTH=1 bats tests/clean_apps.bats tests/clean_hints.bats tests/user_file_ops.bats` — 95 passed.
- `./scripts/check.sh --format` — passed; only the two intended files changed.
- `./scripts/check.sh --no-format` — `go vet`, ShellCheck, and Bash syntax checks passed.
- `env -u NO_COLOR MOLE_TEST_NO_AUTH=1 ./scripts/test.sh` — 1,148 tests ran; the new test passed. One unrelated Chrome AI-model whitelist test failed in that run, then passed both in isolation and in a complete 46-test `clean_user_core.bats` rerun (6 TTY/binary-dependent tests skipped in the full run).

## Safety-related changes

- Preserve the deletion validator exactly as-is and move only this registered internal scratch directory onto the temp registry's existing process-exit cleanup path.

