### PR TITLE
fix(clean): never unlink a live SQLite cache database (#1390)

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -338,6 +338,20 @@ record_dry_run_cleanup_target() {
     if declare -f holds_compiled_model_cache > /dev/null 2>&1 && holds_compiled_model_cache "$path" 2> /dev/null; then
         return 1
     fi
+    # Keep preview eligibility identical to real cleanup (#1390 / PR #1391).
+    if declare -f _mole_should_refuse_live_user_cache_path > /dev/null 2>&1 &&
+        _mole_should_refuse_live_user_cache_path "$path"; then
+        return 1
+    fi
+    if declare -f _mole_is_sqlite_database_path > /dev/null 2>&1 &&
+        _mole_is_sqlite_database_path "$path" &&
+        declare -f _mole_sqlite_database_in_use > /dev/null 2>&1; then
+        local sqlite_state=0
+        _mole_sqlite_database_in_use "$path" || sqlite_state=$?
+        if [[ $sqlite_state -eq 0 || $sqlite_state -eq 2 ]]; then
+            return 1
+        fi
+    fi
 
     if [[ -z "${CLEAN_PREVIEW_LEDGER_FILE:-}" || ! -f "$CLEAN_PREVIEW_LEDGER_FILE" ]]; then
         register_dry_run_cleanup_target "$path" || return 1

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -62,6 +62,21 @@ _final_cut_pro_delete_guard_allows() {
     mole_clean_process_guard final_cut_pro_is_running "Final Cut Pro started"
 }
 
+_autodesk_cleanup_process_state() {
+    # Fusion 360 was renamed "Autodesk Fusion"; the app process and the helpers
+    # that keep the cleaned cache databases open (AcCoreConsole, ADPClientService),
+    # which can outlive the main window, all count as running (#1390).
+    mole_pgrep_any \
+        -x "Autodesk Fusion" \
+        -x "Fusion 360" \
+        -x "AcCoreConsole" \
+        -x "ADPClientService"
+}
+
+_autodesk_app_cache_delete_guard_allows() {
+    mole_clean_process_guard _autodesk_cleanup_process_state "Autodesk Fusion running"
+}
+
 _defer_app_cache_guard_family() {
     case "$1" in
         _simulator_app_cache_delete_guard_allows) mole_defer_cleanup_family "Simulator" ;;

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -183,17 +183,34 @@ _mole_user_cache_owner_component() {
     return 0
 }
 
-_mole_is_user_cache_sqlite_family_path() {
-    local base
-    base=$(basename "$1")
+# SQLite main file or -wal / -shm / -journal companion. Case-insensitive so a
+# cache sweep cannot delete a database through a case variant of its name
+# (contributor PR #1391 + main reverse-DNS gate).
+_mole_is_sqlite_database_path() {
+    local restore_nocasematch=false
+    local result=1
+    local path="$1"
+    local base="${path%-wal}"
+    base="${base%-shm}"
+    base="${base%-journal}"
+
+    if ! shopt -q nocasematch; then
+        shopt -s nocasematch
+        restore_nocasematch=true
+    fi
+
     case "$base" in
-        *.db | *.db-wal | *.db-shm | \
-            *.sqlite | *.sqlite-wal | *.sqlite-shm | \
-            *.sqlite3 | *.sqlite3-wal | *.sqlite3-shm)
-            return 0
+        *.db | *.sqlite | *.sqlite3)
+            result=0
             ;;
     esac
-    return 1
+
+    [[ "$restore_nocasematch" == "true" ]] && shopt -u nocasematch
+    return "$result"
+}
+
+_mole_is_user_cache_sqlite_family_path() {
+    _mole_is_sqlite_database_path "$1"
 }
 
 _mole_user_cache_sqlite_main_path() {
@@ -201,8 +218,13 @@ _mole_user_cache_sqlite_main_path() {
     case "$path" in
         *-wal) printf '%s\n' "${path%-wal}" ;;
         *-shm) printf '%s\n' "${path%-shm}" ;;
+        *-journal) printf '%s\n' "${path%-journal}" ;;
         *) printf '%s\n' "$path" ;;
     esac
+}
+
+_mole_sqlite_family_base_path() {
+    _mole_user_cache_sqlite_main_path "$1"
 }
 
 # Tri-state process probe for a reverse-DNS cache owner:
@@ -253,20 +275,44 @@ _mole_user_cache_owner_process_state() {
     return "$state"
 }
 
-_mole_user_cache_sqlite_has_open_handle() {
+# Is the database family live? 0 = in use, 1 = idle, 2 = could not tell.
+# WAL-mode -shm only exists while at least one connection is open (PR #1391).
+_mole_sqlite_database_in_use() {
     local path="$1"
+    local base
+    base=$(_mole_sqlite_family_base_path "$path")
+
+    if [[ -f "${base}-shm" ]]; then
+        return 0
+    fi
+
     command -v lsof > /dev/null 2>&1 || return 2
 
-    local main_db
-    main_db=$(_mole_user_cache_sqlite_main_path "$path")
     local candidate
-    for candidate in "$main_db" "${main_db}-wal" "${main_db}-shm"; do
+    for candidate in "$base" "${base}-wal" "${base}-shm"; do
         [[ -e "$candidate" ]] || continue
-        if lsof -F n -- "$candidate" > /dev/null 2>&1; then
+        local lsof_rc=0
+        if declare -f run_with_timeout > /dev/null 2>&1; then
+            run_with_timeout "$MOLE_TIMEOUT_QUICK_DETECT_SEC" lsof -F n -- "$candidate" \
+                > /dev/null 2>&1 || lsof_rc=$?
+        else
+            lsof -F n -- "$candidate" > /dev/null 2>&1 || lsof_rc=$?
+        fi
+        if [[ $lsof_rc -eq 0 ]]; then
             return 0
+        fi
+        if [[ $lsof_rc -ne 1 ]]; then
+            return 2
         fi
     done
     return 1
+}
+
+_mole_user_cache_sqlite_has_open_handle() {
+    local path="$1"
+    local state=0
+    _mole_sqlite_database_in_use "$path" || state=$?
+    return "$state"
 }
 
 # Return 0 when deletion must be refused (live owner or open SQLite handle).
@@ -287,7 +333,7 @@ _mole_should_refuse_live_user_cache_path() {
     fi
 
     # Process is conclusively idle. Still refuse SQLite family members that
-    # another process has open under a different name (rare, fail-closed).
+    # another process has open, or that still expose a WAL -shm (PR #1391).
     if _mole_is_user_cache_sqlite_family_path "$path"; then
         local open_state=0
         _mole_user_cache_sqlite_has_open_handle "$path" || open_state=$?
@@ -295,8 +341,7 @@ _mole_should_refuse_live_user_cache_path() {
             debug_log "Open SQLite user cache handle, keep: $path"
             return 0
         fi
-        # open_state 2 (lsof missing) is not evidence of use once the process
-        # probe already returned idle; allow deletion.
+        # open_state 2 (lsof missing) with no -shm: process probe already idle.
     elif [[ -d "$path" ]]; then
         local candidate open_state
         for candidate in "$path/Cache.db" "$path"/*.db; do
@@ -544,6 +589,24 @@ validate_path_for_deletion() {
     if _mole_is_active_powerlog_database_path "$policy_path"; then
         debug_log "Path validation: active powerlog database kept: $policy_path"
         return 1
+    fi
+
+    # Live reverse-DNS user caches (process + SQLite handle). Covers Autodesk
+    # helpers and every other com.vendor tree under ~/Library/Caches (#1390).
+    if _mole_should_refuse_live_user_cache_path "$policy_path"; then
+        debug_log "Path validation: live user cache kept: $policy_path"
+        return 1
+    fi
+
+    # General SQLite family gate from PR #1391: refuse any in-use database even
+    # outside reverse-DNS cache dirs (fail closed when lsof cannot answer).
+    if _mole_is_sqlite_database_path "$policy_path"; then
+        local sqlite_state=0
+        _mole_sqlite_database_in_use "$policy_path" || sqlite_state=$?
+        if [[ $sqlite_state -eq 0 || $sqlite_state -eq 2 ]]; then
+            debug_log "Path validation: in-use SQLite database kept: $policy_path"
+            return 1
+        fi
     fi
 
     # Endpoint-security/EDR agent caches under var/folders look like ordinary

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -134,7 +134,8 @@ safe_clean() {
         "Autodesk cache") echo "UNEXPECTED_CLEAN:${!#}" ;;
     esac
 }
-defer_cleanup_family() { echo "DEFER:$1"; }
+mole_defer_cleanup_family() { echo "DEFER:$1"; }
+note_activity() { :; }
 clean_3d_tools
 EOF
 
@@ -142,7 +143,7 @@ EOF
         echo "$output"
         return 1
     }
-    [[ "$output" == *"DEFER:Autodesk Fusion"* ]] || return 1
+    [[ "$output" == *"DEFER:Autodesk"* ]] || return 1
     [[ "$output" != *"UNEXPECTED_CLEAN"* ]]
 }
 

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -120,6 +120,52 @@ EOF
     [[ "$output" != *"UNEXPECTED_CLEAN"* ]]
 }
 
+@test "clean_3d_tools defers Autodesk cache while Fusion helper is active (#1390)" {
+    mkdir -p "$HOME/Library/Caches/com.autodesk.AcCoreConsole"
+    touch "$HOME/Library/Caches/com.autodesk.AcCoreConsole/Cache.db"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 0; }
+safe_clean() {
+    case "${!#}" in
+        "Autodesk cache") echo "UNEXPECTED_CLEAN:${!#}" ;;
+    esac
+}
+defer_cleanup_family() { echo "DEFER:$1"; }
+clean_3d_tools
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"DEFER:Autodesk Fusion"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_CLEAN"* ]]
+}
+
+@test "clean_3d_tools cleans Autodesk cache when Fusion is not running (#1390)" {
+    mkdir -p "$HOME/Library/Caches/com.autodesk.AcCoreConsole"
+    touch "$HOME/Library/Caches/com.autodesk.AcCoreConsole/Cache.db"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+safe_clean() { echo "CLEAN:${!#}"; }
+clean_3d_tools
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"CLEAN:Autodesk cache"* ]] || return 1
+}
+
 @test "clean_xcode_tools does not defer empty Xcode and Simulator roots" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -1053,6 +1053,30 @@ EOF
     [[ "$output" == *"cache.bin  # size unknown"* ]] || return 1
 }
 
+@test "mo clean --dry-run never previews a live SQLite database family (#1390)" {
+    local test_home
+    test_home="$(mktemp -d "${BATS_TEST_TMPDIR}/clean-1390-home.XXXXXX")"
+    mkdir -p "$test_home/.config/mole" \
+        "$test_home/Library/Caches/com.autodesk.AcCoreConsole"
+
+    local db="$test_home/Library/Caches/com.autodesk.AcCoreConsole/Cache.db"
+    printf 'cache-db' > "$db"
+    printf 'wal' > "$db-wal"
+    printf 'shm' > "$db-shm"
+
+    # Dry-run must not list the family even though the sweep reaches it: a
+    # live WAL-mode database stays put, and the preview must agree with the
+    # real run so the promised totals are the ones actually reclaimable.
+    # Real-run preservation is pinned at the deletion boundary by
+    # validate_path_for_deletion (tests/core_safe_functions.bats).
+    set_mock_host_toolchains
+    run env HOME="$test_home" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=1 \
+        PATH="$MOCK_TOOLCHAIN_BIN:$PATH" "$PROJECT_ROOT/mole" clean --dry-run
+    [ "$status" -eq 0 ] || return 1
+    [[ "$(grep -cF "Cache.db" "$test_home/.config/mole/clean-list.txt")" -eq 0 ]] || return 1
+    [[ -f "$db" && -f "$db-wal" && -f "$db-shm" ]] || return 1
+}
+
 @test "mo clean honors whitelist entries" {
     mkdir -p "$HOME/Library/Caches/WhitelistedApp"
     echo "keep me" > "$HOME/Library/Caches/WhitelistedApp/data.tmp"

--- a/tests/clean_misc.bats
+++ b/tests/clean_misc.bats
@@ -350,7 +350,9 @@ EOF
 @test "clean_3d_tools calls expected caches" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
 safe_clean() { echo "$2"; }
 clean_3d_tools
 EOF
@@ -358,6 +360,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Blender cache"* ]] || return 1
     [[ "$output" == *"Cinema 4D cache"* ]]
+    [[ "$output" == *"Autodesk cache"* ]] || return 1
 }
 
 @test "clean_gaming_platforms calls expected caches" {

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -230,6 +230,51 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "validate_path_for_deletion refuses a live SQLite database family (#1390)" {
+    local db="$TEST_DIR/live-sqlite/Cache.db"
+    mkdir -p "$(dirname "$db")"
+    printf 'db' > "$db"
+    printf 'wal' > "$db-wal"
+    printf 'shm' > "$db-shm"
+
+    for path in "$db" "$db-wal" "$db-shm"; do
+        run /bin/bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '$path'"
+        [ "$status" -eq 1 ] || return 1
+    done
+}
+
+@test "validate_path_for_deletion refuses an SQLite database held open by a process (#1390)" {
+    local db="$TEST_DIR/open-sqlite/Cache.db"
+    mkdir -p "$(dirname "$db")"
+    printf 'db' > "$db"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" db="$db" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+lsof() { return 0; }
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$db"
+EOF
+
+    [ "$status" -eq 1 ]
+}
+
+@test "validate_path_for_deletion allows an idle SQLite cache database (#1390)" {
+    local db="$TEST_DIR/idle-sqlite/Cache.db"
+    mkdir -p "$(dirname "$db")"
+    printf 'db' > "$db"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" db="$db" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+lsof() { return 1; }
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$db"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "should_protect_path applies high-risk cleanup denylist" {
     run /bin/bash -c "
         source '$PROJECT_ROOT/lib/core/common.sh'


### PR DESCRIPTION
## Summary

Fixes #1390: `mo clean` unlinked `~/Library/Caches/com.autodesk.AcCoreConsole/Cache.db` together with its `-wal` / `-shm` companions while the owning helper process had the database open. The owner then kept writing to the orphaned inodes, filling the volume with space `du`/`find` cannot see.

Two layers, so both the reported app and the general mechanism are covered:

1. **General SQLite liveness guard at the deletion boundary** (`lib/core/file_ops.sh`): `validate_path_for_deletion` now refuses any SQLite family member (`*.db` / `-wal` / `-shm` / `-journal`) whose `-shm` companion exists (WAL mode means at least one connection is open) or whose main file `lsof` reports open. A missing or unresponsive `lsof` denies rather than allows, matching the existing tri-state rule that "could not tell" is never permission to delete. The same rule is applied in `record_dry_run_cleanup_target` so the dry-run preview agrees with the real run. This protects every app and helper database a cache sweep can reach, including helpers whose process name does not match the parent app.
2. **Autodesk Fusion-family process guard** (`lib/clean/app_caches.sh`): the Autodesk cache sweep is now guarded like Xcode / Simulator / Final Cut Pro. `Autodesk Fusion`, `Fusion 360`, `AcCoreConsole`, and `ADPClientService` count as running and defer the family to the end-of-run "Skipped while active" list; an unknown process state stops the family with the existing `stopped (process state unknown)` outcome.

This follows the codebase's own boundary: the powerlog guard in `file_ops.sh` and AGENTS.md both say size/mtime are never deletion authority for a database a live process can keep using.

## Reproduction

`repro-scripts/repro-1390-live-sqlite.sh` builds a throwaway HOME (in `/tmp`, no real files touched) with `com.autodesk.AcCoreConsole/Cache.db` + `-wal` + `-shm` + `fsCachedData`, holds the database open with a real `sqlite3` WAL connection (the AcCoreConsole shape), and runs a real `mo clean` for each build:

```text
before (V1.49.2):  ✓ Autodesk cache · 4 items, 46KB
                   files_after:   <empty>
                   link count:    missing   <- unlinked while holder had it open

after (this PR):   ◎ Autodesk cache · stopped (process state unknown)
                   files_after:   Cache.db Cache.db-shm Cache.db-wal fsCachedData
                   link count:    1
```

Evidence logs: `evidence/clean-1390/` (before) and `evidence/clean-1390-fixed/` (after). With the process probe answering "not running", the same after-build keeps the family via the SQLite liveness guard (verified locally with a `pgrep` shim: `✓ Autodesk cache · 0B` and `Cache.db` family intact).

## Tests

- `tests/core_safe_functions.bats`: `validate_path_for_deletion` refuses a live `-shm` family, refuses a database `lsof` reports open, and allows an idle `.db`.
- `tests/clean_app_caches.bats`: `clean_3d_tools` defers the Autodesk family while a Fusion helper runs and cleans it when not running.
- `tests/clean_misc.bats`: `clean_3d_tools` still reaches Blender / Cinema 4D / Autodesk / SketchUp.
- `tests/clean_core.bats`: full `mo clean --dry-run` on a private HOME never previews a live SQLite family.
- `./scripts/check.sh`: go vet, ShellCheck, syntax, function-duplication audit all pass.
