### PR TITLE
fix(uninstall): guard empty array expansion in cask search for bash 3.2 (#1411)

### DIFF
--- a/lib/uninstall/brew.sh
+++ b/lib/uninstall/brew.sh
@@ -159,7 +159,7 @@ _detect_cask_via_caskroom_search() {
     local candidate existing seen
     for candidate in "${tokens[@]}"; do
         seen=false
-        for existing in "${uniq[@]}"; do
+        for existing in "${uniq[@]+"${uniq[@]}"}"; do
             if [[ "$candidate" == "$existing" ]]; then
                 seen=true
                 break

--- a/tests/brew_uninstall.bats
+++ b/tests/brew_uninstall.bats
@@ -717,4 +717,3 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == "test-cask-app" ]]
 }
-

--- a/tests/brew_uninstall.bats
+++ b/tests/brew_uninstall.bats
@@ -690,3 +690,31 @@ EOF
 
     [ "$status" -eq 0 ]
 }
+
+@test "_detect_cask_via_caskroom_search handles empty uniq array expansion under set -u" {
+    mkdir -p "$BATS_TEST_TMPDIR/TestCaskApp.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TEST_APP_PATH="$BATS_TEST_TMPDIR/TestCaskApp.app" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/brew.sh"
+
+find() {
+    echo "/opt/homebrew/Caskroom/test-cask-app/1.0.0/TestCaskApp.app"
+}
+run_with_timeout() {
+    shift
+    "$@"
+}
+_mole_brew_probe() {
+    echo "test-cask-app"
+    return 0
+}
+
+_detect_cask_via_caskroom_search "$TEST_APP_PATH"
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == "test-cask-app" ]]
+}
+


### PR DESCRIPTION
### Summary
Fixes `uniq[@]: unbound variable` failure in `_detect_cask_via_caskroom_search` when running under macOS system `/bin/bash` (version 3.2.57).

### Root Cause
In Bash < 4.4, expanding an empty array (`"${uniq[@]}"`) under `set -u` is treated as an unbound variable. Because `uniq` is initialized empty (`local -a uniq=()`), the deduplication loop in `_detect_cask_via_caskroom_search` throws `unbound variable` and aborts on its very first iteration, breaking Cask detection for installed applications.

### Solution
Guarded the empty array expansion using `"${uniq[@]+"${uniq[@]}"}"`, which is Bash 3.2 compatible and safe under `set -u`.

### Tests
- Added a Bats unit test in `tests/brew_uninstall.bats` verifying `_detect_cask_via_caskroom_search` executes cleanly under `/bin/bash` with `set -euo pipefail`.
- Verified all tests pass.

Closes #1411