### PR TITLE
fix(clean): honor CARGO_HOME and RUSTUP_HOME for Rust caches

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -362,11 +362,35 @@ clean_dev_mise() {
 
     safe_clean "$mise_cache_path"/* "mise cache"
 }
-# Rust/cargo caches.
+# Rust/cargo caches. CARGO_HOME and RUSTUP_HOME are honored when a setup
+# (mise, rustup-wrapper shells, etc.) relocates the homes outside ~/.cargo
+# and ~/.rustup; unsafe roots are rejected instead of swept.
 clean_dev_rust() {
-    safe_clean ~/.cargo/registry/cache/* "Rust cargo cache"
-    safe_clean ~/.cargo/git/* "Cargo git cache"
-    safe_clean ~/.rustup/downloads/* "Rust downloads cache"
+    local cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+    local rustup_home="${RUSTUP_HOME:-$HOME/.rustup}"
+    [[ -n "$cargo_home" && "$cargo_home" == /* ]] || {
+        debug_log "Skipping unsafe Cargo home: $cargo_home"
+        return 0
+    }
+    [[ -n "$rustup_home" && "$rustup_home" == /* ]] || {
+        debug_log "Skipping unsafe Rustup home: $rustup_home"
+        return 0
+    }
+    case "$cargo_home" in
+        / | "$HOME" | "$HOME/" | "$HOME/Library" | "$HOME/Library/")
+            debug_log "Skipping unsafe Cargo home: $cargo_home"
+            return 0
+            ;;
+    esac
+    case "$rustup_home" in
+        / | "$HOME" | "$HOME/" | "$HOME/Library" | "$HOME/Library/")
+            debug_log "Skipping unsafe Rustup home: $rustup_home"
+            return 0
+            ;;
+    esac
+    safe_clean "$cargo_home/registry/cache/"* "Rust cargo cache"
+    safe_clean "$cargo_home/git/"* "Cargo git cache"
+    safe_clean "$rustup_home/downloads/"* "Rust downloads cache"
 }
 # Ruby/gem ecosystem caches (not installed versions).
 clean_dev_ruby() {
@@ -409,9 +433,11 @@ check_multiple_versions() {
 # Check for multiple Rust toolchains.
 check_rust_toolchains() {
     command -v rustup > /dev/null 2>&1 || return 0
+    local rustup_home="${RUSTUP_HOME:-$HOME/.rustup}"
+    [[ -n "$rustup_home" && "$rustup_home" == /* ]] || return 0
 
     check_multiple_versions \
-        "$HOME/.rustup/toolchains" \
+        "$rustup_home/toolchains" \
         "Rust toolchains" \
         "rustup toolchain list"
 }

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -1204,6 +1204,61 @@ EOF
     [[ "$output" != *".local/share/mise"* ]]
 }
 
+@test "clean_dev_rust follows CARGO_HOME and RUSTUP_HOME" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" CARGO_HOME="$HOME/.local/share/mise/cargo" RUSTUP_HOME="$HOME/.local/share/mise/rustup" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "$2|$1"; }
+clean_dev_rust
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Rust cargo cache|$HOME/.local/share/mise/cargo/registry/cache/*"* ]] || return 1
+    [[ "$output" == *"Cargo git cache|$HOME/.local/share/mise/cargo/git/*"* ]] || return 1
+    [[ "$output" == *"Rust downloads cache|$HOME/.local/share/mise/rustup/downloads/*"* ]] || return 1
+    [[ "$output" != *"$HOME/.cargo"* ]]
+}
+
+@test "clean_dev_rust falls back to default homes" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "$2|$1"; }
+clean_dev_rust
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Rust cargo cache|$HOME/.cargo/registry/cache/*"* ]] || return 1
+    [[ "$output" == *"Cargo git cache|$HOME/.cargo/git/*"* ]] || return 1
+    [[ "$output" == *"Rust downloads cache|$HOME/.rustup/downloads/*"* ]] || return 1
+}
+
+@test "clean_dev_rust rejects unsafe custom homes" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" CARGO_HOME="/" RUSTUP_HOME="$HOME" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "UNEXPECTED_SAFE_CLEAN|$2|$1"; }
+clean_dev_rust
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"UNEXPECTED_SAFE_CLEAN"* ]] || return 1
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" CARGO_HOME="relative/cargo" RUSTUP_HOME="relative/rustup" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+safe_clean() { echo "UNEXPECTED_SAFE_CLEAN|$2|$1"; }
+clean_dev_rust
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"UNEXPECTED_SAFE_CLEAN"* ]] || return 1
+}
+
 @test "clean_dev_other_langs cleans configured composer cache paths" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" COMPOSER_HOME="$HOME/.config/composer-home" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/dev_extended.bats
+++ b/tests/dev_extended.bats
@@ -1541,6 +1541,13 @@ EOF
     [[ "$output" != *"Rust toolchains"* ]]
 }
 
+@test "check_rust_toolchains follows RUSTUP_HOME" {
+    run /bin/bash -c 'HOME=$(mktemp -d) && mkdir -p "$HOME/.local/share/mise/rustup/toolchains"/{stable,nightly,1.75.0}-aarch64-apple-darwin && source "$0" && note_activity() { :; } && NC="" && GREEN="" && GRAY="" && YELLOW="" && ICON_REVIEW="☞" && rustup() { :; } && export -f rustup && RUSTUP_HOME="$HOME/.local/share/mise/rustup" check_rust_toolchains' "$PROJECT_ROOT/lib/clean/dev.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Rust toolchains · 3 found"* ]]
+}
+
 @test "clean_dev_jetbrains_toolbox cleans old versions and bypasses toolbox whitelist" {
     local toolbox_channel="$HOME/Library/Application Support/JetBrains/Toolbox/apps/IDEA/ch-0"
     mkdir -p "$toolbox_channel/241.1" "$toolbox_channel/241.2" "$toolbox_channel/241.3"


### PR DESCRIPTION
## Summary

`mo clean` now honors `CARGO_HOME` and `RUSTUP_HOME` instead of only sweeping the hardcoded `~/.cargo` and `~/.rustup` paths, so mise-managed Rust setups are cleaned too (fixes #1378).

- `clean_dev_rust()` resolves the active homes with defaults (`${CARGO_HOME:-$HOME/.cargo}`, `${RUSTUP_HOME:-$HOME/.rustup}`) and keeps the existing cleanup scope: `$cargo_home/registry/cache/*`, `$cargo_home/git/*`, `$rustup_home/downloads/*`.
- Custom homes must be absolute and are rejected (with a debug log) when they point at `/`, `$HOME`, or `$HOME/Library`, mirroring the existing `clean_corepack_cache` guard.
- `check_rust_toolchains()` follows `RUSTUP_HOME` too, so the toolchain-count hint matches the active rustup home.
- Existing path protection, whitelist, dry-run, and logging behavior still apply to the resolved paths.

## Reproduction

Mole 1.49.2 on macOS 27.0 arm64, fake HOME with cache files only under mise-style homes:

```text
CARGO_HOME=$HOME/.local/share/mise/cargo
RUSTUP_HOME=$HOME/.local/share/mise/rustup
```

Before: `mo clean --dry-run --debug` reported zero Rust items.

After this fix the same run reports:

```text
→ Rust cargo cache · 4KB dry
→ Cargo git cache · 4KB dry
→ Rust downloads cache · 4KB dry
```

## Tests

- Regression tests added in `tests/clean_dev_caches.bats` (env override, default fallback, unsafe-root rejection) and `tests/dev_extended.bats` (`RUSTUP_HOME` toolchain hint).
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/dev_extended.bats`: 147/147 pass.
- `shellcheck --rcfile .shellcheckrc` on the changed files: pass.
- Full `./scripts/test.sh`: the 37 failures also reproduce on clean `main` (f06a1927) in this sandboxed environment (writes to `~/Caskroom`, GitHub network access, tty/`DARWIN_USER_TEMP_DIR` probes) and are unrelated to this change.
