### PR TITLE
fix(status): show purgeable space in the disk card (#1357)

### DIFF
--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -155,6 +155,9 @@ type DiskStatus struct {
 	Fstype      string  `json:"fstype"`
 	External    bool    `json:"external"`
 	SmartStatus string  `json:"smart_status"`
+	// Purgeable is the reclaimable purgeable bytes Finder counts as free on
+	// macOS APFS. Zero when unknown.
+	Purgeable uint64 `json:"purgeable,omitempty"`
 }
 
 type NetworkStatus struct {

--- a/cmd/status/metrics_disk.go
+++ b/cmd/status/metrics_disk.go
@@ -105,8 +105,9 @@ func collectDisksWithCorrections(useCorrections bool) ([]DiskStatus, error) {
 		}
 		used := usage.Used
 		usedPercent := usage.UsedPercent
+		purgeable := uint64(0)
 		if useCorrections && runtime.GOOS == "darwin" && strings.ToLower(part.Fstype) == "apfs" {
-			used, usedPercent = correctAPFSDiskUsage(part.Mountpoint, total, usage.Used)
+			used, usedPercent, purgeable = correctAPFSDiskUsage(part.Mountpoint, total, usage.Used)
 		}
 
 		disks = append(disks, DiskStatus{
@@ -118,6 +119,7 @@ func collectDisksWithCorrections(useCorrections bool) ([]DiskStatus, error) {
 			Fstype:      part.Fstype,
 			External:    !useCorrections && strings.HasPrefix(part.Mountpoint, "/Volumes/"),
 			SmartStatus: smartStatusUnknown,
+			Purgeable:   purgeable,
 		})
 		seenDevice[baseDevice] = true
 		seenVolume[volKey] = true
@@ -330,20 +332,21 @@ func getDiskutilTotalBytes(mountpoint string) (uint64, error) {
 	return extractPlistUint(out, "TotalSize", "DiskSize", "Size")
 }
 
-// correctAPFSDiskUsage returns Finder-accurate used bytes and percent for an
-// APFS volume, accounting for purgeable caches and APFS local snapshots that
-// statfs incorrectly counts as "used". Uses a three-tier fallback:
+// correctAPFSDiskUsage returns Finder-accurate used bytes, percent, and the
+// purgeable bytes Finder counts as free, for an APFS volume. It accounts for
+// purgeable caches and APFS local snapshots that statfs incorrectly counts as
+// "used". Uses a three-tier fallback:
 //  1. Finder via osascript (startup disk only), exact match with macOS Finder
 //  2. diskutil APFSContainerFree, corrects APFS snapshot space
 //  3. Raw gopsutil values, original statfs-based calculation
-func correctAPFSDiskUsage(mountpoint string, total, rawUsed uint64) (used uint64, usedPercent float64) {
+func correctAPFSDiskUsage(mountpoint string, total, rawUsed uint64) (used uint64, usedPercent float64, purgeable uint64) {
 	// Tier 1: Finder via osascript (startup disk at "/" only).
 	if mountpoint == "/" && commandExists("osascript") {
 		if finderFree, finderTotal, err := getFinderStartupDiskFreeBytes(); err == nil &&
 			finderTotal > 0 && finderFree <= finderTotal {
 			used = finderTotal - finderFree
 			usedPercent = float64(used) / float64(finderTotal) * 100.0
-			return
+			return used, usedPercent, finderPurgeableBytes(total, rawUsed, finderFree)
 		}
 	}
 
@@ -355,13 +358,27 @@ func correctAPFSDiskUsage(mountpoint string, total, rawUsed uint64) (used uint64
 			if rawUsed > corrected && rawUsed-corrected > 1<<30 {
 				used = corrected
 				usedPercent = float64(used) / float64(total) * 100.0
-				return
+				return used, usedPercent, 0
 			}
 		}
 	}
 
 	// Tier 3: fall back to raw gopsutil values.
-	return rawUsed, float64(rawUsed) / float64(total) * 100.0
+	return rawUsed, float64(rawUsed) / float64(total) * 100.0, 0
+}
+
+// finderPurgeableBytes returns the purgeable portion of Finder's free space:
+// Finder counts reclaimable purgeable files as free, while statfs (df) does
+// not, so the difference is the purgeable total.
+func finderPurgeableBytes(total, rawUsed, finderFree uint64) uint64 {
+	rawFree := uint64(0)
+	if total > rawUsed {
+		rawFree = total - rawUsed
+	}
+	if finderFree <= rawFree {
+		return 0
+	}
+	return finderFree - rawFree
 }
 
 // getAPFSContainerFreeBytes returns the APFS container free space (including

--- a/cmd/status/metrics_disk_test.go
+++ b/cmd/status/metrics_disk_test.go
@@ -363,3 +363,77 @@ func TestCounterDeltaClampsCounterReset(t *testing.T) {
 		t.Fatalf("counterDelta reset = %d, want 0", got)
 	}
 }
+
+func TestCorrectAPFSDiskUsageReportsFinderPurgeable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("APFS Finder corrections are macOS-only")
+	}
+
+	origRunCmd := runCmd
+	origCommandExists := commandExists
+	origCachedAt := finderDiskCachedAt
+	origFree := finderDiskFree
+	origTotal := finderDiskTotal
+	t.Cleanup(func() {
+		runCmd = origRunCmd
+		commandExists = origCommandExists
+		finderDiskCachedAt = origCachedAt
+		finderDiskFree = origFree
+		finderDiskTotal = origTotal
+	})
+	finderDiskCachedAt = time.Time{}
+
+	commandExists = func(name string) bool { return name == "osascript" }
+	// Finder: 663.7 GB free of 1.8897 TB, i.e. statfs free (522.7 GB) plus
+	// 141 GB purgeable, matching the #1357 scenario.
+	runCmd = func(ctx context.Context, name string, args ...string) (string, error) {
+		return "663700000000, 1889700000000", nil
+	}
+
+	total := uint64(1889700000000)
+	rawUsed := total - uint64(522700000000)
+	used, usedPercent, purgeable := correctAPFSDiskUsage("/", total, rawUsed)
+
+	if want := total - uint64(663700000000); used != want {
+		t.Fatalf("used = %d, want %d", used, want)
+	}
+	if usedPercent < 64.87 || usedPercent > 64.89 {
+		t.Fatalf("usedPercent = %f, want ~64.88", usedPercent)
+	}
+	if purgeable != uint64(141000000000) {
+		t.Fatalf("purgeable = %d, want %d", purgeable, uint64(141000000000))
+	}
+}
+
+func TestCorrectAPFSDiskUsageClampsPurgeableToZero(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("APFS Finder corrections are macOS-only")
+	}
+
+	origRunCmd := runCmd
+	origCommandExists := commandExists
+	origCachedAt := finderDiskCachedAt
+	origFree := finderDiskFree
+	origTotal := finderDiskTotal
+	t.Cleanup(func() {
+		runCmd = origRunCmd
+		commandExists = origCommandExists
+		finderDiskCachedAt = origCachedAt
+		finderDiskFree = origFree
+		finderDiskTotal = origTotal
+	})
+	finderDiskCachedAt = time.Time{}
+
+	commandExists = func(name string) bool { return name == "osascript" }
+	// Finder free below the statfs free means there is no purgeable space.
+	runCmd = func(ctx context.Context, name string, args ...string) (string, error) {
+		return "500000000000, 1889700000000", nil
+	}
+
+	total := uint64(1889700000000)
+	rawUsed := total - uint64(522700000000)
+	_, _, purgeable := correctAPFSDiskUsage("/", total, rawUsed)
+	if purgeable != 0 {
+		t.Fatalf("purgeable = %d, want 0", purgeable)
+	}
+}

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -497,6 +497,9 @@ func formatDiskMetaLine(d DiskStatus) string {
 	if d.Fstype != "" {
 		parts = append(parts, strings.ToUpper(d.Fstype))
 	}
+	if d.Purgeable > 0 {
+		parts = append(parts, humanBytesShort(d.Purgeable)+" purgeable")
+	}
 	return fmt.Sprintf("Total  %s", strings.Join(parts, " · "))
 }
 

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -783,6 +783,21 @@ func TestRenderDiskCardAddsMetaLineForSingleDisk(t *testing.T) {
 	}
 }
 
+func TestRenderDiskCardMetaLineShowsPurgeable(t *testing.T) {
+	card := renderDiskCard([]DiskStatus{{
+		UsedPercent: 64.9,
+		Used:        1226 << 30,
+		Total:       926 << 30,
+		Fstype:      "apfs",
+		Purgeable:   141 << 30,
+	}}, DiskIOStatus{}, 0, false)
+
+	meta := stripANSI(card.lines[1])
+	if meta != "Total  926G · APFS · 141G purgeable" {
+		t.Fatalf("renderDiskCard() meta line = %q, want %q", meta, "Total  926G · APFS · 141G purgeable")
+	}
+}
+
 func TestRenderDiskCardDoesNotAddMetaLineForMultipleDisks(t *testing.T) {
 	card := renderDiskCard([]DiskStatus{
 		{UsedPercent: 28.4, Used: 263 << 30, Total: 926 << 30, Fstype: "apfs"},


### PR DESCRIPTION
## Summary

Fixes #1357. `mo status` intentionally reports Finder-accurate free space on
APFS (reclaimable purgeable bytes count as free, matching Finder), while
`mo --version` reports the raw statfs free space shown by `diskutil`/`df`. The
two numbers look contradictory because status never said what its free figure
includes.

This PR makes the relationship explicit:

- `DiskStatus` gains a `purgeable` field (JSON `purgeable`, omitted when
  unknown), populated from the Finder correction: purgeable = Finder free -
  statfs free.
- The disk card meta line now shows the purgeable portion, e.g.
  `Total  1.89T · APFS · 141G purgeable` next to `663.7 GB free`.
- `mo --version` is unchanged: its `Disk Free` line keeps reporting the raw
  statfs free space, consistent with `diskutil`/`df`.

With the reporter's numbers this reconciles everything:
`663.7 GB free` in status = `522.71 GB` from `--version` + `141 GB purgeable`.

## Safety Review

- Status display and JSON metrics only. No cleanup, uninstall, install,
  update, path-validation, or sudo behavior is touched.
- No behavior change when purgeable is unknown (non-APFS, non-macOS, or
  Finder unavailable): the JSON field is omitted and the meta line is
  unchanged.

## Tests

- New `TestCorrectAPFSDiskUsageReportsFinderPurgeable` reproduces the #1357
  numbers: 663.7 GB Finder free = 522.7 GB statfs free + 141 GB purgeable.
- New `TestCorrectAPFSDiskUsageClampsPurgeableToZero` and
  `TestRenderDiskCardMetaLineShowsPurgeable`.
- `go test ./cmd/status/` and `go vet ./cmd/status/` pass. One
  pre-existing test (`TestCollectProcessesUnderCommaLocale`) cannot fork
  `/bin/ps` in this restricted environment and fails identically on
  `origin/main`; the rest of the package is green.

## Safety-related changes

- None.
