### PR TITLE
feat(clean): report unmatched pnpm store generations

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -194,12 +194,19 @@ list_installed_pnpm_binaries() {
     fi
 }
 
-# Resolve the store path of every usable installed pnpm binary, deduplicated,
-# one pair per line: "<store_path><TAB><pnpm_bin>". Never downloads; unusable
-# binaries are skipped. The binary is the first one that resolved the store,
-# which is the one that owns the prune call for that generation.
+# Resolve the store path of every pnpm candidate discovered by
+# list_installed_pnpm_binaries. Results stay in parallel global arrays so the
+# prune and read-only unmatched-generation report consume one snapshot. A
+# failed candidate marks the snapshot incomplete: successful stores may still
+# use their owner prune, but absence from that snapshot never authorizes a
+# filesystem delete or an unmatched-generation report.
 # shellcheck disable=SC2329
-list_in_use_pnpm_store_paths() {
+collect_pnpm_store_snapshot() {
+    _PNPM_STORE_SNAPSHOT_PATHS=()
+    _PNPM_STORE_SNAPSHOT_BINS=()
+    _PNPM_STORE_SNAPSHOT_CANDIDATES=0
+    _PNPM_STORE_SNAPSHOT_COMPLETE=true
+
     local -a pnpm_bins=()
     local bin_line
     while IFS= read -r bin_line; do
@@ -207,13 +214,18 @@ list_in_use_pnpm_store_paths() {
         pnpm_bins+=("$bin_line")
     done < <(list_installed_pnpm_binaries)
 
+    [[ ${#pnpm_bins[@]} -gt 0 ]] || return 0
+
     local -a seen_stores=()
     local pnpm_bin store_path store_seen store_entry
     for pnpm_bin in "${pnpm_bins[@]}"; do
+        _PNPM_STORE_SNAPSHOT_CANDIDATES=$((_PNPM_STORE_SNAPSHOT_CANDIDATES + 1))
+
         # Usable binary only; never prompt Corepack to download another major.
         if ! COREPACK_ENABLE_DOWNLOAD_PROMPT=0 run_with_timeout \
             "$MOLE_TIMEOUT_QUICK_DETECT_SEC" "$pnpm_bin" --version > /dev/null 2>&1; then
             debug_log "Skipping unusable pnpm binary: $pnpm_bin"
+            _PNPM_STORE_SNAPSHOT_COMPLETE=false
             continue
         fi
 
@@ -224,6 +236,7 @@ list_in_use_pnpm_store_paths() {
 
         if ! is_safe_pnpm_store_path "$store_path"; then
             debug_log "Rejecting unsafe or empty pnpm store path from $pnpm_bin: ${store_path:-<empty>}"
+            _PNPM_STORE_SNAPSHOT_COMPLETE=false
             continue
         fi
         store_path="${store_path%/}"
@@ -240,7 +253,50 @@ list_in_use_pnpm_store_paths() {
             continue
         fi
         seen_stores+=("$store_path")
-        printf '%s\t%s\n' "$store_path" "$pnpm_bin"
+        _PNPM_STORE_SNAPSHOT_PATHS+=("$store_path")
+        _PNPM_STORE_SNAPSHOT_BINS+=("$pnpm_bin")
+    done
+}
+
+# Report generation-shaped siblings that the complete supported snapshot did
+# not resolve. This is intentionally read-only: PATH plus known version-manager
+# roots cannot prove that no pnpm binary exists elsewhere, so an unmatched
+# generation is a manual-review candidate, not an orphan deletion target.
+# shellcheck disable=SC2329
+report_unmatched_pnpm_store_generations() {
+    local pnpm_store_root="$HOME/Library/pnpm/store"
+    [[ -d "$pnpm_store_root" && $# -gt 0 ]] || return 0
+
+    local root_has_in_use_generation=false
+    local in_use in_use_name
+    for in_use in "$@"; do
+        case "$in_use" in
+            "$pnpm_store_root"/*)
+                in_use_name="${in_use#"$pnpm_store_root"/}"
+                if [[ "$in_use_name" != */* && "$in_use_name" =~ ^v[0-9]+$ ]]; then
+                    root_has_in_use_generation=true
+                    break
+                fi
+                ;;
+        esac
+    done
+    [[ "$root_has_in_use_generation" == "true" ]] || return 0
+
+    local generation_path generation_name in_use_match
+    for generation_path in "$pnpm_store_root"/v*; do
+        [[ -d "$generation_path" ]] || continue
+        generation_name="${generation_path##*/}"
+        [[ "$generation_name" =~ ^v[0-9]+$ ]] || continue
+
+        in_use_match=false
+        for in_use in "$@"; do
+            if [[ "$in_use" == "$generation_path" ]]; then
+                in_use_match=true
+                break
+            fi
+        done
+        [[ "$in_use_match" == "true" ]] && continue
+        debug_log "Unmatched pnpm store generation left for manual review: $generation_path"
     done
 }
 
@@ -261,80 +317,31 @@ clean_pnpm_stores() {
         return 0
     fi
 
-    local -a store_pairs=()
-    local pair_line
-    while IFS= read -r pair_line; do
-        [[ -n "$pair_line" ]] || continue
-        store_pairs+=("$pair_line")
-    done < <(list_in_use_pnpm_store_paths)
+    collect_pnpm_store_snapshot
 
-    if [[ ${#store_pairs[@]} -eq 0 ]]; then
-        debug_log "pnpm is unavailable, leaving global pnpm store for manual review: $pnpm_default_store"
+    if [[ ${#_PNPM_STORE_SNAPSHOT_PATHS[@]} -eq 0 ]]; then
+        if [[ $_PNPM_STORE_SNAPSHOT_CANDIDATES -eq 0 ]]; then
+            debug_log "pnpm is unavailable, leaving global pnpm store for manual review: $pnpm_default_store"
+        else
+            debug_log "No pruneable pnpm store resolved from installed candidates"
+        fi
         return 0
     fi
 
-    local pair store_path pnpm_bin
-    for pair in "${store_pairs[@]}"; do
-        IFS=$'\t' read -r store_path pnpm_bin <<< "$pair"
+    local index store_path pnpm_bin
+    for ((index = 0; index < ${#_PNPM_STORE_SNAPSHOT_PATHS[@]}; index++)); do
+        store_path="${_PNPM_STORE_SNAPSHOT_PATHS[$index]}"
+        pnpm_bin="${_PNPM_STORE_SNAPSHOT_BINS[$index]}"
         COREPACK_ENABLE_DOWNLOAD_PROMPT=0 clean_tool_cache "pnpm cache" "$store_path" \
             run_with_timeout "$MOLE_TIMEOUT_PKG_CLEANUP_SEC" \
             env COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$pnpm_bin" store prune
     done
-}
 
-# pnpm `store prune` only prunes the generation its own store path points at.
-# Generations left behind by older pnpm majors (for example v3 from pnpm 6-8)
-# are never touched by any prune and stay orphaned after an upgrade. Remove
-# them only on exact evidence: every usable installed pnpm resolves its store
-# path, and cleanup requires at least one resolved generation inside this root
-# so the root's role as a pnpm generation container is proven before any
-# sibling generation is judged orphaned.
-# shellcheck disable=SC2329
-clean_orphaned_pnpm_store_generations() {
-    local pnpm_store_root="$HOME/Library/pnpm/store"
-    [[ -d "$pnpm_store_root" ]] || return 0
-
-    if pnpm_process_blocks_prune; then
-        debug_log "pnpm process running or process state unknown, skipping orphaned store generation cleanup"
-        return 0
+    if [[ "$_PNPM_STORE_SNAPSHOT_COMPLETE" == "true" ]]; then
+        report_unmatched_pnpm_store_generations "${_PNPM_STORE_SNAPSHOT_PATHS[@]}"
+    else
+        debug_log "pnpm store snapshot incomplete, skipping unmatched-generation report"
     fi
-
-    local -a in_use_paths=()
-    local pair_line in_use
-    while IFS= read -r pair_line; do
-        [[ -n "$pair_line" ]] || continue
-        IFS=$'\t' read -r in_use _ <<< "$pair_line"
-        in_use_paths+=("$in_use")
-    done < <(list_in_use_pnpm_store_paths)
-
-    [[ ${#in_use_paths[@]} -gt 0 ]] || return 0
-
-    # Fail closed without at least one resolved generation under this root:
-    # an unusable or unresolved pnpm may still own a generation here.
-    local root_has_in_use_generation=false
-    for in_use in "${in_use_paths[@]}"; do
-        case "$in_use" in
-            "$pnpm_store_root"/v[0-9]*)
-                root_has_in_use_generation=true
-                ;;
-        esac
-    done
-    [[ "$root_has_in_use_generation" == "true" ]] || return 0
-
-    local generation_path in_use_match generation_name
-    for generation_path in "$pnpm_store_root"/v[0-9]*; do
-        [[ -d "$generation_path" ]] || continue
-        in_use_match=false
-        for in_use in "${in_use_paths[@]}"; do
-            if [[ "$in_use" == "$generation_path" ]]; then
-                in_use_match=true
-                break
-            fi
-        done
-        [[ "$in_use_match" == "true" ]] && continue
-        generation_name="${generation_path##*/}"
-        safe_clean "$generation_path" "Orphaned pnpm store generation ($generation_name)"
-    done
 }
 
 # npm/pnpm/yarn/bun caches.
@@ -383,7 +390,6 @@ clean_dev_npm() {
     fi
 
     clean_pnpm_stores
-    clean_orphaned_pnpm_store_generations
     clean_corepack_cache
     local bun_default_cache="$HOME/.bun/install/cache"
     local bun_cache_path="$bun_default_cache"

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -194,23 +194,12 @@ list_installed_pnpm_binaries() {
     fi
 }
 
-# Prune every distinct pnpm store generation reachable through an already
-# installed matching pnpm binary. Owner command only (plain `store prune`,
-# no --force, no raw directory delete). Dedupes by store path so two
-# binaries that resolve to the same generation run once (issue #1370).
+# Resolve the store path of every usable installed pnpm binary, deduplicated,
+# one pair per line: "<store_path><TAB><pnpm_bin>". Never downloads; unusable
+# binaries are skipped. The binary is the first one that resolved the store,
+# which is the one that owns the prune call for that generation.
 # shellcheck disable=SC2329
-clean_pnpm_stores() {
-    local pnpm_default_store="$HOME/Library/pnpm/store"
-
-    if pnpm_process_blocks_prune; then
-        debug_log "pnpm process running or process state unknown, skipping store prune"
-        if [[ "${DRY_RUN:-false}" == "true" ]]; then
-            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} pnpm cache · would skip (pnpm busy)"
-            note_activity
-        fi
-        return 0
-    fi
-
+list_in_use_pnpm_store_paths() {
     local -a pnpm_bins=()
     local bin_line
     while IFS= read -r bin_line; do
@@ -218,13 +207,7 @@ clean_pnpm_stores() {
         pnpm_bins+=("$bin_line")
     done < <(list_installed_pnpm_binaries)
 
-    if [[ ${#pnpm_bins[@]} -eq 0 ]]; then
-        debug_log "pnpm is unavailable, leaving global pnpm store for manual review: $pnpm_default_store"
-        return 0
-    fi
-
     local -a seen_stores=()
-    local pruned_any=false
     local pnpm_bin store_path store_seen store_entry
     for pnpm_bin in "${pnpm_bins[@]}"; do
         # Usable binary only; never prompt Corepack to download another major.
@@ -257,16 +240,101 @@ clean_pnpm_stores() {
             continue
         fi
         seen_stores+=("$store_path")
+        printf '%s\t%s\n' "$store_path" "$pnpm_bin"
+    done
+}
 
+# Prune every distinct pnpm store generation reachable through an already
+# installed matching pnpm binary. Owner command only (plain `store prune`,
+# no --force, no raw directory delete). Dedupes by store path so two
+# binaries that resolve to the same generation run once (issue #1370).
+# shellcheck disable=SC2329
+clean_pnpm_stores() {
+    local pnpm_default_store="$HOME/Library/pnpm/store"
+
+    if pnpm_process_blocks_prune; then
+        debug_log "pnpm process running or process state unknown, skipping store prune"
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} pnpm cache · would skip (pnpm busy)"
+            note_activity
+        fi
+        return 0
+    fi
+
+    local -a store_pairs=()
+    local pair_line
+    while IFS= read -r pair_line; do
+        [[ -n "$pair_line" ]] || continue
+        store_pairs+=("$pair_line")
+    done < <(list_in_use_pnpm_store_paths)
+
+    if [[ ${#store_pairs[@]} -eq 0 ]]; then
+        debug_log "pnpm is unavailable, leaving global pnpm store for manual review: $pnpm_default_store"
+        return 0
+    fi
+
+    local pair store_path pnpm_bin
+    for pair in "${store_pairs[@]}"; do
+        IFS=$'\t' read -r store_path pnpm_bin <<< "$pair"
         COREPACK_ENABLE_DOWNLOAD_PROMPT=0 clean_tool_cache "pnpm cache" "$store_path" \
             run_with_timeout "$MOLE_TIMEOUT_PKG_CLEANUP_SEC" \
             env COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$pnpm_bin" store prune
-        pruned_any=true
     done
+}
 
-    if [[ "$pruned_any" != "true" ]]; then
-        debug_log "No pruneable pnpm store resolved from installed binaries"
+# pnpm `store prune` only prunes the generation its own store path points at.
+# Generations left behind by older pnpm majors (for example v3 from pnpm 6-8)
+# are never touched by any prune and stay orphaned after an upgrade. Remove
+# them only on exact evidence: every usable installed pnpm resolves its store
+# path, and cleanup requires at least one resolved generation inside this root
+# so the root's role as a pnpm generation container is proven before any
+# sibling generation is judged orphaned.
+# shellcheck disable=SC2329
+clean_orphaned_pnpm_store_generations() {
+    local pnpm_store_root="$HOME/Library/pnpm/store"
+    [[ -d "$pnpm_store_root" ]] || return 0
+
+    if pnpm_process_blocks_prune; then
+        debug_log "pnpm process running or process state unknown, skipping orphaned store generation cleanup"
+        return 0
     fi
+
+    local -a in_use_paths=()
+    local pair_line in_use
+    while IFS= read -r pair_line; do
+        [[ -n "$pair_line" ]] || continue
+        IFS=$'\t' read -r in_use _ <<< "$pair_line"
+        in_use_paths+=("$in_use")
+    done < <(list_in_use_pnpm_store_paths)
+
+    [[ ${#in_use_paths[@]} -gt 0 ]] || return 0
+
+    # Fail closed without at least one resolved generation under this root:
+    # an unusable or unresolved pnpm may still own a generation here.
+    local root_has_in_use_generation=false
+    for in_use in "${in_use_paths[@]}"; do
+        case "$in_use" in
+            "$pnpm_store_root"/v[0-9]*)
+                root_has_in_use_generation=true
+                ;;
+        esac
+    done
+    [[ "$root_has_in_use_generation" == "true" ]] || return 0
+
+    local generation_path in_use_match generation_name
+    for generation_path in "$pnpm_store_root"/v[0-9]*; do
+        [[ -d "$generation_path" ]] || continue
+        in_use_match=false
+        for in_use in "${in_use_paths[@]}"; do
+            if [[ "$in_use" == "$generation_path" ]]; then
+                in_use_match=true
+                break
+            fi
+        done
+        [[ "$in_use_match" == "true" ]] && continue
+        generation_name="${generation_path##*/}"
+        safe_clean "$generation_path" "Orphaned pnpm store generation ($generation_name)"
+    done
 }
 
 # npm/pnpm/yarn/bun caches.
@@ -315,6 +383,7 @@ clean_dev_npm() {
     fi
 
     clean_pnpm_stores
+    clean_orphaned_pnpm_store_generations
     clean_corepack_cache
     local bun_default_cache="$HOME/.bun/install/cache"
     local bun_cache_path="$bun_default_cache"

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -158,6 +158,145 @@ EOF
     [[ "$output" != *"UNEXPECTED"* ]] || return 1
 }
 
+@test "clean_orphaned_pnpm_store_generations removes generations no pnpm resolves" {
+    rm -rf "$HOME/Library/pnpm" "$HOME/bin"
+    mkdir -p "$HOME/bin" "$HOME/Library/pnpm/store/v3" "$HOME/Library/pnpm/store/v10" "$HOME/Library/pnpm/store/v11"
+    touch "$HOME/Library/pnpm/store/v3/entry" "$HOME/Library/pnpm/store/v10/entry" "$HOME/Library/pnpm/store/v11/entry"
+    cat > "$HOME/bin/pnpm" <<'SCRIPT'
+#!/bin/bash
+case "${1:-}" in
+    --version) echo "11.17.0"; exit 0 ;;
+    store)
+        if [[ "${2:-}" == "path" ]]; then
+            echo "$HOME/Library/pnpm/store/v11"
+            exit 0
+        fi
+        ;;
+esac
+exit 2
+SCRIPT
+    chmod +x "$HOME/bin/pnpm"
+
+    run env HOME="$HOME" PATH="$HOME/bin:/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+pgrep() { return 1; }
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+export -f pgrep
+clean_orphaned_pnpm_store_generations
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"SAFE_CLEAN:Orphaned pnpm store generation (v3)|$HOME/Library/pnpm/store/v3"* ]] || return 1
+    [[ "$output" == *"SAFE_CLEAN:Orphaned pnpm store generation (v10)|$HOME/Library/pnpm/store/v10"* ]] || return 1
+    [[ "$output" != *"|$HOME/Library/pnpm/store/v11"* ]] || return 1
+}
+
+@test "clean_orphaned_pnpm_store_generations fails closed when no resolved generation lives in root" {
+    rm -rf "$HOME/Library/pnpm" "$HOME/bin" "$HOME/.local"
+    mkdir -p "$HOME/bin" "$HOME/Library/pnpm/store/v10"
+    touch "$HOME/Library/pnpm/store/v10/entry"
+    cat > "$HOME/bin/pnpm" <<'SCRIPT'
+#!/bin/bash
+case "${1:-}" in
+    --version) echo "10.34.5"; exit 0 ;;
+    store)
+        if [[ "${2:-}" == "path" ]]; then
+            echo "$HOME/.local/share/pnpm/store/v10"
+            exit 0
+        fi
+        ;;
+esac
+exit 2
+SCRIPT
+    chmod +x "$HOME/bin/pnpm"
+
+    run env HOME="$HOME" PATH="$HOME/bin:/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+pgrep() { return 1; }
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+export -f pgrep
+clean_orphaned_pnpm_store_generations
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" != *"SAFE_CLEAN"* ]] || return 1
+}
+
+@test "clean_orphaned_pnpm_store_generations skips while pnpm is running" {
+    rm -rf "$HOME/Library/pnpm"
+    mkdir -p "$HOME/Library/pnpm/store/v3"
+    touch "$HOME/Library/pnpm/store/v3/entry"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+debug_log() { printf 'DEBUG:%s\n' "$*"; }
+pgrep() { return 0; }
+pnpm() { echo "UNEXPECTED"; return 0; }
+export -f pgrep pnpm
+clean_orphaned_pnpm_store_generations
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"skipping orphaned store generation cleanup"* ]] || return 1
+    [[ "$output" != *"SAFE_CLEAN"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED"* ]] || return 1
+}
+
+@test "clean_orphaned_pnpm_store_generations leaves generations alone without pnpm" {
+    rm -rf "$HOME/Library/pnpm" "$HOME/bin"
+    mkdir -p "$HOME/Library/pnpm/store/v3" "$HOME/Library/pnpm/store/v10"
+    touch "$HOME/Library/pnpm/store/v3/entry" "$HOME/Library/pnpm/store/v10/entry"
+
+    run env HOME="$HOME" PATH="/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+pgrep() { return 1; }
+safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
+export -f pgrep
+clean_orphaned_pnpm_store_generations
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" != *"SAFE_CLEAN"* ]] || return 1
+}
+
 # Corepack and npm-installed pnpm run as `node .../pnpm.cjs`, so the busy
 # guard has to match the invoked program, not the process name. `-x pnpm`
 # saw only the standalone binary and let a prune race a live install.

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -158,122 +158,111 @@ EOF
     [[ "$output" != *"UNEXPECTED"* ]] || return 1
 }
 
-@test "clean_orphaned_pnpm_store_generations removes generations no pnpm resolves" {
-    rm -rf "$HOME/Library/pnpm" "$HOME/bin"
-    mkdir -p "$HOME/bin" "$HOME/Library/pnpm/store/v3" "$HOME/Library/pnpm/store/v10" "$HOME/Library/pnpm/store/v11"
-    touch "$HOME/Library/pnpm/store/v3/entry" "$HOME/Library/pnpm/store/v10/entry" "$HOME/Library/pnpm/store/v11/entry"
-    cat > "$HOME/bin/pnpm" <<'SCRIPT'
-#!/bin/bash
-case "${1:-}" in
-    --version) echo "11.17.0"; exit 0 ;;
-    store)
-        if [[ "${2:-}" == "path" ]]; then
-            echo "$HOME/Library/pnpm/store/v11"
-            exit 0
-        fi
-        ;;
-esac
-exit 2
-SCRIPT
-    chmod +x "$HOME/bin/pnpm"
-
-    run env HOME="$HOME" PATH="$HOME/bin:/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
-        /bin/bash --noprofile --norc <<'EOF'
-set -euo pipefail
-source "$PROJECT_ROOT/lib/core/common.sh"
-source "$PROJECT_ROOT/lib/clean/dev.sh"
-start_section_spinner() { :; }
-stop_section_spinner() { :; }
-note_activity() { :; }
-run_with_timeout() { shift; "$@"; }
-pgrep() { return 1; }
-safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
-export -f pgrep
-clean_orphaned_pnpm_store_generations
-EOF
-
-    [ "$status" -eq 0 ] || {
-        echo "$output"
-        return 1
-    }
-    [[ "$output" == *"SAFE_CLEAN:Orphaned pnpm store generation (v3)|$HOME/Library/pnpm/store/v3"* ]] || return 1
-    [[ "$output" == *"SAFE_CLEAN:Orphaned pnpm store generation (v10)|$HOME/Library/pnpm/store/v10"* ]] || return 1
-    [[ "$output" != *"|$HOME/Library/pnpm/store/v11"* ]] || return 1
-}
-
-@test "clean_orphaned_pnpm_store_generations fails closed when no resolved generation lives in root" {
-    rm -rf "$HOME/Library/pnpm" "$HOME/bin" "$HOME/.local"
-    mkdir -p "$HOME/bin" "$HOME/Library/pnpm/store/v10"
-    touch "$HOME/Library/pnpm/store/v10/entry"
-    cat > "$HOME/bin/pnpm" <<'SCRIPT'
-#!/bin/bash
-case "${1:-}" in
-    --version) echo "10.34.5"; exit 0 ;;
-    store)
-        if [[ "${2:-}" == "path" ]]; then
-            echo "$HOME/.local/share/pnpm/store/v10"
-            exit 0
-        fi
-        ;;
-esac
-exit 2
-SCRIPT
-    chmod +x "$HOME/bin/pnpm"
-
-    run env HOME="$HOME" PATH="$HOME/bin:/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
-        /bin/bash --noprofile --norc <<'EOF'
-set -euo pipefail
-source "$PROJECT_ROOT/lib/core/common.sh"
-source "$PROJECT_ROOT/lib/clean/dev.sh"
-start_section_spinner() { :; }
-stop_section_spinner() { :; }
-note_activity() { :; }
-run_with_timeout() { shift; "$@"; }
-pgrep() { return 1; }
-safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
-export -f pgrep
-clean_orphaned_pnpm_store_generations
-EOF
-
-    [ "$status" -eq 0 ] || {
-        echo "$output"
-        return 1
-    }
-    [[ "$output" != *"SAFE_CLEAN"* ]] || return 1
-}
-
-@test "clean_orphaned_pnpm_store_generations skips while pnpm is running" {
-    rm -rf "$HOME/Library/pnpm"
-    mkdir -p "$HOME/Library/pnpm/store/v3"
-    touch "$HOME/Library/pnpm/store/v3/entry"
+@test "report_unmatched_pnpm_store_generations reports only exact generation directories" {
+    rm -rf "${HOME:?}/Library/pnpm"
+    mkdir -p "$HOME/Library/pnpm/store/v3" "$HOME/Library/pnpm/store/v10" \
+        "$HOME/Library/pnpm/store/v11" "$HOME/Library/pnpm/store/v10-backup" \
+        "$HOME/Library/pnpm/store/v1.2" "$HOME/Library/pnpm/store/vendor"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
-start_section_spinner() { :; }
-stop_section_spinner() { :; }
-note_activity() { :; }
 debug_log() { printf 'DEBUG:%s\n' "$*"; }
-pgrep() { return 0; }
-pnpm() { echo "UNEXPECTED"; return 0; }
-export -f pgrep pnpm
-clean_orphaned_pnpm_store_generations
+safe_clean() { printf 'UNEXPECTED_DELETE:%s\n' "$1"; }
+report_unmatched_pnpm_store_generations "$HOME/Library/pnpm/store/v11"
 EOF
 
     [ "$status" -eq 0 ] || {
         echo "$output"
         return 1
     }
-    [[ "$output" == *"skipping orphaned store generation cleanup"* ]] || return 1
-    [[ "$output" != *"SAFE_CLEAN"* ]] || return 1
-    [[ "$output" != *"UNEXPECTED"* ]] || return 1
+    [[ "$output" == *"manual review: $HOME/Library/pnpm/store/v3"* ]] || return 1
+    [[ "$output" == *"manual review: $HOME/Library/pnpm/store/v10"* ]] || return 1
+    [[ "$output" != *"manual review: $HOME/Library/pnpm/store/v11"* ]] || return 1
+    [[ "$output" != *"v10-backup"* ]] || return 1
+    [[ "$output" != *"v1.2"* ]] || return 1
+    [[ "$output" != *"vendor"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_DELETE"* ]] || return 1
 }
 
-@test "clean_orphaned_pnpm_store_generations leaves generations alone without pnpm" {
-    rm -rf "$HOME/Library/pnpm" "$HOME/bin"
-    mkdir -p "$HOME/Library/pnpm/store/v3" "$HOME/Library/pnpm/store/v10"
-    touch "$HOME/Library/pnpm/store/v3/entry" "$HOME/Library/pnpm/store/v10/entry"
+@test "clean_dev_npm does not delete or report generations from an incomplete pnpm snapshot" {
+    rm -rf "${HOME:?}/Library/pnpm" "${HOME:?}/bin" "${HOME:?}/.local"
+    mkdir -p "$HOME/bin" "$HOME/.local/share/mise/installs/pnpm/10.34.5" \
+        "$HOME/Library/pnpm/store/v10" "$HOME/Library/pnpm/store/v11"
+    cat > "$HOME/bin/pnpm" <<'SCRIPT'
+#!/bin/bash
+case "${1:-}" in
+    --version) echo "11.17.0"; exit 0 ;;
+    store)
+        [[ "${2:-}" == "path" ]] && { echo "$HOME/Library/pnpm/store/v11"; exit 0; }
+        [[ "${2:-}" == "prune" ]] && { echo "PRUNE_V11"; exit 0; }
+        ;;
+esac
+exit 2
+SCRIPT
+    cat > "$HOME/.local/share/mise/installs/pnpm/10.34.5/pnpm" <<'SCRIPT'
+#!/bin/bash
+[[ "${1:-}" == "--version" ]] && { echo "10.34.5"; exit 0; }
+# An installed candidate whose store path cannot be resolved makes ownership incomplete.
+exit 2
+SCRIPT
+    chmod +x "$HOME/bin/pnpm" "$HOME/.local/share/mise/installs/pnpm/10.34.5/pnpm"
+
+    run env HOME="$HOME" PATH="$HOME/bin:/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+run_with_timeout() { shift; "$@"; }
+pgrep() { return 1; }
+safe_clean() { printf 'SAFE_CLEAN:%s|%s\n' "$2" "$1"; }
+clean_tool_cache() {
+    local description="$1"
+    local cache_path="$2"
+    shift 2
+    printf 'CACHE:%s|%s\n' "$description" "$cache_path"
+    "$@"
+}
+export -f pgrep
+clean_dev_npm
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"PRUNE_V11"* ]] || return 1
+    [[ "$output" != *"Orphaned pnpm store"* ]] || return 1
+    [[ "$output" != *"manual review: $HOME/Library/pnpm/store/v10"* ]] || return 1
+}
+
+@test "report_unmatched_pnpm_store_generations requires a resolved generation in the default root" {
+    rm -rf "${HOME:?}/Library/pnpm"
+    mkdir -p "$HOME/Library/pnpm/store/v10"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+debug_log() { printf 'DEBUG:%s\n' "$*"; }
+report_unmatched_pnpm_store_generations "$HOME/.local/share/pnpm/store/v11"
+printf 'COMPLETE\n'
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == "COMPLETE" ]] || return 1
+}
+
+@test "clean_pnpm_stores is quiet under nounset when no pnpm is installed" {
+    rm -rf "${HOME:?}/Library/pnpm" "${HOME:?}/bin" "${HOME:?}/.local"
+    mkdir -p "$HOME/Library/pnpm/store/v3"
 
     run env HOME="$HOME" PATH="/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
         /bin/bash --noprofile --norc <<'EOF'
@@ -285,16 +274,17 @@ stop_section_spinner() { :; }
 note_activity() { :; }
 run_with_timeout() { shift; "$@"; }
 pgrep() { return 1; }
-safe_clean() { echo "SAFE_CLEAN:$2|$1"; }
 export -f pgrep
-clean_orphaned_pnpm_store_generations
+clean_pnpm_stores
+printf 'COMPLETE\n'
 EOF
 
     [ "$status" -eq 0 ] || {
         echo "$output"
         return 1
     }
-    [[ "$output" != *"SAFE_CLEAN"* ]] || return 1
+    [[ "$output" == "COMPLETE" ]] || return 1
+    [[ "$output" != *"unbound variable"* ]] || return 1
 }
 
 # Corepack and npm-installed pnpm run as `node .../pnpm.cjs`, so the busy


### PR DESCRIPTION
## Why

`pnpm store prune` only prunes the generation selected by the binary that runs it. #1370 covers every store reachable through the supported installed-binary inventory (PATH plus mise), but generation-shaped siblings can still remain under `~/Library/pnpm/store/`.

An unmatched directory is not enough evidence for automatic deletion: a usable pnpm binary may live outside the supported inventory, and a discovered binary may temporarily fail or time out while resolving its store. This PR makes those generations observable for manual review without treating an incomplete owner inventory as proof that they are orphaned.

## Change

- `collect_pnpm_store_snapshot` resolves the supported pnpm candidates once and stores deduplicated path/binary pairs in one snapshot.
- Resolved stores still run one plain owner-native `pnpm store prune`, with no `--force` and no downloads.
- A complete snapshot reports unmatched default-root generations through debug logging for manual review; it never sends them to a filesystem deletion sink.
- Generation candidates must be direct children whose basename matches `^v[0-9]+$`; names such as `v10-backup`, `v1.2`, and `vendor` are ignored.
- Any unusable, unresolved, timed-out, empty, relative, or unsafe candidate marks the snapshot incomplete, suppressing the unmatched-generation report.
- The no-pnpm path is quiet under macOS Bash 3.2 with `set -u`.

## Safety

- Unmatched generations are never deleted. PATH plus known version-manager roots cannot prove that no pnpm binary exists elsewhere.
- Native pruning remains bound to the same binary that resolved each store path.
- The whole flow skips when a pnpm process is running or process state is unknown.
- Corepack download prompts remain disabled; version and store-path probes remain timeout-bounded.
- Non-targets include every in-use generation, non-default store roots, non-generation sibling names, incomplete snapshots, and the entire default root when no supported pnpm resolves there.

## Validation

- `./scripts/check.sh` — passed (format, ShellCheck, Bash syntax, function duplication, diagnostic guidance).
- ShellCheck over every `tests/**/*.bats` and `tests/**/*.sh` file — passed.
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/dev_extended.bats` — 169/169 passed.
- New regressions cover strict generation names, incomplete snapshots, root containment, no raw deletion, and the no-pnpm Bash 3.2 nounset path.
- The full local suite was also attempted; all pnpm/developer-cleanup cases passed. The run was stopped after 1,384/1,581 tests because unrelated environment-sensitive suites had already failed locally.

## Scope

This revision deliberately does not automate whole-generation deletion. Doing that safely would require either owner-complete evidence or an explicit product decision to wipe unmatched stores as rebuildable caches rather than calling them proven orphans.
