### PR TITLE
fix: align battery Health percentage format with Level

### DIFF
--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -752,7 +752,7 @@ func renderBatteryCard(batts []BatteryStatus, thermal ThermalStatus) cardData {
 
 		// Add capacity line if available.
 		if b.Capacity > 0 {
-			capacityText := fmt.Sprintf("%5d%%", b.Capacity)
+			capacityText := fmt.Sprintf("%5.1f%%", float64(b.Capacity))
 			if b.Capacity < 70 {
 				capacityText = dangerStyle.Render(capacityText)
 			} else if b.Capacity < 85 {


### PR DESCRIPTION
## Summary

- `Health` used `%5d%%` (integer, no decimal place) while `Level` used `%5.1f%%` (one decimal place)
- This caused two extra leading spaces before the Health percentage value in the status TUI
- Fix: use `%5.1f%%` with `float64(b.Capacity)` for consistent formatting

**Before:**
```
Level  █████████████░░░   83.0%
Health █████████████░░░     86%
```

**After:**
```
Level  █████████████░░░   83.0%
Health █████████████░░░   86.0%
```

## Test plan

- [ ] Run `mo status` and verify Level and Health percentages are visually aligned

🤖 Generated with [Claude Code](https://claude.ai/claude-code)