### PR TITLE
fix(purge): resolve on-disk casing so projects appear once (#1416)

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -170,8 +170,22 @@ save_discovered_paths() {
 load_purge_config() {
     PURGE_SEARCH_PATHS=()
 
+    local line existing_path already_found
     while IFS= read -r line; do
-        [[ -n "$line" ]] && PURGE_SEARCH_PATHS+=("$line")
+        [[ -n "$line" ]] || continue
+        # mole_purge_read_paths_config already folds case variants to the
+        # on-disk path, so a config listing ~/code and ~/Code yields the
+        # same resolved string twice. Drop the duplicate here so downstream
+        # scans and the menu show each path once (#1416).
+        already_found=false
+        for existing_path in "${PURGE_SEARCH_PATHS[@]+"${PURGE_SEARCH_PATHS[@]}"}"; do
+            if [[ "$line" == "$existing_path" ]]; then
+                already_found=true
+                break
+            fi
+        done
+        [[ "$already_found" == "true" ]] && continue
+        PURGE_SEARCH_PATHS+=("$line")
     done < <(mole_purge_read_paths_config "$PURGE_CONFIG_FILE")
 
     if [[ ${#PURGE_SEARCH_PATHS[@]} -eq 0 ]]; then

--- a/lib/clean/purge_shared.sh
+++ b/lib/clean/purge_shared.sh
@@ -172,10 +172,18 @@ mole_purge_quick_hint_target_names() {
 # On case-insensitive macOS (APFS), ~/Code and ~/code point to the same
 # directory but with different display names.  This function returns the
 # real (on-disk) path so that string comparisons work correctly for dedup.
+#
+# Uses the external /bin/pwd rather than the bash builtin: bash's `pwd -P`
+# resolves symlink chains in $PWD but reuses the casing of the `cd`
+# argument instead of querying the filesystem, so on case-insensitive APFS
+# it returns ~/Workspace even when the on-disk directory is ~/workspace.
+# That breaks the string dedup in discover_project_dirs and a project
+# appears twice (#1416). /bin/pwd calls getcwd(3), which returns the real
+# on-disk name.
 mole_purge_resolve_path_case() {
     local path="$1"
     if [[ -d "$path" ]]; then
-        (cd "$path" 2> /dev/null && pwd -P) || printf '%s\n' "$path"
+        (cd "$path" 2> /dev/null && /bin/pwd -P) || printf '%s\n' "$path"
     else
         printf '%s\n' "$path"
     fi

--- a/tests/purge_config_paths.bats
+++ b/tests/purge_config_paths.bats
@@ -153,8 +153,11 @@ EOF
     # On case-insensitive FS (macOS default) both resolve to the same path,
     # so count should be 1. On case-sensitive FS, Code doesn't exist, so
     # resolve_path_case returns it unchanged, count may be 2 which is correct
-    # since they really are different directories.
-    if [[ -d "$HOME/Code" && "$(cd "$HOME/Code" && pwd -P)" == "$(cd "$HOME/code" && pwd -P)" ]]; then
+    # since they really are different directories. /bin/pwd queries the
+    # filesystem (getcwd) so the case-folding test actually fires here,
+    # unlike the bash builtin `pwd -P` which reuses the cd argument's
+    # casing and makes this guard a no-op on APFS (#1416).
+    if [[ -d "$HOME/Code" && "$(cd "$HOME/Code" && /bin/pwd -P)" == "$(cd "$HOME/code" && /bin/pwd -P)" ]]; then
         [ "$output" = "1" ]
     fi
 }
@@ -172,10 +175,38 @@ EOF
 
     [ "$status" -eq 0 ]
 
-    # On case-insensitive FS, $HOME/code should appear only once
-    if [[ -d "$HOME/Code" && "$(cd "$HOME/Code" && pwd -P)" == "$(cd "$HOME/code" && pwd -P)" ]]; then
+    # On case-insensitive FS, $HOME/code should appear only once. See the
+    # load_purge_config test above for why the guard uses /bin/pwd -P.
+    if [[ -d "$HOME/Code" && "$(cd "$HOME/Code" && /bin/pwd -P)" == "$(cd "$HOME/code" && /bin/pwd -P)" ]]; then
         local count
         count=$(echo "$output" | grep -c "$HOME/code" || true)
         [ "$count" -le 1 ]
+    fi
+}
+
+@test "discover_project_dirs shows a Workspace default once when the on-disk dir is workspace (#1416)" {
+    # The default search paths include ~/Workspace (capital W). When the
+    # real on-disk directory is ~/workspace (lowercase) on a
+    # case-insensitive APFS volume, mole_purge_resolve_path_case used to
+    # return ~/Workspace (bash's `pwd -P` reuses the cd argument's casing
+    # instead of querying the filesystem), so the string dedup failed and
+    # the project appeared twice in `mo purge` output.
+    mkdir -p "$HOME/workspace/myproject"
+    touch "$HOME/workspace/myproject/package.json"
+
+    run env HOME="$HOME" /bin/bash -c "
+        source '$PROJECT_ROOT/lib/clean/project.sh'
+        discover_project_dirs
+    "
+
+    [ "$status" -eq 0 ]
+
+    # Only run the count assertion where ~/Workspace folds onto
+    # ~/workspace. On a case-sensitive FS ~/Workspace genuinely does not
+    # exist and is correctly absent, so there is nothing to dedup.
+    if [[ -d "$HOME/Workspace" && "$(cd "$HOME/Workspace" && /bin/pwd -P)" == "$(cd "$HOME/workspace" && /bin/pwd -P)" ]]; then
+        local workspace_count
+        workspace_count=$(printf '%s\n' "$output" | grep -c -iE "${HOME//\//\\/}/[Ww]orkspace$" || true)
+        [ "$workspace_count" -eq 1 ]
     fi
 }


### PR DESCRIPTION
## Summary

`mo purge` displayed the same project folder twice when the on-disk directory's casing differed from a default search path. The most common trigger: the real directory is `~/workspace` but the default search path list contains `~/Workspace`, so both `workspace` and `Workspace` showed up even though only `workspace` exists.

Root cause: `mole_purge_resolve_path_case` used the **bash builtin `pwd -P`** to resolve canonical casing. On case-insensitive APFS, bash's `pwd -P` resolves symlink chains in `$PWD` but **reuses the casing of the `cd` argument** instead of querying the filesystem. So `cd ~/Workspace && pwd -P` returns `~/Workspace` even when the on-disk directory is `~/workspace`. The string dedup in `discover_project_dirs` then failed to match `~/workspace` against the default-path `~/Workspace`, and both landed in the output.

### Fix

- **`mole_purge_resolve_path_case`** (`lib/clean/purge_shared.sh`): switch from the bash builtin `pwd -P` to the **external `/bin/pwd -P`**, which calls `getcwd(3)` and returns the real on-disk name. `/bin/pwd` is universal on macOS and matches the codebase's existing use of absolute-path externals (`/usr/bin/stat`, `/bin/date`).

- **`load_purge_config`** (`lib/clean/project.sh`): a related second site. Config lines were appended to `PURGE_SEARCH_PATHS` without dedup, so a `purge_paths` file listing both `~/code` and `~/Code` produced the same resolved path twice. Added an already-seen loop matching the shape of the dedup already in `discover_project_dirs` (guarded expansion `${arr[@]+"${arr[@]}"}` for bash 3.2 / `set -u` safety).

### Why this went unnoticed

The two existing case-fold tests (`load_purge_config deduplicates case variants`, `discover_project_dirs deduplicates default Code vs actual code`) used the **same bash-builtin `pwd -P`** in their own detection guards, so the guards were no-ops on case-insensitive APFS — the assertions never ran, and the bug was invisible. This PR switches those guards to `/bin/pwd -P` so they actually fire, and adds a dedicated regression test for the `Workspace`-vs-`workspace` default-path scenario.

## Safety Review

- **Does this change affect cleanup, uninstall, optimize, installer, remove, analyze delete, update, or install behavior?** Yes — purge project-artifact cleanup. The change is confined to how `mo purge` resolves and deduplicates project directories before scanning; it does not touch removal, deletion safety, sudo, or protected-path logic.
- **Does this change affect path validation, protected directories, symlink handling, sudo boundaries, or release/install integrity?** Path resolution only, in a direction that *narrows* the set of scanned paths (dedup removes a duplicate). Symlink handling is preserved: `/bin/pwd -P` resolves symlink chains the same way the bash builtin did (verified with a symlink → realdir edge case). No sudo, protected-directory, or release-integrity boundary changes.

The change reduces risk rather than adding it: before the fix, `mo uninstall --list`-style duplicate entries could cause a cask project to be scanned twice and its artifacts counted/displayed twice; after the fix each path is scanned once.

## Tests

Automated:
- `bats tests/purge_config_paths.bats` — all 10 tests pass, including the two re-activated case-fold tests and the new `#1416` regression test.
- `bats tests/purge.bats` — all 85 tests pass.
- `shellcheck --rcfile .shellcheckrc` clean on both modified source files and the test file.

Regression test added (`tests/purge_config_paths.bats`): `discover_project_dirs shows a Workspace default once when the on-disk dir is workspace (#1416)` — creates `~/workspace/myproject`, runs `discover_project_dirs`, asserts the workspace path appears exactly once. **Verified to fail without the fix** (count = 2) and **pass with it** (count = 1).

Manual end-to-end check with `mo purge --paths` on a case-insensitive APFS volume:
- Before fix: `Current Scan Paths` showed `✓ ~/Projects`, `✓ ~/Workspace`, `✓ ~/workspace` (duplicate, `Workspace` does not exist on disk).
- After fix: shows `✓ ~/Projects`, `✓ ~/workspace` only.

## Safety-related changes

- The `load_purge_config` dedup loop uses the guarded expansion `"${PURGE_SEARCH_PATHS[@]+"${PURGE_SEARCH_PATHS[@]}"}"` so it is safe under `set -u` with an initially-empty array (bash 3.2 compatibility), matching the idiom already used in `discover_project_dirs` and elsewhere.

Closes #1416