### PR TITLE
fix(clean): skip a Mail Downloads dir whose sizing times out (#1344)

### DIFF
--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -199,6 +199,16 @@ _clean_mail_downloads() {
             local size_rc=0
             dir_size_kb=$(get_path_size_kb "$target_path") || size_rc=$?
             if [[ $size_rc -ne 0 ]]; then
+                if [[ $size_rc -eq 124 ]]; then
+                    # A stalled or unreadable Mail Downloads directory (e.g. a
+                    # protected app container) must not end the whole run:
+                    # skip this one target and keep cleaning.
+                    [[ "$spinner_active" == "true" ]] && stop_section_spinner
+                    spinner_active=false
+                    echo -e "  ${GRAY}${ICON_WARNING}${NC} Mail Downloads · skipped (sizing timed out)"
+                    note_activity
+                    continue
+                fi
                 _mole_record_clean_cancellation "$size_rc"
                 [[ "$spinner_active" == "true" ]] && stop_section_spinner
                 return "$size_rc"
@@ -219,6 +229,10 @@ _clean_mail_downloads() {
                     size_rc=0
                     file_size_kb=$(get_path_size_kb "$file_path") || size_rc=$?
                     if [[ $size_rc -ne 0 ]]; then
+                        if [[ $size_rc -eq 124 ]]; then
+                            debug_log "Mail attachment sizing timed out, skipping: $file_path"
+                            continue
+                        fi
                         _mole_record_clean_cancellation "$size_rc"
                         [[ "$spinner_active" == "true" ]] && stop_section_spinner
                         return "$size_rc"

--- a/tests/clean_mail_downloads.bats
+++ b/tests/clean_mail_downloads.bats
@@ -161,7 +161,25 @@ SHIM
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
         PATH="$SHIM_DIR:$PATH" MOLE_TIMEOUT_DISK_VERIFY_SEC=2 \
-        /bin/bash --noprofile --norc "$PROJECT_ROOT/bin/clean.sh" --debug
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+# Stub every other section so the run reaches the summary quickly; only
+# clean_user_essentials (which contains _clean_mail_downloads) stays real.
+for fn in clean_finder_metadata clean_app_caches clean_browsers \
+    run_cloud_and_office_cleanup clean_developer_tools \
+    clean_user_gui_applications clean_virtualization_tools \
+    clean_application_support_logs clean_orphaned_app_data \
+    clean_orphaned_system_services clean_orphaned_container_stubs \
+    clean_stale_launch_services_registrations show_user_launch_agent_hint_notice \
+    clean_apple_silicon_caches clean_cached_device_firmware \
+    clean_time_machine_failed_backups check_large_file_candidates \
+    show_project_artifact_hint_notice; do
+    eval "$fn() { return 0; }"
+done
+run_with_shell_timeout() { return 0; }
+perform_cleanup
+EOF
 
     rm -rf "$SHIM_DIR"
 

--- a/tests/clean_mail_downloads.bats
+++ b/tests/clean_mail_downloads.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# Regression for #1344: a Mail Downloads directory that cannot be sized within
+# the disk-verify timeout (exit 124) must be skipped as a single target, not
+# end the whole `mo clean` run at User essentials. Signal-class statuses
+# (>=128) keep their cancellation semantics.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-mail-downloads.XXXXXX")"
+    export HOME
+}
+
+teardown_file() {
+    if [[ "$HOME" == "${BATS_TEST_DIRNAME}/tmp-mail-downloads."* ]]; then
+        rm -rf "$HOME"
+    fi
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+setup() {
+    if [[ "$HOME" != "${BATS_TEST_DIRNAME}/tmp-mail-downloads."* ]]; then
+        printf 'FATAL: HOME is not a test temp dir: %s\n' "$HOME" >&2
+        return 1
+    fi
+    rm -rf "$HOME/Library"
+}
+
+@test "mail dir sizing timeout (124) skips the target and keeps the run going" {
+    mkdir -p "$HOME/Library/Containers/com.apple.mail/Data/Library/Mail Downloads"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+pgrep() { return 1; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+get_path_size_kb() { return 124; }
+_clean_mail_downloads
+echo "RC=$?"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Mail Downloads · skipped (sizing timed out)"* ]]
+    [[ "$output" == *"RC=0"* ]]
+}
+
+@test "mail dir sizing timeout (124) skips one dir and still cleans the other" {
+    mkdir -p "$HOME/Library/Mail Downloads"
+    echo x > "$HOME/Library/Mail Downloads/old.bin"
+    touch -t 202401010000 "$HOME/Library/Mail Downloads/old.bin"
+    mkdir -p "$HOME/Library/Containers/com.apple.mail/Data/Library/Mail Downloads"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+pgrep() { return 1; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+safe_remove() { echo "REMOVE:$1"; return 0; }
+get_path_size_kb() {
+    if [[ "$1" == "$HOME/Library/Containers/com.apple.mail/Data/Library/Mail Downloads" ]]; then
+        return 124
+    fi
+    if [[ "$1" == "$HOME/Library/Mail Downloads" ]]; then
+        echo "6000"
+        return 0
+    fi
+    echo "6000"
+}
+_clean_mail_downloads
+echo "RC=$?"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"REMOVE:$HOME/Library/Mail Downloads/old.bin"* ]]
+    [[ "$output" == *"Mail Downloads · skipped (sizing timed out)"* ]]
+    [[ "$output" == *"RC=0"* ]]
+}
+
+@test "mail attachment sizing timeout (124) skips the file without aborting" {
+    mkdir -p "$HOME/Library/Mail Downloads"
+    echo x > "$HOME/Library/Mail Downloads/stuck.bin"
+    touch -t 202401010000 "$HOME/Library/Mail Downloads/stuck.bin"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+pgrep() { return 1; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+debug_log() { echo "DEBUG:$*"; }
+safe_remove() { echo "REMOVE:$1"; return 0; }
+get_path_size_kb() {
+    if [[ "$1" == "$HOME/Library/Mail Downloads" ]]; then
+        echo "6000"
+        return 0
+    fi
+    return 124
+}
+_clean_mail_downloads
+echo "RC=$?"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Mail attachment sizing timed out, skipping"* ]]
+    [[ "$output" != *"REMOVE:"* ]]
+    [[ "$output" == *"RC=0"* ]]
+}
+
+@test "mail dir sizing signal (130) still cancels the run" {
+    mkdir -p "$HOME/Library/Containers/com.apple.mail/Data/Library/Mail Downloads"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+pgrep() { return 1; }
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+get_path_size_kb() { return 130; }
+_clean_mail_downloads
+echo "RC=$?"
+EOF
+
+    [ "$status" -eq 130 ]
+    [[ "$output" != *"skipped (sizing timed out)"* ]]
+}
+
+@test "mo clean completes when the Mail Downloads du stalls (#1344)" {
+    mkdir -p "$HOME/Library/Caches"
+    mkdir -p "$HOME/Library/Containers/com.apple.mail/Data/Library/Mail Downloads"
+    echo x > "$HOME/Library/Containers/com.apple.mail/Data/Library/Mail Downloads/old.docx"
+
+    SHIM_DIR="$(mktemp -d "${BATS_TEST_TMPDIR:-/tmp}/mail-shim.XXXXXX")"
+    cat > "$SHIM_DIR/du" << 'SHIM'
+#!/bin/bash
+for a in "$@"; do
+    if [[ "$a" == *"Mail Downloads"* ]]; then
+        /bin/sleep 60
+        exit 124
+    fi
+done
+exec /usr/bin/du "$@"
+SHIM
+    chmod +x "$SHIM_DIR/du"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        PATH="$SHIM_DIR:$PATH" MOLE_TIMEOUT_DISK_VERIFY_SEC=2 \
+        /bin/bash --noprofile --norc "$PROJECT_ROOT/bin/clean.sh" --debug
+
+    rm -rf "$SHIM_DIR"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleanup complete"* ]]
+    [[ "$output" == *"Mail Downloads · skipped (sizing timed out)"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes #1344. When `du` stalls on a Mail Downloads directory (the reporter's `~/Library/Containers/com.apple.mail/.../Mail Downloads` returns `Operation not permitted` on macOS 26, even to root), the 30s sizing probe times out and `_clean_mail_downloads` propagates exit `124` up through `clean_user_essentials`, ending the whole `mo clean` run at "User essentials". On V1.49.1 that exit is silent, which is the reported "silently crashes" behavior (same family as #1342).

This is the follow-up the #1345 merge note asked for: skip the single slow target instead of letting it end the run.

## Change

- In `_clean_mail_downloads`, a directory sizing timeout (`124`) now stops the spinner, prints a warning (`Mail Downloads · skipped (sizing timed out)`), and moves on to the next directory instead of recording a cancellation and returning the status.
- A per-attachment sizing timeout now skips that file (`debug_log` only) instead of aborting the whole mail cleanup.
- Signal-class statuses (`>=128`, e.g. Ctrl-C `130`) keep their existing cancellation semantics: `_mole_record_clean_cancellation` + `return`.

## Reproduction (mechanism, macOS 27 x86 host via a stalled `du` shim)

```console
$ env HOME=<fake-home-with-unreadable-Mail-Downloads> PATH=<shim>$PATH MOLE_TIMEOUT_DISK_VERIFY_SEC=2 bash bin/clean.sh --debug
```

Before, V1.49.1:

```text
➤ User essentials
...
$ echo $?
124
```

(no summary, silent exit - matches the issue)

Before, current main: same exit `124` but with the `Cleanup cancelled` summary from #1345; the run still stops at User essentials.

After this PR:

```text
➤ User essentials
  ◎ Mail Downloads · skipped (sizing timed out)
➤ App caches
...
Cleanup complete
$ echo $?
0
```

The fast-fail variant in the issue (du exits `1` with no output, the `(returned: )` debug line) already resolves to a zero-size skip and is covered by existing behavior; the timeout variant is what ends the run and is fixed here.

## Tests

New `tests/clean_mail_downloads.bats` (5 tests):
- dir sizing timeout skips the target and keeps the run going
- one dir timing out does not stop cleanup of the other dir
- attachment sizing timeout skips the file without aborting
- signal (130) still cancels the run
- end-to-end `bin/clean.sh` completes with `Cleanup complete` when the Mail Downloads `du` stalls (shimmed `du`)

Verified:
- `bats tests/clean_mail_downloads.bats tests/clean_user_core.bats tests/clean_core.bats tests/clean_summary_cancel.bats` - 110 passed
- `./scripts/check.sh --no-format` - passed
- `shfmt -i 4 -ci -sr -d lib/clean/user.sh tests/clean_mail_downloads.bats` - clean