### PR TITLE
fix(update): stop hashless nightly reinstall loops

### DIFF
--- a/lib/manage/update.sh
+++ b/lib/manage/update.sh
@@ -632,7 +632,48 @@ get_latest_commit_from_github() {
     fi
     sha=$(printf '%s\n' "$response" |
         grep '"sha"[[:space:]]*:[[:space:]]*"[0-9a-f]\{40\}"' | head -1 | sed -E 's/.*"sha"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/') || sha=""
-    echo "$sha"
+    if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+        printf '%s\n' "$sha"
+        return 0
+    fi
+
+    # The unauthenticated API can be rate-limited even while ordinary GitHub
+    # access works. Keep the fallback bounded and accept only main's exact SHA.
+    if command -v git > /dev/null 2>&1; then
+        # Ignore ambient credential helpers and URL rewrites: this public,
+        # read-only probe must resolve the literal GitHub remote or fail.
+        if response=$(run_with_timeout "$MOLE_TIMEOUT_MEDIUM_PROBE_SEC" \
+            /usr/bin/env \
+            -u GIT_CONFIG_PARAMETERS \
+            -u GIT_EXEC_PATH \
+            -u GIT_DIR \
+            -u GIT_WORK_TREE \
+            -u GIT_COMMON_DIR \
+            -u GIT_CONFIG \
+            -u GIT_PROXY_COMMAND \
+            -u GIT_SSH \
+            -u GIT_SSH_COMMAND \
+            -u GIT_SSL_NO_VERIFY \
+            GIT_TERMINAL_PROMPT=0 \
+            GIT_ASKPASS=/usr/bin/false \
+            SSH_ASKPASS=/usr/bin/false \
+            GIT_CONFIG_NOSYSTEM=1 \
+            GIT_CONFIG_GLOBAL=/dev/null \
+            GIT_CONFIG_COUNT=0 \
+            LC_ALL=C \
+            git -c credential.helper= -c core.askPass=/usr/bin/false \
+            -c protocol.allow=never -c protocol.https.allow=always \
+            -c http.sslVerify=true -C / \
+            ls-remote https://github.com/tw93/mole.git refs/heads/main \
+            2> /dev/null); then
+            sha=$(printf '%s\n' "$response" |
+                awk '$2 == "refs/heads/main" { print $1; exit }')
+        else
+            sha=""
+        fi
+    fi
+    [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || sha=""
+    printf '%s\n' "$sha"
 }
 
 mole_update_message_cache_is_current() {
@@ -878,6 +919,13 @@ update_mole() (
 
         latest_commit=$(get_latest_commit_from_github)
         if [[ "$force_update" != "true" ]]; then
+            if [[ ! "$latest_commit" =~ ^[0-9a-f]{40}$ ]]; then
+                log_error "Unable to resolve latest nightly commit. No update was installed."
+                echo -e "${ICON_REVIEW} Check GitHub access and try again."
+                echo -e "${ICON_REVIEW} To explicitly reinstall anyway: ${GRAY}mo update --nightly --force${NC}"
+                exit 1
+            fi
+
             local installed_commit
             installed_commit=$(get_install_commit)
 

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -177,6 +177,67 @@ SCRIPT
 	chmod +x "$bin_dir/curl"
 }
 
+make_nightly_api_failure_stubs() {
+	local bin_dir="$1"
+	local latest_commit="${2:-}"
+	cat > "$bin_dir/curl" <<'SCRIPT'
+#!/usr/bin/env bash
+out=""
+url=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-o)
+			out="$2"
+			shift 2
+			;;
+		http*://*)
+			url="$1"
+			shift
+			;;
+		*) shift ;;
+	esac
+done
+[[ -n "$url" ]] && printf '%s\n' "$url" >> "$CURL_URL_LOG"
+
+if [[ -n "$out" ]]; then
+	cat > "$out" <<'INSTALLER'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$INSTALLER_ARGS_LOG"
+printf '%s\n' "${MOLE_INSTALL_COMMIT:-}" > "$INSTALLER_COMMIT_LOG"
+echo "Updated to latest version, ${MOLE_VERSION#V}"
+INSTALLER
+	exit 0
+fi
+
+exit 22
+SCRIPT
+	cat > "$bin_dir/git" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "\$GIT_ARGS_LOG"
+if [[ -n "\${GIT_CONFIG_PARAMETERS:-}" || -n "\${GIT_EXEC_PATH:-}" ]]; then
+	[[ -n "\${GIT_POISON_LOG:-}" ]] && : > "\$GIT_POISON_LOG"
+	printf 'badc0de0000000000000000000000000000000000\trefs/heads/main\n'
+	exit 0
+fi
+if [[ -n "\${GIT_ENV_LOG:-}" ]]; then
+	printf '%s|%s|%s|%s|%s|%s|%s\n' \
+		"\${GIT_TERMINAL_PROMPT:-}" "\${GIT_ASKPASS:-}" "\${SSH_ASKPASS:-}" \
+		"\${GIT_CONFIG_NOSYSTEM:-}" "\${GIT_CONFIG_GLOBAL:-}" \
+		"\${GIT_CONFIG_COUNT:-}" "\${LC_ALL:-}" > "\$GIT_ENV_LOG"
+fi
+if [[ -n "$latest_commit" ]]; then
+	printf '%s\trefs/heads/main\n' "$latest_commit"
+	case "\${GIT_STUB_MODE:-success}" in
+		nonzero) exit 1 ;;
+		hang) sleep 30 ;;
+	esac
+	exit 0
+fi
+exit 1
+SCRIPT
+	chmod +x "$bin_dir/curl" "$bin_dir/git"
+}
+
 @test "mo update repairs missing helpers at the current stable version (#1193)" {
 	local manual_bin="$TEST_ROOT/manual/bin"
 	local manual_config="$TEST_ROOT/manual/config"
@@ -402,6 +463,152 @@ SCRIPT
 	if grep -q "raw.githubusercontent.com/tw93/mole/main/install.sh" "$curl_url_log"; then
 		return 1
 	fi
+}
+
+@test "mo update --nightly falls back to git when the commit API is unavailable" {
+	local manual_bin="$TEST_ROOT/manual/bin"
+	local manual_config="$TEST_ROOT/manual/config"
+	local fake_bin="$TEST_ROOT/fake-bin"
+	local curl_url_log="$TEST_ROOT/curl.urls"
+	local git_args_log="$TEST_ROOT/git.args"
+	local git_env_log="$TEST_ROOT/git.env"
+	local git_poison_log="$TEST_ROOT/git.poison"
+	local installer_args_log="$TEST_ROOT/installer.args"
+	local latest_commit="e31d46faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	mkdir -p "$fake_bin"
+	make_manual_mole_install "$manual_bin" "$manual_config" "1.41.0"
+	make_nightly_api_failure_stubs "$fake_bin" "$latest_commit"
+	printf 'CHANNEL=nightly\nCOMMIT_HASH=e31d46f\n' > "$manual_config/install_channel"
+	: > "$curl_url_log"
+	: > "$git_args_log"
+
+	run env \
+		HOME="$HOME" \
+		PATH="$fake_bin:/usr/bin:/bin" \
+		CURL_URL_LOG="$curl_url_log" \
+		GIT_ARGS_LOG="$git_args_log" \
+		GIT_ENV_LOG="$git_env_log" \
+		GIT_POISON_LOG="$git_poison_log" \
+		GIT_CONFIG_PARAMETERS=poison-rewrite \
+		GIT_EXEC_PATH="$TEST_ROOT/untrusted-git-exec" \
+		INSTALLER_ARGS_LOG="$installer_args_log" \
+		"$manual_bin/mo" update --nightly
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"Already on latest nightly, e31d46f"* ]] || return 1
+	[ ! -e "$installer_args_log" ] || return 1
+	[ ! -e "$git_poison_log" ] || return 1
+	grep -qF 'ls-remote https://github.com/tw93/mole.git refs/heads/main' "$git_args_log" || return 1
+	[ "$(cat "$git_env_log")" = '0|/usr/bin/false|/usr/bin/false|1|/dev/null|0|C' ] || return 1
+	grep -qF -- '-c credential.helper= -c core.askPass=/usr/bin/false' "$git_args_log" || return 1
+	grep -qF -- '-c protocol.allow=never -c protocol.https.allow=always -c http.sslVerify=true -C /' "$git_args_log" || return 1
+	if grep -q 'raw.githubusercontent.com/tw93/mole/main/install.sh' "$curl_url_log"; then
+		return 1
+	fi
+}
+
+@test "mo update --nightly refuses an unforced reinstall when HEAD is unknown" {
+	local manual_bin="$TEST_ROOT/manual/bin"
+	local manual_config="$TEST_ROOT/manual/config"
+	local fake_bin="$TEST_ROOT/fake-bin"
+	local curl_url_log="$TEST_ROOT/curl.urls"
+	local git_args_log="$TEST_ROOT/git.args"
+	local installer_args_log="$TEST_ROOT/installer.args"
+
+	mkdir -p "$fake_bin"
+	make_manual_mole_install "$manual_bin" "$manual_config" "1.41.0"
+	make_nightly_api_failure_stubs "$fake_bin" ""
+	printf 'CHANNEL=nightly\n' > "$manual_config/install_channel"
+	: > "$curl_url_log"
+	: > "$git_args_log"
+
+	run env \
+		HOME="$HOME" \
+		PATH="$fake_bin:/usr/bin:/bin" \
+		CURL_URL_LOG="$curl_url_log" \
+		GIT_ARGS_LOG="$git_args_log" \
+		INSTALLER_ARGS_LOG="$installer_args_log" \
+		"$manual_bin/mo" update --nightly
+
+	[ "$status" -eq 1 ] || return 1
+	[[ "$output" == *"Unable to resolve latest nightly commit"* ]] || return 1
+	[[ "$output" == *"mo update --nightly --force"* ]] || return 1
+	[ ! -e "$installer_args_log" ] || return 1
+	grep -qF 'ls-remote https://github.com/tw93/mole.git refs/heads/main' "$git_args_log" || return 1
+	if grep -q 'raw.githubusercontent.com/tw93/mole/main/install.sh' "$curl_url_log"; then
+		return 1
+	fi
+}
+
+@test "mo update --nightly rejects partial output from a failed or timed-out git probe" {
+	local manual_bin="$TEST_ROOT/manual/bin"
+	local manual_config="$TEST_ROOT/manual/config"
+	local fake_bin="$TEST_ROOT/fake-bin"
+	local curl_url_log="$TEST_ROOT/curl.urls"
+	local git_args_log="$TEST_ROOT/git.args"
+	local installer_args_log="$TEST_ROOT/installer.args"
+	local latest_commit="f42c0debbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	local mode start elapsed
+
+	mkdir -p "$fake_bin"
+	make_manual_mole_install "$manual_bin" "$manual_config" "1.41.0"
+	make_nightly_api_failure_stubs "$fake_bin" "$latest_commit"
+	printf 'CHANNEL=nightly\nCOMMIT_HASH=deadbee\n' > "$manual_config/install_channel"
+
+	for mode in nonzero hang; do
+		: > "$curl_url_log"
+		: > "$git_args_log"
+		rm -f "$installer_args_log"
+		start=$SECONDS
+		run env \
+			HOME="$HOME" \
+			PATH="$fake_bin:/usr/bin:/bin" \
+			MOLE_TIMEOUT_MEDIUM_PROBE_SEC=0.2 \
+			GIT_STUB_MODE="$mode" \
+			CURL_URL_LOG="$curl_url_log" \
+			GIT_ARGS_LOG="$git_args_log" \
+			INSTALLER_ARGS_LOG="$installer_args_log" \
+			"$manual_bin/mo" update --nightly
+		elapsed=$((SECONDS - start))
+
+		[ "$status" -eq 1 ] || return 1
+		[[ "$output" == *"Unable to resolve latest nightly commit"* ]] || return 1
+		[ ! -e "$installer_args_log" ] || return 1
+		[ "$elapsed" -lt 5 ] || return 1
+	done
+}
+
+@test "mo update --nightly forwards the git-resolved commit to the installer" {
+	local manual_bin="$TEST_ROOT/manual/bin"
+	local manual_config="$TEST_ROOT/manual/config"
+	local fake_bin="$TEST_ROOT/fake-bin"
+	local curl_url_log="$TEST_ROOT/curl.urls"
+	local git_args_log="$TEST_ROOT/git.args"
+	local installer_args_log="$TEST_ROOT/installer.args"
+	local installer_commit_log="$TEST_ROOT/installer.commit"
+	local latest_commit="f42c0debbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	mkdir -p "$fake_bin"
+	make_manual_mole_install "$manual_bin" "$manual_config" "1.41.0"
+	make_nightly_api_failure_stubs "$fake_bin" "$latest_commit"
+	printf 'CHANNEL=nightly\nCOMMIT_HASH=deadbee\n' > "$manual_config/install_channel"
+	: > "$curl_url_log"
+	: > "$git_args_log"
+
+	run env \
+		HOME="$HOME" \
+		PATH="$fake_bin:/usr/bin:/bin" \
+		CURL_URL_LOG="$curl_url_log" \
+		GIT_ARGS_LOG="$git_args_log" \
+		INSTALLER_ARGS_LOG="$installer_args_log" \
+		INSTALLER_COMMIT_LOG="$installer_commit_log" \
+		"$manual_bin/mo" update --nightly
+
+	[ "$status" -eq 0 ] || return 1
+	[ -f "$installer_args_log" ] || return 1
+	[ "$(cat "$installer_commit_log")" = "$latest_commit" ] || return 1
+	grep -q 'raw.githubusercontent.com/tw93/mole/main/install.sh' "$curl_url_log" || return 1
 }
 
 @test "mo update --nightly --force reinstalls even when the installed commit is current" {


### PR DESCRIPTION
Fixes #1336.

## What changed

- Fall back from the unauthenticated commit API to a bounded, non-interactive `git ls-remote` lookup for `main`.
- Accept the fallback SHA only after a successful probe, with ambient Git config, credential helpers, URL rewrites, and non-HTTPS transports disabled.
- If neither lookup produces a trustworthy 40-character SHA, stop an ordinary nightly update before downloading or installing anything. An explicit `--force` keeps the existing repair behavior.

This prevents an unknown HEAD from being treated as evidence that a reinstall is needed. A successful update continues to pass the resolved SHA to the installer, so `COMMIT_HASH` is written and the next nightly check is idempotent.

## Verification

- `MOLE_TEST_NO_AUTH=1 bats tests/update.bats` — 27/27 passed
- `./scripts/check.sh` — formatting, `go vet`, ShellCheck, syntax, and diagnostic guidance passed
- Full runner reached 1,459 tests. Five unrelated `scan_installed_apps` cache tests fail identically on untouched `origin/main` in this environment; the focused updater suite is green on the current base.
