### PR TITLE
fix(tests): make container stub, sudo batch, and scan tests host-independent

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -1678,6 +1678,50 @@ clean_orphaned_system_services() {
 # Orphaned container stubs
 # ============================================================================
 
+# Whether a stub container's app is still installed anywhere Mole scans.
+# Defined at file scope so callers and tests can pin it deterministically.
+_container_stub_app_exists() {
+    local bundle_id="$1"
+    local app_path="$2"
+
+    [[ -d "$app_path" || -e "$app_path" ]] && return 0
+
+    local app_name
+    app_name=$(basename "$app_path")
+    case "$app_path" in
+        /Applications/*)
+            [[ -d "$HOME/Applications/$app_name" ]] && return 0
+            [[ -d "/Applications/Setapp/$app_name" ]] && return 0
+            [[ -d "$HOME/Library/Application Support/Setapp/Applications/$app_name" ]] && return 0
+            ;;
+    esac
+
+    if mole_is_reverse_dns_bundle_id "$bundle_id"; then
+        local _cache_rc=0
+        _mdfind_cache_check "$bundle_id" || _cache_rc=$?
+        if [[ $_cache_rc -eq 0 ]]; then
+            return 0
+        elif [[ $_cache_rc -eq 2 ]]; then
+            # On mdfind timeout/error assume the app exists (return 0 =
+            # installed here) so a transient Spotlight stall never flags a
+            # live app's service/container as an orphan; do not cache.
+            local app_found _mdfind_rc=0
+            app_found=$(run_with_timeout "$MOLE_TIMEOUT_MEDIUM_PROBE_SEC" mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null) || _mdfind_rc=$?
+            if [[ $_mdfind_rc -eq 124 || $_mdfind_rc -ge 128 ]]; then
+                return "$_mdfind_rc"
+            elif [[ $_mdfind_rc -ne 0 ]]; then
+                return 0
+            elif [[ -n "$app_found" ]]; then
+                _mdfind_cache_store "$bundle_id" "true"
+                return 0
+            fi
+            _mdfind_cache_store "$bundle_id" "false"
+        fi
+    fi
+
+    return 1
+}
+
 # Remove stub-only ~/Library/Containers directories left by uninstalled apps.
 # A stub container contains only .com.apple.containermanagerd.metadata.plist
 # with no Data/ subdirectory, it holds no user data and is safe to remove.
@@ -1733,48 +1777,6 @@ clean_orphaned_container_stubs() {
     local _ng_state
     _ng_state=$(shopt -p nullglob || true)
     shopt -s nullglob
-
-    _container_stub_app_exists() {
-        local bundle_id="$1"
-        local app_path="$2"
-
-        [[ -d "$app_path" || -e "$app_path" ]] && return 0
-
-        local app_name
-        app_name=$(basename "$app_path")
-        case "$app_path" in
-            /Applications/*)
-                [[ -d "$HOME/Applications/$app_name" ]] && return 0
-                [[ -d "/Applications/Setapp/$app_name" ]] && return 0
-                [[ -d "$HOME/Library/Application Support/Setapp/Applications/$app_name" ]] && return 0
-                ;;
-        esac
-
-        if mole_is_reverse_dns_bundle_id "$bundle_id"; then
-            local _cache_rc=0
-            _mdfind_cache_check "$bundle_id" || _cache_rc=$?
-            if [[ $_cache_rc -eq 0 ]]; then
-                return 0
-            elif [[ $_cache_rc -eq 2 ]]; then
-                # On mdfind timeout/error assume the app exists (return 0 =
-                # installed here) so a transient Spotlight stall never flags a
-                # live app's service/container as an orphan; do not cache.
-                local app_found _mdfind_rc=0
-                app_found=$(run_with_timeout "$MOLE_TIMEOUT_MEDIUM_PROBE_SEC" mdfind "kMDItemCFBundleIdentifier == '$bundle_id'" 2> /dev/null) || _mdfind_rc=$?
-                if [[ $_mdfind_rc -eq 124 || $_mdfind_rc -ge 128 ]]; then
-                    return "$_mdfind_rc"
-                elif [[ $_mdfind_rc -ne 0 ]]; then
-                    return 0
-                elif [[ -n "$app_found" ]]; then
-                    _mdfind_cache_store "$bundle_id" "true"
-                    return 0
-                fi
-                _mdfind_cache_store "$bundle_id" "false"
-            fi
-        fi
-
-        return 1
-    }
 
     local pattern_entry
     for pattern_entry in "${stub_patterns[@]}"; do

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -2331,6 +2331,10 @@ set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/apps.sh"
 
+# Pin the app-existence probe: the hardcoded example bundle id may match an
+# app that is actually installed on the developer's machine.
+_container_stub_app_exists() { return 1; }
+
 # Stub container: only the metadata plist, no Data/ subdir
 stub="$HOME/Library/Containers/com.macpaw.CleanMyMac-mas"
 mkdir -p "$stub"
@@ -2368,6 +2372,10 @@ EOF
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/apps.sh"
+
+# Pin the app-existence probe: the hardcoded example bundle id may match an
+# app that is actually installed on the developer's machine.
+_container_stub_app_exists() { return 1; }
 
 stub="$HOME/Library/Containers/com.macpaw.CleanMyMac-mas"
 mkdir -p "$stub"

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -889,7 +889,7 @@ case "${1:-}" in
         ;;
     xargs)
         printf 'xargs %s\n' "$*" >> "$MOLE_SUDO_BATCH_TRACE"
-        exec sleep 4
+        exec sleep 30
         ;;
     *)
         exit 99
@@ -919,7 +919,7 @@ SCRIPT
     [[ "$(< "$trace")" == *"xargs xargs -0 /bin/sh -c"* ]] || return 1
     local elapsed="${output##*ELAPSED=}"
     [[ "$elapsed" =~ ^[0-9]+$ ]] || return 1
-    [ "$elapsed" -lt 3 ]
+    [ "$elapsed" -lt 10 ]
 }
 
 @test "safe_sudo_find_delete stops before scanning when its deadline is exhausted" {

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -114,6 +114,11 @@ set -euo pipefail
 # shellcheck source=/dev/null
 source "$SRC_PATH"
 
+# Skip the real pkgutil receipt scan: it walks every package on the host and
+# can take longer than this test's watchdog on machines with large receipt
+# databases. The regression under test is the empty app_data_tuples guard.
+pkg_receipt_nonstandard_app_paths() { return 0; }
+
 # Restrict the discovered search dirs to our sandboxed Applications folder
 # so scan_applications does not pick up real /Applications and dilute the
 # all-cached condition we are exercising.


### PR DESCRIPTION
## Summary

Four bats tests failed on developer machines whose host state the tests had assumed away, and one timing assertion flaked under load. All of them now pass deterministically:

1. `clean_apps.bats` "clean_orphaned_container_stubs removes stub..." and "preserves content that appears during removal": the hardcoded example bundle id `com.macpaw.CleanMyMac-mas` maps to `/Applications/CleanMyMac X.app`, which is genuinely installed on some machines. The cleaner correctly kept the stub and the tests reported failure. `_container_stub_app_exists` was defined inside `clean_orphaned_container_stubs`, so tests could not pin it; it is extracted to file scope (it closes over nothing) and both tests now stub it.
2. `core_safe_functions.bats` "safe_sudo_find_delete bounds a stalled sudo batch removal": asserted `elapsed < 3s` around a 1s deadline and a 4s mock `xargs`. Under load the assertion flaked. The mock now sleeps 30s and the bound is 10s, so a real timeout failure still fails the test but scheduling noise cannot.
3. `uninstall_scan_bash32.bats` "scan_applications: Pass 2 tolerates empty app_data_tuples on /bin/bash 3.2": `scan_applications` walks `pkgutil --files` for every receipt on the host; on machines with large receipt databases it outlived the test's 5s watchdog and was killed. The regression under test is the bash 3.2 empty-array guard, so `pkg_receipt_nonstandard_app_paths` is stubbed (a pattern already used elsewhere in `uninstall.bats`).

## Validation

- The four tests pass on a macOS 27 host that previously failed all of them.
- Full `clean_apps.bats` + `core_safe_functions.bats` + `uninstall_scan_bash32.bats`: 137/137 green.
- `./scripts/check.sh` green.
