### PR TITLE
fix(install): derive source temp dir from TMPDIR so cleanup accepts it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -622,7 +622,7 @@ resolve_source_dir() {
     fi
 
     local tmp
-    tmp="$(mktemp -d)"
+    tmp="$(mktemp -d "${TMPDIR:-/tmp}/mole.XXXXXX")"
     INSTALL_SOURCE_TMP="$tmp"
 
     local branch="${MOLE_VERSION:-}"

--- a/tests/install_checksum.bats
+++ b/tests/install_checksum.bats
@@ -710,6 +710,44 @@ EOF
 	[[ "$output" != *"safe_rm: refusing to remove non-temp path"* ]] || return 1
 }
 
+@test "installer source temp stays removable by safe_rm when TMPDIR is unset" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+unset TMPDIR
+log_error() { printf 'ERROR:%s\n' "$*"; }
+stop_line_spinner() { :; }
+release_install_lock() { :; }
+
+eval "$(sed -n '/^safe_rm() {/,/^}/p' "$PROJECT_ROOT/install.sh")"
+eval "$(sed -n '/^cleanup_installer() {/,/^}/p' "$PROJECT_ROOT/install.sh")"
+
+# Evaluate install.sh's own source-download mktemp lines with TMPDIR unset,
+# then run the same EXIT-trap cleanup path against the created directory.
+tmp_lines="$(sed -n '/mktemp -d/{p;n;p;q;}' "$PROJECT_ROOT/install.sh" | sed 's/^[[:space:]]*//')"
+eval "$tmp_lines"
+source_tmp="$INSTALL_SOURCE_TMP"
+printf 'downloaded source\n' > "$source_tmp/payload"
+cleanup_installer
+
+[[ -z "$INSTALL_SOURCE_TMP" ]] || exit 1
+[[ ! -e "$source_tmp" ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
+	[[ "$output" != *"safe_rm: refusing to remove non-temp path"* ]] || return 1
+}
+
+@test "source download mktemp template derives from TMPDIR" {
+	run grep -qE 'mktemp -d "\$\{TMPDIR:-/tmp\}/mole\.XXXXXX"' "$PROJECT_ROOT/install.sh"
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
+}
+
 @test "standalone installer serializes writers with the stable install lock" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

Fixes #1343. On macOS, `install.sh` exits `1` after a fully successful install whenever `TMPDIR` is unset. `resolve_source_dir` creates the source temp dir with a bare `mktemp -d`, which on macOS ignores `TMPDIR` and returns the Darwin per-user temp root (`/var/folders/.../T/`). `safe_rm` only accepts paths under `${TMPDIR:-/tmp}`, so the EXIT-trap cleanup refuses to remove the source dir and its non-zero status becomes the script's exit status. This is a regression in V1.49.1 (the V1.48.1 cleanup early-returned and leaked the dir instead).

## Fix

Create the temp dir with an explicit template derived from the same root `safe_rm` uses, keeping a single notion of "temp root" for both sides:

```bash
tmp="$(mktemp -d "${TMPDIR:-/tmp}/mole.XXXXXX")"
```

This matches the existing checksums-file call (`mktemp "${TMPDIR:-/tmp}/mole-checksums.XXXXXX"`) and is independent of macOS version: with the template, `mktemp` honours the explicit path whether `TMPDIR` is unset, `/tmp`, or the Darwin user temp dir. The `update` path uses the same `resolve_source_dir`, so one change covers both.

## Tests

- Behavioral regression: evaluates `install.sh`'s own source-download `mktemp` lines and `cleanup_installer` with `TMPDIR` unset, then asserts the dir is removed and `safe_rm` did not refuse. Before this fix on macOS it fails with the exact `safe_rm: refusing to remove non-temp path` error.
- Source guard: pins the `${TMPDIR:-/tmp}` template in `install.sh`.
- `bats tests/install_checksum.bats` passes (21 tests); `./scripts/check.sh` passes.

## Reproduction

```console
$ env -u TMPDIR bash install.sh --prefix "$HOME/mole-repro-test" --config "$HOME/mole-repro-cfg"
◎ Mole installed successfully, version 1.49.1
☻ safe_rm: refusing to remove non-temp path: /var/folders/.../T/tmp.89JgkkmD95
$ echo $?
1
```

With the fix the same run exits `0` and the source temp dir is removed.
