### PR TITLE
fix(update): limit the git fallback to explicit nightly updates

### DIFF
--- a/lib/manage/update.sh
+++ b/lib/manage/update.sh
@@ -685,6 +685,7 @@ get_install_receipt() {
 }
 
 get_latest_commit_from_github() {
+    local lookup_scope="${1:-allow-git-fallback}"
     local response=""
     local sha=""
     if command -v curl > /dev/null 2>&1; then
@@ -698,6 +699,13 @@ get_latest_commit_from_github() {
         grep '"sha"[[:space:]]*:[[:space:]]*"[0-9a-f]\{40\}"' | head -1 | sed -E 's/.*"sha"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/') || sha=""
     if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
         printf '%s\n' "$sha"
+        return 0
+    fi
+
+    # Background notices are best-effort and should not spawn a Git process.
+    # Explicit update paths retain the bounded fallback below.
+    if [[ "$lookup_scope" == "api-only" ]]; then
+        printf '\n'
         return 0
     fi
 
@@ -786,7 +794,7 @@ check_for_updates() {
                 # Nightly: compare commit hashes instead of version numbers
                 local installed_commit latest_commit
                 installed_commit=$(get_install_commit)
-                latest_commit=$(get_latest_commit_from_github)
+                latest_commit=$(get_latest_commit_from_github api-only)
 
                 if [[ -n "$installed_commit" && -n "$latest_commit" && "${installed_commit:0:7}" != "${latest_commit:0:7}" ]]; then
                     printf "\nNew nightly commit %s available, run %smo update --nightly%s\n\n" "${latest_commit:0:7}" "$GREEN" "$NC" > "$msg_cache"

--- a/tests/update.bats
+++ b/tests/update.bats
@@ -563,6 +563,68 @@ SCRIPT
 	fi
 }
 
+@test "background nightly checks skip the git fallback while explicit lookups retain it" {
+	local fake_bin="$TEST_ROOT/fake-bin"
+	local curl_url_log="$TEST_ROOT/curl.urls"
+	local git_args_log="$TEST_ROOT/git.args"
+	local lookup_scope_log="$TEST_ROOT/lookup.scope"
+	local latest_commit="e31d46faaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	mkdir -p "$fake_bin"
+	make_nightly_api_failure_stubs "$fake_bin" "$latest_commit"
+	: > "$curl_url_log"
+	: > "$git_args_log"
+
+	run env \
+		HOME="$HOME" \
+		PATH="$fake_bin:/usr/bin:/bin" \
+		PROJECT_ROOT="$PROJECT_ROOT" \
+		LATEST_COMMIT="$latest_commit" \
+		CURL_URL_LOG="$curl_url_log" \
+		GIT_ARGS_LOG="$git_args_log" \
+		LOOKUP_SCOPE_LOG="$lookup_scope_log" \
+		/bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+mkdir -p "$HOME/config"
+source "$PROJECT_ROOT/lib/core/common.sh"
+VERSION="0.0.1"
+SCRIPT_DIR="$HOME/config"
+source "$PROJECT_ROOT/lib/manage/update.sh"
+
+background_commit=$(get_latest_commit_from_github api-only)
+[[ -z "$background_commit" ]] || exit 1
+[[ ! -s "$GIT_ARGS_LOG" ]] || exit 1
+
+explicit_commit=$(get_latest_commit_from_github)
+[[ "$explicit_commit" == "$LATEST_COMMIT" ]] || exit 1
+grep -qF 'ls-remote https://github.com/tw93/mole.git refs/heads/main' "$GIT_ARGS_LOG"
+
+get_install_channel() {
+	printf 'nightly\n'
+}
+get_install_commit() {
+	printf 'e31d46f\n'
+}
+get_latest_commit_from_github() {
+	printf '%s\n' "${1:-}" > "$LOOKUP_SCOPE_LOG"
+	printf '\n'
+}
+check_for_updates
+
+attempt=0
+while [[ ! -s "$LOOKUP_SCOPE_LOG" && "$attempt" -lt 100 ]]; do
+	sleep 0.01
+	attempt=$((attempt + 1))
+done
+[[ "$(cat "$LOOKUP_SCOPE_LOG")" == "api-only" ]] || exit 1
+INNER
+
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
+}
+
 @test "mo update --nightly refuses an unforced reinstall when HEAD is unknown" {
 	local manual_bin="$TEST_ROOT/manual/bin"
 	local manual_config="$TEST_ROOT/manual/config"


### PR DESCRIPTION
## Summary

- keep background nightly notices on the commit API without starting a Git probe when that request fails
- preserve the bounded, isolated `git ls-remote` fallback for explicit nightly updates and self-heal paths
- add a regression covering both lookup scopes and the background caller

Follow-up to #1337, as requested by @tw93 after that fix merged.

## Test plan

- `MOLE_TEST_NO_AUTH=1 bats tests/update.bats` (31 tests)
- `./scripts/check.sh --format`
