### PR TITLE
fix(core): bound every pkgutil file listing in the non-strict receipt scan

### DIFF
--- a/lib/core/pkg_receipts.sh
+++ b/lib/core/pkg_receipts.sh
@@ -94,7 +94,18 @@ pkg_receipt_nonstandard_app_paths() {
                 return 2
             fi
         else
-            pkg_files=$(pkgutil --files "$pkg_id" 2> /dev/null || true)
+            if [[ $scan_deadline -gt 0 ]]; then
+                local remaining=$((scan_deadline - SECONDS))
+                [[ $remaining -gt 0 ]] || break
+                if declare -f run_with_timeout > /dev/null 2>&1; then
+                    pkg_files=$(run_with_timeout "$remaining" \
+                        pkgutil --files "$pkg_id" 2> /dev/null || true)
+                else
+                    pkg_files=$(pkgutil --files "$pkg_id" 2> /dev/null || true)
+                fi
+            else
+                pkg_files=$(pkgutil --files "$pkg_id" 2> /dev/null || true)
+            fi
         fi
         [[ -n "$pkg_files" ]] || continue
 

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -786,6 +786,42 @@ EOF
     [[ "$output" == *"RC=124 OUTPUT="* ]]
 }
 
+@test "non-strict receipt discovery bounds each pkgutil file listing" {
+	local mock_bin="$HOME/mock-pkgutil-bin"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/pkgutil" <<'MOCK'
+#!/bin/bash
+case "$1" in
+    --pkgs) printf 'com.example.big\ncom.example.after\n' ;;
+    --files) exec sleep 30 ;;
+esac
+MOCK
+	chmod +x "$mock_bin/pkgutil"
+
+	run env HOME="$HOME/pkg-bound" PROJECT_ROOT="$PROJECT_ROOT" \
+		PATH="$mock_bin:/usr/bin:/bin" \
+		MOLE_PKG_RECEIPT_CACHE_DISABLE=1 \
+		MOLE_PKG_RECEIPT_SCAN_TIMEOUT=1 \
+		MOLE_PKG_RECEIPT_LIST_TIMEOUT=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+started=$(date +%s)
+rc=0
+output=$(pkg_receipt_nonstandard_app_paths) || rc=$?
+elapsed=$(( $(date +%s) - started ))
+printf 'RC=%s ELAPSED=%s OUTPUT=%s\n' "$rc" "$elapsed" "$output"
+[[ $elapsed -lt 8 ]]
+EOF
+
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
+	[[ "$output" == *"RC=0 "* ]] || return 1
+	[[ "$output" == *" OUTPUT=" ]]
+}
+
 @test "live same-bundle scan discards partial find output" {
     local app_root="$HOME/partial-live-apps"
     mkdir -p "$app_root/Selected.app" "$app_root/Partial.app/Contents"


### PR DESCRIPTION
## Summary

`scan_applications` calls `pkg_receipt_nonstandard_app_paths` without `--require-complete`, and that path ran `pkgutil --files` **unbounded**. One slow receipt (a large file list, or a cold disk) could blow through the whole scan budget, leaving the app-list scan effectively hung on real machines - the same user-visible symptom as #863.

The strict (`--require-complete`) path already bounded each listing with `run_with_timeout "$remaining"`. This change gives the non-strict path the same treatment: each `pkgutil --files` runs under the remaining deadline, and when the budget is exhausted the scan skips the package instead of hanging (non-strict scans stay non-fatal).

## Validation

- New test "non-strict receipt discovery bounds each pkgutil file listing": mock `pkgutil --files` sleeps 30s; asserts the scan returns within 8s with `RC=0`. Red-green verified: without the fix it takes `ELAPSED=30`, with the fix it stays well under the deadline.
- Full `uninstall.bats`: 94/94 green.
- `./scripts/check.sh` green.
