### PR TITLE
fix(clean): defer Gradle build-cache and notifications while a daemon runs (#1360)

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -2123,23 +2123,39 @@ clean_dev_jvm() {
     safe_clean ~/.sbt/boot/* "SBT boot cache"
     safe_clean ~/.sbt/launchers/* "SBT launcher cache"
     safe_clean ~/.ivy2/cache/* "Ivy cache"
-    safe_clean ~/.gradle/caches/build-cache-*/* "Gradle build cache"
-    safe_clean ~/.gradle/notifications/* "Gradle notifications cache"
-    if mole_cleanup_targets_exist "$HOME/.gradle/daemon"/* "$HOME/.gradle/workers"/*; then
+    if mole_cleanup_targets_exist \
+        "$HOME/.gradle/caches/build-cache-"*/* \
+        "$HOME/.gradle/notifications"/* \
+        "$HOME/.gradle/daemon"/* \
+        "$HOME/.gradle/workers"/*; then
         local gradle_state=0
         gradle_daemon_running || gradle_state=$?
         if [[ $gradle_state -eq 0 ]]; then
             mole_defer_cleanup_family "Gradle"
         elif [[ $gradle_state -eq 1 ]]; then
+            # Each group rechecks the probe at its deletion boundary; any
+            # refusal stops the remaining Gradle cleanup.
+            _dev_safe_clean_process_guarded \
+                gradle_daemon_running \
+                "Gradle" \
+                "Gradle build cache" \
+                "$HOME/.gradle/caches/build-cache-"*/* \
+                "Gradle build cache" || return 0
+            _dev_safe_clean_process_guarded \
+                gradle_daemon_running \
+                "Gradle" \
+                "Gradle notifications cache" \
+                "$HOME/.gradle/notifications"/* \
+                "Gradle notifications cache" || return 0
             _dev_safe_clean_process_guarded \
                 gradle_daemon_running \
                 "Gradle" \
                 "Gradle daemon/workers" \
-                ~/.gradle/daemon/* \
-                ~/.gradle/workers/* \
-                "Gradle daemon/workers" || true
+                "$HOME/.gradle/daemon"/* \
+                "$HOME/.gradle/workers"/* \
+                "Gradle daemon/workers" || return 0
         else
-            echo -e "  ${GRAY}${ICON_WARNING}${NC} Gradle daemon/workers · skipped (process state unknown)"
+            echo -e "  ${GRAY}${ICON_WARNING}${NC} Gradle targets · skipped (process state unknown)"
             note_activity
         fi
     fi

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -100,9 +100,10 @@ EOF
     [[ "$output" != *"SAFE_CLEAN:Gradle workers"* ]]
 }
 
-@test "clean_dev_jvm fails closed when the Gradle process probe errors" {
-    mkdir -p "$HOME/.gradle/daemon" "$HOME/.gradle/workers"
-    touch "$HOME/.gradle/daemon/candidate"
+@test "clean_dev_jvm fails closed for every Gradle target when the process probe errors" {
+    rm -rf "$HOME/.gradle/caches" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon" "$HOME/.gradle/workers"
+    mkdir -p "$HOME/.gradle/caches/build-cache-1" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon/8.14" "$HOME/.gradle/workers/worker-1"
+    touch "$HOME/.gradle/caches/build-cache-1/entry" "$HOME/.gradle/notifications/entry" "$HOME/.gradle/daemon/8.14/entry" "$HOME/.gradle/workers/worker-1/entry"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
@@ -117,9 +118,81 @@ EOF
         echo "$output"
         return 1
     }
-    [[ "$output" == *"Gradle daemon/workers · skipped (process state unknown)"* ]] || return 1
-    [[ "$output" != *"SAFE_CLEAN:Gradle daemon"* ]] || return 1
-    [[ "$output" != *"SAFE_CLEAN:Gradle workers"* ]]
+    [[ "$output" == *"Gradle targets · skipped (process state unknown)"* ]] || return 1
+    [[ "$output" != *"SAFE_CLEAN:Gradle"* ]] || return 1
+}
+
+@test "clean_dev_jvm defers every Gradle target while Gradle is running" {
+    rm -rf "$HOME/.gradle/caches" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon" "$HOME/.gradle/workers"
+    mkdir -p "$HOME/.gradle/caches/build-cache-1" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon/8.14" "$HOME/.gradle/workers/worker-1"
+    touch "$HOME/.gradle/caches/build-cache-1/entry" "$HOME/.gradle/notifications/entry" "$HOME/.gradle/daemon/8.14/entry" "$HOME/.gradle/workers/worker-1/entry"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+gradle_daemon_running() { return 0; }
+defer_cleanup_family() { echo "DEFER:$1"; }
+safe_clean() { echo "UNEXPECTED_CLEAN:${!#}"; }
+clean_dev_jvm
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"DEFER:Gradle"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_CLEAN:Gradle"* ]] || return 1
+}
+
+@test "clean_dev_jvm cleans every Gradle target when idle" {
+    rm -rf "$HOME/.gradle/caches" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon" "$HOME/.gradle/workers"
+    mkdir -p "$HOME/.gradle/caches/build-cache-1" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon/8.14" "$HOME/.gradle/workers/worker-1"
+    touch "$HOME/.gradle/caches/build-cache-1/entry" "$HOME/.gradle/notifications/entry" "$HOME/.gradle/daemon/8.14/entry" "$HOME/.gradle/workers/worker-1/entry"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+gradle_daemon_running() { return 1; }
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+clean_dev_jvm
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"SAFE_CLEAN:Gradle build cache|"* ]] || return 1
+    [[ "$output" == *"SAFE_CLEAN:Gradle notifications cache|"* ]] || return 1
+    [[ "$output" == *"SAFE_CLEAN:"*".gradle/daemon/8.14"* ]] || return 1
+    [[ "$output" == *"SAFE_CLEAN:"*".gradle/workers/worker-1"* ]] || return 1
+    rm -rf "$HOME/.gradle"
+}
+
+@test "clean_dev_jvm stops remaining Gradle cleanup when the delete guard refuses" {
+    rm -rf "$HOME/.gradle/caches" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon" "$HOME/.gradle/workers"
+    mkdir -p "$HOME/.gradle/caches/build-cache-1" "$HOME/.gradle/notifications" "$HOME/.gradle/daemon/8.14" "$HOME/.gradle/workers/worker-1"
+    touch "$HOME/.gradle/caches/build-cache-1/entry" "$HOME/.gradle/notifications/entry" "$HOME/.gradle/daemon/8.14/entry" "$HOME/.gradle/workers/worker-1/entry"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+gradle_daemon_running() { return 1; }
+_dev_process_delete_guard_allows() { return 1; }
+defer_cleanup_family() { echo "DEFER:$1"; }
+safe_clean() { echo "UNEXPECTED_CLEAN:${!#}"; }
+clean_dev_jvm
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"DEFER:Gradle"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_CLEAN:Gradle"* ]] || return 1
+    rm -rf "$HOME/.gradle"
 }
 
 @test "clean_dev_jvm ignores empty Gradle daemon roots while active" {


### PR DESCRIPTION
## Summary

- Move Gradle build-cache and notifications cleanup inside the existing
  tri-state daemon guard, so an active daemon or an unknown process state
  defers/skips every Gradle target instead of deleting caches first.
- Include all four existing target groups (build-cache, notifications, daemon,
  workers) in `mole_cleanup_targets_exist`.
- Recheck the daemon probe at each deletion boundary via
  `_dev_safe_clean_process_guarded` and stop the remaining Gradle cleanup after
  a refusal.

Fixes #1360. This is the narrow Gradle follow-up the owner invited in #1295.

## Real reproduction (V1.49.2, ad82a47b)

Production `clean_dev_jvm` with a real Gradle 9.5.1 daemon in an isolated temp
HOME (real user files untouched):

Before (main):
- daemon running: `Gradle build cache` and `Gradle notifications cache`
  deleted; daemon/workers preserved; family deferred
- probe unknown: same two targets deleted; daemon/workers skipped with
  "process state unknown"
- idle: all four target groups cleaned

After (this branch):
- daemon running: all four target groups preserved; family deferred
- probe unknown: all four target groups preserved
- idle: all four target groups cleaned (unchanged)

Stock-config note: the default whitelist already protects
`~/.gradle/caches/*` and `~/.gradle/daemon/*`; the always-exposed target is
`~/.gradle/notifications/*`. Build-cache becomes exposed once the user removes
the default protections (`mo clean --whitelist`). Both paths are now guarded.

## Test

- Extended `tests/clean_dev_caches.bats`: the probe-error case now covers all
  four target groups; added active-defer, idle-clean, and delete-boundary
  refusal cases.
- `bats tests/clean_dev_caches.bats`: 61/61
- `./scripts/test.sh`: 1532 tests, 0 failures, 15 skipped
- `./scripts/check.sh --no-format`: passed
