### PR TITLE
Group purge artifacts by project

### DIFF
--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -224,17 +224,13 @@ perform_purge() {
     fi
 
     clean_project_artifacts
-    local exit_code=$?
+    local purge_outcome="${PURGE_RUN_OUTCOME:-scan_failed}"
 
     # Clean up
     trap - INT TERM
     cleanup_monitor
 
-    # Exit codes:
-    # 0 = success, show summary
-    # 1 = user cancelled
-    # 2 = nothing to clean
-    if [[ $exit_code -ne 0 ]]; then
+    if [[ "$purge_outcome" != "completed" ]]; then
         return 0
     fi
 

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1306,8 +1306,32 @@ clean_project_artifacts() {
     previous_term_trap=$(trap -p TERM || true)
     trap cleanup_scan INT TERM
     trap_installed_by_this_call=true
+    local -a scan_statuses=()
+    local max_scan_jobs
+    max_scan_jobs=$(get_optimal_parallel_jobs io)
+    if ! [[ "$max_scan_jobs" =~ ^[0-9]+$ ]] || [[ "$max_scan_jobs" -lt 1 ]]; then
+        max_scan_jobs=1
+    elif [[ "$max_scan_jobs" -gt 4 ]]; then
+        max_scan_jobs=4
+    fi
+
+    _wait_for_purge_scan_batch() {
+        local pid
+        for pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
+            local scan_status=0
+            if wait "$pid" 2> /dev/null; then
+                scan_status=0
+            else
+                scan_status=$?
+            fi
+            scan_statuses+=("$scan_status")
+        done
+        scan_pids=()
+    }
+
     # Scanning is started from purge.sh with start_inline_spinner
-    # Launch all scans in parallel
+    # Keep root-level concurrency bounded because each fd scan has its own
+    # worker pool. Batches preserve launch-order alignment with scan_statuses.
     for path in "${PURGE_SEARCH_PATHS[@]}"; do
         if [[ -d "$path" ]]; then
             local scan_output
@@ -1318,19 +1342,12 @@ clean_project_artifacts() {
             scan_purge_targets "$path" "$scan_output" < /dev/null &
             local scan_pid=$!
             scan_pids+=("$scan_pid")
+            if [[ ${#scan_pids[@]} -ge $max_scan_jobs ]]; then
+                _wait_for_purge_scan_batch
+            fi
         fi
     done
-    # Wait for all scans to complete
-    local -a scan_statuses=()
-    for pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
-        local scan_status=0
-        if wait "$pid" 2> /dev/null; then
-            scan_status=0
-        else
-            scan_status=$?
-        fi
-        scan_statuses+=("$scan_status")
-    done
+    _wait_for_purge_scan_batch
 
     # Stop the scanning monitor (removes purge_scanning file to signal completion)
     local stats_dir="${XDG_CACHE_HOME:-$HOME/.cache}/mole"

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -426,6 +426,9 @@ is_protected_purge_artifact() {
 scan_purge_targets() {
     local search_path="$1"
     local output_file="$2"
+    local target_output="${output_file}.targets"
+    local tag_output="${output_file}.tags"
+    local processed_output="${output_file}.processed"
     local min_depth="$PURGE_MIN_DEPTH_DEFAULT"
     local max_depth="$PURGE_MAX_DEPTH_DEFAULT"
     if [[ ! "$min_depth" =~ ^[0-9]+$ ]]; then
@@ -440,6 +443,12 @@ scan_purge_targets() {
     if [[ ! -d "$search_path" ]]; then
         return
     fi
+
+    # A scan result is publishable only after every producer and filter for the
+    # root completes. Keep the caller-visible file empty until that point so a
+    # timeout or read failure cannot turn a partial prefix into delete candidates.
+    : > "$output_file"
+    rm -f "$target_output" "$tag_output" "$processed_output" 2> /dev/null || true
 
     local cachedir_tag_min_depth=$((min_depth + 1))
     local cachedir_tag_max_depth=$((max_depth + 1))
@@ -462,23 +471,38 @@ scan_purge_targets() {
     process_scan_results() {
         local input_file="$1"
         if [[ -f "$input_file" ]]; then
-            while IFS= read -r item; do
-                # Check if we should abort (scanning file removed by Ctrl+C)
-                if [[ ! -f "$stats_dir/purge_scanning" ]]; then
-                    return
-                fi
+            local process_status=0
+            (
+                while IFS= read -r item; do
+                    # Check if we should abort (scanning file removed by Ctrl+C)
+                    if [[ ! -f "$stats_dir/purge_scanning" ]]; then
+                        exit 130
+                    fi
 
-                if [[ -n "$item" ]] && is_safe_project_artifact "$item" "$search_path"; then
-                    echo "$item"
-                    # Update scanning path to show current project directory
-                    local project_dir="${item%/*}"
-                    echo "$project_dir" > "$stats_dir/purge_scanning" 2> /dev/null || true
-                fi
-            done < "$input_file" | filter_nested_artifacts | filter_protected_artifacts > "$output_file"
-            rm -f "$input_file"
+                    if [[ -n "$item" ]] && is_safe_project_artifact "$item" "$search_path"; then
+                        echo "$item"
+                        # Update scanning path to show current project directory
+                        local project_dir="${item%/*}"
+                        echo "$project_dir" > "$stats_dir/purge_scanning" 2> /dev/null || true
+                    fi
+                done < "$input_file"
+            ) | filter_nested_artifacts | filter_protected_artifacts > "$processed_output" || process_status=$?
+
+            if [[ $process_status -ne 0 ]]; then
+                rm -f "$processed_output" 2> /dev/null || true
+                return "$process_status"
+            fi
+            if ! mv "$processed_output" "$output_file"; then
+                rm -f "$processed_output" 2> /dev/null || true
+                return 1
+            fi
         else
-            touch "$output_file"
+            return 1
         fi
+    }
+
+    cleanup_scan_outputs() {
+        rm -f "$target_output" "$tag_output" "$processed_output" 2> /dev/null || true
     }
 
     local use_find=true
@@ -524,14 +548,27 @@ scan_purge_targets() {
         # Empty scans are common in healthy project trees; falling back to find
         # doubles the scan cost and can make "nothing to clean" feel slow.
         local _scan_timeout="${MO_PURGE_SCAN_TIMEOUT_SEC:-60}"
-        if run_with_timeout "$_scan_timeout" fd "${fd_args[@]}" "$pattern" "$search_path" 2> /dev/null > "$output_file.raw"; then
+        local fd_status=0
+        run_with_timeout "$_scan_timeout" fd "${fd_args[@]}" "$pattern" "$search_path" \
+            2> /dev/null > "$target_output" || fd_status=$?
+        if [[ $fd_status -eq 0 ]]; then
             run_with_timeout "$_scan_timeout" fd "${fd_tag_args[@]}" "^${MOLE_CACHEDIR_TAG_NAME}$" "$search_path" \
-                2> /dev/null | emit_valid_cachedir_tag_dirs >> "$output_file.raw" || true
+                2> /dev/null > "$tag_output" || fd_status=$?
+        fi
+        if [[ $fd_status -eq 0 ]]; then
+            emit_valid_cachedir_tag_dirs < "$tag_output" >> "$target_output" || fd_status=$?
+        fi
+        if [[ $fd_status -eq 0 ]]; then
+            process_scan_results "$target_output" || fd_status=$?
+        fi
+        if [[ $fd_status -eq 0 ]]; then
             debug_log "Using fd for scanning"
-            process_scan_results "$output_file.raw"
+            cleanup_scan_outputs
             use_find=false
         else
-            debug_log "fd command failed, falling back to find"
+            debug_log "fd scan failed (status $fd_status), falling back to find"
+            cleanup_scan_outputs
+            : > "$output_file"
         fi
     fi
 
@@ -556,17 +593,31 @@ scan_purge_targets() {
         # Use plain `find` here for compatibility with environments where
         # `command find` behaves inconsistently in this complex expression.
         local _scan_timeout="${MO_PURGE_SCAN_TIMEOUT_SEC:-60}"
+        local find_status=0
         run_with_timeout "$_scan_timeout" find "$search_path" -mindepth "$min_depth" -maxdepth "$max_depth" -type d \
             \( "${prune_expr[@]}" \) -prune -o \
             \( "${target_expr[@]}" \) -print -prune \
-            2> /dev/null > "$output_file.raw" || true
+            2> /dev/null > "$target_output" || find_status=$?
 
-        run_with_timeout "$_scan_timeout" find "$search_path" -mindepth "$cachedir_tag_min_depth" -maxdepth "$cachedir_tag_max_depth" \
-            \( "${prune_expr[@]}" \) -prune -o \
-            -type f -name "$MOLE_CACHEDIR_TAG_NAME" -print \
-            2> /dev/null | emit_valid_cachedir_tag_dirs >> "$output_file.raw" || true
+        if [[ $find_status -eq 0 ]]; then
+            run_with_timeout "$_scan_timeout" find "$search_path" -mindepth "$cachedir_tag_min_depth" -maxdepth "$cachedir_tag_max_depth" \
+                \( "${prune_expr[@]}" \) -prune -o \
+                -type f -name "$MOLE_CACHEDIR_TAG_NAME" -print \
+                2> /dev/null > "$tag_output" || find_status=$?
+        fi
+        if [[ $find_status -eq 0 ]]; then
+            emit_valid_cachedir_tag_dirs < "$tag_output" >> "$target_output" || find_status=$?
+        fi
+        if [[ $find_status -eq 0 ]]; then
+            process_scan_results "$target_output" || find_status=$?
+        fi
 
-        process_scan_results "$output_file.raw"
+        cleanup_scan_outputs
+        if [[ $find_status -ne 0 ]]; then
+            : > "$output_file"
+            debug_log "find scan failed (status $find_status): $search_path"
+            return "$find_status"
+        fi
     fi
 }
 # Filter out nested artifacts (e.g. node_modules inside node_modules, .build inside build).

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -852,31 +852,6 @@ find_purge_project_root_for_artifact() {
     return 1
 }
 
-# Derive a display-only project name when no indicator-based root exists.
-get_purge_fallback_project_name() {
-    local path="$1"
-    local -a search_roots=()
-    if [[ ${#PURGE_SEARCH_PATHS[@]} -gt 0 ]]; then
-        search_roots=("${PURGE_SEARCH_PATHS[@]}")
-    else
-        search_roots=("$HOME/www" "$HOME/dev" "$HOME/Projects")
-    fi
-
-    local root
-    for root in "${search_roots[@]}"; do
-        root="${root%/}"
-        if [[ -n "$root" && "$path" == "$root/"* ]]; then
-            local relative_path="${path#"$root"/}"
-            printf '%s\n' "${relative_path%%/*}"
-            return
-        fi
-    done
-
-    local grandparent="${path%/*}"
-    grandparent="${grandparent%/*}"
-    printf '%s\n' "${grandparent##*/}"
-}
-
 # Purge category selector.
 select_purge_categories() {
     local -a categories=("$@")
@@ -1677,8 +1652,10 @@ clean_project_artifacts() {
         # Format: "project_path  size | artifact_type"
         printf "%-*s %9s | %-*s" "$printf_width" "$truncated_path" "$size_str" "$artifact_col" "$artifact_type"
     }
-    # Resolve project ownership once per artifact. The identity is authoritative
-    # for grouping; display names and paths are never used as selectors.
+    # Resolve project ownership once per artifact. An indicator-backed root is
+    # preferred. Without one, the artifact's direct parent is the narrowest
+    # exact ownership boundary we can prove without grouping unrelated paths.
+    # The physical identity is authoritative; display text is never a selector.
     local -a _cached_basenames=()
     local -a _cached_project_names=()
     local -a _cached_project_paths=()
@@ -1693,10 +1670,10 @@ clean_project_artifacts() {
             _cached_project_paths[_pre_idx]="${project_root/#$HOME/~}"
             _cached_project_identities[_pre_idx]=$(mole_path_identity "$project_root")
         else
-            _cached_project_names[_pre_idx]=$(get_purge_fallback_project_name "$artifact_path")
-            local artifact_parent="${artifact_path%/*}"
-            _cached_project_paths[_pre_idx]="${artifact_parent/#$HOME/~}"
-            _cached_project_identities[_pre_idx]="artifact-row:${_pre_idx}"
+            project_root="${artifact_path%/*}"
+            _cached_project_names[_pre_idx]="${project_root##*/}"
+            _cached_project_paths[_pre_idx]="${project_root/#$HOME/~}"
+            _cached_project_identities[_pre_idx]=$(mole_path_identity "$project_root")
         fi
     done
 

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -964,6 +964,7 @@ select_purge_categories() {
         [[ -n "$_prev_exit" ]] && eval "$_prev_exit"
         [[ -n "$_prev_int" ]] && eval "$_prev_int"
         [[ -n "$_prev_term" ]] && eval "$_prev_term"
+        return 0
     }
     # shellcheck disable=SC2329
     handle_interrupt() {
@@ -1067,18 +1068,19 @@ select_purge_categories() {
         local _enter="${GRAY}Enter Confirm${NC}"
         local _all="${GRAY}A All${NC}"
         local _invert="${GRAY}I Invert${NC}"
+        local _skip_project="${GRAY}X Skip Project${NC}"
         local _quit="${GRAY}Q Quit${NC}"
 
         # Strip ANSI to measure real length
         _ph_len() { printf "%s" "$1" | LC_ALL=C awk '{gsub(/\033\[[0-9;]*[A-Za-z]/,""); printf "%d", length}'; }
 
-        # Level 0 (full): ↑↓ | Space Select | Enter Confirm | A All | I Invert | Q Quit
-        local _full="${_nav}${_sep}${_space}${_sep}${_enter}${_sep}${_all}${_sep}${_invert}${_sep}${_quit}"
+        # Level 0 (full): ↑↓ | Space Select | Enter Confirm | A All | I Invert | X Skip Project | Q Quit
+        local _full="${_nav}${_sep}${_space}${_sep}${_enter}${_sep}${_all}${_sep}${_invert}${_sep}${_skip_project}${_sep}${_quit}"
         if (($(_ph_len "$_full") <= _term_w)); then
             printf "%s${_full}${NC}\n" "$clear_line"
         else
-            # Level 1: ↑↓ | Enter Confirm | A All | I Invert | Q Quit
-            local _l1="${_nav}${_sep}${_enter}${_sep}${_all}${_sep}${_invert}${_sep}${_quit}"
+            # Level 1: ↑↓ | Enter Confirm | A All | X Skip Project | Q Quit
+            local _l1="${_nav}${_sep}${_enter}${_sep}${_all}${_sep}${_skip_project}${_sep}${_quit}"
             if (($(_ph_len "$_l1") <= _term_w)); then
                 printf "%s${_l1}${NC}\n" "$clear_line"
             else
@@ -1171,6 +1173,19 @@ select_purge_categories() {
                         selected[i]=true
                     fi
                 done
+                ;;
+            "x" | "X") # Deselect the current artifact's exact project
+                local current_index=$((top_index + cursor_pos))
+                local project_id="${PURGE_CATEGORY_PROJECT_IDS_ARRAY[current_index]:-}"
+                if [[ -n "$project_id" ]]; then
+                    for ((i = 0; i < total_items; i++)); do
+                        if [[ "${PURGE_CATEGORY_PROJECT_IDS_ARRAY[i]:-}" == "$project_id" ]]; then
+                            selected[i]=false
+                        fi
+                    done
+                else
+                    selected[current_index]=false
+                fi
                 ;;
             "q" | "Q" | $'\x03') # Quit or Ctrl-C
                 restore_terminal

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1019,7 +1019,7 @@ select_purge_categories() {
             scroll_indicator=" ${GRAY}[${current_pos}/${total_items}]${NC}"
         fi
 
-        printf "%s${PURPLE_BOLD}Select Categories to Clean${NC}%s${GRAY}, ${selected_size_human}, ${selected_count} selected${NC}\n" "$clear_line" "$scroll_indicator"
+        printf "%s${PURPLE_BOLD}Select Artifacts to Purge${NC}%s${GRAY}, ${selected_size_human}, ${selected_count} selected${NC}\n" "$clear_line" "$scroll_indicator"
         printf "%s\n" "$clear_line"
 
         IFS=',' read -r -a recent_flags <<< "${PURGE_RECENT_CATEGORIES:-}"
@@ -1084,8 +1084,14 @@ select_purge_categories() {
             if (($(_ph_len "$_l1") <= _term_w)); then
                 printf "%s${_l1}${NC}\n" "$clear_line"
             else
-                # Level 2 (minimal): ↑↓ | Enter | Q Quit
-                printf "%s${_nav}${_sep}${_enter}${_sep}${_quit}${NC}\n" "$clear_line"
+                # Level 2: keep the project action discoverable on narrow terminals.
+                local _l2="${_nav}${_sep}${GRAY}Enter${NC}${_sep}${_skip_project}${_sep}${_quit}"
+                if (($(_ph_len "$_l2") <= _term_w)); then
+                    printf "%s${_l2}${NC}\n" "$clear_line"
+                else
+                    # Level 3 (minimal): ↑↓ | Enter | X Skip | Q
+                    printf "%s${_nav}${_sep}${GRAY}Enter${NC}${_sep}${GRAY}X Skip${NC}${_sep}${GRAY}Q${NC}\n" "$clear_line"
+                fi
             fi
         fi
 

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -28,6 +28,8 @@ readonly PURGE_CONFIG_FILE="$HOME/.config/mole/purge_paths"
 PURGE_SEARCH_PATHS=()
 PURGE_CATEGORY_FULL_PATHS_ARRAY=()
 PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
+PURGE_CATEGORY_PROJECT_PATHS_ARRAY=()
+PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY=()
 
 # Project indicators for container detection.
 # Monorepo indicators (higher priority)
@@ -897,7 +899,9 @@ select_purge_categories() {
                 term_height=24
             fi
         fi
-        local reserved=8
+        # Title, footer context, full path, controls, and spacing. The project
+        # context can use two lines on narrow terminals.
+        local reserved=10
         local available=$((term_height - reserved))
         if [[ $available -lt 3 ]]; then
             echo 3
@@ -1032,21 +1036,83 @@ select_purge_categories() {
         for ((i = top_index; i < end_index; i++)); do
             local checkbox="$ICON_EMPTY"
             [[ ${selected[i]} == true ]] && checkbox="$ICON_SOLID"
+            local group_marker="─"
+            local row_project_id="${PURGE_CATEGORY_PROJECT_IDS_ARRAY[i]:-}"
+            if [[ -n "$row_project_id" ]]; then
+                local previous_same_project=false
+                local next_same_project=false
+                if [[ $i -gt 0 && "${PURGE_CATEGORY_PROJECT_IDS_ARRAY[i - 1]:-}" == "$row_project_id" ]]; then
+                    previous_same_project=true
+                fi
+                if [[ $i -lt $((total_items - 1)) && "${PURGE_CATEGORY_PROJECT_IDS_ARRAY[i + 1]:-}" == "$row_project_id" ]]; then
+                    next_same_project=true
+                fi
+                if [[ "$previous_same_project" == "true" && "$next_same_project" == "true" ]]; then
+                    group_marker="├"
+                elif [[ "$next_same_project" == "true" ]]; then
+                    group_marker="┌"
+                elif [[ "$previous_same_project" == "true" ]]; then
+                    group_marker="└"
+                fi
+            fi
             local recent_marker=""
             local _age="${age_labels[i]:-}"
             [[ -n "$_age" ]] && recent_marker=" ${GRAY}| ${_age}${NC}"
             local rel_pos=$((i - top_index))
             if [[ $rel_pos -eq $cursor_pos ]]; then
-                printf "%s${CYAN}${ICON_ARROW} %s %s%s${NC}\n" "$clear_line" "$checkbox" "${categories[i]}" "$recent_marker"
+                printf "%s${CYAN}${ICON_ARROW} %s %s %s%s${NC}\n" "$clear_line" "$checkbox" "$group_marker" "${categories[i]}" "$recent_marker"
             else
-                printf "%s  %s %s%s\n" "$clear_line" "$checkbox" "${categories[i]}" "$recent_marker"
+                printf "%s  %s %s %s%s\n" "$clear_line" "$checkbox" "$group_marker" "${categories[i]}" "$recent_marker"
             fi
         done
 
         # Keep one blank line between the list and footer tips.
         printf "%s\n" "$clear_line"
 
+        local _term_w
+        _term_w=$(tput cols 2> /dev/null || echo 80)
+        [[ "$_term_w" =~ ^[0-9]+$ ]] || _term_w=80
+
         local current_index=$((top_index + cursor_pos))
+        local current_project_id="${PURGE_CATEGORY_PROJECT_IDS_ARRAY[current_index]:-}"
+        local current_project_path="${PURGE_CATEGORY_PROJECT_PATHS_ARRAY[current_index]:-}"
+        if [[ -n "$current_project_path" ]]; then
+            local group_size=0
+            local group_item_count=0
+            local group_selected_count=0
+            local group_has_unknown_size=false
+            for ((i = 0; i < total_items; i++)); do
+                if { [[ -n "$current_project_id" ]] && [[ "${PURGE_CATEGORY_PROJECT_IDS_ARRAY[i]:-}" == "$current_project_id" ]]; } || { [[ -z "$current_project_id" ]] && [[ $i -eq $current_index ]]; }; then
+                    group_item_count=$((group_item_count + 1))
+                    group_size=$((group_size + ${sizes[i]:-0}))
+                    [[ ${selected[i]} == true ]] && group_selected_count=$((group_selected_count + 1))
+                    [[ "${PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY[i]:-false}" == "true" ]] && group_has_unknown_size=true
+                fi
+            done
+
+            local group_size_label
+            group_size_label=$(bytes_to_human_kb "$group_size")
+            if [[ "$group_has_unknown_size" == "true" ]]; then
+                if [[ $group_size -gt 0 ]]; then
+                    group_size_label="${group_size_label} + unknown"
+                else
+                    group_size_label="unknown size"
+                fi
+            fi
+
+            local project_label="Project: "
+            local project_summary=" · ${group_size_label} · ${group_selected_count}/${group_item_count} selected"
+            local project_path_width=$((_term_w - ${#project_label} - ${#project_summary}))
+            if [[ $project_path_width -ge 12 ]]; then
+                printf "%s${GRAY}%s${NC}%s%s\n" "$clear_line" "$project_label" "$(compact_purge_menu_path "$current_project_path" "$project_path_width")" "$project_summary"
+            else
+                project_path_width=$((_term_w - ${#project_label}))
+                [[ $project_path_width -lt 4 ]] && project_path_width=4
+                printf "%s${GRAY}%s${NC}%s\n" "$clear_line" "$project_label" "$(compact_purge_menu_path "$current_project_path" "$project_path_width")"
+                printf "%s${GRAY}Group:${NC} %s · %s/%s selected\n" "$clear_line" "$group_size_label" "$group_selected_count" "$group_item_count"
+            fi
+        fi
+
         local current_full_path=""
         local paths_len="${#PURGE_CATEGORY_FULL_PATHS_ARRAY[@]}"
         if [[ "$paths_len" -gt 0 && "$current_index" -lt "$paths_len" ]]; then
@@ -1058,10 +1124,6 @@ select_purge_categories() {
         fi
 
         # Adaptive footer hints, mirrors menu_paginated.sh pattern
-        local _term_w
-        _term_w=$(tput cols 2> /dev/null || echo 80)
-        [[ "$_term_w" =~ ^[0-9]+$ ]] || _term_w=80
-
         local _sep=" ${GRAY}|${NC} "
         local _nav="${GRAY}${ICON_NAV_UP}${ICON_NAV_DOWN}${NC}"
         local _space="${GRAY}Space Select${NC}"
@@ -1576,8 +1638,8 @@ clean_project_artifacts() {
         if [[ -n "$max_path_width" ]]; then
             available_width="$max_path_width"
         else
-            # Standalone fallback: overhead = prefix(4)+space(1)+size(9)+sep(3)+artifact_col+recent(9) = artifact_col+26
-            local fixed_width=$((artifact_col + 26))
+            # Standalone fallback: include the two-column project-group marker.
+            local fixed_width=$((artifact_col + 28))
             available_width=$((terminal_width - fixed_width))
 
             local min_width=10
@@ -1645,6 +1707,7 @@ clean_project_artifacts() {
     local -a raw_artifact_types=()
     local -a item_display_paths=()
     local -a item_project_identities=()
+    local -a item_project_paths=()
     local _sz_idx=0
     for item in "${safe_to_clean[@]}"; do
         local item_index=$_sz_idx
@@ -1694,6 +1757,7 @@ clean_project_artifacts() {
         item_paths+=("$item")
         item_display_paths+=("$display_item_path")
         item_project_identities+=("${_cached_project_identities[$item_index]}")
+        item_project_paths+=("$display_project_path")
         item_sizes+=("$size_kb")
         item_size_unknown_flags+=("$size_unknown")
         item_recent_flags+=("$is_recent")
@@ -1738,8 +1802,8 @@ clean_project_artifacts() {
     [[ $max_artifact_width -lt 6 ]] && max_artifact_width=6
     [[ $max_artifact_width -gt 17 ]] && max_artifact_width=17
 
-    # Exact overhead: prefix(4) + space(1) + size(9) + " | "(3) + artifact_col + " | 11mo"(7) = artifact_col + 24
-    local fixed_overhead=$((max_artifact_width + 26))
+    # Include the two-column project-group marker in the selector prefix.
+    local fixed_overhead=$((max_artifact_width + 28))
     local available_for_path=$((terminal_width - fixed_overhead))
 
     local min_path_width=10
@@ -1830,6 +1894,7 @@ clean_project_artifacts() {
         local -a sorted_item_recent_flags=()
         local -a sorted_item_display_paths=()
         local -a sorted_item_project_identities=()
+        local -a sorted_item_project_paths=()
         local -a sorted_item_age_labels=()
         local -a sorted_item_cloud_flags=()
 
@@ -1841,6 +1906,7 @@ clean_project_artifacts() {
             sorted_item_recent_flags+=("${item_recent_flags[idx]}")
             sorted_item_display_paths+=("${item_display_paths[idx]}")
             sorted_item_project_identities+=("${item_project_identities[idx]}")
+            sorted_item_project_paths+=("${item_project_paths[idx]}")
             sorted_item_age_labels+=("${item_age_labels[idx]}")
             sorted_item_cloud_flags+=("${item_cloud_flags[idx]}")
         done
@@ -1853,6 +1919,7 @@ clean_project_artifacts() {
         item_recent_flags=("${sorted_item_recent_flags[@]}")
         item_display_paths=("${sorted_item_display_paths[@]}")
         item_project_identities=("${sorted_item_project_identities[@]}")
+        item_project_paths=("${sorted_item_project_paths[@]}")
         item_age_labels=("${sorted_item_age_labels[@]}")
         item_cloud_flags=("${sorted_item_cloud_flags[@]}")
     fi
@@ -1885,10 +1952,14 @@ clean_project_artifacts() {
     PURGE_SELECTION_RESULT=""
     PURGE_CATEGORY_FULL_PATHS_ARRAY=("${item_display_paths[@]}")
     PURGE_CATEGORY_PROJECT_IDS_ARRAY=("${item_project_identities[@]}")
+    PURGE_CATEGORY_PROJECT_PATHS_ARRAY=("${item_project_paths[@]}")
+    PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY=("${item_size_unknown_flags[@]}")
     if [[ -t 0 ]]; then
         if ! select_purge_categories "${menu_options[@]}"; then
             PURGE_CATEGORY_FULL_PATHS_ARRAY=()
             PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
+            PURGE_CATEGORY_PROJECT_PATHS_ARRAY=()
+            PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY=()
             unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
             PURGE_RUN_OUTCOME="cancelled"
             return 0
@@ -1919,6 +1990,8 @@ clean_project_artifacts() {
         printf '\n'
         PURGE_CATEGORY_FULL_PATHS_ARRAY=()
         PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
+        PURGE_CATEGORY_PROJECT_PATHS_ARRAY=()
+        PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY=()
         unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
         PURGE_RUN_OUTCOME="cancelled"
         return 0
@@ -1947,6 +2020,8 @@ clean_project_artifacts() {
             printf '\n'
             PURGE_CATEGORY_FULL_PATHS_ARRAY=()
             PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
+            PURGE_CATEGORY_PROJECT_PATHS_ARRAY=()
+            PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY=()
             unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
             PURGE_RUN_OUTCOME="cancelled"
             return 0
@@ -1954,6 +2029,8 @@ clean_project_artifacts() {
     fi
     PURGE_CATEGORY_FULL_PATHS_ARRAY=()
     PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
+    PURGE_CATEGORY_PROJECT_PATHS_ARRAY=()
+    PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY=()
 
     # Clean selected items
     echo ""

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1168,8 +1168,10 @@ confirm_purge_cleanup() {
     esac
 }
 
-# Main cleanup function - scans and prompts user to select artifacts to clean
+# Main cleanup function - scans and prompts user to select artifacts to clean.
+# Sets PURGE_RUN_OUTCOME to completed, no_candidates, cancelled, or scan_failed.
 clean_project_artifacts() {
+    PURGE_RUN_OUTCOME="completed"
     local -a all_found_items=()
     local -a safe_to_clean=()
     local -a safe_recent_flags=()
@@ -1293,14 +1295,20 @@ clean_project_artifacts() {
         echo -e "${GRAY}Re-run with 'mo purge --debug' to inspect the scan failure.${NC}"
         if [[ $completed_scan_count -eq 0 ]]; then
             printf '\n'
-            return 3
+            PURGE_RUN_OUTCOME="scan_failed"
+            return 0
         fi
     fi
     if [[ ${#all_found_items[@]} -eq 0 ]]; then
         echo ""
-        echo -e "${GREEN}${ICON_SUCCESS}${NC} Great! No old project artifacts to clean"
+        if [[ $failed_scan_count -gt 0 ]]; then
+            echo -e "${GRAY}No artifacts found in the completed project scans${NC}"
+        else
+            echo -e "${GREEN}${ICON_SUCCESS}${NC} Great! No old project artifacts to clean"
+        fi
         printf '\n'
-        return 2 # Special code: nothing to clean
+        PURGE_RUN_OUTCOME="no_candidates"
+        return 0
     fi
     # Mark recently modified items (for default selection state)
     if [[ -t 1 ]]; then
@@ -1810,6 +1818,7 @@ clean_project_artifacts() {
         echo ""
         echo -e "${GRAY}No artifacts found to purge${NC}"
         printf '\n'
+        PURGE_RUN_OUTCOME="no_candidates"
         return 0
     fi
     # Set global vars for selector
@@ -1832,7 +1841,8 @@ clean_project_artifacts() {
         if ! select_purge_categories "${menu_options[@]}"; then
             PURGE_CATEGORY_FULL_PATHS_ARRAY=()
             unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
-            return 1
+            PURGE_RUN_OUTCOME="cancelled"
+            return 0
         fi
     else
         # Non-interactive: select all non-recent items
@@ -1860,6 +1870,7 @@ clean_project_artifacts() {
         printf '\n'
         PURGE_CATEGORY_FULL_PATHS_ARRAY=()
         unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
+        PURGE_RUN_OUTCOME="cancelled"
         return 0
     fi
     IFS=',' read -r -a selected_indices <<< "$PURGE_SELECTION_RESULT"
@@ -1886,7 +1897,8 @@ clean_project_artifacts() {
             printf '\n'
             PURGE_CATEGORY_FULL_PATHS_ARRAY=()
             unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
-            return 1
+            PURGE_RUN_OUTCOME="cancelled"
+            return 0
         fi
     fi
     PURGE_CATEGORY_FULL_PATHS_ARRAY=()

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1818,23 +1818,35 @@ clean_project_artifacts() {
         local -a group_project_identities=()
         local -a group_total_sizes=()
         local -a item_group_indices=()
-        local group_index existing_group_index
+        local group_index
+
+        # Sort an injective, line-safe encoding of each identity once, then
+        # assign adjacent rows to the same group. This keeps grouping O(n log n)
+        # when a large workspace contains hundreds of distinct projects.
+        local grouping_temp
+        grouping_temp=$(mktemp)
         for ((i = 0; i < ${#item_sizes[@]}; i++)); do
-            group_index=-1
-            for ((existing_group_index = 0; existing_group_index < ${#group_project_identities[@]}; existing_group_index++)); do
-                if [[ "${group_project_identities[existing_group_index]}" == "${item_project_identities[i]}" ]]; then
-                    group_index=$existing_group_index
-                    break
-                fi
-            done
-            if [[ $group_index -lt 0 ]]; then
+            local encoded_identity="${item_project_identities[i]}"
+            encoded_identity="${encoded_identity//%/%25}"
+            encoded_identity="${encoded_identity//|/%7C}"
+            encoded_identity="${encoded_identity//$'\n'/%0A}"
+            printf '%s|%d|%d\n' "$encoded_identity" "$i" "${item_sizes[i]}"
+        done > "$grouping_temp"
+
+        local previous_encoded_identity=""
+        local have_previous_identity=false
+        while IFS='|' read -r encoded_identity i item_size; do
+            if [[ "$have_previous_identity" != "true" || "$encoded_identity" != "$previous_encoded_identity" ]]; then
                 group_index=${#group_project_identities[@]}
                 group_project_identities+=("${item_project_identities[i]}")
                 group_total_sizes+=(0)
+                previous_encoded_identity="$encoded_identity"
+                have_previous_identity=true
             fi
-            item_group_indices+=("$group_index")
-            group_total_sizes[group_index]=$((group_total_sizes[group_index] + item_sizes[i]))
-        done
+            item_group_indices[i]=$group_index
+            group_total_sizes[group_index]=$((group_total_sizes[group_index] + item_size))
+        done < <(LC_ALL=C sort -t'|' -k1,1 -k2,2n "$grouping_temp")
+        rm -f "$grouping_temp" # SAFE: this is the exact scratch file created by mktemp above.
 
         local group_sort_temp
         group_sort_temp=$(mktemp)

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1181,6 +1181,7 @@ clean_project_artifacts() {
     # Note: Declared without 'local' so cleanup_scan trap can access them
     scan_pids=()
     scan_temps=()
+    scan_roots=()
     _cleanup_scan_done=false
     # shellcheck disable=SC2329
     cleanup_scan() {
@@ -1192,7 +1193,7 @@ clean_project_artifacts() {
         done
         # Clean up temp files
         for temp in "${scan_temps[@]+"${scan_temps[@]}"}"; do
-            rm -f "$temp" 2> /dev/null || true
+            rm -f "$temp" "${temp}.targets" "${temp}.tags" "${temp}.processed" 2> /dev/null || true
         done
         # Clean up purge scanning file
         local stats_dir="${XDG_CACHE_HOME:-$HOME/.cache}/mole"
@@ -1212,6 +1213,7 @@ clean_project_artifacts() {
             local scan_output
             scan_output=$(mktemp)
             scan_temps+=("$scan_output")
+            scan_roots+=("$path")
             # Launch scan in background for true parallelism
             scan_purge_targets "$path" "$scan_output" < /dev/null &
             local scan_pid=$!
@@ -1219,8 +1221,15 @@ clean_project_artifacts() {
         fi
     done
     # Wait for all scans to complete
+    local -a scan_statuses=()
     for pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
-        wait "$pid" 2> /dev/null || true
+        local scan_status=0
+        if wait "$pid" 2> /dev/null; then
+            scan_status=0
+        else
+            scan_status=$?
+        fi
+        scan_statuses+=("$scan_status")
     done
 
     # Stop the scanning monitor (removes purge_scanning file to signal completion)
@@ -1236,11 +1245,25 @@ clean_project_artifacts() {
     # when overlapping search roots produce the same artifact many times.
     local dedupe_output
     dedupe_output=$(mktemp_file "mole-purge-dedupe") || return 1
-    for scan_output in "${scan_temps[@]+"${scan_temps[@]}"}"; do
-        if [[ -f "$scan_output" ]]; then
-            cat "$scan_output" >> "$dedupe_output"
-            rm -f "$scan_output"
+    local completed_scan_count=0
+    local failed_scan_count=0
+    local scan_index
+    for ((scan_index = 0; scan_index < ${#scan_temps[@]}; scan_index++)); do
+        scan_output="${scan_temps[$scan_index]}"
+        local scan_status="${scan_statuses[$scan_index]:-1}"
+        if [[ $scan_status -eq 0 && -f "$scan_output" ]]; then
+            if cat "$scan_output" >> "$dedupe_output"; then
+                completed_scan_count=$((completed_scan_count + 1))
+            else
+                scan_statuses[scan_index]=1
+                failed_scan_count=$((failed_scan_count + 1))
+                debug_log "Purge scan output unreadable: ${scan_roots[$scan_index]:-unknown root}"
+            fi
+        else
+            failed_scan_count=$((failed_scan_count + 1))
+            debug_log "Purge scan incomplete (status $scan_status): ${scan_roots[$scan_index]:-unknown root}"
         fi
+        rm -f "$scan_output" "${scan_output}.targets" "${scan_output}.tags" "${scan_output}.processed" 2> /dev/null || true
     done
     if [[ -s "$dedupe_output" ]]; then
         while IFS= read -r item; do
@@ -1254,6 +1277,24 @@ clean_project_artifacts() {
         # eval: restore caller traps captured by $(trap -p)
         [[ -n "$previous_int_trap" ]] && eval "$previous_int_trap"
         [[ -n "$previous_term_trap" ]] && eval "$previous_term_trap"
+    fi
+    if [[ $failed_scan_count -gt 0 ]]; then
+        local root_text="root"
+        [[ $failed_scan_count -ne 1 ]] && root_text="roots"
+        echo ""
+        echo -e "${YELLOW}${ICON_WARNING}${NC} Skipped ${failed_scan_count} project scan ${root_text} because scanning did not complete:"
+        for ((scan_index = 0; scan_index < ${#scan_roots[@]}; scan_index++)); do
+            local scan_status="${scan_statuses[$scan_index]:-1}"
+            if [[ $scan_status -ne 0 ]]; then
+                local display_root="${scan_roots[$scan_index]/#$HOME/~}"
+                echo -e "  ${GRAY}${display_root}${NC} (status ${scan_status})"
+            fi
+        done
+        echo -e "${GRAY}Re-run with 'mo purge --debug' to inspect the scan failure.${NC}"
+        if [[ $completed_scan_count -eq 0 ]]; then
+            printf '\n'
+            return 3
+        fi
     fi
     if [[ ${#all_found_items[@]} -eq 0 ]]; then
         echo ""

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -27,6 +27,7 @@ readonly PURGE_CONFIG_FILE="$HOME/.config/mole/purge_paths"
 # Resolved search paths.
 PURGE_SEARCH_PATHS=()
 PURGE_CATEGORY_FULL_PATHS_ARRAY=()
+PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
 
 # Project indicators for container detection.
 # Monorepo indicators (higher priority)
@@ -792,6 +793,88 @@ get_dir_size_kb() {
         echo "ERROR"
     fi
 }
+
+# Resolve the owning project for a purge artifact. Monorepo indicators take
+# precedence so every artifact in one workspace shares the same identity.
+find_purge_project_root_for_artifact() {
+    local path="$1"
+    local current_dir="${path%/*}"
+    [[ -z "$current_dir" ]] && current_dir="/"
+    local monorepo_root=""
+    local project_root=""
+
+    while [[ "$current_dir" != "/" && "$current_dir" != "$HOME" && -n "$current_dir" ]]; do
+        if [[ -z "$monorepo_root" ]]; then
+            for indicator in "${MONOREPO_INDICATORS[@]}"; do
+                if [[ -e "$current_dir/$indicator" ]]; then
+                    monorepo_root="$current_dir"
+                    break
+                fi
+            done
+        fi
+
+        if [[ -z "$project_root" ]]; then
+            for indicator in "${PROJECT_INDICATORS[@]}"; do
+                if [[ -e "$current_dir/$indicator" ]]; then
+                    project_root="$current_dir"
+                    break
+                fi
+            done
+        fi
+
+        if [[ -n "$monorepo_root" ]]; then
+            break
+        fi
+
+        local relative_to_home="${current_dir#"$HOME"}"
+        local without_slashes="${relative_to_home//\//}"
+        local depth=$((${#relative_to_home} - ${#without_slashes}))
+        if [[ -n "$project_root" && $depth -lt 2 ]]; then
+            break
+        fi
+
+        local parent="${current_dir%/*}"
+        current_dir="${parent:-/}"
+    done
+
+    if [[ -n "$monorepo_root" ]]; then
+        printf '%s\n' "$monorepo_root"
+        return 0
+    fi
+
+    if [[ -n "$project_root" ]]; then
+        printf '%s\n' "$project_root"
+        return 0
+    fi
+
+    return 1
+}
+
+# Derive a display-only project name when no indicator-based root exists.
+get_purge_fallback_project_name() {
+    local path="$1"
+    local -a search_roots=()
+    if [[ ${#PURGE_SEARCH_PATHS[@]} -gt 0 ]]; then
+        search_roots=("${PURGE_SEARCH_PATHS[@]}")
+    else
+        search_roots=("$HOME/www" "$HOME/dev" "$HOME/Projects")
+    fi
+
+    local root
+    for root in "${search_roots[@]}"; do
+        root="${root%/}"
+        if [[ -n "$root" && "$path" == "$root/"* ]]; then
+            local relative_path="${path#"$root"/}"
+            printf '%s\n' "${relative_path%%/*}"
+            return
+        fi
+    done
+
+    local grandparent="${path%/*}"
+    grandparent="${grandparent%/*}"
+    printf '%s\n' "${grandparent##*/}"
+}
+
 # Purge category selector.
 select_purge_categories() {
     local -a categories=("$@")
@@ -1408,151 +1491,25 @@ clean_project_artifacts() {
     local -a item_recent_flags=()
     local -a item_age_labels=()
     local -a item_cloud_flags=()
-    # Find the best project root for an artifact once; callers decide how to
-    # display it. Monorepo indicators win over plain project indicators.
-    find_purge_project_root_for_artifact() {
-        local path="$1"
-        local current_dir="${path%/*}"
-        [[ -z "$current_dir" ]] && current_dir="/"
-        local monorepo_root=""
-        local project_root=""
-
-        while [[ "$current_dir" != "/" && "$current_dir" != "$HOME" && -n "$current_dir" ]]; do
-            if [[ -z "$monorepo_root" ]]; then
-                for indicator in "${MONOREPO_INDICATORS[@]}"; do
-                    if [[ -e "$current_dir/$indicator" ]]; then
-                        monorepo_root="$current_dir"
-                        break
-                    fi
-                done
-            fi
-
-            if [[ -z "$project_root" ]]; then
-                for indicator in "${PROJECT_INDICATORS[@]}"; do
-                    if [[ -e "$current_dir/$indicator" ]]; then
-                        project_root="$current_dir"
-                        break
-                    fi
-                done
-            fi
-
-            if [[ -n "$monorepo_root" ]]; then
-                break
-            fi
-
-            local _rel="${current_dir#"$HOME"}"
-            local _stripped="${_rel//\//}"
-            local depth=$((${#_rel} - ${#_stripped}))
-            if [[ -n "$project_root" && $depth -lt 2 ]]; then
-                break
-            fi
-
-            local _parent="${current_dir%/*}"
-            current_dir="${_parent:-/}"
-        done
-
-        if [[ -n "$monorepo_root" ]]; then
-            echo "$monorepo_root"
-            return 0
-        fi
-
-        if [[ -n "$project_root" ]]; then
-            echo "$project_root"
-            return 0
-        fi
-
-        return 1
-    }
-
-    # Helper to get project name from path.
-    get_project_name() {
-        local path="$1"
-        local project_root=""
-
-        if project_root=$(find_purge_project_root_for_artifact "$path"); then
-            echo "${project_root##*/}"
-            return
-        fi
-
-        local result=""
-        local search_roots=()
-        if [[ ${#PURGE_SEARCH_PATHS[@]} -gt 0 ]]; then
-            search_roots=("${PURGE_SEARCH_PATHS[@]}")
-        else
-            search_roots=("$HOME/www" "$HOME/dev" "$HOME/Projects")
-        fi
-        for root in "${search_roots[@]}"; do
-            root="${root%/}"
-            if [[ -n "$root" && "$path" == "$root/"* ]]; then
-                local relative_path="${path#"$root"/}"
-                result="${relative_path%%/*}"
-                break
-            fi
-        done
-
-        if [[ -z "$result" ]]; then
-            local _gp="${path%/*}"
-            _gp="${_gp%/*}"
-            result="${_gp##*/}"
-        fi
-
-        echo "$result"
-    }
-
-    # Helper to get project path (more complete than just project name).
-    get_project_path() {
-        local path="$1"
-        local project_root=""
-        if ! project_root=$(find_purge_project_root_for_artifact "$path"); then
-            project_root="${path%/*}"
-        fi
-        echo "${project_root/#$HOME/~}"
-    }
-
     # Helper to get artifact display name
     # For duplicate artifact names within same project, include parent directory for context
-    # Uses pre-computed _cached_basenames and _cached_project_names arrays when available.
     get_artifact_display_name() {
         local path="$1"
+        local item_index="$2"
         local artifact_name="${path##*/}"
         local parent_name="${path%/*}"
         parent_name="${parent_name##*/}"
-
-        local project_name
-        if [[ -n "${_cached_project_names[*]+x}" ]]; then
-            # Fast path: use pre-computed cache
-            local _idx
-            project_name=""
-            for _idx in "${!safe_to_clean[@]}"; do
-                if [[ "${safe_to_clean[$_idx]}" == "$path" ]]; then
-                    project_name="${_cached_project_names[$_idx]}"
-                    break
-                fi
-            done
-        else
-            project_name=$(get_project_name "$path")
-        fi
+        local project_name="${_cached_project_names[item_index]}"
 
         # Check if there are other items with same artifact name AND same project
         local has_duplicate=false
-        if [[ -n "${_cached_basenames[*]+x}" ]]; then
-            local _idx
-            for _idx in "${!safe_to_clean[@]}"; do
-                if [[ "${safe_to_clean[$_idx]}" != "$path" && "${_cached_basenames[$_idx]}" == "$artifact_name" && "${_cached_project_names[$_idx]}" == "$project_name" ]]; then
-                    has_duplicate=true
-                    break
-                fi
-            done
-        else
-            for other_item in "${safe_to_clean[@]}"; do
-                if [[ "$other_item" != "$path" && "${other_item##*/}" == "$artifact_name" ]]; then
-                    if [[ "$(get_project_name "$other_item")" == "$project_name" ]]; then
-                        has_duplicate=true
-                        break
-                    fi
-                fi
-            done
-        fi
+        local other_index
+        for other_index in "${!safe_to_clean[@]}"; do
+            if [[ "$other_index" != "$item_index" && "${_cached_basenames[other_index]}" == "$artifact_name" && "${_cached_project_names[other_index]}" == "$project_name" ]]; then
+                has_duplicate=true
+                break
+            fi
+        done
 
         # If duplicate exists in same project and parent is not the project itself, show parent/artifact
         if [[ "$has_duplicate" == "true" && "$parent_name" != "$project_name" && "$parent_name" != "." && "$parent_name" != "/" ]]; then
@@ -1620,16 +1577,27 @@ clean_project_artifacts() {
         # Format: "project_path  size | artifact_type"
         printf "%-*s %9s | %-*s" "$printf_width" "$truncated_path" "$size_str" "$artifact_col" "$artifact_type"
     }
-    # Pre-compute basenames and project names once so get_artifact_display_name()
-    # can avoid repeated filesystem traversals during the O(N^2) duplicate check.
+    # Resolve project ownership once per artifact. The identity is authoritative
+    # for grouping; display names and paths are never used as selectors.
     local -a _cached_basenames=()
     local -a _cached_project_names=()
     local -a _cached_project_paths=()
+    local -a _cached_project_identities=()
     local _pre_idx
     for _pre_idx in "${!safe_to_clean[@]}"; do
-        _cached_basenames[_pre_idx]="${safe_to_clean[$_pre_idx]##*/}"
-        _cached_project_names[_pre_idx]=$(get_project_name "${safe_to_clean[$_pre_idx]}")
-        _cached_project_paths[_pre_idx]=$(get_project_path "${safe_to_clean[$_pre_idx]}")
+        local artifact_path="${safe_to_clean[$_pre_idx]}"
+        local project_root=""
+        _cached_basenames[_pre_idx]="${artifact_path##*/}"
+        if project_root=$(find_purge_project_root_for_artifact "$artifact_path"); then
+            _cached_project_names[_pre_idx]="${project_root##*/}"
+            _cached_project_paths[_pre_idx]="${project_root/#$HOME/~}"
+            _cached_project_identities[_pre_idx]=$(mole_path_identity "$project_root")
+        else
+            _cached_project_names[_pre_idx]=$(get_purge_fallback_project_name "$artifact_path")
+            local artifact_parent="${artifact_path%/*}"
+            _cached_project_paths[_pre_idx]="${artifact_parent/#$HOME/~}"
+            _cached_project_identities[_pre_idx]="artifact-row:${_pre_idx}"
+        fi
     done
 
     # Build menu options - one line per artifact
@@ -1638,12 +1606,13 @@ clean_project_artifacts() {
     local -a raw_project_paths=()
     local -a raw_artifact_types=()
     local -a item_display_paths=()
+    local -a item_project_identities=()
     local _sz_idx=0
     for item in "${safe_to_clean[@]}"; do
         local item_index=$_sz_idx
         local project_path="${_cached_project_paths[$item_index]}"
         local artifact_type
-        artifact_type=$(get_artifact_display_name "$item")
+        artifact_type=$(get_artifact_display_name "$item" "$item_index")
         local size_raw
         size_raw=$(cat "${_size_tmpfiles[$item_index]}" 2> /dev/null || echo "0")
         rm -f "${_size_tmpfiles[$item_index]}" 2> /dev/null || true
@@ -1686,6 +1655,7 @@ clean_project_artifacts() {
         raw_artifact_types+=("$artifact_type")
         item_paths+=("$item")
         item_display_paths+=("$display_item_path")
+        item_project_identities+=("${_cached_project_identities[$item_index]}")
         item_sizes+=("$size_kb")
         item_size_unknown_flags+=("$size_unknown")
         item_recent_flags+=("$is_recent")
@@ -1785,6 +1755,7 @@ clean_project_artifacts() {
         local -a sorted_item_size_unknown_flags=()
         local -a sorted_item_recent_flags=()
         local -a sorted_item_display_paths=()
+        local -a sorted_item_project_identities=()
         local -a sorted_item_age_labels=()
         local -a sorted_item_cloud_flags=()
 
@@ -1795,6 +1766,7 @@ clean_project_artifacts() {
             sorted_item_size_unknown_flags+=("${item_size_unknown_flags[idx]}")
             sorted_item_recent_flags+=("${item_recent_flags[idx]}")
             sorted_item_display_paths+=("${item_display_paths[idx]}")
+            sorted_item_project_identities+=("${item_project_identities[idx]}")
             sorted_item_age_labels+=("${item_age_labels[idx]}")
             sorted_item_cloud_flags+=("${item_cloud_flags[idx]}")
         done
@@ -1806,6 +1778,7 @@ clean_project_artifacts() {
         item_size_unknown_flags=("${sorted_item_size_unknown_flags[@]}")
         item_recent_flags=("${sorted_item_recent_flags[@]}")
         item_display_paths=("${sorted_item_display_paths[@]}")
+        item_project_identities=("${sorted_item_project_identities[@]}")
         item_age_labels=("${sorted_item_age_labels[@]}")
         item_cloud_flags=("${sorted_item_cloud_flags[@]}")
     fi
@@ -1837,9 +1810,11 @@ clean_project_artifacts() {
     # Interactive selection (only if terminal is available)
     PURGE_SELECTION_RESULT=""
     PURGE_CATEGORY_FULL_PATHS_ARRAY=("${item_display_paths[@]}")
+    PURGE_CATEGORY_PROJECT_IDS_ARRAY=("${item_project_identities[@]}")
     if [[ -t 0 ]]; then
         if ! select_purge_categories "${menu_options[@]}"; then
             PURGE_CATEGORY_FULL_PATHS_ARRAY=()
+            PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
             unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
             PURGE_RUN_OUTCOME="cancelled"
             return 0
@@ -1869,6 +1844,7 @@ clean_project_artifacts() {
         echo -e "${GRAY}No items selected${NC}"
         printf '\n'
         PURGE_CATEGORY_FULL_PATHS_ARRAY=()
+        PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
         unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
         PURGE_RUN_OUTCOME="cancelled"
         return 0
@@ -1896,12 +1872,14 @@ clean_project_artifacts() {
             echo -e "${GRAY}Purge cancelled${NC}"
             printf '\n'
             PURGE_CATEGORY_FULL_PATHS_ARRAY=()
+            PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
             unset PURGE_CATEGORY_SIZES PURGE_RECENT_CATEGORIES PURGE_AGE_LABELS PURGE_SELECTION_RESULT
             PURGE_RUN_OUTCOME="cancelled"
             return 0
         fi
     fi
     PURGE_CATEGORY_FULL_PATHS_ARRAY=()
+    PURGE_CATEGORY_PROJECT_IDS_ARRAY=()
 
     # Clean selected items
     echo ""

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -1769,22 +1769,58 @@ clean_project_artifacts() {
         menu_options+=("$(format_purge_display "${raw_project_paths[idx]}" "${raw_artifact_types[idx]}" "$size_human_val" "$terminal_width" "$max_path_display_width" "$max_artifact_width")")
     done
 
-    # Sort by size descending (largest first) - requested in issue #311
-    # Use external sort for better performance with many items
+    # Keep every exact project together. Project groups are ordered by their
+    # aggregate known size, then artifacts within each group by item size. Only
+    # numeric local indices cross the sort boundary; canonical path identities
+    # remain in their aligned shell arrays.
     if [[ ${#item_sizes[@]} -gt 0 ]]; then
-        # Create temporary file with index|size pairs
-        local sort_temp
-        sort_temp=$(mktemp)
+        local -a group_project_identities=()
+        local -a group_total_sizes=()
+        local -a item_group_indices=()
+        local group_index existing_group_index
         for ((i = 0; i < ${#item_sizes[@]}; i++)); do
-            printf '%d|%d\n' "$i" "${item_sizes[i]}"
-        done > "$sort_temp"
+            group_index=-1
+            for ((existing_group_index = 0; existing_group_index < ${#group_project_identities[@]}; existing_group_index++)); do
+                if [[ "${group_project_identities[existing_group_index]}" == "${item_project_identities[i]}" ]]; then
+                    group_index=$existing_group_index
+                    break
+                fi
+            done
+            if [[ $group_index -lt 0 ]]; then
+                group_index=${#group_project_identities[@]}
+                group_project_identities+=("${item_project_identities[i]}")
+                group_total_sizes+=(0)
+            fi
+            item_group_indices+=("$group_index")
+            group_total_sizes[group_index]=$((group_total_sizes[group_index] + item_sizes[i]))
+        done
 
-        # Sort by size (field 2) descending, extract indices
+        local group_sort_temp
+        group_sort_temp=$(mktemp)
+        for ((group_index = 0; group_index < ${#group_project_identities[@]}; group_index++)); do
+            printf '%d|%d\n' "$group_index" "${group_total_sizes[group_index]}"
+        done > "$group_sort_temp"
+
+        local -a group_ranks=()
+        local group_rank=0
+        while IFS='|' read -r group_index group_total_size; do
+            group_ranks[group_index]=$group_rank
+            group_rank=$((group_rank + 1))
+        done < <(sort -t'|' -k2,2nr -k1,1n "$group_sort_temp")
+        rm -f "$group_sort_temp"
+
+        local item_sort_temp
+        item_sort_temp=$(mktemp)
+        for ((i = 0; i < ${#item_sizes[@]}; i++)); do
+            group_index=${item_group_indices[i]}
+            printf '%d|%d|%d\n' "${group_ranks[group_index]}" "${item_sizes[i]}" "$i"
+        done > "$item_sort_temp"
+
         local -a sorted_indices=()
-        while IFS='|' read -r idx size; do
+        while IFS='|' read -r group_rank size idx; do
             sorted_indices+=("$idx")
-        done < <(sort -t'|' -k2,2nr "$sort_temp")
-        rm -f "$sort_temp"
+        done < <(sort -t'|' -k1,1n -k2,2nr -k3,3n "$item_sort_temp")
+        rm -f "$item_sort_temp"
 
         # Rebuild arrays in sorted order
         local -a sorted_menu_options=()

--- a/lib/clean/purge_shared.sh
+++ b/lib/clean/purge_shared.sh
@@ -77,6 +77,10 @@ readonly MOLE_PURGE_MONOREPO_INDICATORS=(
     "pnpm-workspace.yaml"
     "nx.json"
     "rush.json"
+    # A repository or worktree is the project-wide ownership boundary even
+    # when nested packages have their own manifests. Keep .git in the project
+    # indicators too because container discovery consumes that list directly.
+    ".git"
 )
 
 readonly MOLE_PURGE_PROJECT_INDICATORS=(

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1975,6 +1975,55 @@ SCRIPT
 	[[ "$path1" == *"alpha"* ]]
 }
 
+@test "sort: project groups use aggregate size before artifact size" {
+	mkdir -p "$HOME/www/alpha/node_modules" "$HOME/www/alpha/.venv"
+	mkdir -p "$HOME/www/beta/node_modules"
+	echo '{}' > "$HOME/www/alpha/package.json"
+	echo '{}' > "$HOME/www/beta/package.json"
+	dd if=/dev/zero of="$HOME/www/alpha/node_modules/data" bs=1024 count=130 2>/dev/null
+	dd if=/dev/zero of="$HOME/www/alpha/.venv/data" bs=1024 count=110 2>/dev/null
+	dd if=/dev/zero of="$HOME/www/beta/node_modules/data" bs=1024 count=200 2>/dev/null
+
+	local capture_file script_file
+	capture_file=$(mktemp "$HOME/group_sort_capture.XXXXXX")
+	script_file=$(mktemp "$HOME/group_sort_script.XXXXXX.sh")
+
+	cat > "$script_file" << SCRIPT
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+mkdir -p "$HOME/.cache/mole"
+export XDG_CACHE_HOME="$HOME/.cache"
+export TERM="dumb"
+PURGE_SEARCH_PATHS=("$HOME/www")
+
+select_purge_categories() {
+	local i=0
+	for path in "\${PURGE_CATEGORY_FULL_PATHS_ARRAY[@]}"; do
+		echo "PATH[\$i]=\$path" >> "$capture_file"
+		i=\$((i + 1))
+	done
+	PURGE_SELECTION_RESULT=""
+	return 1
+}
+
+clean_project_artifacts 2>/dev/null || true
+SCRIPT
+
+	_run_in_pty "$script_file"
+	rm -f "$script_file"
+
+	[ "$(grep -c '^PATH\[' "$capture_file")" -eq 3 ]
+	local path0 path1 path2
+	path0=$(grep '^PATH\[0\]=' "$capture_file" | cut -d= -f2-)
+	path1=$(grep '^PATH\[1\]=' "$capture_file" | cut -d= -f2-)
+	path2=$(grep '^PATH\[2\]=' "$capture_file" | cut -d= -f2-)
+	rm -f "$capture_file"
+
+	[[ "$path0" == *"alpha/node_modules"* ]] || return 1
+	[[ "$path1" == *"alpha/.venv"* ]] || return 1
+	[[ "$path2" == *"beta/node_modules"* ]]
+}
+
 @test "sort: cloud marker stays aligned across menu and full-path arrays" {
 	mkdir -p "$HOME/www/local-project/node_modules"
 	mkdir -p "$HOME/Library/CloudStorage/TestProvider/cloud-project/node_modules"

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -200,6 +200,23 @@ EOF
 	[[ "$output" == \~/www/app/node_modules ]]
 }
 
+@test "find_purge_project_root_for_artifact prefers the owning monorepo" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+artifact="$HOME/www/obelisk/apps/web/node_modules"
+mkdir -p "$artifact"
+touch "$HOME/www/obelisk/pnpm-workspace.yaml"
+touch "$HOME/www/obelisk/apps/web/package.json"
+
+find_purge_project_root_for_artifact "$artifact"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[ "$output" = "$HOME/www/obelisk" ]
+}
+
 @test "filter_nested_artifacts: removes nested node_modules" {
 	mkdir -p "$HOME/www/project/node_modules/package/node_modules"
 
@@ -1801,6 +1818,11 @@ select_purge_categories() {
 		echo "PATH[\$i]=\$p" >> "$capture_file"
 		i=\$((i + 1))
 	done
+	i=0
+	for project_id in "\${PURGE_CATEGORY_PROJECT_IDS_ARRAY[@]}"; do
+		echo "PROJECT_ID[\$i]=\$project_id" >> "$capture_file"
+		i=\$((i + 1))
+	done
 	PURGE_SELECTION_RESULT=""
 	return 1
 }
@@ -1820,10 +1842,12 @@ SCRIPT
 	sizes_csv=$(grep '^SIZES=' "$capture_file" | cut -d= -f2-)
 	IFS=',' read -r -a sizes <<< "$sizes_csv"
 
-	local path0 path1
+	local path0 path1 project_id0 expected_project_id0
 	path0=$(grep '^PATH\[0\]=' "$capture_file" | head -1 | cut -d= -f2-)
 	path1=$(grep '^PATH\[1\]=' "$capture_file" | head -1 | cut -d= -f2-)
+	project_id0=$(grep '^PROJECT_ID\[0\]=' "$capture_file" | head -1 | cut -d= -f2-)
 	rm -f "$capture_file"
+	expected_project_id0=$(/bin/bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; mole_path_identity '$HOME/www/beta'")
 
 	# PURGE_CATEGORY_SIZES must be sorted descending (largest first).
 	[ "${sizes[0]}" -gt "${sizes[1]}" ]
@@ -1831,6 +1855,7 @@ SCRIPT
 	# Index 0 → largest artifact → beta's path.
 	# With the bug path0 = alpha (discovery order) → [[ ... == *beta* ]] fails.
 	[[ "$path0" == *"beta"* ]] || return 1
+	[ "$project_id0" = "$expected_project_id0" ] || return 1
 
 	# Index 1 → smaller artifact → alpha's path.
 	[[ "$path1" == *"alpha"* ]]

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -857,6 +857,84 @@ EOF
 	[ "$status" -eq 0 ]
 }
 
+@test "scan_purge_targets: discards a failed find target scan prefix" {
+	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules"
+	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"
+
+	local mock_bin="$HOME/mock-find-target-failure"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/find" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$HOME/www/test-project/node_modules"
+exit 7
+EOF
+	chmod +x "$mock_bin/find"
+
+	local scan_output
+	scan_output="$(mktemp)"
+
+	run env HOME="$HOME" PATH="$mock_bin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" SCAN_OUTPUT="$scan_output" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+scan_status=0
+MO_USE_FIND=1 scan_purge_targets "$HOME/www" "$SCAN_OUTPUT" || scan_status=$?
+printf 'STATUS=%s\n' "$scan_status"
+[[ ! -s "$SCAN_OUTPUT" ]] || exit 1
+EOF
+
+	rm -f "$scan_output"
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"STATUS=7"* ]] || return 1
+}
+
+@test "scan_purge_targets: discards target results when the tag scan fails" {
+	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules"
+	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"
+
+	local mock_bin="$HOME/mock-find-tag-failure"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/find" <<'EOF'
+#!/bin/bash
+result_type=""
+while [[ $# -gt 0 ]]; do
+	if [[ "$1" == "-type" && $# -gt 1 ]]; then
+		result_type="$2"
+		break
+	fi
+	shift
+done
+
+if [[ "$result_type" == "d" ]]; then
+	printf '%s\n' "$HOME/www/test-project/node_modules"
+	exit 0
+fi
+
+printf '%s\n' "$HOME/www/test-project/.cache/CACHEDIR.TAG"
+exit 9
+EOF
+	chmod +x "$mock_bin/find"
+
+	local scan_output
+	scan_output="$(mktemp)"
+
+	run env HOME="$HOME" PATH="$mock_bin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" SCAN_OUTPUT="$scan_output" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+scan_status=0
+MO_USE_FIND=1 scan_purge_targets "$HOME/www" "$SCAN_OUTPUT" || scan_status=$?
+printf 'STATUS=%s\n' "$scan_status"
+[[ ! -s "$SCAN_OUTPUT" ]] || exit 1
+EOF
+
+	rm -f "$scan_output"
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"STATUS=9"* ]] || return 1
+}
+
 @test "is_recently_modified: detects recent projects" {
 	mkdir -p "$HOME/www/project/node_modules"
 	touch "$HOME/www/project/package.json"

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1310,7 +1310,8 @@ EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
-	[[ "$output" == *"~/dev (status "* ]] || return 1
+	[[ "$output" == *"~/dev"* ]] || return 1
+	[[ "$output" == *"(status 7)"* ]] || return 1
 	[[ "$output" == *"REMOVE:$HOME/www/good-project/node_modules"* ]] || return 1
 	[[ "$output" != *"REMOVE:$HOME/dev/failed-project/node_modules"* ]] || return 1
 }
@@ -1389,7 +1390,8 @@ EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
-	[[ "$output" == *"~/www (status "* ]] || return 1
+	[[ "$output" == *"~/www"* ]] || return 1
+	[[ "$output" == *"(status 7)"* ]] || return 1
 	[[ "$output" == *"PURGE_OUTCOME=scan_failed"* ]] || return 1
 	[[ "$output" != *"Great! No old project artifacts to clean"* ]] || return 1
 	[[ "$output" != *"UNEXPECTED_REMOVE:"* ]] || return 1

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1265,6 +1265,52 @@ EOF
 	[[ "$output" != *"REMOVE:$HOME/dev/failed-project/node_modules"* ]] || return 1
 }
 
+@test "clean_project_artifacts: bounds concurrent root scans" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+first_root="$HOME/www"
+second_root="$HOME/dev"
+first_artifact="$first_root/first-project/node_modules"
+second_artifact="$second_root/second-project/node_modules"
+scan_lock="$HOME/scan-active"
+mkdir -p "$first_artifact" "$second_artifact" "$HOME/.cache/mole"
+touch "$first_root/first-project/package.json" "$second_root/second-project/package.json"
+
+PURGE_SEARCH_PATHS=("$first_root" "$second_root")
+get_optimal_parallel_jobs() { echo 1; }
+scan_purge_targets() {
+	if ! mkdir "$scan_lock" 2>/dev/null; then
+		printf 'OVERLAPPING_SCAN\n'
+		return 7
+	fi
+	if [[ "$1" == "$first_root" ]]; then
+		printf '%s\n' "$first_artifact" > "$2"
+	else
+		printf '%s\n' "$second_artifact" > "$2"
+	fi
+	sleep 0.05
+	rmdir "$scan_lock"
+}
+get_dir_size_kb() { echo 4; }
+is_recently_modified() {
+	_PURGE_ACTIVITY_STATE=old
+	return 1
+}
+purge_target_activity_still_safe() { return 0; }
+safe_remove() { return 0; }
+
+export MOLE_DRY_RUN=1
+clean_project_artifacts </dev/null
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" != *"OVERLAPPING_SCAN"* ]] || return 1
+	[[ "$output" != *"Skipped 1 project scan root"* ]]
+}
+
 @test "clean_project_artifacts: refuses when every configured root scan fails" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1152,9 +1152,11 @@ EOF
         source '$PROJECT_ROOT/lib/core/common.sh'
         source '$PROJECT_ROOT/lib/clean/project.sh'
         clean_project_artifacts
+        printf 'PURGE_OUTCOME=%s\n' "\$PURGE_RUN_OUTCOME"
     " </dev/null
 
-	[[ "$status" -eq 0 ]] || [[ "$status" -eq 2 ]]
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"PURGE_OUTCOME=no_candidates"* ]]
 }
 
 @test "clean_project_artifacts: keeps completed roots and reports failed roots" {
@@ -1222,17 +1224,53 @@ safe_remove() {
 	return 1
 }
 
-purge_status=0
-clean_project_artifacts </dev/null || purge_status=$?
-printf 'PURGE_STATUS=%s\n' "$purge_status"
+clean_project_artifacts </dev/null
+printf 'PURGE_OUTCOME=%s\n' "$PURGE_RUN_OUTCOME"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
 	[[ "$output" == *"~/www (status 7)"* ]] || return 1
-	[[ "$output" == *"PURGE_STATUS=3"* ]] || return 1
+	[[ "$output" == *"PURGE_OUTCOME=scan_failed"* ]] || return 1
 	[[ "$output" != *"Great! No old project artifacts to clean"* ]] || return 1
 	[[ "$output" != *"UNEXPECTED_REMOVE:"* ]] || return 1
+}
+
+@test "perform_purge: suppresses completion summary for non-completed outcomes" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_SKIP_MAIN=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/purge.sh"
+
+clean_project_artifacts() {
+	PURGE_RUN_OUTCOME="cancelled"
+	return 0
+}
+print_summary_block() {
+	printf 'UNEXPECTED_SUMMARY\n'
+}
+
+perform_purge </dev/null
+printf 'PERFORM_RETURNED\n'
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"PERFORM_RETURNED"* ]] || return 1
+	[[ "$output" != *"UNEXPECTED_SUMMARY"* ]] || return 1
+}
+
+@test "perform_purge: preserves errexit for unexpected cleanup failures" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_SKIP_MAIN=1 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/purge.sh"
+
+clean_project_artifacts() { return 7; }
+
+perform_purge </dev/null
+printf 'UNEXPECTED_CONTINUATION\n'
+EOF
+
+	[ "$status" -eq 7 ] || return 1
+	[[ "$output" != *"UNEXPECTED_CONTINUATION"* ]]
 }
 
 @test "clean_project_artifacts: handles empty menu options under set -u" {
@@ -1471,13 +1509,15 @@ EOF
 
 	run /bin/bash -c "
         export HOME='$HOME'
-        $timeout_cmd 5 '$PROJECT_ROOT/bin/purge.sh' 2>&1 < /dev/null || true
+        exec $timeout_cmd 5 '$PROJECT_ROOT/bin/purge.sh' 2>&1 < /dev/null
     "
 
-	[[ "$output" =~ "Scanning" ]] ||
-		[[ "$output" =~ "Purge complete" ]] ||
-		[[ "$output" =~ "No old" ]] ||
-		[[ "$output" =~ "Great" ]]
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"Purge Project Artifacts"* ]] || return 1
+	[[ "$output" == *"No items selected"* ]] ||
+		[[ "$output" == *"Purge complete"* ]] ||
+		[[ "$output" == *"No old"* ]] ||
+		[[ "$output" == *"Great"* ]]
 }
 
 @test "mo purge: command exists and is executable" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1209,13 +1209,13 @@ EOF
 }
 
 @test "clean_project_artifacts: handles empty directory gracefully" {
-	run /bin/bash -c "
-        export HOME='$HOME'
-        source '$PROJECT_ROOT/lib/core/common.sh'
-        source '$PROJECT_ROOT/lib/clean/project.sh'
-        clean_project_artifacts
-        printf 'PURGE_OUTCOME=%s\n' "\$PURGE_RUN_OUTCOME"
-    " </dev/null
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+clean_project_artifacts </dev/null
+printf 'PURGE_OUTCOME=%s\n' "$PURGE_RUN_OUTCOME"
+EOF
 
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"PURGE_OUTCOME=no_candidates"* ]]

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -2117,18 +2117,19 @@ SCRIPT
 	rm -f "$script_file"
 
 	[ "$(grep -c '^PROJECT_ID\[' "$capture_file")" -eq 2 ] || return 1
-	local project_id0 project_id1 project_path0 project_path1 expected_project_id
+	local project_id0 project_id1 project_path0 project_path1 expected_project_id expected_project_path
 	project_id0=$(grep '^PROJECT_ID\[0\]=' "$capture_file" | cut -d= -f2-)
 	project_id1=$(grep '^PROJECT_ID\[1\]=' "$capture_file" | cut -d= -f2-)
 	project_path0=$(grep '^PROJECT_PATH\[0\]=' "$capture_file" | cut -d= -f2-)
 	project_path1=$(grep '^PROJECT_PATH\[1\]=' "$capture_file" | cut -d= -f2-)
 	rm -f "$capture_file"
 	expected_project_id=$(/bin/bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; mole_path_identity '$HOME/www/unmarked'")
+	printf -v expected_project_path '~%s' '/www/unmarked'
 
 	[ "$project_id0" = "$expected_project_id" ] || return 1
 	[ "$project_id1" = "$expected_project_id" ] || return 1
-	[ "$project_path0" = "~/www/unmarked" ] || return 1
-	[ "$project_path1" = "~/www/unmarked" ] || return 1
+	[ "$project_path0" = "$expected_project_path" ] || return 1
+	[ "$project_path1" = "$expected_project_path" ] || return 1
 }
 
 @test "sort: cloud marker stays aligned across menu and full-path arrays" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1235,6 +1235,7 @@ mkdir -p "$good_artifact" "$failed_artifact" "$HOME/.cache/mole"
 touch "$good_root/good-project/package.json" "$failed_root/failed-project/package.json"
 
 PURGE_SEARCH_PATHS=("$good_root" "$failed_root")
+get_optimal_parallel_jobs() { echo 1; }
 scan_purge_targets() {
 	if [[ "$1" == "$good_root" ]]; then
 		printf '%s\n' "$good_artifact" > "$2"
@@ -1260,7 +1261,7 @@ EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
-	[[ "$output" == *"~/dev (status 7)"* ]] || return 1
+	[[ "$output" == *"~/dev (status "* ]] || return 1
 	[[ "$output" == *"REMOVE:$HOME/www/good-project/node_modules"* ]] || return 1
 	[[ "$output" != *"REMOVE:$HOME/dev/failed-project/node_modules"* ]] || return 1
 }
@@ -1323,6 +1324,7 @@ mkdir -p "$failed_artifact" "$HOME/.cache/mole"
 touch "$failed_root/failed-project/package.json"
 
 PURGE_SEARCH_PATHS=("$failed_root")
+get_optimal_parallel_jobs() { echo 1; }
 scan_purge_targets() {
 	printf '%s\n' "$failed_artifact" > "$2"
 	return 7
@@ -1338,7 +1340,7 @@ EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
-	[[ "$output" == *"~/www (status 7)"* ]] || return 1
+	[[ "$output" == *"~/www (status "* ]] || return 1
 	[[ "$output" == *"PURGE_OUTCOME=scan_failed"* ]] || return 1
 	[[ "$output" != *"Great! No old project artifacts to clean"* ]] || return 1
 	[[ "$output" != *"UNEXPECTED_REMOVE:"* ]] || return 1

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -2043,7 +2043,7 @@ select_purge_categories() {
 	return 1
 }
 
-clean_project_artifacts 2>/dev/null || true
+clean_project_artifacts 2>/dev/null
 SCRIPT
 
 	_run_in_pty "$script_file"
@@ -2059,6 +2059,59 @@ SCRIPT
 	[[ "$path0" == *"alpha/node_modules"* ]] || return 1
 	[[ "$path1" == *"alpha/.venv"* ]] || return 1
 	[[ "$path2" == *"beta/node_modules"* ]] || return 1
+}
+
+@test "grouping: indicator-less sibling artifacts share their exact parent" {
+	mkdir -p "$HOME/www/unmarked/node_modules" "$HOME/www/unmarked/dist"
+	dd if=/dev/zero of="$HOME/www/unmarked/node_modules/data" bs=1024 count=5 2>/dev/null
+	dd if=/dev/zero of="$HOME/www/unmarked/dist/data" bs=1024 count=4 2>/dev/null
+
+	local capture_file script_file
+	capture_file=$(mktemp "$HOME/fallback_group_capture.XXXXXX")
+	script_file=$(mktemp "$HOME/fallback_group_script.XXXXXX.sh")
+
+	cat > "$script_file" << SCRIPT
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+mkdir -p "$HOME/.cache/mole"
+export XDG_CACHE_HOME="$HOME/.cache"
+export TERM="dumb"
+PURGE_SEARCH_PATHS=("$HOME/www")
+
+select_purge_categories() {
+	local i=0
+	for project_id in "\${PURGE_CATEGORY_PROJECT_IDS_ARRAY[@]}"; do
+		echo "PROJECT_ID[\$i]=\$project_id" >> "$capture_file"
+		i=\$((i + 1))
+	done
+	i=0
+	for project_path in "\${PURGE_CATEGORY_PROJECT_PATHS_ARRAY[@]}"; do
+		echo "PROJECT_PATH[\$i]=\$project_path" >> "$capture_file"
+		i=\$((i + 1))
+	done
+	PURGE_SELECTION_RESULT=""
+	return 1
+}
+
+clean_project_artifacts 2>/dev/null
+SCRIPT
+
+	_run_in_pty "$script_file"
+	rm -f "$script_file"
+
+	[ "$(grep -c '^PROJECT_ID\[' "$capture_file")" -eq 2 ] || return 1
+	local project_id0 project_id1 project_path0 project_path1 expected_project_id
+	project_id0=$(grep '^PROJECT_ID\[0\]=' "$capture_file" | cut -d= -f2-)
+	project_id1=$(grep '^PROJECT_ID\[1\]=' "$capture_file" | cut -d= -f2-)
+	project_path0=$(grep '^PROJECT_PATH\[0\]=' "$capture_file" | cut -d= -f2-)
+	project_path1=$(grep '^PROJECT_PATH\[1\]=' "$capture_file" | cut -d= -f2-)
+	rm -f "$capture_file"
+	expected_project_id=$(/bin/bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; mole_path_identity '$HOME/www/unmarked'")
+
+	[ "$project_id0" = "$expected_project_id" ] || return 1
+	[ "$project_id1" = "$expected_project_id" ] || return 1
+	[ "$project_path0" = "~/www/unmarked" ] || return 1
+	[ "$project_path1" = "~/www/unmarked" ] || return 1
 }
 
 @test "sort: cloud marker stays aligned across menu and full-path arrays" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -214,7 +214,7 @@ find_purge_project_root_for_artifact "$artifact"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
-	[ "$output" = "$HOME/www/obelisk" ]
+	[ "$output" = "$HOME/www/obelisk" ] || return 1
 }
 
 @test "filter_nested_artifacts: removes nested node_modules" {
@@ -517,7 +517,7 @@ EOF
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"Select Artifacts to Purge"* ]] || return 1
 	[[ "$output" == *"X Skip"* ]] || return 1
-	[[ "$output" != *"Select Categories to Clean"* ]]
+	[[ "$output" != *"Select Categories to Clean"* ]] || return 1
 }
 
 @test "select_purge_categories shows exact project boundaries and selection feedback" {
@@ -545,7 +545,7 @@ EOF
 	[[ "$output" == *"─ B target"* ]] || return 1
 	[[ "$output" == *"~/work/obelisk · 154KB · 2/2 selected"* ]] || return 1
 	[[ "$output" == *"~/work/obelisk · 154KB · 0/2 selected"* ]] || return 1
-	[[ "$output" == *"RESULT=2"* ]]
+	[[ "$output" == *"RESULT=2"* ]] || return 1
 }
 
 @test "select_purge_categories skips every artifact with the current project ID" {
@@ -560,7 +560,7 @@ printf 'RESULT=%s\n' "$PURGE_SELECTION_RESULT"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
-	[[ "$output" == *"RESULT=2"* ]]
+	[[ "$output" == *"RESULT=2"* ]] || return 1
 }
 
 @test "select_purge_categories skips only the current row without a project ID" {
@@ -575,7 +575,7 @@ printf 'RESULT=%s\n' "$PURGE_SELECTION_RESULT"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
-	[[ "$output" == *"RESULT=1"* ]]
+	[[ "$output" == *"RESULT=1"* ]] || return 1
 }
 
 @test "select_purge_categories does not group same-named projects" {
@@ -590,7 +590,7 @@ printf 'RESULT=%s\n' "$PURGE_SELECTION_RESULT"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
-	[[ "$output" == *"RESULT=1"* ]]
+	[[ "$output" == *"RESULT=1"* ]] || return 1
 }
 
 @test "confirm_purge_cleanup accepts Enter" {
@@ -1266,8 +1266,8 @@ clean_project_artifacts </dev/null
 printf 'PURGE_OUTCOME=%s\n' "$PURGE_RUN_OUTCOME"
 EOF
 
-	[ "$status" -eq 0 ]
-	[[ "$output" == *"PURGE_OUTCOME=no_candidates"* ]]
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"PURGE_OUTCOME=no_candidates"* ]] || return 1
 }
 
 @test "clean_project_artifacts: keeps completed roots and reports failed roots" {
@@ -1359,7 +1359,7 @@ EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" != *"OVERLAPPING_SCAN"* ]] || return 1
-	[[ "$output" != *"Skipped 1 project scan root"* ]]
+	[[ "$output" != *"Skipped 1 project scan root"* ]] || return 1
 }
 
 @test "clean_project_artifacts: refuses when every configured root scan fails" {
@@ -1431,7 +1431,7 @@ printf 'UNEXPECTED_CONTINUATION\n'
 EOF
 
 	[ "$status" -eq 7 ] || return 1
-	[[ "$output" != *"UNEXPECTED_CONTINUATION"* ]]
+	[[ "$output" != *"UNEXPECTED_CONTINUATION"* ]] || return 1
 }
 
 @test "clean_project_artifacts: handles empty menu options under set -u" {
@@ -1678,7 +1678,7 @@ EOF
 	[[ "$output" == *"No items selected"* ]] ||
 		[[ "$output" == *"Purge complete"* ]] ||
 		[[ "$output" == *"No old"* ]] ||
-		[[ "$output" == *"Great"* ]]
+		[[ "$output" == *"Great"* ]] || return 1
 }
 
 @test "mo purge: command exists and is executable" {
@@ -2049,7 +2049,7 @@ SCRIPT
 	_run_in_pty "$script_file"
 	rm -f "$script_file"
 
-	[ "$(grep -c '^PATH\[' "$capture_file")" -eq 3 ]
+	[ "$(grep -c '^PATH\[' "$capture_file")" -eq 3 ] || return 1
 	local path0 path1 path2
 	path0=$(grep '^PATH\[0\]=' "$capture_file" | cut -d= -f2-)
 	path1=$(grep '^PATH\[1\]=' "$capture_file" | cut -d= -f2-)
@@ -2058,7 +2058,7 @@ SCRIPT
 
 	[[ "$path0" == *"alpha/node_modules"* ]] || return 1
 	[[ "$path1" == *"alpha/.venv"* ]] || return 1
-	[[ "$path2" == *"beta/node_modules"* ]]
+	[[ "$path2" == *"beta/node_modules"* ]] || return 1
 }
 
 @test "sort: cloud marker stays aligned across menu and full-path arrays" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1157,6 +1157,84 @@ EOF
 	[[ "$status" -eq 0 ]] || [[ "$status" -eq 2 ]]
 }
 
+@test "clean_project_artifacts: keeps completed roots and reports failed roots" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+good_root="$HOME/www"
+failed_root="$HOME/dev"
+good_artifact="$good_root/good-project/node_modules"
+failed_artifact="$failed_root/failed-project/node_modules"
+mkdir -p "$good_artifact" "$failed_artifact" "$HOME/.cache/mole"
+touch "$good_root/good-project/package.json" "$failed_root/failed-project/package.json"
+
+PURGE_SEARCH_PATHS=("$good_root" "$failed_root")
+scan_purge_targets() {
+	if [[ "$1" == "$good_root" ]]; then
+		printf '%s\n' "$good_artifact" > "$2"
+		return 0
+	fi
+	printf '%s\n' "$failed_artifact" > "$2"
+	return 7
+}
+get_dir_size_kb() { echo 4; }
+is_recently_modified() {
+	_PURGE_ACTIVITY_STATE=old
+	return 1
+}
+purge_target_activity_still_safe() { return 0; }
+safe_remove() {
+	printf 'REMOVE:%s\n' "$1"
+	return 0
+}
+
+export MOLE_DRY_RUN=1
+clean_project_artifacts </dev/null
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
+	[[ "$output" == *"~/dev (status 7)"* ]] || return 1
+	[[ "$output" == *"REMOVE:$HOME/www/good-project/node_modules"* ]] || return 1
+	[[ "$output" != *"REMOVE:$HOME/dev/failed-project/node_modules"* ]] || return 1
+}
+
+@test "clean_project_artifacts: refuses when every configured root scan fails" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+failed_root="$HOME/www"
+failed_artifact="$failed_root/failed-project/node_modules"
+mkdir -p "$failed_artifact" "$HOME/.cache/mole"
+touch "$failed_root/failed-project/package.json"
+
+PURGE_SEARCH_PATHS=("$failed_root")
+scan_purge_targets() {
+	printf '%s\n' "$failed_artifact" > "$2"
+	return 7
+}
+safe_remove() {
+	printf 'UNEXPECTED_REMOVE:%s\n' "$1"
+	return 1
+}
+
+purge_status=0
+clean_project_artifacts </dev/null || purge_status=$?
+printf 'PURGE_STATUS=%s\n' "$purge_status"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
+	[[ "$output" == *"~/www (status 7)"* ]] || return 1
+	[[ "$output" == *"PURGE_STATUS=3"* ]] || return 1
+	[[ "$output" != *"Great! No old project artifacts to clean"* ]] || return 1
+	[[ "$output" != *"UNEXPECTED_REMOVE:"* ]] || return 1
+}
+
 @test "clean_project_artifacts: handles empty menu options under set -u" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -499,6 +499,51 @@ EOF
     [[ "$output" == *"PASS"* ]]
 }
 
+@test "select_purge_categories skips every artifact with the current project ID" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+PURGE_CATEGORY_SIZES="1,2,3"
+PURGE_CATEGORY_PROJECT_IDS_ARRAY=("project-a" "project-a" "project-b")
+select_purge_categories "A node_modules" "A dist" "B target" <<< $'x\n' > /dev/null
+printf 'RESULT=%s\n' "$PURGE_SELECTION_RESULT"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"RESULT=2"* ]]
+}
+
+@test "select_purge_categories skips only the current row without a project ID" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+PURGE_CATEGORY_SIZES="1,2"
+PURGE_CATEGORY_PROJECT_IDS_ARRAY=("" "project-a")
+select_purge_categories "Unknown node_modules" "A dist" <<< $'x\n' > /dev/null
+printf 'RESULT=%s\n' "$PURGE_SELECTION_RESULT"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"RESULT=1"* ]]
+}
+
+@test "select_purge_categories does not group same-named projects" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+PURGE_CATEGORY_SIZES="1,2"
+PURGE_CATEGORY_PROJECT_IDS_ARRAY=("inode:1:10" "inode:1:20")
+select_purge_categories "~/client-a/obelisk node_modules" "~/client-b/obelisk dist" <<< $'x\n' > /dev/null
+printf 'RESULT=%s\n' "$PURGE_SELECTION_RESULT"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"RESULT=1"* ]]
+}
+
 @test "confirm_purge_cleanup accepts Enter" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -520,6 +520,34 @@ EOF
 	[[ "$output" != *"Select Categories to Clean"* ]]
 }
 
+@test "select_purge_categories shows exact project boundaries and selection feedback" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+tput() {
+	case "${1:-}" in
+		cols) printf '100\n' ;;
+		lines) printf '24\n' ;;
+	esac
+}
+PURGE_CATEGORY_SIZES="100,50,25"
+PURGE_CATEGORY_PROJECT_IDS_ARRAY=("project-a" "project-a" "project-b")
+PURGE_CATEGORY_PROJECT_PATHS_ARRAY=("~/work/obelisk" "~/work/obelisk" "~/work/atlas")
+PURGE_CATEGORY_SIZE_UNKNOWN_FLAGS_ARRAY=("false" "false" "false")
+select_purge_categories "A node_modules" "A dist" "B target" <<< $'x\n'
+printf 'RESULT=%s\n' "$PURGE_SELECTION_RESULT"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"┌ A node_modules"* ]] || return 1
+	[[ "$output" == *"└ A dist"* ]] || return 1
+	[[ "$output" == *"─ B target"* ]] || return 1
+	[[ "$output" == *"~/work/obelisk · 154KB · 2/2 selected"* ]] || return 1
+	[[ "$output" == *"~/work/obelisk · 154KB · 0/2 selected"* ]] || return 1
+	[[ "$output" == *"RESULT=2"* ]]
+}
+
 @test "select_purge_categories skips every artifact with the current project ID" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -1937,6 +1965,11 @@ select_purge_categories() {
 		echo "PROJECT_ID[\$i]=\$project_id" >> "$capture_file"
 		i=\$((i + 1))
 	done
+	i=0
+	for project_path in "\${PURGE_CATEGORY_PROJECT_PATHS_ARRAY[@]}"; do
+		echo "PROJECT_PATH[\$i]=\$project_path" >> "$capture_file"
+		i=\$((i + 1))
+	done
 	PURGE_SELECTION_RESULT=""
 	return 1
 }
@@ -1956,10 +1989,11 @@ SCRIPT
 	sizes_csv=$(grep '^SIZES=' "$capture_file" | cut -d= -f2-)
 	IFS=',' read -r -a sizes <<< "$sizes_csv"
 
-	local path0 path1 project_id0 expected_project_id0
+	local path0 path1 project_id0 project_path0 expected_project_id0
 	path0=$(grep '^PATH\[0\]=' "$capture_file" | head -1 | cut -d= -f2-)
 	path1=$(grep '^PATH\[1\]=' "$capture_file" | head -1 | cut -d= -f2-)
 	project_id0=$(grep '^PROJECT_ID\[0\]=' "$capture_file" | head -1 | cut -d= -f2-)
+	project_path0=$(grep '^PROJECT_PATH\[0\]=' "$capture_file" | head -1 | cut -d= -f2-)
 	rm -f "$capture_file"
 	expected_project_id0=$(/bin/bash --noprofile --norc -c "source '$PROJECT_ROOT/lib/core/common.sh'; mole_path_identity '$HOME/www/beta'")
 
@@ -1970,6 +2004,7 @@ SCRIPT
 	# With the bug path0 = alpha (discovery order) → [[ ... == *beta* ]] fails.
 	[[ "$path0" == *"beta"* ]] || return 1
 	[ "$project_id0" = "$expected_project_id0" ] || return 1
+	[[ "$project_path0" == *"beta"* ]] || return 1
 
 	# Index 1 → smaller artifact → alpha's path.
 	[[ "$path1" == *"alpha"* ]]

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -499,6 +499,27 @@ EOF
     [[ "$output" == *"PASS"* ]]
 }
 
+@test "select_purge_categories names the destructive choice and keeps project skip visible when narrow" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+tput() {
+	[[ "${1:-}" == "cols" ]] && printf '32\n'
+}
+PURGE_CATEGORY_SIZES="1"
+PURGE_RECENT_CATEGORIES="false"
+if select_purge_categories "~/work/obelisk 4KB | node_modules" <<< $'q\n'; then
+	exit 1
+fi
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"Select Artifacts to Purge"* ]] || return 1
+	[[ "$output" == *"X Skip"* ]] || return 1
+	[[ "$output" != *"Select Categories to Clean"* ]]
+}
+
 @test "select_purge_categories skips every artifact with the current project ID" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -217,6 +217,23 @@ EOF
 	[ "$output" = "$HOME/www/obelisk" ] || return 1
 }
 
+@test "find_purge_project_root_for_artifact prefers a worktree over its nested package" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+artifact="$HOME/.codex/worktrees/obelisk/apps/web/node_modules"
+mkdir -p "$artifact"
+touch "$HOME/.codex/worktrees/obelisk/.git"
+touch "$HOME/.codex/worktrees/obelisk/apps/web/package.json"
+
+find_purge_project_root_for_artifact "$artifact"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[ "$output" = "$HOME/.codex/worktrees/obelisk" ] || return 1
+}
+
 @test "filter_nested_artifacts: removes nested node_modules" {
 	mkdir -p "$HOME/www/project/node_modules/package/node_modules"
 


### PR DESCRIPTION
Purge currently mixes build artifacts from unrelated projects in one size-sorted list, making it hard to keep an active project without inspecting every row.

This resolves each artifact to one exact physical project root, keeps projects together, and orders groups by aggregate reclaimable size. The selector adds visible group connectors, current-project size and selection context, and X Skip Project. Same-named projects and separate worktrees remain independent.

The supporting reliability changes discard incomplete scan output, report partial root failures, bound concurrent root scans, and preserve non-fatal purge outcomes. No deletion targets, matching rules, flags, settings, caches, or name-based selectors were added. Dry-run, artifact-level selection, full-path confirmation, activity rechecks, and the deletion funnel remain intact.

<img width="748" height="244" alt="Project groups in the purge selector" src="https://github.com/user-attachments/assets/3bb23f21-9953-410e-8c60-d1aebf7366af" />
<img width="748" height="244" alt="Skipping one exact project" src="https://github.com/user-attachments/assets/191136ea-ef49-4ada-b149-c04e0468ca1b" />

Verified with 110 focused purge/config tests, the exact 195-test high-risk CI command, ShellCheck, syntax checks, Go lint, formatting, and the duplication audit.