### PR TITLE
fix(uninstall): recover App Management-blocked app bundles through Finder

### DIFF
--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -16,6 +16,7 @@ readonly MOLE_ERR_AUTH_FAILED=11
 readonly MOLE_ERR_READONLY_FS=12
 readonly MOLE_ERR_PROTECTED_PATH=13
 readonly MOLE_ERR_PRIVACY_DENIED=14
+readonly MOLE_ERR_APP_MANAGEMENT_DENIED=15
 
 # Ensure dependencies are loaded
 _MOLE_CORE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -750,6 +751,7 @@ safe_sudo_remove() {
 mole_delete() {
     local path="$1"
     local needs_sudo="${2:-false}"
+    local sudo_was_downgraded=false
     local mode="${MOLE_DELETE_MODE:-permanent}"
 
     [[ -z "$path" ]] && return 1
@@ -787,6 +789,7 @@ mole_delete() {
         if [[ ${EUID:-0} -ne 0 ]]; then
             debug_log "Downgrading privileged delete below mutable parent: $path"
             needs_sudo=false
+            sudo_was_downgraded=true
         else
             _mole_delete_log "$mode" "unknown" "mutable-parent" "$path"
             debug_log "Refusing privileged delete below mutable parent: $path"
@@ -838,7 +841,7 @@ mole_delete() {
     # fail closed instead of silently switching to permanent removal.
     if [[ "$mode" == "trash" ]]; then
         local trash_rc=0
-        _mole_move_to_trash "$path" "$needs_sudo" || trash_rc=$?
+        _mole_move_to_trash "$path" "$needs_sudo" "$sudo_was_downgraded" || trash_rc=$?
         if [[ $trash_rc -eq 0 ]]; then
             _mole_delete_log "trash" "$size_kb" "ok" "$path"
             log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "TRASHED" "$path" "${size_kb}KB"
@@ -854,6 +857,17 @@ mole_delete() {
             fi
             debug_log "macOS privacy permission denied while moving to Trash: $path"
             return "$MOLE_ERR_PRIVACY_DENIED"
+        fi
+        if [[ $trash_rc -eq $MOLE_ERR_APP_MANAGEMENT_DENIED ]]; then
+            _mole_delete_log "trash" "$size_kb" "app-management-denied" "$path"
+            log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "SKIPPED" "$path" "app management denied"
+            if [[ -z "${_MOLE_APP_MANAGEMENT_DENIED_WARNED:-}" ]]; then
+                _MOLE_APP_MANAGEMENT_DENIED_WARNED=1
+                export _MOLE_APP_MANAGEMENT_DENIED_WARNED
+                printf 'Error: macOS blocked app-bundle removal, and Finder could not complete the Trash move. Allow App Management and Finder automation for your terminal in System Settings, or move the app to Trash in Finder, then retry.\n' >&2
+            fi
+            debug_log "macOS app management denied app-bundle removal after Finder fallback: $path"
+            return "$MOLE_ERR_APP_MANAGEMENT_DENIED"
         fi
         _mole_delete_log "trash" "$size_kb" "trash-failed" "$path"
         log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "SKIPPED" "$path" "trash-failed"
@@ -909,13 +923,18 @@ _mole_path_is_immediate_child_of() {
     [[ -n "$child" && "$child" != */* ]]
 }
 
+_mole_path_is_top_level_application_bundle() {
+    local path="${1%/}"
+    _mole_path_is_immediate_child_of "$path" "/Applications" &&
+        [[ "${path##*/}" == *.app ]]
+}
+
 # Finder and third-party Trash helpers can fail on app bundles and TCC-managed
 # app data even after authentication. Route only these exact one-level targets
 # through the direct, recoverable Trash mover.
 _mole_path_requires_direct_trash() {
     local path="${1%/}"
-    if _mole_path_is_immediate_child_of "$path" "/Applications" &&
-        [[ "${path##*/}" == *.app ]]; then
+    if _mole_path_is_top_level_application_bundle "$path"; then
         return 0
     fi
 
@@ -927,11 +946,31 @@ _mole_path_requires_direct_trash() {
     return 1
 }
 
+_mole_move_with_finder() {
+    local path="$1"
+
+    if [[ "${MOLE_TEST_MODE:-0}" == "1" || "${MOLE_TEST_NO_AUTH:-0}" == "1" ]]; then
+        return 1
+    fi
+
+    # Pass the path via argv so special chars (quotes, backslashes) cannot
+    # break out of the quoted AppleScript string.
+    osascript - "$path" > /dev/null 2>&1 << 'APPLESCRIPT'
+on run argv
+    set p to POSIX file (item 1 of argv)
+    tell application "Finder"
+        delete p
+    end tell
+end run
+APPLESCRIPT
+}
+
 # Move a path to the macOS Trash. Test harnesses set MOLE_TEST_TRASH_DIR to
 # redirect the move to a tmpdir, avoiding any Finder/osascript interaction.
 _mole_move_to_trash() {
     local path="$1"
     local needs_sudo="${2:-false}"
+    local sudo_was_downgraded="${3:-false}"
 
     if [[ -n "${MOLE_TEST_TRASH_DIR:-}" ]]; then
         mkdir -p "$MOLE_TEST_TRASH_DIR" 2> /dev/null || return 1
@@ -946,7 +985,7 @@ _mole_move_to_trash() {
     fi
 
     if [[ "$needs_sudo" == "true" ]] || _mole_path_requires_direct_trash "$path"; then
-        _mole_move_path_to_user_trash "$path" "$needs_sudo"
+        _mole_move_path_to_user_trash "$path" "$needs_sudo" "$sudo_was_downgraded"
         return $?
     fi
 
@@ -955,16 +994,8 @@ _mole_move_to_trash() {
         trash "$path" > /dev/null 2>&1 && return 0
     fi
 
-    # AppleScript fallback. Pass the path via argv so special chars (quotes,
-    # backslashes) cannot break out of the quoted string.
-    osascript - "$path" > /dev/null 2>&1 << 'APPLESCRIPT'
-on run argv
-    set p to POSIX file (item 1 of argv)
-    tell application "Finder"
-        delete p
-    end tell
-end run
-APPLESCRIPT
+    # AppleScript fallback.
+    _mole_move_with_finder "$path"
 }
 
 # /Library/Caches is mode 0777 on supported macOS releases, so it cannot anchor a
@@ -1031,6 +1062,7 @@ _mole_create_privileged_trash_stage() {
 _mole_move_path_to_user_trash() {
     local path="$1"
     local needs_sudo="${2:-false}"
+    local sudo_was_downgraded="${3:-false}"
 
     if [[ "${MOLE_TEST_MODE:-0}" == "1" || "${MOLE_TEST_NO_AUTH:-0}" == "1" ]]; then
         return 1
@@ -1048,6 +1080,7 @@ _mole_move_path_to_user_trash() {
         if [[ ${EUID:-0} -ne 0 ]]; then
             debug_log "Downgrading Trash move below mutable parent: $path"
             needs_sudo=false
+            sudo_was_downgraded=true
         else
             debug_log "Refusing privileged Trash move below mutable parent: $path"
             return 1
@@ -1200,6 +1233,20 @@ _mole_move_path_to_user_trash() {
         case "$move_output" in
             *"Operation not permitted"* | *"operation not permitted"* | \
                 *"Permission denied"* | *"permission denied"*)
+                if [[ "$sudo_was_downgraded" == "true" ]] &&
+                    _mole_path_is_top_level_application_bundle "$path" &&
+                    [[ -e "$path" || -L "$path" ]]; then
+                    if _mole_move_with_finder "$path"; then
+                        if [[ ! -e "$path" && ! -L "$path" ]]; then
+                            debug_log "Moved App Management-blocked bundle to Trash through Finder: $path"
+                            return 0
+                        fi
+                        debug_log "Finder reported success but left app bundle in place: $path"
+                    else
+                        debug_log "Finder failed to move App Management-blocked bundle to Trash: $path"
+                    fi
+                    return "$MOLE_ERR_APP_MANAGEMENT_DENIED"
+                fi
                 return "$MOLE_ERR_PRIVACY_DENIED"
                 ;;
         esac
@@ -1642,6 +1689,10 @@ diagnose_removal_failure() {
         "$MOLE_ERR_PRIVACY_DENIED")
             reason="macOS privacy permission denied"
             suggestion="Grant App Data or Full Disk Access to your terminal in System Settings"
+            ;;
+        "$MOLE_ERR_APP_MANAGEMENT_DENIED")
+            reason="macOS App Management denied app-bundle removal"
+            suggestion="Allow App Management and Finder automation for your terminal, or move the app to Trash in Finder"
             ;;
         *)
             reason="permission denied"

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -302,6 +302,11 @@ osascript() {
 _mole_path_requires_direct_trash "/Applications/Microsoft Word.app"
 ! _mole_path_requires_direct_trash "/Applications/Utilities/Microsoft Word.app"
 ! _mole_path_requires_direct_trash "/Applications/Microsoft Word.app/Contents"
+_mole_path_is_top_level_application_bundle "/Applications/Microsoft Word.app"
+_mole_path_is_top_level_application_bundle "/Applications/Microsoft Word.app/"
+! _mole_path_is_top_level_application_bundle "/Applications/Microsoft Word"
+! _mole_path_is_top_level_application_bundle "/Applications/Utilities/Microsoft Word.app"
+! _mole_path_is_top_level_application_bundle "/ApplicationsX/Microsoft Word.app"
 _mole_move_to_trash "/Applications/Microsoft Word.app" false
 EOF
 
@@ -309,6 +314,187 @@ EOF
     grep -qF "direct:/Applications/Microsoft Word.app:false" "$trace"
     [[ "$(grep -c '^trash:' "$trace" 2> /dev/null || true)" -eq 0 ]] || return 1
     [[ "$(grep -c '^osascript:' "$trace" 2> /dev/null || true)" -eq 0 ]]
+}
+
+@test "downgraded application bundle retries a denied direct move through Finder" {
+    local fake_home="$SANDBOX/home"
+    local victim="$SANDBOX/Microsoft Teams.app"
+    local finder_dest="$SANDBOX/Finder Trash/Microsoft Teams.app"
+    local trace="$SANDBOX/app-management-fallback.log"
+    mkdir -p "$fake_home" "$victim" "$(dirname "$finder_dest")"
+    printf 'payload' > "$victim/data.txt"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+unset MOLE_TEST_TRASH_DIR
+unset MOLE_TEST_NO_AUTH
+export HOME="$fake_home"
+export MOLE_DELETE_MODE=trash
+_mole_privileged_path_has_mutable_ancestor() { return 0; }
+_mole_path_is_top_level_application_bundle() { return 0; }
+mv() {
+    printf 'mv:%s:%s\n' "\$1" "\$2" >> "$trace"
+    printf 'mv: rename %s to %s: Permission denied\n' "\$1" "\$2" >&2
+    return 1
+}
+osascript() {
+    printf 'osascript:%s\n' "\$*" >> "$trace"
+    /bin/mv "\$2" "$finder_dest"
+}
+trash() {
+    printf 'trash:%s\n' "\$*" >> "$trace"
+    return 98
+}
+sudo() {
+    printf 'sudo:%s\n' "\$*" >> "$trace"
+    return 97
+}
+safe_remove() {
+    printf 'safe_remove:%s\n' "\$*" >> "$trace"
+    return 96
+}
+mole_delete "$victim" true
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ ! -e "$victim" ]] || return 1
+    [[ -f "$finder_dest/data.txt" ]] || return 1
+    [[ "$(grep -c '^mv:' "$trace" 2> /dev/null || true)" -eq 1 ]] || return 1
+    [[ "$(grep -c '^osascript:- ' "$trace" 2> /dev/null || true)" -eq 1 ]] || return 1
+    [[ "$(grep -c '^trash:' "$trace" 2> /dev/null || true)" -eq 0 ]] || return 1
+    [[ "$(grep -c '^sudo:' "$trace" 2> /dev/null || true)" -eq 0 ]] || return 1
+    [[ "$(grep -c '^safe_remove:' "$trace" 2> /dev/null || true)" -eq 0 ]] || return 1
+    [ "$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")" = "ok" ]
+}
+
+@test "failed Finder retry reports App Management and preserves the application bundle" {
+    local fake_home="$SANDBOX/home"
+    local victim="$SANDBOX/WhatsApp.app"
+    local trace="$SANDBOX/app-management-failed.log"
+    mkdir -p "$fake_home" "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+unset MOLE_TEST_TRASH_DIR
+unset MOLE_TEST_NO_AUTH
+export HOME="$fake_home"
+export MOLE_DELETE_MODE=trash
+_mole_privileged_path_has_mutable_ancestor() { return 0; }
+_mole_path_is_top_level_application_bundle() { return 0; }
+mv() {
+    printf 'mv:%s:%s\n' "\$1" "\$2" >> "$trace"
+    printf 'mv: rename %s to %s: Operation not permitted\n' "\$1" "\$2" >&2
+    return 1
+}
+osascript() {
+    printf 'osascript:%s\n' "\$*" >> "$trace"
+    return 1
+}
+trash() {
+    printf 'trash:%s\n' "\$*" >> "$trace"
+    return 98
+}
+sudo() {
+    printf 'sudo:%s\n' "\$*" >> "$trace"
+    return 97
+}
+safe_remove() {
+    printf 'safe_remove:%s\n' "\$*" >> "$trace"
+    return 96
+}
+set +e
+mole_delete "$victim" true
+rc=\$?
+set -e
+printf 'RC=%s\n' "\$rc"
+[[ \$rc -eq \$MOLE_ERR_APP_MANAGEMENT_DENIED ]] || exit 1
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ -f "$victim/data.txt" ]] || return 1
+    [[ "$output" == *"App Management"* ]] || return 1
+    [[ "$output" == *"Finder"* ]] || return 1
+    [[ "$output" != *"Full Disk Access"* ]] || return 1
+    [[ "$output" == *"RC=15"* ]] || return 1
+    [[ "$(grep -c '^mv:' "$trace" 2> /dev/null || true)" -eq 1 ]] || return 1
+    [[ "$(grep -c '^osascript:- ' "$trace" 2> /dev/null || true)" -eq 1 ]] || return 1
+    [[ "$(grep -c '^trash:' "$trace" 2> /dev/null || true)" -eq 0 ]] || return 1
+    [[ "$(grep -c '^sudo:' "$trace" 2> /dev/null || true)" -eq 0 ]] || return 1
+    [[ "$(grep -c '^safe_remove:' "$trace" 2> /dev/null || true)" -eq 0 ]] || return 1
+    [ "$(awk -F'\t' 'END { print $4 }' "$MOLE_DELETE_LOG")" = "app-management-denied" ]
+}
+
+@test "application bundle without a privilege downgrade does not use Finder retry" {
+    local fake_home="$SANDBOX/home"
+    local victim="$SANDBOX/User App.app"
+    local trace="$SANDBOX/no-downgrade-fallback.log"
+    mkdir -p "$fake_home" "$victim"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+unset MOLE_TEST_TRASH_DIR
+unset MOLE_TEST_NO_AUTH
+export HOME="$fake_home"
+export MOLE_DELETE_MODE=trash
+_mole_path_is_top_level_application_bundle() { return 0; }
+mv() {
+    printf 'mv: permission denied\n' >&2
+    return 1
+}
+osascript() {
+    printf 'osascript\n' >> "$trace"
+    return 98
+}
+set +e
+mole_delete "$victim" false
+rc=\$?
+set -e
+printf 'RC=%s\n' "\$rc"
+[[ \$rc -eq \$MOLE_ERR_PRIVACY_DENIED ]] || exit 1
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ -d "$victim" ]] || return 1
+    [[ "$output" == *"RC=14"* ]] || return 1
+    [[ ! -s "$trace" ]] || return 1
+}
+
+@test "downgraded app data keeps the existing privacy error without Finder retry" {
+    local fake_home="$SANDBOX/home"
+    local victim="$fake_home/Library/Containers/com.microsoft.Word"
+    local trace="$SANDBOX/container-no-finder.log"
+    mkdir -p "$victim"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+unset MOLE_TEST_TRASH_DIR
+unset MOLE_TEST_NO_AUTH
+export HOME="$fake_home"
+export MOLE_DELETE_MODE=trash
+export MOLE_UNINSTALL_MODE=1
+_mole_privileged_path_has_mutable_ancestor() { return 0; }
+mv() {
+    printf 'mv: permission denied\n' >&2
+    return 1
+}
+osascript() {
+    printf 'osascript\n' >> "$trace"
+    return 98
+}
+set +e
+mole_delete "$victim" true
+rc=\$?
+set -e
+printf 'RC=%s\n' "\$rc"
+[[ \$rc -eq \$MOLE_ERR_PRIVACY_DENIED ]] || exit 1
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ -d "$victim" ]] || return 1
+    [[ "$output" == *"App Data or Full Disk Access"* ]] || return 1
+    [[ "$output" == *"RC=14"* ]] || return 1
+    [[ ! -s "$trace" ]] || return 1
 }
 
 @test "normal app data uses direct Trash with a unique name and mode 0700" {
@@ -494,6 +680,19 @@ EOF
     [[ "$output" == *"macOS privacy permission denied"* ]] || return 1
     [[ "$output" == *"App Data or Full Disk Access"* ]] || return 1
     [[ "$output" != *"touchid"* ]] || return 1
+    [[ "$output" != *"Touch ID"* ]]
+}
+
+@test "App Management diagnosis recommends Finder without blaming Full Disk Access" {
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+diagnose_removal_failure "\$MOLE_ERR_APP_MANAGEMENT_DENIED" "Microsoft Teams"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"macOS App Management denied app-bundle removal"* ]] || return 1
+    [[ "$output" == *"Finder"* ]] || return 1
+    [[ "$output" != *"Full Disk Access"* ]] || return 1
     [[ "$output" != *"Touch ID"* ]]
 }
 


### PR DESCRIPTION
## Summary

- Preserve whether a sudo-required uninstall was downgraded because an ancestor is mutable.
- When the unprivileged direct Trash move is permission-denied for an exact top-level `/Applications/*.app` bundle, retry through the existing Finder/AppleScript Trash path.
- Return a distinct App Management/Finder diagnostic if that retry fails, while leaving sandbox container paths on their existing App Data / Full Disk Access path.

Addresses #1299.

## Safety Review

- This changes the uninstall deletion sink, so the fallback is gated on all four observed conditions: the caller originally required sudo, the mutable-ancestor guard downgraded it, the target is an immediate `/Applications/*.app` child, and the direct `mv` returned a permission/TCC denial.
- The change does not bypass `_mole_privileged_path_has_mutable_ancestor` and never retries with sudo. Finder receives the path as argv, not interpolated AppleScript.
- Finder success is accepted only when the original bundle path is gone. Finder failure returns a dedicated error and does not fall through to permanent deletion or privileged staging.
- `~/Library/Containers`, Group Containers, and Application Scripts keep their existing direct-move and privacy-diagnostic behavior.
- `--permanent` remains intentionally unchanged and fail-closed below a mutable `/Applications` ancestor; this patch restores the default recoverable Trash path only.

## Tests

- `MOLE_TEST_NO_AUTH=1 bats tests/file_ops_mole_delete.bats tests/user_file_ops.bats` (69 passed)
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats tests/uninstall_remove_file_list.bats` (77 passed)
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_user_core.bats` (46 passed)
- `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh` (1240 passed, 6 environment-dependent skips)
- `./scripts/check.sh --format`
- `./scripts/check.sh --no-format` (go vet, ShellCheck, and Bash syntax passed)
- All authorization-capable paths were mocked; verification did not invoke real sudo, Finder, or AppleScript authorization.

## Safety-related changes

- Adds a narrowly scoped, recoverable Finder fallback for App Management-blocked top-level app bundles after the existing privilege downgrade.

