### PR TITLE
Add app-scan skip list to unblock App leftovers when a bundle is unreadable (#1339)

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1973,6 +1973,20 @@ main() {
                 manage_whitelist "clean"
                 exit 0
                 ;;
+            "--skip-app")
+                shift
+                if [[ $# -eq 0 ]]; then
+                    echo "Missing app name for --skip-app (e.g. \"SecuritySpy.app\")" >&2
+                    exit 1
+                fi
+                if ! add_app_scan_skip "$1"; then
+                    echo "Failed to update $APP_SCAN_SKIP_CONFIG" >&2
+                    exit 1
+                fi
+                echo "Added \"$1\" to the app-scan skip list ($APP_SCAN_SKIP_CONFIG)."
+                echo "It will be excluded from installed-app scanning on the next 'mo clean' run."
+                exit 0
+                ;;
             "--select" | "--categories" | "--exclude")
                 echo "mo clean $1 was removed in this release." >&2
                 echo "Use 'mo clean --dry-run' to preview cleanup and 'mo clean --whitelist' to protect paths." >&2

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -5,6 +5,80 @@ set -euo pipefail
 readonly ORPHAN_AGE_THRESHOLD=${ORPHAN_AGE_THRESHOLD:-${MOLE_ORPHAN_AGE_DAYS:-30}}
 readonly CLAUDE_VM_ORPHAN_AGE_THRESHOLD=${MOLE_CLAUDE_VM_ORPHAN_AGE_DAYS:-7}
 readonly INSTALLED_APPS_CACHE_COMPLETE_MARKER="# mole-installed-apps-cache:v3:complete"
+
+# User-configurable list of app bundles to exclude from the installed-app
+# scan below. One "*.app" basename per line, "#" comments allowed. Populated
+# via "mo clean --skip-app <name>" or by hand.
+#
+# Why this exists: some bundles (Mac Catalyst / wrapped iOS apps on Apple
+# Silicon, e.g. apps that ship an "Info.plist" under Wrapper/*.app instead of
+# the usual Contents/Info.plist) can't be read by the scan below. Because we
+# can't tell "unreadable" apart from "this app might be an orphan we should
+# feel free to delete", a single such bundle used to abort the *entire*
+# installed-app scan for every /Applications entry, which in turn skipped
+# "App leftovers" cleanup entirely (see #1339). Letting the user explicitly
+# name a known-fine bundle here lets the scan skip just that one app and
+# keep trusting the rest of the results, without weakening orphan detection
+# for anything the user hasn't vouched for.
+readonly APP_SCAN_SKIP_CONFIG="$HOME/.config/mole/app_scan_skip"
+
+# Populate the (bash 3.2 compatible, no associative arrays) skip list from
+# APP_SCAN_SKIP_CONFIG into the newline-delimited _MOLE_APP_SCAN_SKIP_LIST
+# global. Safe to call repeatedly; each call re-reads the config so
+# "mo clean --skip-app" changes take effect on the next run without needing
+# a fresh shell.
+_MOLE_APP_SCAN_SKIP_LIST=""
+load_app_scan_skip_list() {
+    _MOLE_APP_SCAN_SKIP_LIST=""
+    [[ -f "$APP_SCAN_SKIP_CONFIG" ]] || return 0
+    local line
+    while IFS= read -r line; do
+        # shellcheck disable=SC2295
+        line="${line#"${line%%[![:space:]]*}"}"
+        # shellcheck disable=SC2295
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" || "$line" =~ ^# ]] && continue
+        _MOLE_APP_SCAN_SKIP_LIST="${_MOLE_APP_SCAN_SKIP_LIST}${_MOLE_APP_SCAN_SKIP_LIST:+$'\n'}${line}"
+    done < "$APP_SCAN_SKIP_CONFIG"
+}
+
+# Usage: is_app_scan_skipped "/Applications/SecuritySpy.app"
+# Matches on the bundle's basename (e.g. "SecuritySpy.app"), exact string
+# only, same "no glob expansion" safety rule the whitelist matcher uses.
+is_app_scan_skipped() {
+    local app_path="$1"
+    [[ -n "$_MOLE_APP_SCAN_SKIP_LIST" ]] || return 1
+    local app_name
+    app_name=$(basename -- "$app_path")
+    local _nl=$'\n'
+    case "${_nl}${_MOLE_APP_SCAN_SKIP_LIST}${_nl}" in
+        *"${_nl}${app_name}${_nl}"*) return 0 ;;
+    esac
+    return 1
+}
+
+# Usage: add_app_scan_skip "SecuritySpy.app"
+# Appends to APP_SCAN_SKIP_CONFIG if not already present. Returns 0 whether
+# or not the entry was newly added (idempotent), 1 only on a write failure.
+add_app_scan_skip() {
+    local app_name="$1"
+    [[ -n "$app_name" ]] || return 1
+    ensure_user_file "$APP_SCAN_SKIP_CONFIG"
+    load_app_scan_skip_list
+    if is_app_scan_skipped "$app_name"; then
+        return 0
+    fi
+    if [[ ! -s "$APP_SCAN_SKIP_CONFIG" ]]; then
+        {
+            echo "# Mole app-scan skip list"
+            echo "# App bundles listed here (one *.app basename per line) are excluded"
+            echo "# from the installed-app scan that 'mo clean' uses for orphan detection,"
+            echo "# so an unreadable Info.plist in one of these no longer aborts scanning"
+            echo "# every other app. Add with: mo clean --skip-app <name>"
+        } >> "$APP_SCAN_SKIP_CONFIG"
+    fi
+    echo "$app_name" >> "$APP_SCAN_SKIP_CONFIG"
+}
 # Args: $1=target_dir, $2=label
 clean_ds_store_tree() {
     local target="$1"
@@ -182,16 +256,30 @@ scan_installed_apps() {
         debug_log "Failed to initialize installed application scan output"
         return 1
     fi
-    local -a app_dirs=(
-        "/Applications"
-        "/System/Applications"
-        "$HOME/Applications"
-        # Homebrew Cask locations
-        "/opt/homebrew/Caskroom"
-        "/usr/local/Caskroom"
-        # Setapp applications
-        "$HOME/Library/Application Support/Setapp/Applications"
-    )
+    # Loaded once here (not inside each per-directory subshell below): forked
+    # subshells inherit the parent's variables at fork time, so this is
+    # visible to all of them without re-reading the config file per app.
+    load_app_scan_skip_list
+    # Overridable from tests (same convention as
+    # _MOLE_BUNDLE_RESOLVER_APP_ROOTS in bundle_resolver.sh), so a test can
+    # exercise this function without every real bundle under the actual
+    # /Applications on the machine running the suite needing to have a
+    # readable Info.plist.
+    local -a app_dirs=()
+    if [[ -n "${MOLE_APP_SCAN_DIRS_OVERRIDE+x}" && ${#MOLE_APP_SCAN_DIRS_OVERRIDE[@]} -gt 0 ]]; then
+        app_dirs=("${MOLE_APP_SCAN_DIRS_OVERRIDE[@]}")
+    else
+        app_dirs=(
+            "/Applications"
+            "/System/Applications"
+            "$HOME/Applications"
+            # Homebrew Cask locations
+            "/opt/homebrew/Caskroom"
+            "/usr/local/Caskroom"
+            # Setapp applications
+            "$HOME/Library/Application Support/Setapp/Applications"
+        )
+    fi
     # Temp dir avoids write contention across parallel scans. The temp registry
     # owns cleanup because safe_remove intentionally rejects root's private tree.
     local scan_tmp_dir
@@ -217,6 +305,20 @@ scan_installed_apps() {
                 if [[ ! -f "$plist_path" || ! -r "$plist_path" ]] ||
                     ! bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$plist_path" 2> /dev/null) ||
                     [[ -z "$bundle_id" || "$bundle_id" == "missing value" ]]; then
+                    # A bundle we can't read normally means we can't trust the
+                    # installed-app list, so the whole scan aborts (better to
+                    # skip orphan cleanup than risk deleting a live app's data
+                    # off a false "not installed" read). But some apps are
+                    # unreadable this way for reasons that have nothing to do
+                    # with whether they're installed -- e.g. Mac Catalyst /
+                    # wrapped iOS bundles keep Info.plist under Wrapper/*.app
+                    # instead of Contents/. The user can explicitly vouch for
+                    # those via "mo clean --skip-app", in which case we just
+                    # leave this one bundle out of the list instead of giving
+                    # up on scanning every other app too (#1339).
+                    if is_app_scan_skipped "$app_path"; then
+                        continue
+                    fi
                     printf '%s\n' "$app_path" >> "$scan_tmp_dir/scan_failures.list"
                     exit 1
                 fi

--- a/lib/core/help.sh
+++ b/lib/core/help.sh
@@ -9,6 +9,9 @@ show_clean_help() {
     echo "  --dry-run, -n     Preview cleanup without making changes"
     echo "  --external PATH   Clean OS metadata from a mounted external volume"
     echo "  --whitelist       Manage protected paths"
+    echo "  --skip-app NAME   Exclude an app (e.g. \"SecuritySpy.app\") from installed-app"
+    echo "                    scanning, so an unreadable bundle doesn't skip App leftovers"
+    echo "                    cleanup for every other app (~/.config/mole/app_scan_skip)"
     echo "  --debug           Show detailed operation logs"
     echo "  -h, --help        Show this help message"
 }

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -283,6 +283,83 @@ EOF
 	[[ "$output" == *"APP_METADATA_FAILURE_CLOSED"* ]] || return 1
 }
 
+@test "scan_installed_apps skips a bundle on the app-scan skip list instead of failing closed (#1339)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+rm -f "$HOME/.cache/mole/installed_apps_cache"
+
+# Same "unreadable bundle" fixture as the fails-closed test above, but this
+# time the broken app is on the skip list -- e.g. a Mac Catalyst / wrapped
+# iOS bundle whose Info.plist lives under Wrapper/*.app instead of
+# Contents/, which is a real, reproducible case (#1339), not just a
+# synthetic one; this fixture just exercises the same "unreadable" path.
+mkdir -p "$HOME/Applications/FakeApp.app/Contents"
+cat > "$HOME/Applications/FakeApp.app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>FakeApp</string>
+</dict>
+</plist>
+PLIST
+
+mkdir -p "$HOME/Applications/GoodApp.app/Contents"
+cat > "$HOME/Applications/GoodApp.app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.GoodApp</string>
+</dict>
+</plist>
+PLIST
+
+add_app_scan_skip "FakeApp.app"
+
+# Scope the scan to just this fixture directory: the real /Applications on
+# whatever machine runs this suite may contain its own unreadable bundles
+# (that's the whole bug this feature works around), which would otherwise
+# make this test flaky depending on what's installed on the CI box.
+MOLE_APP_SCAN_DIRS_OVERRIDE=("$HOME/Applications")
+
+debug_log() { :; }
+scan_installed_apps "$HOME/installed.txt"
+grep -Fxq "com.example.GoodApp" "$HOME/installed.txt" || exit 1
+! grep -q "FakeApp" "$HOME/installed.txt" || exit 1
+printf 'APP_SCAN_SKIP_HONORED\n'
+EOF
+
+	[ "$status" -eq 0 ] || { echo "$output"; return 1; }
+	[[ "$output" == *"APP_SCAN_SKIP_HONORED"* ]] || return 1
+}
+
+@test "add_app_scan_skip is idempotent and is_app_scan_skipped matches by basename only" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+add_app_scan_skip "SecuritySpy.app"
+add_app_scan_skip "SecuritySpy.app"
+[[ "$(grep -c '^SecuritySpy\.app$' "$APP_SCAN_SKIP_CONFIG")" -eq 1 ]] || exit 1
+
+load_app_scan_skip_list
+is_app_scan_skipped "/Applications/SecuritySpy.app" || exit 1
+is_app_scan_skipped "/Applications/Other.app" && exit 1
+
+printf 'SKIP_LIST_OK\n'
+EOF
+
+	[ "$status" -eq 0 ] || { echo "$output"; return 1; }
+	[[ "$output" == *"SKIP_LIST_OK"* ]] || return 1
+}
+
 @test "scan_installed_apps fails closed when every running-app probe fails" {
     local scan_home="$HOME/running-probe-failure"
     rm -rf "$scan_home"


### PR DESCRIPTION
## Summary

Fixes the underlying cause of #1339 for `mo clean` as well (the original issue only covers `mo uninstall`): a single `.app` bundle with no readable `Info.plist` currently aborts the *entire* installed-app scan, so `mo clean`'s "App leftovers" section gets skipped for every app on the machine, not just the offending one.

Reproduced with a real Mac Catalyst / wrapped-iOS bundle on Apple Silicon (SecuritySpy Viewer, bundle ID `com.bensoftware.SecuritySpyViewer`, and separately JW Library) — both ship `Info.plist` under `Wrapper/*.app` instead of the usual `Contents/Info.plist`, which the scanner in `lib/clean/apps.sh` doesn't know how to read.

## What this adds

- **`mo clean --skip-app "SomeApp.app"`** — lets the user explicitly vouch for a bundle they know is fine, so the scanner skips just that one app instead of giving up on scanning every other app. Backed by a plain-text config at `~/.config/mole/app_scan_skip` (one bundle basename per line, `#` comments allowed) — same conventions as the existing whitelist config.
- The scan otherwise keeps its current "fail closed" behavior for anything *not* on the list — we still can't tell "unreadable due to an unusual bundle layout" apart from "might actually be an uninstalled orphan," so nothing gets more permissive by default.
- `MOLE_APP_SCAN_DIRS_OVERRIDE` — lets tests point `scan_installed_apps` at a fixture directory instead of the real `/Applications` etc. (same "overridable from tests" convention already used by `_MOLE_BUNDLE_RESOLVER_APP_ROOTS` in `lib/core/bundle_resolver.sh`). Without this, `tests/clean_apps.bats` is unintentionally sensitive to whatever's actually installed on the machine running the suite — I only noticed because a real bundle on my own Mac reproduced this exact bug and made several *pre-existing* tests fail non-deterministically depending on what's in `/Applications`. Confirmed those same failures reproduce on a clean checkout of `main`, unrelated to this change.

## Testing

- `./scripts/check.sh` — formatting, ShellCheck, syntax all pass
- `bats tests/clean_apps.bats` — 2 new tests pass; no regressions vs. `main`
- Manually verified against a real installed app with the Wrapper/-bundle layout: `mo clean --dry-run` went from `Skipped: Unable to scan installed applications (...)` to a completed "App leftovers" scan (`✓ Nothing to clean`) after `mo clean --skip-app`.

## Notes for maintainers

Happy to also fold the fallback `Wrapper/*.app/Info.plist` path-resolution approach suggested in #1339 into this PR if you'd rather fix bundle detection at the source instead of (or in addition to) an explicit skip list — wanted to keep this PR's scope to one approach first. The skip list has the advantage of working for *any* reason a bundle might be unreadable (not just the Wrapper/ case), and gives the user an explicit, auditable escape hatch rather than silently trusting more bundle shapes.
