### PR TITLE
fix(clean): print final summary when a cleanup step times out (#1342)

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1675,116 +1675,123 @@ perform_cleanup() {
         return 0
     }
 
-    if [[ -n "$EXTERNAL_VOLUME_TARGET" ]]; then
-        start_section "External volume"
-        _run_cleanup_step clean_external_volume_target "$EXTERNAL_VOLUME_TARGET" || return $?
-        end_section
-    else
-        # ===== 1. System =====
-        if [[ "$SYSTEM_CLEAN" == "true" ]]; then
-            start_section "System"
-            _run_cleanup_step clean_deep_system || return $?
-            _run_cleanup_step clean_local_snapshots || return $?
+    local cleanup_cancel_rc=0
+    # Sections run inside a function so a cancelled step (timeout/signal,
+    # exit 124+) stops the remaining sections but still falls through to the
+    # final summary instead of returning from perform_cleanup with no output.
+    run_clean_sections() {
+        if [[ -n "$EXTERNAL_VOLUME_TARGET" ]]; then
+            start_section "External volume"
+            _run_cleanup_step clean_external_volume_target "$EXTERNAL_VOLUME_TARGET" || return $?
+            end_section
+        else
+            # ===== 1. System =====
+            if [[ "$SYSTEM_CLEAN" == "true" ]]; then
+                start_section "System"
+                _run_cleanup_step clean_deep_system || return $?
+                _run_cleanup_step clean_local_snapshots || return $?
+                end_section
+            fi
+
+            if [[ ${#WHITELIST_WARNINGS[@]} -gt 0 ]]; then
+                flush_idle_section_slot
+                echo ""
+                for warning in "${WHITELIST_WARNINGS[@]}"; do
+                    echo -e "  ${GRAY}${ICON_WARNING}${NC} Whitelist: $warning"
+                done
+            fi
+
+            # ===== 2. User essentials =====
+            start_section "User essentials"
+            _run_cleanup_step clean_user_essentials || return $?
+            _run_cleanup_step clean_finder_metadata || return $?
+            end_section
+
+            # ===== 3. App caches (merged sandboxed and standard app caches) =====
+            start_section "App caches"
+            _run_cleanup_step clean_app_caches || return $?
+            end_section
+
+            # ===== 4. Browsers =====
+            start_section "Browsers"
+            _run_cleanup_step clean_browsers || return $?
+            end_section
+
+            # ===== 5. Cloud & Office =====
+            start_section "Cloud & Office"
+            # Force shell fallback so timeout runs in this shell context.
+            # The Cloud/Office cleaners rely on helpers (safe_clean, whitelist checks)
+            # defined in this script and sourced modules.
+            if run_with_shell_timeout 300 run_cloud_and_office_cleanup; then
+                : # completed successfully
+            else
+                local ret=$?
+                if [[ $ret -eq 124 ]]; then
+                    log_warning "Cloud & Office cleanup timed out after 5 minutes, skipping remaining items"
+                elif [[ $ret -ge 128 ]]; then
+                    return "$ret"
+                else
+                    log_warning "Cloud & Office cleanup failed with exit code $ret"
+                fi
+            fi
+            end_section
+
+            # ===== 6. Developer tools (merged CLI and GUI tooling) =====
+            start_section "Developer tools"
+            _run_cleanup_step clean_developer_tools || return $?
+            end_section
+
+            # ===== 7. Apps & utilities =====
+            start_section "Apps & utilities"
+            _run_cleanup_step clean_user_gui_applications || return $?
+            end_section
+
+            # ===== 8. Virtualization =====
+            start_section "Virtualization"
+            _run_cleanup_step clean_virtualization_tools || return $?
+            end_section
+
+            # ===== 9. Application Support =====
+            start_section "Application Support"
+            _run_cleanup_step clean_application_support_logs || return $?
+            end_section
+
+            # ===== 10. App leftovers =====
+            start_section "App leftovers"
+            _run_cleanup_step clean_orphaned_app_data || return $?
+            _run_cleanup_step clean_orphaned_system_services || return $?
+            _run_cleanup_step clean_orphaned_container_stubs || return $?
+            _run_cleanup_step clean_stale_launch_services_registrations || return $?
+            _run_cleanup_step show_user_launch_agent_hint_notice || return $?
+            end_section
+
+            # ===== 11. Apple Silicon =====
+            _run_cleanup_step clean_apple_silicon_caches || return $?
+
+            # ===== 12. Device backups & firmware =====
+            # iOS backups are reported once, in the Large files section; a second
+            # row here used a different size formatter and confused users.
+            start_section "Device backups & firmware"
+            _run_cleanup_step clean_cached_device_firmware || return $?
+            end_section
+
+            # ===== 13. Time Machine =====
+            start_section "Time Machine"
+            _run_cleanup_step clean_time_machine_failed_backups || return $?
+            end_section
+
+            # ===== 14. Large files =====
+            start_section "Large files"
+            _run_cleanup_step check_large_file_candidates || return $?
+            end_section
+
+            # ===== 15. Project artifacts =====
+            start_section "Project artifacts"
+            _run_cleanup_step show_project_artifact_hint_notice || return $?
             end_section
         fi
-
-        if [[ ${#WHITELIST_WARNINGS[@]} -gt 0 ]]; then
-            flush_idle_section_slot
-            echo ""
-            for warning in "${WHITELIST_WARNINGS[@]}"; do
-                echo -e "  ${GRAY}${ICON_WARNING}${NC} Whitelist: $warning"
-            done
-        fi
-
-        # ===== 2. User essentials =====
-        start_section "User essentials"
-        _run_cleanup_step clean_user_essentials || return $?
-        _run_cleanup_step clean_finder_metadata || return $?
-        end_section
-
-        # ===== 3. App caches (merged sandboxed and standard app caches) =====
-        start_section "App caches"
-        _run_cleanup_step clean_app_caches || return $?
-        end_section
-
-        # ===== 4. Browsers =====
-        start_section "Browsers"
-        _run_cleanup_step clean_browsers || return $?
-        end_section
-
-        # ===== 5. Cloud & Office =====
-        start_section "Cloud & Office"
-        # Force shell fallback so timeout runs in this shell context.
-        # The Cloud/Office cleaners rely on helpers (safe_clean, whitelist checks)
-        # defined in this script and sourced modules.
-        if run_with_shell_timeout 300 run_cloud_and_office_cleanup; then
-            : # completed successfully
-        else
-            local ret=$?
-            if [[ $ret -eq 124 ]]; then
-                log_warning "Cloud & Office cleanup timed out after 5 minutes, skipping remaining items"
-            elif [[ $ret -ge 128 ]]; then
-                return "$ret"
-            else
-                log_warning "Cloud & Office cleanup failed with exit code $ret"
-            fi
-        fi
-        end_section
-
-        # ===== 6. Developer tools (merged CLI and GUI tooling) =====
-        start_section "Developer tools"
-        _run_cleanup_step clean_developer_tools || return $?
-        end_section
-
-        # ===== 7. Apps & utilities =====
-        start_section "Apps & utilities"
-        _run_cleanup_step clean_user_gui_applications || return $?
-        end_section
-
-        # ===== 8. Virtualization =====
-        start_section "Virtualization"
-        _run_cleanup_step clean_virtualization_tools || return $?
-        end_section
-
-        # ===== 9. Application Support =====
-        start_section "Application Support"
-        _run_cleanup_step clean_application_support_logs || return $?
-        end_section
-
-        # ===== 10. App leftovers =====
-        start_section "App leftovers"
-        _run_cleanup_step clean_orphaned_app_data || return $?
-        _run_cleanup_step clean_orphaned_system_services || return $?
-        _run_cleanup_step clean_orphaned_container_stubs || return $?
-        _run_cleanup_step clean_stale_launch_services_registrations || return $?
-        _run_cleanup_step show_user_launch_agent_hint_notice || return $?
-        end_section
-
-        # ===== 11. Apple Silicon =====
-        _run_cleanup_step clean_apple_silicon_caches || return $?
-
-        # ===== 12. Device backups & firmware =====
-        # iOS backups are reported once, in the Large files section; a second
-        # row here used a different size formatter and confused users.
-        start_section "Device backups & firmware"
-        _run_cleanup_step clean_cached_device_firmware || return $?
-        end_section
-
-        # ===== 13. Time Machine =====
-        start_section "Time Machine"
-        _run_cleanup_step clean_time_machine_failed_backups || return $?
-        end_section
-
-        # ===== 14. Large files =====
-        start_section "Large files"
-        _run_cleanup_step check_large_file_candidates || return $?
-        end_section
-
-        # ===== 15. Project artifacts =====
-        start_section "Project artifacts"
-        _run_cleanup_step show_project_artifact_hint_notice || return $?
-        end_section
-    fi
+    }
+    run_clean_sections || cleanup_cancel_rc=$?
 
     # ===== Final summary =====
     flush_idle_section_slot
@@ -1798,13 +1805,34 @@ perform_cleanup() {
 
     local summary_heading=""
     local summary_status="success"
-    if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ $cleanup_cancel_rc -eq 124 ]]; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            summary_heading="Dry run cancelled"
+        else
+            summary_heading="Cleanup cancelled"
+        fi
+        summary_status="warning"
+    elif [[ $cleanup_cancel_rc -ge 128 ]]; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            summary_heading="Dry run interrupted"
+        else
+            summary_heading="Cleanup interrupted"
+        fi
+        summary_status="warning"
+    elif [[ "$DRY_RUN" == "true" ]]; then
         summary_heading="Dry run complete - no changes made"
     else
         summary_heading="Cleanup complete"
     fi
 
     local -a summary_details=()
+    if [[ $cleanup_cancel_rc -ne 0 ]]; then
+        if [[ $cleanup_cancel_rc -eq 124 ]]; then
+            summary_details+=("${GRAY}${ICON_WARNING}${NC} Cancelled: a scan or size check timed out (exit 124). Remaining cleanup was skipped.")
+        elif [[ $cleanup_cancel_rc -ge 128 ]]; then
+            summary_details+=("${GRAY}${ICON_WARNING}${NC} Cancelled: a cleanup step was interrupted (exit $cleanup_cancel_rc). Remaining cleanup was skipped.")
+        fi
+    fi
 
     # Emit one "Free space" line, with the measured delta in parentheses when
     # available. $1 is the free space in KB captured before cleanup started.
@@ -1930,6 +1958,8 @@ perform_cleanup() {
 
     print_summary_block "$summary_heading" "${summary_details[@]}"
     printf '\n'
+
+    return "$cleanup_cancel_rc"
 }
 
 run_with_shell_timeout() {

--- a/tests/clean_summary_cancel.bats
+++ b/tests/clean_summary_cancel.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+# Regression for #1342: when a cleanup scan/size check hits its internal
+# timeout (exit 124), `mo clean` must still print the final summary with an
+# explicit reason instead of exiting silently mid-run.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-clean-summary-cancel.XXXXXX")"
+    export HOME
+
+    mkdir -p "$HOME/Library/Caches"
+    mkdir -p "$HOME/.config/mole"
+    for i in 1 2 3 4 5; do
+        mkdir -p "$HOME/Library/Caches/cachedir$i"
+    done
+}
+
+teardown_file() {
+    if [[ "$HOME" == "${BATS_TEST_DIRNAME}/tmp-clean-summary-cancel."* ]]; then
+        rm -rf "$HOME"
+    fi
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+setup() {
+    if [[ "$HOME" != "${BATS_TEST_DIRNAME}/tmp-clean-summary-cancel."* ]]; then
+        printf 'FATAL: HOME is not a test temp dir: %s\n' "$HOME" >&2
+        return 1
+    fi
+}
+
+run_perform_cleanup_with() {
+    export SECTION_RC="$1"
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+# Stub every section so perform_cleanup never scans the real machine.
+# run_with_shell_timeout is stubbed too: its shell-fallback killer process
+# would otherwise outlive the test when pgrep is unavailable.
+for fn in clean_user_essentials clean_finder_metadata clean_app_caches \
+    clean_browsers run_cloud_and_office_cleanup clean_developer_tools \
+    clean_user_gui_applications clean_virtualization_tools \
+    clean_application_support_logs clean_orphaned_app_data \
+    clean_orphaned_system_services clean_orphaned_container_stubs \
+    clean_stale_launch_services_registrations show_user_launch_agent_hint_notice \
+    clean_apple_silicon_caches clean_cached_device_firmware \
+    clean_time_machine_failed_backups check_large_file_candidates \
+    show_project_artifact_hint_notice; do
+    eval "$fn() { return 0; }"
+done
+run_with_shell_timeout() { return 0; }
+clean_user_essentials() { return "$SECTION_RC"; }
+perform_cleanup
+EOF
+}
+
+@test "sizing timeout (124) still prints the summary (#1342)" {
+    run_perform_cleanup_with 124
+
+    [ "$status" -eq 124 ]
+    [[ "$output" == *"Cleanup cancelled"* ]]
+    [[ "$output" == *"timed out (exit 124)"* ]]
+    [[ "$output" == *"Remaining cleanup was skipped"* ]]
+}
+
+@test "interrupted section (>=128) prints an interrupted summary" {
+    run_perform_cleanup_with 130
+
+    [ "$status" -eq 130 ]
+    [[ "$output" == *"Cleanup interrupted"* ]]
+    [[ "$output" == *"was interrupted (exit 130)"* ]]
+}
+
+@test "successful run still prints a complete summary" {
+    run_perform_cleanup_with 0
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleanup complete"* ]]
+    [[ "$output" != *"Cleanup cancelled"* ]]
+}


### PR DESCRIPTION
## Summary

When a `mo clean` scan or size check hits its internal safety timeout (`MOLE_TIMEOUT_DISK_VERIFY_SEC`, default 30s), the whole run aborts with exit status `124` and **no summary at all** - the output just stops mid-run. This was reported in #1342 (exit 124 after ~30s, output stopping at "User essentials", no "Cleanup complete" block).

The sizing timeout is intentional cancellation semantics (see `get_path_size_kb` in `lib/core/file_ops.sh`), so this PR keeps the cancellation and the exit code, but makes the outcome comprehensible:

- Cleanup sections now run inside a `run_clean_sections()` wrapper, so a cancelled step (timeout `124` or signal `128+`) stops the remaining sections but falls through to the final summary.
- The summary heading becomes `Cleanup cancelled` / `Cleanup interrupted` (or `Dry run ...` variants), with an explicit reason line, e.g.:
  `◎ Cancelled: a scan or size check timed out (exit 124). Remaining cleanup was skipped.`
- Normal runs are unchanged: `Cleanup complete`, exit 0.

## Reproduction

Issue #1342: `mo clean` runs ~30s, exits `124`, no summary. Root cause: with a Time Machine backup (or any disk I/O stall) running, `du`/`stat` sizing of `~/Library/Caches/*` exceeds the 30s `run_with_timeout` deadline; `_safe_clean_impl` returns 124, which propagated through `clean_user_essentials` -> `perform_cleanup` and exited before the summary block.

Deterministic repro used during development (fake HOME + slow `du` in PATH, no real files touched):

```bash
mkdir -p /tmp/mr/Library/Caches /tmp/mrbin
for i in $(seq -w 1 30); do mkdir /tmp/mr/Library/Caches/cache$i; done
printf '#!/bin/bash\nsleep 40\n' > /tmp/mrbin/du && chmod +x /tmp/mrbin/du
PATH=/tmp/mrbin:$PATH HOME=/tmp/mr MOLE_TEST_NO_AUTH=1 ./mo clean; echo $?   # 124 after ~30s
```

Before: output ends at `➤ User essentials`, exit `124`, no summary.
After: same exit `124`, but now:

```
======================================================================
Cleanup cancelled
◎ Cancelled: a scan or size check timed out (exit 124). Remaining cleanup was skipped.
System was already clean; no additional space freed.
Free space: 22.77GB (+11.3MB)
======================================================================
```

## Tests

- New `tests/clean_summary_cancel.bats`: end-to-end-ish regression for #1342 (cancel/success headings and exit codes via stubbed sections), 3 cases.
- `bats tests/clean_core.bats tests/clean_user_core.bats tests/file_ops_size.bats tests/regression.bats tests/core_common.bats tests/clean_summary_cancel.bats` - all 187 tests pass.
- `shellcheck bin/clean.sh`, `bash -n`, `shfmt -d`, `scripts/audit_function_duplication.py` - all clean.
