### PR TITLE
List uv cache in 'mole analyze'

### DIFF
--- a/cmd/analyze/insights.go
+++ b/cmd/analyze/insights.go
@@ -64,6 +64,7 @@ func createInsightEntries() []dirEntry {
 		{"JetBrains Cache", filepath.Join(home, "Library", "Caches", "JetBrains")},
 		{"Docker Data", filepath.Join(home, "Library", "Containers", "com.docker.docker", "Data")},
 		{"pip Cache", filepath.Join(home, "Library", "Caches", "pip")},
+		{"uv Cache", filepath.Join(home, ".cache", "uv")},
 		{"Gradle Cache", filepath.Join(home, ".gradle", "caches")},
 		{"CocoaPods Cache", filepath.Join(home, "Library", "Caches", "CocoaPods")},
 	}

--- a/cmd/analyze/insights_test.go
+++ b/cmd/analyze/insights_test.go
@@ -55,6 +55,27 @@ func TestCreateInsightEntriesIncludesOrbStackData(t *testing.T) {
 	t.Fatal("OrbStack Data insight not found")
 }
 
+func TestCreateInsightEntriesIncludesUvCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	uvCache := filepath.Join(home, ".cache", "uv")
+	if err := os.MkdirAll(uvCache, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := createInsightEntries()
+	for _, entry := range entries {
+		if entry.Name == "uv Cache" {
+			if entry.Path != uvCache {
+				t.Fatalf("uv Cache path = %q, want %q", entry.Path, uvCache)
+			}
+			return
+		}
+	}
+	t.Fatal("uv Cache insight not found")
+}
+
 func TestMeasureOldDownloads(t *testing.T) {
 	// Create a temp directory with old and new files.
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

- `mo clean` can already clear uv's cache, but doesn't list it under `mo analyze`.
- On this machine, which doesn't have a huge disk and where Mole is very useful, I have 9.9 GB uv cache after `mo clean` (if uv is on the path, it does a `uv cache purge` not a full wipe; if not on the path, it deletes the cache dir)
- On another machine with a much bigger disk, the uv cache is 121 GB (I've not needed to clear this yet).
- So the uv cache is definitely measurable, and often bigger than the already-listed pip cache.


## Safety Review

- Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?

Affects `mo analyze` output.

Before:

```
Analyze Disk  (10.6 GB free)
Select a location to explore:

 ▶  1. ███████████████████████▒  57.2%  |  Home                     108.6 GB
    2. ████████                  21.1%  |  User Library              40.0 GB
    3. ███                        9.0%  |  Applications              17.1 GB
    4. ██                         6.5%  |  System Library            12.3 GB
    5. █                          3.9%  |  JetBrains Cache            7.4 GB
    6. ▏                          1.3%  |  Docker Data                2.4 GB
    7. ▏                          0.4%  |  Homebrew Cache           835.8 MB
    8. ▏                          0.3%  |  Old Downloads (90d+)     654.5 MB
    9. ▏                          0.2%  |  System Logs              390.5 MB
   10. ▏                        < 0.1%  |  Spotify Cache             56.6 MB
   11. ▏                        < 0.1%  |  pip Cache                 56.5 MB

↑↓→ | Enter | R Refresh | O Open | P Preview | F File | Esc/Q Quit
```

After:

Adds `uv Cache                   9.9 GB`

```
Analyze Disk  (10.6 GB free)
Select a location to explore:

 ▶  1. ████████████████████████  54.4%  |  Home                     108.6 GB
    2. ████████▉                 20.0%  |  User Library              40.0 GB
    3. ███▊                       8.6%  |  Applications              17.1 GB
    4. ██▊                        6.2%  |  System Library            12.3 GB
    5. ██▏                        4.9%  |  uv Cache                   9.9 GB
    6. █▋                         3.7%  |  JetBrains Cache            7.4 GB
    7. ▌                          1.2%  |  Docker Data                2.4 GB
    8. ▏                          0.4%  |  Homebrew Cache           835.8 MB
    9. ▏                          0.3%  |  Old Downloads (90d+)     654.5 MB
   10. ▏                          0.2%  |  System Logs              390.5 MB
   11. ▏                        < 0.1%  |  Spotify Cache             56.6 MB
   12. ▏                        < 0.1%  |  pip Cache                 56.5 MB

↑↓→ | Enter | R Refresh | O Open | P Preview | F File | Esc/Q Quit
```



- Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?

No

- If yes, describe the new boundary or risk change clearly.

## Tests

- List the automated tests you ran.

```console
❯ make build
Downloading Go modules (1/3)...
Building for local architecture...
go build -ldflags="-s -w" -o bin/analyze-go ./cmd/analyze
go build -ldflags="-s -w" -o bin/status-go ./cmd/status

❯ make verify
./scripts/check.sh --no-format
=== Mole Check, check ===

3. Running Go linters...
● golangci-lint not installed, falling back to go vet
✓ go vet passed

4. Running ShellCheck...
✓ ShellCheck passed

5. Running syntax check...
✓ Syntax check passed

function-duplication-ok groups=3/3 allowed
✓ Function duplication check passed

✓ Diagnostic install guidance passed

=== Checks Completed ===
go test ./...
ok  	github.com/tw93/mole/cmd/analyze	(cached)
ok  	github.com/tw93/mole/cmd/status	(cached)
ok  	github.com/tw93/mole/internal/units	(cached)```
```

CI passed:

* https://github.com/hugovk/Mole/actions/runs/31378988015
* https://github.com/hugovk/Mole/actions/runs/31378988036

- List any manual checks for high-risk paths or destructive flows.

## Safety-related changes

- None.
