### PR TITLE
AudioCopy.app triggers edge-case fail closed

### DIFF
--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -245,10 +245,14 @@ scan_installed_apps() {
                     # Vendor uninstallers and Steam launchers ship those, and a
                     # bundle with no id owns no bundle-id-named leftovers, so
                     # leaving it out of the list cannot invent an orphan.
+                    # No plist at all (absent Contents/ and no Wrapper/ found,
+                    # e.g. an iOS app whose WrappedBundle symlink is dangling)
+                    # is the same: the bundle cannot own any bundle-id-named
+                    # leftovers and cannot be mistaken for one.
                     # Anything that will not parse still fails the scan closed,
                     # because there the id may exist and simply be unreadable,
                     # which is what would turn a live app's data into an orphan.
-                    if [[ -f "$plist_path" ]] && /usr/bin/plutil -lint "$plist_path" > /dev/null 2>&1; then
+                    if [[ ! -f "$plist_path" ]] || /usr/bin/plutil -lint "$plist_path" > /dev/null 2>&1; then
                         continue
                     fi
                     printf '%s\n' "$app_path" >> "$scan_tmp_dir/scan_failures.list"

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -2660,3 +2660,42 @@ EOF
 		return 1
 	}
 }
+
+@test "installed-app scan skips an iOS app with a dangling WrappedBundle symlink" {
+  # This was found when mole tried to scan AudioCopy.app. It has no
+  # Contents/ and WarpBundle is a symlink -> Wrapper/<name>.app. Great...
+  # but Wrapper/ does not exist!
+  # No plist can be found anywhere, so the bundle has no bundle ID and cannot
+  # own any bundle-ID-named leftovers. The scan should skip it (not fail closed,
+  # and skip scanning altogether).
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+rm -f "$HOME/.cache/mole/installed_apps_cache"
+
+apps="$HOME/Applications"
+rm -rf "$apps"
+mkdir -p "$apps/Good.app/Contents"
+mkdir -p "$apps/AudioCopy.app"
+# WrappedBundle symlink pointing to a Wrapper/ path that does not exist.
+ln -s "Wrapper/AudioCopy.app" "$apps/AudioCopy.app/WrappedBundle"
+
+plist() {
+	cat > "$1" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>$2</dict></plist>
+PLIST
+}
+plist "$apps/Good.app/Contents/Info.plist" '<key>CFBundleIdentifier</key><string>com.example.good</string>'
+
+debug_log() { :; }
+scan_installed_apps "$HOME/installed.txt" || { echo "SCAN_FAILED"; exit 1; }
+grep -Fxq "com.example.good" "$HOME/installed.txt" || { echo "MISSING_GOOD"; exit 1; }
+EOF
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
+}


### PR DESCRIPTION
AudioCopy.app has a strange internal structure (a broken WrappedBundle symlink) that causes Mole to fail closed while looking for orphaned app data. This fix skips over apps for which we simply can't find a plist path at all.

## Summary

- Checks to see if we can actually find Info.plist at all. Skips if not.

## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?
- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?
- If yes, describe the new boundary or risk change clearly.

Will allow cleanup behavior to proceed that otherwise would be blocked, but does not add any ADDITIONAL cleanup.

Affects symlink handling (detects invalid symlinks during lookup and skips affected apps altogether).

## Tests

- List the automated tests you ran.

Added new test that creates a fake version of the buggy app that breaks the scan, and a good app. Verifies that the scan does not break if the buggy app is present.

- List any manual checks for high-risk paths or destructive flows.

Ran a full cleanup; nothing extra was cleaned up, but the scan continued successfully through the `scan_installed_apps` step without skipping it.

## Safety-related changes

- None.
