### PR TITLE
fix(clean): keep cleaning when a cache removal times out (#1384)

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1071,8 +1071,12 @@ _safe_clean_impl() {
             run_with_timeout "$MOLE_TIMEOUT_DISK_VERIFY_SEC" \
                 stat -f%z "${existing_paths[@]}" < /dev/null \
                 > "$bulk_stat_file" 2> /dev/null || bulk_stat_rc=$?
-            if [[ $bulk_stat_rc -eq 124 || $bulk_stat_rc -ge 128 ]]; then
+            if [[ $bulk_stat_rc -ge 128 ]]; then
                 cleanup_interrupt_rc=$bulk_stat_rc
+            elif [[ $bulk_stat_rc -eq 124 ]]; then
+                # The size is only used for the freed total; a stalled stat
+                # must not cancel the delete set. Sizes are already 0 here.
+                MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
             fi
             while IFS= read -r _bytes; do
                 [[ "$_bytes" =~ ^[0-9]+$ ]] || _bytes=0
@@ -1094,9 +1098,11 @@ _safe_clean_impl() {
                     local _dsize_rc=0
                     _dsize=$(get_cleanup_path_size_kb \
                         "${existing_paths[$idx]}") || _dsize_rc=$?
-                    if [[ $_dsize_rc -eq 124 || $_dsize_rc -ge 128 ]]; then
+                    if [[ $_dsize_rc -ge 128 ]]; then
                         cleanup_interrupt_rc=$_dsize_rc
                         break
+                    elif [[ $_dsize_rc -eq 124 ]]; then
+                        MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
                     fi
                     [[ "$_dsize" =~ ^[0-9]+$ ]] || _dsize=0
                     if [[ "$_dsize" -gt 0 ]]; then
@@ -1118,16 +1124,22 @@ _safe_clean_impl() {
                 for path in "${existing_paths[@]}"; do
                     (
                         local size=0 size_rc=0
+                        local size_unknown=0
                         size=$(get_cleanup_path_size_kb "$path") || size_rc=$?
-                        if [[ $size_rc -eq 124 || $size_rc -ge 128 ]]; then
+                        if [[ $size_rc -ge 128 ]]; then
                             exit "$size_rc"
+                        fi
+                        if [[ $size_rc -eq 124 ]]; then
+                            # Sizing budget exhausted: keep the item in the
+                            # delete set and report its size as 0.
+                            size_unknown=1
                         fi
                         [[ ! "$size" =~ ^[0-9]+$ ]] && size=0
                         local tmp_file="$temp_dir/result_${idx}.$$"
                         if [[ "$size" -gt 0 ]]; then
-                            echo "$size 1" > "$tmp_file"
+                            echo "$size 1 $size_unknown" > "$tmp_file"
                         else
-                            echo "0 0" > "$tmp_file"
+                            echo "0 0 $size_unknown" > "$tmp_file"
                         fi
                         mv "$tmp_file" "$temp_dir/result_${idx}" 2> /dev/null || true
                     ) < /dev/null &
@@ -1137,7 +1149,7 @@ _safe_clean_impl() {
                     if ((${#pids[@]} >= MOLE_MAX_PARALLEL_JOBS)); then
                         local wait_rc=0
                         wait "${pids[0]}" 2> /dev/null || wait_rc=$?
-                        if [[ $wait_rc -eq 124 || $wait_rc -ge 128 ]]; then
+                        if [[ $wait_rc -ge 128 ]]; then
                             cleanup_interrupt_rc=$wait_rc
                             break
                         fi
@@ -1155,7 +1167,7 @@ _safe_clean_impl() {
                 for pid in "${pids[@]}"; do
                     local wait_rc=0
                     wait "$pid" 2> /dev/null || wait_rc=$?
-                    if [[ $wait_rc -eq 124 || $wait_rc -ge 128 ]]; then
+                    if [[ $wait_rc -ge 128 ]]; then
                         [[ $cleanup_interrupt_rc -ne 0 ]] || cleanup_interrupt_rc=$wait_rc
                     fi
                     completed=$((completed + 1))
@@ -1166,6 +1178,19 @@ _safe_clean_impl() {
                 done
             fi
         fi
+
+        # Count the items whose size check hit the budget; they were still
+        # cleaned, only the freed total is under-reported.
+        local _t_size=0
+        local _t_count=0
+        local _t_flag=0
+        local _t_file
+        for _t_file in "$temp_dir"/result_*; do
+            [[ -f "$_t_file" ]] || continue
+            _t_flag=0
+            read -r _t_size _t_count _t_flag < "$_t_file" 2> /dev/null || true
+            [[ "$_t_flag" == "1" ]] && MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
+        done
 
         if [[ $cleanup_interrupt_rc -ne 0 ]]; then
             if [[ "$show_spinner" == "true" || "$show_scan_feedback" == "true" ]]; then
@@ -1192,7 +1217,7 @@ _safe_clean_impl() {
             for path in "${existing_paths[@]}"; do
                 local result_file="$temp_dir/result_${idx}"
                 if [[ -f "$result_file" ]]; then
-                    read -r size count < "$result_file" 2> /dev/null || true
+                    read -r size count size_unknown < "$result_file" 2> /dev/null || true
                     local removed=0
                     local action_rc=0
                     if [[ "$DRY_RUN" != "true" ]]; then
@@ -1289,9 +1314,12 @@ _safe_clean_impl() {
                 local size_kb=0
                 local size_rc=0
                 size_kb=$(get_cleanup_path_size_kb "$path") || size_rc=$?
-                if [[ $size_rc -eq 124 || $size_rc -ge 128 ]]; then
+                if [[ $size_rc -ge 128 ]]; then
                     cleanup_interrupt_rc=$size_rc
                     break
+                elif [[ $size_rc -eq 124 ]]; then
+                    # Sizing budget exhausted: keep cleaning with size 0.
+                    MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
                 fi
                 [[ ! "$size_kb" =~ ^[0-9]+$ ]] && size_kb=0
 
@@ -1452,6 +1480,8 @@ start_cleanup() {
     export MOLE_CURRENT_COMMAND="clean"
     MOLE_CLEAN_CANCEL_STATUS=0
     export MOLE_CLEAN_CANCEL_STATUS
+    MOLE_CLEAN_SIZING_TIMEOUTS=0
+    export MOLE_CLEAN_SIZING_TIMEOUTS
     log_operation_session_start "clean"
     DRY_RUN_SEEN_IDENTITIES=()
     DRY_RUN_TOTAL_PARTIAL=false
@@ -1958,6 +1988,10 @@ perform_cleanup() {
         fi
     elif [[ "$DRY_RUN" == "true" ]]; then
         publish_clean_preview_file || true
+    fi
+
+    if [[ ${MOLE_CLEAN_SIZING_TIMEOUTS:-0} -gt 0 ]]; then
+        summary_details+=("${GRAY}${ICON_WARNING}${NC} Some items exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s size-check budget and were counted as 0, so the total is under-reported. Raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} to measure them.")
     fi
 
     if [[ $had_errexit -eq 1 ]]; then

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1247,7 +1247,10 @@ _safe_clean_impl() {
                         safe_remove "$path" true "$size" "" \
                             "$bound_parent" "$bound_parent_id" \
                             "$bound_target_id" || action_rc=$?
-                        if [[ $action_rc -eq 124 || $action_rc -ge 128 ]]; then
+                        # A removal timeout (124) is a failed removal, not a
+                        # user interrupt: count it below and keep cleaning so
+                        # one slow disk item never cancels the rest of the run.
+                        if [[ $action_rc -ge 128 ]]; then
                             cleanup_interrupt_rc=$action_rc
                             break
                         elif [[ $action_rc -eq 0 ]]; then
@@ -1352,7 +1355,9 @@ _safe_clean_impl() {
                     safe_remove "$path" true "$size_kb" "" \
                         "$bound_parent" "$bound_parent_id" \
                         "$bound_target_id" || action_rc=$?
-                    if [[ $action_rc -eq 124 || $action_rc -ge 128 ]]; then
+                    # Same non-fatal removal-timeout policy as the
+                    # parallel-result loop above.
+                    if [[ $action_rc -ge 128 ]]; then
                         cleanup_interrupt_rc=$action_rc
                         break
                     elif [[ $action_rc -eq 0 ]]; then
@@ -1418,7 +1423,7 @@ _safe_clean_impl() {
         debug_log "Permission denied while cleaning: $description"
     fi
     if [[ $removal_failed_count -gt 0 && "$DRY_RUN" != "true" ]]; then
-        debug_log "Skipped $removal_failed_count items, permission denied or in use, for: $description"
+        debug_log "Skipped $removal_failed_count items, permission denied, in use, or timed out, for: $description"
     fi
 
     if [[ $removed_any -eq 1 ]]; then
@@ -1482,6 +1487,8 @@ start_cleanup() {
     export MOLE_CLEAN_CANCEL_STATUS
     MOLE_CLEAN_SIZING_TIMEOUTS=0
     export MOLE_CLEAN_SIZING_TIMEOUTS
+    MOLE_CLEAN_REMOVAL_TIMEOUTS=0
+    export MOLE_CLEAN_REMOVAL_TIMEOUTS
     log_operation_session_start "clean"
     DRY_RUN_SEEN_IDENTITIES=()
     DRY_RUN_TOTAL_PARTIAL=false
@@ -1992,6 +1999,10 @@ perform_cleanup() {
 
     if [[ ${MOLE_CLEAN_SIZING_TIMEOUTS:-0} -gt 0 ]]; then
         summary_details+=("${GRAY}${ICON_WARNING}${NC} Some items exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s size-check budget and were counted as 0, so the total is under-reported. Raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} to measure them.")
+    fi
+
+    if [[ ${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} -gt 0 ]]; then
+        summary_details+=("${GRAY}${ICON_WARNING}${NC} ${MOLE_CLEAN_REMOVAL_TIMEOUTS} item(s) exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s removal budget and were left in place. Raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} for slower disks.")
     fi
 
     if [[ $had_errexit -eq 1 ]]; then

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -610,7 +610,14 @@ _record_file_ops_dry_run_target() {
         local measured_size=""
         local measure_rc=0
         measured_size=$(get_path_size_kb "$path" 2> /dev/null) || measure_rc=$?
-        [[ $measure_rc -eq 124 || $measure_rc -ge 128 ]] && return "$measure_rc"
+        if [[ $measure_rc -ge 128 ]]; then
+            return "$measure_rc"
+        fi
+        if [[ $measure_rc -eq 124 ]]; then
+            # Sizing budget exhausted: preview the item as size-unknown rather
+            # than cancelling the whole dry run.
+            MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
+        fi
         if [[ $measure_rc -eq 0 && "$measured_size" =~ ^[0-9]+$ ]]; then
             size_kb="$measured_size"
         else
@@ -772,8 +779,9 @@ safe_remove() {
                 size_kb=$(get_path_size_kb "$path" "$size_probe_timeout" 2> /dev/null) || size_probe_rc=$?
             fi
             if [[ $size_probe_rc -eq 124 ]]; then
-                _mole_record_clean_cancellation 124
-                return 124
+                # Sizing budget exhausted: still remove the item, with the
+                # freed total under-reported, matching the batch-sizing policy.
+                MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
             fi
             if [[ $size_probe_rc -ge 128 ]]; then
                 _mole_record_clean_cancellation "$size_probe_rc"
@@ -829,7 +837,10 @@ safe_remove() {
     if [[ $rm_exit -eq 124 ]]; then
         debug_log "Removal timed out: $path"
         log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "removal timed out"
-        _mole_record_clean_cancellation 124
+        # A slow disk can exceed the per-item removal budget. That is a failed
+        # removal, not a user interrupt: count it and keep going so one slow
+        # cache never cancels the remaining cleanup.
+        MOLE_CLEAN_REMOVAL_TIMEOUTS=$((${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} + 1))
         return 124
     fi
 
@@ -1187,8 +1198,7 @@ safe_sudo_remove() {
                         -n du -skP "$path" < /dev/null 2> /dev/null | awk '{print $1}') || size_probe_rc=$?
                 fi
                 if [[ $size_probe_rc -eq 124 ]]; then
-                    _mole_record_clean_cancellation 124
-                    return 124
+                    MOLE_CLEAN_SIZING_TIMEOUTS=$((${MOLE_CLEAN_SIZING_TIMEOUTS:-0} + 1))
                 fi
                 if [[ $size_probe_rc -ge 128 ]]; then
                     _mole_record_clean_cancellation "$size_probe_rc"
@@ -1233,7 +1243,7 @@ safe_sudo_remove() {
 
     if [[ $ret -eq 124 ]]; then
         log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "removal timed out"
-        _mole_record_clean_cancellation 124
+        MOLE_CLEAN_REMOVAL_TIMEOUTS=$((${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} + 1))
         return 124
     fi
     if [[ $ret -ge 128 ]]; then

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -445,7 +445,7 @@ EOF
     [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
 }
 
-@test "safe_clean propagates a real directory size timeout before deletion" {
+@test "safe_clean treats a real directory size timeout as size-unknown and keeps cleaning" {
     local base="$HOME/safe-clean-real-timeout"
     mkdir -p "$base/candidate"
 
@@ -455,21 +455,69 @@ set -euo pipefail
 source "\$PROJECT_ROOT/bin/clean.sh"
 DRY_RUN=false
 MOLE_CURRENT_COMMAND=clean
+unset MOLE_CLEAN_SIZING_TIMEOUTS
 run_with_timeout() { return 124; }
-safe_remove() { echo "UNEXPECTED_REMOVE:\$1"; return 0; }
+safe_remove() { echo "REMOVE:\$1"; /bin/rm -rf "\$1"; }
 
 rc=0
 safe_clean "$base/candidate" "Timed out directory" || rc=\$?
-printf 'RC=%s CANCEL=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}"
-[[ -d "$base/candidate" ]]
+printf 'RC=%s CANCEL=%s TIMEOUTS=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}" "\${MOLE_CLEAN_SIZING_TIMEOUTS:-0}"
+[[ ! -e "$base/candidate" ]]
 EOF
 
     [ "$status" -eq 0 ] || {
         echo "$output"
         return 1
     }
-    [[ "$output" == *"RC=124 CANCEL=124"* ]] || return 1
-    [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
+    [[ "$output" == *"RC=0 CANCEL=0 TIMEOUTS=1"* ]] || return 1
+    [[ "$output" == *"REMOVE:$base/candidate"* ]] || return 1
+}
+
+@test "safe_clean keeps cleaning when a parallel size worker times out (#1374)" {
+    local base="$HOME/safe_clean_parallel_timeout"
+    mkdir -p "$base/a" "$base/b" "$base/c" "$base/d" "$base/e"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc << EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+MOLE_CURRENT_COMMAND=clean
+MOLE_CLEAN_CANCEL_STATUS=0
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+unset MOLE_CLEAN_SIZING_TIMEOUTS
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+note_activity() { :; }
+is_path_whitelisted() { return 1; }
+get_cleanup_path_size_kb() {
+    [[ "\$1" == "$base/c" ]] && return 124
+    echo 1
+}
+safe_remove() { echo "REMOVE:\$1"; /bin/rm -rf "\$1"; }
+
+rc=0
+safe_clean "$base/a" "$base/b" "$base/c" "$base/d" "$base/e" \
+    "Timed out size batch" || rc=\$?
+printf 'RC=%s CANCEL=%s TIMEOUTS=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}" "\${MOLE_CLEAN_SIZING_TIMEOUTS:-0}"
+for path in "$base/a" "$base/b" "$base/c" "$base/d" "$base/e"; do
+    if [[ -d "\$path" ]]; then
+        echo "WRONG: kept \$path"
+        exit 1
+    fi
+done
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC=0 CANCEL=0 TIMEOUTS=1"* ]] || return 1
+    [[ "$output" == *"REMOVE:$base/c"* ]] || return 1
 }
 
 @test "mo clean --dry-run skips system cleanup in non-interactive mode" {

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -520,6 +520,136 @@ EOF
     [[ "$output" == *"REMOVE:$base/c"* ]] || return 1
 }
 
+@test "safe_clean keeps cleaning when a removal times out (#1384)" {
+    local base="$HOME/safe_clean_removal_timeout"
+    mkdir -p "$base/a" "$base/b"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 \
+        /bin/bash --noprofile --norc << EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+MOLE_CURRENT_COMMAND=clean
+MOLE_CLEAN_CANCEL_STATUS=0
+export MO_NO_OPLOG=1
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+unset MOLE_CLEAN_SIZING_TIMEOUTS MOLE_CLEAN_REMOVAL_TIMEOUTS
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+note_activity() { :; }
+is_path_whitelisted() { return 1; }
+get_cleanup_path_size_kb() { echo 1; }
+run_with_timeout() {
+    [[ "\${2:-}" == "rm" ]] && return 124
+    "\$@"
+}
+
+rc=0
+safe_clean "$base/a" "$base/b" "Removal timeout batch" || rc=\$?
+printf 'RC=%s CANCEL=%s REMOVAL=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}" "\${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0}"
+[[ -d "$base/a" && -d "$base/b" ]]
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC=0 CANCEL=0 REMOVAL=2"* ]] || return 1
+}
+
+@test "safe_clean keeps cleaning when a parallel removal times out (#1384)" {
+    local base="$HOME/safe_clean_parallel_removal_timeout"
+    mkdir -p "$base/a" "$base/b" "$base/c" "$base/d" "$base/e"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 \
+        /bin/bash --noprofile --norc << EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+MOLE_CURRENT_COMMAND=clean
+MOLE_CLEAN_CANCEL_STATUS=0
+export MO_NO_OPLOG=1
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+unset MOLE_CLEAN_SIZING_TIMEOUTS MOLE_CLEAN_REMOVAL_TIMEOUTS
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+note_activity() { :; }
+is_path_whitelisted() { return 1; }
+get_cleanup_path_size_kb() { echo 1; }
+run_with_timeout() {
+    [[ "\${2:-}" == "rm" ]] && return 124
+    "\$@"
+}
+
+rc=0
+safe_clean "$base/a" "$base/b" "$base/c" "$base/d" "$base/e" \
+    "Parallel removal timeout batch" || rc=\$?
+printf 'RC=%s CANCEL=%s REMOVAL=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}" "\${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0}"
+for path in "$base/a" "$base/b" "$base/c" "$base/d" "$base/e"; do
+    [[ -d "\$path" ]] || echo "WRONG: missing \$path"
+done
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC=0 CANCEL=0 REMOVAL=5"* ]] || return 1
+    [[ "$output" != *"WRONG"* ]] || return 1
+}
+
+@test "safe_clean still cancels on an interrupted removal (>=128)" {
+    local base="$HOME/safe_clean_removal_interrupt"
+    mkdir -p "$base/a" "$base/b"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 \
+        /bin/bash --noprofile --norc << EOF
+set -euo pipefail
+source "\$PROJECT_ROOT/lib/core/common.sh"
+source "\$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+MOLE_CURRENT_COMMAND=clean
+MOLE_CLEAN_CANCEL_STATUS=0
+export MO_NO_OPLOG=1
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+unset MOLE_CLEAN_SIZING_TIMEOUTS MOLE_CLEAN_REMOVAL_TIMEOUTS
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+note_activity() { :; }
+is_path_whitelisted() { return 1; }
+get_cleanup_path_size_kb() { echo 1; }
+run_with_timeout() {
+    [[ "\${2:-}" == "rm" ]] && return 130
+    "\$@"
+}
+
+rc=0
+safe_clean "$base/a" "$base/b" "Interrupted removal batch" || rc=\$?
+printf 'RC=%s CANCEL=%s REMOVAL=%s\n' "\$rc" "\${MOLE_CLEAN_CANCEL_STATUS:-0}" "\${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0}"
+[[ -d "$base/a" && -d "$base/b" ]]
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC=130 CANCEL=130 REMOVAL=0"* ]] || return 1
+}
+
 @test "mo clean --dry-run skips system cleanup in non-interactive mode" {
     set_mock_sudo_uncached
     run_clean_dry_run

--- a/tests/clean_summary_cancel.bats
+++ b/tests/clean_summary_cancel.bats
@@ -87,3 +87,45 @@ EOF
     [[ "$output" == *"Cleanup complete"* ]]
     [[ "$output" != *"Cleanup cancelled"* ]]
 }
+
+@test "sizing timeouts still clean and the summary reports the under-count (#1374)" {
+    mkdir -p "$HOME/Library/Caches/cache1374"
+    printf x > "$HOME/Library/Caches/cache1374/file.bin"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+# Stub every section so perform_cleanup never scans the real machine.
+# run_with_shell_timeout is stubbed too: its shell-fallback killer process
+# would otherwise outlive the test when pgrep is unavailable.
+for fn in clean_finder_metadata clean_app_caches \
+    clean_browsers run_cloud_and_office_cleanup clean_developer_tools \
+    clean_user_gui_applications clean_virtualization_tools \
+    clean_application_support_logs clean_orphaned_app_data \
+    clean_orphaned_system_services clean_orphaned_container_stubs \
+    clean_stale_launch_services_registrations show_user_launch_agent_hint_notice \
+    clean_apple_silicon_caches clean_cached_device_firmware \
+    clean_time_machine_failed_backups check_large_file_candidates \
+    show_project_artifact_hint_notice; do
+    eval "$fn() { return 0; }"
+done
+run_with_shell_timeout() { return 0; }
+# Force every size check to hit the sizing budget.
+get_cleanup_path_size_kb() { return 124; }
+clean_user_essentials() {
+    safe_clean "$HOME/Library/Caches/cache1374" "User app cache"
+}
+perform_cleanup
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"Cleanup complete"* ]] || return 1
+    [[ "$output" != *"Cleanup cancelled"* ]] || return 1
+    [[ "$output" == *"size-check budget"* ]] || return 1
+    [[ "$output" == *"under-reported"* ]] || return 1
+    [[ ! -e "$HOME/Library/Caches/cache1374" ]]
+}

--- a/tests/clean_summary_cancel.bats
+++ b/tests/clean_summary_cancel.bats
@@ -88,6 +88,34 @@ EOF
     [[ "$output" != *"Cleanup cancelled"* ]]
 }
 
+@test "run with removal timeouts completes and reports them (#1384)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+# Stub every section so perform_cleanup never scans the real machine.
+for fn in clean_user_essentials clean_finder_metadata clean_app_caches \
+    clean_browsers run_cloud_and_office_cleanup clean_developer_tools \
+    clean_user_gui_applications clean_virtualization_tools \
+    clean_application_support_logs clean_orphaned_app_data \
+    clean_orphaned_system_services clean_orphaned_container_stubs \
+    clean_stale_launch_services_registrations show_user_launch_agent_hint_notice \
+    clean_apple_silicon_caches clean_cached_device_firmware \
+    clean_time_machine_failed_backups check_large_file_candidates \
+    show_project_artifact_hint_notice; do
+    eval "$fn() { return 0; }"
+done
+run_with_shell_timeout() { return 0; }
+clean_user_essentials() { MOLE_CLEAN_REMOVAL_TIMEOUTS=3; return 0; }
+perform_cleanup
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Cleanup complete"* ]]
+    [[ "$output" != *"Cleanup cancelled"* ]]
+    [[ "$output" == *"3 item(s) exceeded the 30s removal budget"* ]]
+}
+
 @test "sizing timeouts still clean and the summary reports the under-count (#1374)" {
     mkdir -p "$HOME/Library/Caches/cache1374"
     printf x > "$HOME/Library/Caches/cache1374/file.bin"


### PR DESCRIPTION
## Summary

Fixes #1384: on slow machines (2017/2018 iMac, Fusion drive, macOS 13), `mo clean` consistently cancelled the whole run with `Cancelled: a scan or size check timed out (exit 124)` right after the `User essentials` section started, even though `--dry-run` completed fine. One slow `~/Library/Caches` item was enough to end every remaining section.

Two commits:

1. `fix(clean): keep cleaning when a cache size check times out (#1374)` - a sizing timeout (the per-item 30s `du` budget) now means "size unknown, keep cleaning" instead of cancelling. The affected item is still deleted, only the freed total is under-reported.
2. `fix(clean): keep cleaning when a cache removal times out (#1384)` - a removal timeout (the per-item 30s `rm -rf` budget) now means "this item was not removed, skip it and continue" instead of cancelling. `safe_remove`/`safe_sudo_remove` still return 124 to dedicated callers but no longer set the sticky `MOLE_CLEAN_CANCEL_STATUS`; only signals (`>=128`) remain fatal. Sizing probes inside the removal sinks (oplog size probe, sudo size probe, dry-run preview measurement) get the same non-fatal treatment as the batch sizing from #1374.

The summary now reports both cases instead of cancelling:

```text
Cleanup complete
Tracked cleanup: 25KB | Items cleaned: 6 | Categories: 1
◎ 1 item(s) exceeded the 30s removal budget and were left in place. Raise MOLE_TIMEOUT_DISK_VERIFY_SEC for slower disks.
```

Operators on very slow disks can raise `MOLE_TIMEOUT_DISK_VERIFY_SEC` to keep the per-item budgets while still getting a complete run either way.

## Reproduction

`repro-scripts/repro-1384-removal-timeout.sh` (throwaway HOME in /tmp, PATH stubs, no real files touched) seeds seven cache dirs and makes one of them slow via a 40s `du` or `rm` stub against the 30s budget:

```text
v1.49.1-slow-cache-du  exit 124  <- released version, exact reporter symptom
main-slow-cache-du     exit   0  <- sizing timeout is size-unknown (#1374)
main-slow-cache-rm     exit   0  <- removal timeout skips the item (#1384)
```

Before this PR, current main still exited 124 in the `rm` case with `Removal timed out` followed by `Cleanup cancelled`. Evidence logs: `evidence/clean-1384/` (before) and `evidence/clean-1384-fixed/` (after).

## Tests

- `tests/clean_core.bats`: removal timeout keeps cleaning (small batch and parallel-result loop), interrupted removal (`>=128`) still cancels.
- `tests/clean_summary_cancel.bats`: a run with removal timeouts completes and prints the under-report note.
- Existing sizing-timeout tests from #1374 continue to pass.
- `shellcheck` and `bash -n` pass for `bin/clean.sh` and `lib/core/file_ops.sh`.
