### PR TITLE
fix(clean): keep cleaning when a cache size check times out (#1374)

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1071,8 +1071,12 @@ _safe_clean_impl() {
             run_with_timeout "$MOLE_TIMEOUT_DISK_VERIFY_SEC" \
                 stat -f%z "${existing_paths[@]}" < /dev/null \
                 > "$bulk_stat_file" 2> /dev/null || bulk_stat_rc=$?
-            if [[ $bulk_stat_rc -eq 124 || $bulk_stat_rc -ge 128 ]]; then
+            if [[ $bulk_stat_rc -ge 128 ]]; then
                 cleanup_interrupt_rc=$bulk_stat_rc
+            elif [[ $bulk_stat_rc -eq 124 ]]; then
+                # The size is only used for the freed total; a stalled stat
+                # must not cancel the delete set. Sizes are already 0 here.
+                MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
             fi
             while IFS= read -r _bytes; do
                 [[ "$_bytes" =~ ^[0-9]+$ ]] || _bytes=0
@@ -1094,9 +1098,11 @@ _safe_clean_impl() {
                     local _dsize_rc=0
                     _dsize=$(get_cleanup_path_size_kb \
                         "${existing_paths[$idx]}") || _dsize_rc=$?
-                    if [[ $_dsize_rc -eq 124 || $_dsize_rc -ge 128 ]]; then
+                    if [[ $_dsize_rc -ge 128 ]]; then
                         cleanup_interrupt_rc=$_dsize_rc
                         break
+                    elif [[ $_dsize_rc -eq 124 ]]; then
+                        MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
                     fi
                     [[ "$_dsize" =~ ^[0-9]+$ ]] || _dsize=0
                     if [[ "$_dsize" -gt 0 ]]; then
@@ -1118,16 +1124,22 @@ _safe_clean_impl() {
                 for path in "${existing_paths[@]}"; do
                     (
                         local size=0 size_rc=0
+                        local size_unknown=0
                         size=$(get_cleanup_path_size_kb "$path") || size_rc=$?
-                        if [[ $size_rc -eq 124 || $size_rc -ge 128 ]]; then
+                        if [[ $size_rc -ge 128 ]]; then
                             exit "$size_rc"
+                        fi
+                        if [[ $size_rc -eq 124 ]]; then
+                            # Sizing budget exhausted: keep the item in the
+                            # delete set and report its size as 0.
+                            size_unknown=1
                         fi
                         [[ ! "$size" =~ ^[0-9]+$ ]] && size=0
                         local tmp_file="$temp_dir/result_${idx}.$$"
                         if [[ "$size" -gt 0 ]]; then
-                            echo "$size 1" > "$tmp_file"
+                            echo "$size 1 $size_unknown" > "$tmp_file"
                         else
-                            echo "0 0" > "$tmp_file"
+                            echo "0 0 $size_unknown" > "$tmp_file"
                         fi
                         mv "$tmp_file" "$temp_dir/result_${idx}" 2> /dev/null || true
                     ) < /dev/null &
@@ -1137,7 +1149,7 @@ _safe_clean_impl() {
                     if ((${#pids[@]} >= MOLE_MAX_PARALLEL_JOBS)); then
                         local wait_rc=0
                         wait "${pids[0]}" 2> /dev/null || wait_rc=$?
-                        if [[ $wait_rc -eq 124 || $wait_rc -ge 128 ]]; then
+                        if [[ $wait_rc -ge 128 ]]; then
                             cleanup_interrupt_rc=$wait_rc
                             break
                         fi
@@ -1155,7 +1167,7 @@ _safe_clean_impl() {
                 for pid in "${pids[@]}"; do
                     local wait_rc=0
                     wait "$pid" 2> /dev/null || wait_rc=$?
-                    if [[ $wait_rc -eq 124 || $wait_rc -ge 128 ]]; then
+                    if [[ $wait_rc -ge 128 ]]; then
                         [[ $cleanup_interrupt_rc -ne 0 ]] || cleanup_interrupt_rc=$wait_rc
                     fi
                     completed=$((completed + 1))
@@ -1166,6 +1178,19 @@ _safe_clean_impl() {
                 done
             fi
         fi
+
+        # Count the items whose size check hit the budget; they were still
+        # cleaned, only the freed total is under-reported.
+        local _t_size=0
+        local _t_count=0
+        local _t_flag=0
+        local _t_file
+        for _t_file in "$temp_dir"/result_*; do
+            [[ -f "$_t_file" ]] || continue
+            _t_flag=0
+            read -r _t_size _t_count _t_flag < "$_t_file" 2> /dev/null || true
+            [[ "$_t_flag" == "1" ]] && MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
+        done
 
         if [[ $cleanup_interrupt_rc -ne 0 ]]; then
             if [[ "$show_spinner" == "true" || "$show_scan_feedback" == "true" ]]; then
@@ -1192,7 +1217,7 @@ _safe_clean_impl() {
             for path in "${existing_paths[@]}"; do
                 local result_file="$temp_dir/result_${idx}"
                 if [[ -f "$result_file" ]]; then
-                    read -r size count < "$result_file" 2> /dev/null || true
+                    read -r size count size_unknown < "$result_file" 2> /dev/null || true
                     local removed=0
                     local action_rc=0
                     if [[ "$DRY_RUN" != "true" ]]; then
@@ -1289,9 +1314,12 @@ _safe_clean_impl() {
                 local size_kb=0
                 local size_rc=0
                 size_kb=$(get_cleanup_path_size_kb "$path") || size_rc=$?
-                if [[ $size_rc -eq 124 || $size_rc -ge 128 ]]; then
+                if [[ $size_rc -ge 128 ]]; then
                     cleanup_interrupt_rc=$size_rc
                     break
+                elif [[ $size_rc -eq 124 ]]; then
+                    # Sizing budget exhausted: keep cleaning with size 0.
+                    MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
                 fi
                 [[ ! "$size_kb" =~ ^[0-9]+$ ]] && size_kb=0
 
@@ -1452,6 +1480,8 @@ start_cleanup() {
     export MOLE_CURRENT_COMMAND="clean"
     MOLE_CLEAN_CANCEL_STATUS=0
     export MOLE_CLEAN_CANCEL_STATUS
+    MOLE_CLEAN_SIZING_TIMEOUTS=0
+    export MOLE_CLEAN_SIZING_TIMEOUTS
     log_operation_session_start "clean"
     DRY_RUN_SEEN_IDENTITIES=()
     DRY_RUN_TOTAL_PARTIAL=false
@@ -1958,6 +1988,10 @@ perform_cleanup() {
         fi
     elif [[ "$DRY_RUN" == "true" ]]; then
         publish_clean_preview_file || true
+    fi
+
+    if [[ ${MOLE_CLEAN_SIZING_TIMEOUTS:-0} -gt 0 ]]; then
+        summary_details+=("${GRAY}${ICON_WARNING}${NC} Some items exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s size-check budget and were counted as 0, so the total is under-reported. Raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} to measure them.")
     fi
 
     if [[ $had_errexit -eq 1 ]]; then

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -445,7 +445,7 @@ EOF
     [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
 }
 
-@test "safe_clean propagates a real directory size timeout before deletion" {
+@test "safe_clean treats a real directory size timeout as size-unknown and keeps cleaning" {
     local base="$HOME/safe-clean-real-timeout"
     mkdir -p "$base/candidate"
 
@@ -455,21 +455,69 @@ set -euo pipefail
 source "\$PROJECT_ROOT/bin/clean.sh"
 DRY_RUN=false
 MOLE_CURRENT_COMMAND=clean
+unset MOLE_CLEAN_SIZING_TIMEOUTS
 run_with_timeout() { return 124; }
-safe_remove() { echo "UNEXPECTED_REMOVE:\$1"; return 0; }
+safe_remove() { echo "REMOVE:\$1"; /bin/rm -rf "\$1"; }
 
 rc=0
 safe_clean "$base/candidate" "Timed out directory" || rc=\$?
-printf 'RC=%s CANCEL=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}"
-[[ -d "$base/candidate" ]]
+printf 'RC=%s CANCEL=%s TIMEOUTS=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}" "\${MOLE_CLEAN_SIZING_TIMEOUTS:-0}"
+[[ ! -e "$base/candidate" ]]
 EOF
 
     [ "$status" -eq 0 ] || {
         echo "$output"
         return 1
     }
-    [[ "$output" == *"RC=124 CANCEL=124"* ]] || return 1
-    [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
+    [[ "$output" == *"RC=0 CANCEL=0 TIMEOUTS=1"* ]] || return 1
+    [[ "$output" == *"REMOVE:$base/candidate"* ]] || return 1
+}
+
+@test "safe_clean keeps cleaning when a parallel size worker times out (#1374)" {
+    local base="$HOME/safe_clean_parallel_timeout"
+    mkdir -p "$base/a" "$base/b" "$base/c" "$base/d" "$base/e"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc << EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+MOLE_CURRENT_COMMAND=clean
+MOLE_CLEAN_CANCEL_STATUS=0
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+unset MOLE_CLEAN_SIZING_TIMEOUTS
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+note_activity() { :; }
+is_path_whitelisted() { return 1; }
+get_cleanup_path_size_kb() {
+    [[ "\$1" == "$base/c" ]] && return 124
+    echo 1
+}
+safe_remove() { echo "REMOVE:\$1"; /bin/rm -rf "\$1"; }
+
+rc=0
+safe_clean "$base/a" "$base/b" "$base/c" "$base/d" "$base/e" \
+    "Timed out size batch" || rc=\$?
+printf 'RC=%s CANCEL=%s TIMEOUTS=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}" "\${MOLE_CLEAN_SIZING_TIMEOUTS:-0}"
+for path in "$base/a" "$base/b" "$base/c" "$base/d" "$base/e"; do
+    if [[ -d "\$path" ]]; then
+        echo "WRONG: kept \$path"
+        exit 1
+    fi
+done
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC=0 CANCEL=0 TIMEOUTS=1"* ]] || return 1
+    [[ "$output" == *"REMOVE:$base/c"* ]] || return 1
 }
 
 @test "mo clean --dry-run skips system cleanup in non-interactive mode" {

--- a/tests/clean_summary_cancel.bats
+++ b/tests/clean_summary_cancel.bats
@@ -87,3 +87,45 @@ EOF
     [[ "$output" == *"Cleanup complete"* ]]
     [[ "$output" != *"Cleanup cancelled"* ]]
 }
+
+@test "sizing timeouts still clean and the summary reports the under-count (#1374)" {
+    mkdir -p "$HOME/Library/Caches/cache1374"
+    printf x > "$HOME/Library/Caches/cache1374/file.bin"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+# Stub every section so perform_cleanup never scans the real machine.
+# run_with_shell_timeout is stubbed too: its shell-fallback killer process
+# would otherwise outlive the test when pgrep is unavailable.
+for fn in clean_finder_metadata clean_app_caches \
+    clean_browsers run_cloud_and_office_cleanup clean_developer_tools \
+    clean_user_gui_applications clean_virtualization_tools \
+    clean_application_support_logs clean_orphaned_app_data \
+    clean_orphaned_system_services clean_orphaned_container_stubs \
+    clean_stale_launch_services_registrations show_user_launch_agent_hint_notice \
+    clean_apple_silicon_caches clean_cached_device_firmware \
+    clean_time_machine_failed_backups check_large_file_candidates \
+    show_project_artifact_hint_notice; do
+    eval "$fn() { return 0; }"
+done
+run_with_shell_timeout() { return 0; }
+# Force every size check to hit the sizing budget.
+get_cleanup_path_size_kb() { return 124; }
+clean_user_essentials() {
+    safe_clean "$HOME/Library/Caches/cache1374" "User app cache"
+}
+perform_cleanup
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"Cleanup complete"* ]] || return 1
+    [[ "$output" != *"Cleanup cancelled"* ]] || return 1
+    [[ "$output" == *"size-check budget"* ]] || return 1
+    [[ "$output" == *"under-reported"* ]] || return 1
+    [[ ! -e "$HOME/Library/Caches/cache1374" ]]
+}


### PR DESCRIPTION
## Summary

Fixes #1374: a single `~/Library/Caches/*` item whose size check exceeds `MOLE_TIMEOUT_DISK_VERIFY_SEC` (exit 124) cancelled the whole `mo clean` run. The size is only used for the "freed" total; the delete set is chosen separately, so a stalled sizing scan should not stop cleanup (same reasoning as #1350).

Changes in `_safe_clean_impl` (bin/clean.sh):
- All three sizing paths (bulk `stat`, parallel per-item workers, small-batch) now treat a sizing `124` as "size unknown": the item is still cleaned and counted as 0 KB.
- Signals (`>=128`) and real `rm`/guard timeouts stay fatal, unchanged.
- A run that under-counted sizes now prints one summary line:
  `Some items exceeded the Ns size-check budget and were counted as 0, so the total is under-reported. Raise MOLE_TIMEOUT_DISK_VERIFY_SEC to measure them.`
- `process_project_cache_matches` intentionally keeps its stop-on-timeout behavior, unchanged.

## Reproduction

Harness: throwaway `HOME` + a PATH `du` stub that stalls one cache dir past the budget, `MOLE_TEST_NO_AUTH=1`, no real files touched (script: `repro-scripts/repro-1374-cache-size-timeout.sh` in the mole-fix workspace, not part of this PR).

| case | version | exit | result |
|---|---|---|---|
| control, no slow item | main | 0 | `Cleanup complete` |
| one slow cache item | main (before) | 124 | `Cleanup cancelled` + all remaining sections skipped |
| one slow cache item | main (after) | 0 | `Cleanup complete`, all 9 items cleaned, note printed |
| one slow cache item, default 30s budget | main (after) | 0 | same |
| one slow cache item | V1.49.2 (released) | 124 | unchanged bug |

## Tests

- `tests/clean_core.bats`: updated the old "size timeout cancels deletion" test to the new semantics; added a parallel-worker timeout test (one of five workers times out, all five items are removed, `MOLE_CLEAN_CANCEL_STATUS` stays 0).
- `tests/clean_summary_cancel.bats`: added a full-`perform_cleanup` test asserting the run completes and prints the under-reported note.
- `make check` passes (go vet, shellcheck, syntax, duplication audit).
- Bats: clean_core 53/53, clean_summary_cancel 4/4, clean_mail_downloads 6/6, plus 14 related clean/size/safe-function files all green. Full `make test`: 1550 tests, 1 failure, 15 skipped; the failure is a pre-existing `core_timeout.bats` tty/perl-fallback test that also fails on unmodified `main` in this environment.