### PR TITLE
fix(optimize): resolve the notification database on macOS 15+ (#1368)

### DIFF
--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -1419,14 +1419,53 @@ opt_shared_file_list_repair() {
 
 # Clean old delivered notifications from NotificationCenter database.
 opt_notification_cleanup() {
-    local nc_db_dir
-    nc_db_dir="$(getconf DARWIN_USER_DIR 2> /dev/null || true)/com.apple.notificationcenter/db2"
-    local nc_db="$nc_db_dir/db"
+    if [[ "${MO_DEBUG:-}" == "1" ]]; then
+        debug_operation_start "Notification Center Cleanup" "Remove delivered notifications older than 30 days from the active NotificationCenter database"
+        debug_operation_detail "Method" "DELETE + VACUUM on the active SQLite database (group-container path on macOS 15+)"
+        debug_risk_level "LOW" "Only delivered notifications older than 30 days are removed"
+    fi
 
-    if [[ ! -f "$nc_db" ]]; then
-        opt_msg "Notification Center database not found"
-        optimize_task_result "$MOLE_OPTIMIZE_OUTCOME_UNCHANGED"
+    # The notification database moved in macOS 15 to the usernoted group
+    # container; the Darwin-user-directory path only holds stale files there.
+    local os_major=""
+    os_major=$(sw_vers -productVersion 2> /dev/null | cut -d. -f1 || true)
+
+    local group_db="$HOME/Library/Group Containers/group.com.apple.usernoted/db2/db"
+    local legacy_dir=""
+    local darwin_user_dir=""
+    darwin_user_dir=$(getconf DARWIN_USER_DIR 2> /dev/null || true)
+    if [[ -n "$darwin_user_dir" ]]; then
+        legacy_dir="$darwin_user_dir/com.apple.notificationcenter/db2/db"
+    fi
+
+    local -a db_candidates=()
+    if [[ "$os_major" =~ ^[0-9]+$ && "$os_major" -ge 15 ]]; then
+        db_candidates=("$group_db")
+        [[ -n "$legacy_dir" ]] && db_candidates+=("$legacy_dir")
+    else
+        [[ -n "$legacy_dir" ]] && db_candidates+=("$legacy_dir")
+        db_candidates+=("$group_db")
+    fi
+
+    local nc_db=""
+    local -a attempted_paths=()
+    local candidate=""
+    for candidate in "${db_candidates[@]}"; do
+        attempted_paths+=("$candidate")
+        if [[ -f "$candidate" ]]; then
+            nc_db="$candidate"
+            break
+        fi
+    done
+
+    if [[ -z "$nc_db" ]]; then
+        echo -e "  ${YELLOW}${ICON_WARNING}${NC} Notification Center database not found (tried: ${attempted_paths[*]})"
+        optimize_task_result "$MOLE_OPTIMIZE_OUTCOME_UNAVAILABLE"
         return 0
+    fi
+
+    if [[ "${MO_DEBUG:-}" == "1" ]]; then
+        debug_operation_detail "Database" "$nc_db"
     fi
 
     local db_size=""
@@ -1434,6 +1473,10 @@ opt_notification_cleanup() {
         echo -e "  ${YELLOW}${ICON_WARNING}${NC} Failed to inspect Notification Center database size"
         optimize_task_result "$MOLE_OPTIMIZE_OUTCOME_FAILED"
         return 0
+    fi
+
+    if [[ "${MO_DEBUG:-}" == "1" ]]; then
+        debug_operation_detail "Size" "$(bytes_to_human $((db_size * 1024)))"
     fi
 
     # Only clean if database exceeds 50MB (51200 KB)
@@ -1445,6 +1488,22 @@ opt_notification_cleanup() {
 
     if [[ "${MOLE_DRY_RUN:-0}" != "1" ]]; then
         if command -v sqlite3 > /dev/null 2>&1; then
+            local schema_probe_rc=0
+            local record_table=""
+            record_table=$(sqlite3 "$nc_db" \
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='record' LIMIT 1;" \
+                2> /dev/null) || schema_probe_rc=$?
+            if [[ $schema_probe_rc -ne 0 ]]; then
+                echo -e "  ${YELLOW}${ICON_WARNING}${NC} Notification Center cleanup skipped (database busy or locked)"
+                optimize_task_result "$MOLE_OPTIMIZE_OUTCOME_FAILED"
+                return 0
+            fi
+            if [[ "$record_table" != "record" ]]; then
+                echo -e "  ${YELLOW}${ICON_WARNING}${NC} Notification Center cleanup skipped (unexpected database schema)"
+                optimize_task_result "$MOLE_OPTIMIZE_OUTCOME_FAILED"
+                return 0
+            fi
+
             local sql_ok=0
             sqlite3 "$nc_db" \
                 "DELETE FROM record WHERE delivered_date < strftime('%s','now','-30 days'); VACUUM;" \

--- a/tests/optimize_db.bats
+++ b/tests/optimize_db.bats
@@ -42,6 +42,7 @@ create_logical_file() {
 set -euo pipefail
 source "\$PROJECT_ROOT/lib/core/common.sh"
 source "\$PROJECT_ROOT/lib/optimize/tasks.sh"
+sw_vers() { echo "14.0"; }
 getconf() { echo "$tmp_dir"; }
 execute_optimization notification_cleanup
 EOF
@@ -62,6 +63,7 @@ EOF
 set -euo pipefail
 source "\$PROJECT_ROOT/lib/core/common.sh"
 source "\$PROJECT_ROOT/lib/optimize/tasks.sh"
+sw_vers() { echo "14.0"; }
 getconf() { echo "$tmp_dir"; }
 sqlite3() { return 1; }
 execute_optimization notification_cleanup
@@ -70,6 +72,99 @@ EOF
 	rm -rf "$tmp_dir"
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"busy or locked"* ]]
+}
+
+@test "opt_notification_cleanup uses the group-container database on macOS 15+" {
+	local tmp_dir group_db
+	tmp_dir=$(mktemp -d)
+	group_db="$tmp_dir/Library/Group Containers/group.com.apple.usernoted/db2/db"
+	mkdir -p "$(dirname "$group_db")"
+	create_logical_file "$group_db" 1k
+
+	run env HOME="$tmp_dir" PROJECT_ROOT="$PROJECT_ROOT" MO_DEBUG=1 /bin/bash --noprofile --norc <<EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/lib/optimize/tasks.sh"
+sw_vers() { echo "15.0"; }
+getconf() { echo "$tmp_dir/runtime"; }
+execute_optimization notification_cleanup
+EOF
+
+	rm -rf "$tmp_dir"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"healthy"* ]]
+	[[ "$output" == *"Database: $group_db"* ]]
+}
+
+@test "opt_notification_cleanup falls back to the legacy database below macOS 15" {
+	local tmp_dir legacy_db
+	tmp_dir=$(mktemp -d)
+	legacy_db="$tmp_dir/runtime/com.apple.notificationcenter/db2/db"
+	mkdir -p "$(dirname "$legacy_db")"
+	create_logical_file "$legacy_db" 1k
+
+	run env HOME="$tmp_dir" PROJECT_ROOT="$PROJECT_ROOT" MO_DEBUG=1 /bin/bash --noprofile --norc <<EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/lib/optimize/tasks.sh"
+sw_vers() { echo "14.0"; }
+getconf() { echo "$tmp_dir/runtime"; }
+execute_optimization notification_cleanup
+EOF
+
+	rm -rf "$tmp_dir"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"healthy"* ]]
+	[[ "$output" == *"Database: $legacy_db"* ]]
+}
+
+@test "opt_notification_cleanup reports attempted paths as unavailable when no database exists" {
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+
+	run env HOME="$tmp_dir" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/lib/optimize/tasks.sh"
+sw_vers() { echo "15.0"; }
+getconf() { echo "$tmp_dir/runtime"; }
+execute_optimization notification_cleanup
+[[ "\$(optimize_outcome_count unavailable)" == "1" ]] || exit 1
+EOF
+
+	rm -rf "$tmp_dir"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Notification Center database not found"* ]]
+	[[ "$output" == *"group.com.apple.usernoted/db2/db"* ]]
+	[[ "$output" == *"com.apple.notificationcenter/db2/db"* ]]
+}
+
+@test "opt_notification_cleanup skips cleanup when the record table is missing" {
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	mkdir -p "$tmp_dir/Library/Group Containers/group.com.apple.usernoted/db2"
+	create_logical_file "$tmp_dir/Library/Group Containers/group.com.apple.usernoted/db2/db" 60m
+
+	run env HOME="$tmp_dir" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/lib/optimize/tasks.sh"
+sw_vers() { echo "15.0"; }
+getconf() { echo "$tmp_dir/runtime"; }
+sqlite3() {
+	if [[ "\$2" == *sqlite_master* ]]; then
+		echo ""
+		return 0
+	fi
+	return 1
+}
+execute_optimization notification_cleanup
+[[ "\$(optimize_outcome_count failed)" == "1" ]] || exit 1
+EOF
+
+	rm -rf "$tmp_dir"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"unexpected database schema"* ]]
 }
 
 @test "opt_coreduet_cleanup reports healthy when db is small" {


### PR DESCRIPTION
## Summary

Fix #1368: resolve the active NotificationCenter database by macOS version instead of always using the pre-Sequoia Darwin-user-directory path.

- Prefer `$HOME/<local-path>` on macOS 15 and later.
- Keep `$(getconf DARWIN_USER_DIR)/com.apple.notificationcenter/db2/db` as the fallback for older systems.
- Verify the `record` table exists before running `DELETE` + `VACUUM`; a probe failure is reported as busy/locked, a missing table as an unexpected schema.
- Report the selected database path and size in `--debug` output.
- When no supported database exists, report the attempted paths and mark the task `unavailable` instead of a green "not found" `unchanged`.

The size threshold (50MB) and the 30-day delete window are unchanged.

## Real-system reproduction

macOS 27 (arm64). Before the fix, the old path has no main `db` file and `mo optimize` reports `Notification Center database not found`:

```console
$ ls -l "$(getconf DARWIN_USER_DIR)/com.apple.notificationcenter/db2"
ls: /com.apple.notificationcenter/db2: No such file or directory

$ ls -l "$HOME/<local-path>"
-rw-r--r--  1 <user>  staff  1429504 Aug  4 20:10 .../<local-path>

$ sqlite3 "$HOME/<local-path>" \
    "SELECT name FROM sqlite_master WHERE type='table' AND name='record';"
record
```

After the fix, the same machine resolves the group-container database and reports it healthy (below the 50MB threshold), with the path and size in debug output:

```console
$ MO_DEBUG=1 MOLE_DRY_RUN=1 bash -c 'source lib/core/common.sh; source lib/optimize/tasks.sh; execute_optimization notification_cleanup'
[DEBUG] Database: <local-path>
[DEBUG] Size: 1.4MB
  → Notification Center database is healthy (1.4MB)
```

## Tests

- `bats tests/optimize_db.bats` (12/12, including 4 new notification cases: macOS 15+ group-container path, pre-15 legacy fallback, no-database unavailable with attempted paths, missing `record` table)
- `bats tests/optimize.bats tests/optimize_probe_outcomes.bats tests/optimize_catalog.bats tests/optimize_outcomes.bats tests/optimize_summary.bats tests/optimize_removal_outcomes.bats`
- `shellcheck mole install.sh bin/*.sh lib/*/*.sh scripts/*.sh`
- `bash -n` on changed files



