### PR TITLE
fix(clean): recognize ChatGPT as Codex Desktop

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1752,6 +1752,8 @@ clean_dev_api_tools() {
 codex_desktop_running() {
     command -v pgrep > /dev/null 2>&1 || return 1
 
+    pgrep -x "ChatGPT" > /dev/null 2>&1 && return 0
+    pgrep -f "/ChatGPT.app/" > /dev/null 2>&1 && return 0
     pgrep -x "Codex" > /dev/null 2>&1 && return 0
     pgrep -f "/Codex.app/" > /dev/null 2>&1 && return 0
     return 1

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -434,6 +434,63 @@ EOF
     [[ "$output" != *"docker called"* ]]
 }
 
+@test "codex_desktop_running recognizes current and legacy app aliases (#1305)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+
+matched_query=""
+pgrep() {
+    [[ "$*" == "$matched_query" ]]
+}
+
+for matched_query in "-x Codex" "-f /Codex.app/" "-x ChatGPT" "-f /ChatGPT.app/"; do
+    codex_desktop_running || exit 1
+done
+
+matched_query="-x unrelated"
+if codex_desktop_running; then
+    exit 1
+fi
+printf 'CODEX_DESKTOP_ALIASES_OK\n'
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"CODEX_DESKTOP_ALIASES_OK"* ]] || return 1
+}
+
+@test "ChatGPT running keeps Codex runtime and update staging cleanup dormant (#1305)" {
+    local case_home="$HOME/chatgpt-running-case"
+    local runtime_root="$case_home/.cache/codex-runtimes"
+    local staging_root="$case_home/Library/Caches/com.openai.codex/org.sparkle-project.Sparkle/Installation"
+    rm -rf "$case_home"
+    mkdir -p "$runtime_root/incomplete-install" "$staging_root/stale"
+    touch -t 202001010000 "$staging_root/stale"
+
+    run env HOME="$case_home" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+pgrep() { [[ "$1" == "-x" && "$2" == "ChatGPT" ]]; }
+lsof() { return 1; }
+run_with_timeout() { shift; "$@"; }
+is_path_whitelisted() { return 1; }
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+get_path_size_kb() { echo "1024"; }
+bytes_to_human() { echo "1M"; }
+note_activity() { :; }
+
+clean_codex_runtimes
+clean_codex_desktop_staging
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"Codex runtimes · skipped (Codex running)"* ]] || return 1
+    [[ "$output" == *"Codex Desktop update staging · skipped (Codex running)"* ]] || return 1
+    [[ "$output" != *"SAFE_CLEAN:"* ]] || return 1
+}
+
 @test "clean_codex_runtimes reports active runtime for manual review" {
     mkdir -p "$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin"
     touch "$HOME/.cache/codex-runtimes/codex-primary-runtime/runtime.json"


### PR DESCRIPTION
## Summary

- Recognize the current unified `ChatGPT` process and `/ChatGPT.app/` path in the existing Codex Desktop running guard.
- Preserve the legacy `Codex` process and `/Codex.app/` aliases.
- Add regression coverage proving both Codex runtime cleanup and Sparkle staging cleanup stay dormant while the current app is active.

Fixes #1305.

## Safety Review

- The new checks use the same exact-name and app-path forms as the existing guard; they do not introduce a broad `ChatGPT` substring match.
- This does not add or broaden a cleanup target. A match only defers cleanup while the app is running.
- The runtime layout checks, Sparkle updater/open-file checks, age threshold, whitelist, and protected-path validation remain unchanged.
- The integration regression exercises both destructive consumers and fails if either reaches `safe_clean` while `ChatGPT` is detected.

## Tests

- Red/green: both new #1305 regressions failed against the previous `Codex`-only guard and pass with this change.
- `env -u NO_COLOR MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/dev_extended.bats` — 77 passed.
- `./scripts/check.sh --format` — passed; only the two intended files changed.
- `./scripts/check.sh --no-format` — `go vet`, ShellCheck, and Bash syntax checks passed.
- `env -u NO_COLOR MOLE_TEST_NO_AUTH=1 ./scripts/test.sh` — 1,149 tests, 0 failures, 6 skipped; Go and integration checks passed (Homebrew-dependent installation check skipped).

## Safety-related changes

- Extend the existing hard running-app skip to the current ChatGPT packaging without weakening any downstream cleanup safeguard.
