### PR TITLE
feat(clean): remove leftover cask staging dirs under var/homebrew/tmp

### DIFF
--- a/lib/clean/brew.sh
+++ b/lib/clean/brew.sh
@@ -198,6 +198,71 @@ restore_homebrew_active_links() {
     fi
 }
 
+# Clean leftover cask staging files under var/homebrew/tmp/.caskroom.
+# Homebrew stages cask installs here; an interrupted or failed upgrade (e.g.
+# the app is running, or a .pkg installer needs sudo) leaves the <version>
+# dir and its <version>.staged symlink behind, which can grow to several GB.
+# Runs independently of the 7-day clean_homebrew throttle so leftovers are
+# removed on every clean.
+clean_homebrew_tmp_staged() {
+    command -v brew > /dev/null 2>&1 || return 0
+    # Never race an in-progress cask install.
+    if pgrep -x brew > /dev/null 2>&1; then
+        debug_log "Homebrew cask staging cleanup skipped: brew is running"
+        return 0
+    fi
+
+    local prefix=""
+    prefix=$(HOMEBREW_NO_ENV_HINTS=1 HOMEBREW_NO_AUTO_UPDATE=1 \
+        run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" brew --prefix 2> /dev/null) || return 0
+    [[ -n "$prefix" && -d "$prefix" ]] || return 0
+
+    local staged_root="$prefix/var/homebrew/tmp/.caskroom"
+    [[ -d "$staged_root" ]] || return 0
+
+    if is_path_whitelisted "$staged_root"; then
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Homebrew cask staging · would skip (whitelist)"
+        else
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Homebrew cask staging · skipped (whitelist)"
+        fi
+        note_activity
+        return 0
+    fi
+
+    local removed=0
+    local cask_dir link target resolved
+    for cask_dir in "$staged_root"/*/; do
+        [[ -d "$cask_dir" ]] || continue
+        while IFS= read -r -d '' link; do
+            target=$(readlink "$link" 2> /dev/null) || continue
+            case "$target" in
+                /*) resolved="$target" ;;
+                *) resolved="$(cd "$(dirname "$link")" && pwd)/$target" ;;
+            esac
+            # Only ever remove leftovers inside the staging root.
+            case "$resolved" in
+                "$staged_root"/*) ;;
+                *) continue ;;
+            esac
+            if [[ -e "$resolved" || -L "$resolved" ]]; then
+                safe_remove "$resolved" || true
+            fi
+            safe_remove_symlink "$link" || true
+            removed=$((removed + 1))
+        done < <(find "$cask_dir" -maxdepth 1 -name "*.staged" -type l -print0 2> /dev/null)
+    done
+
+    if [[ $removed -gt 0 ]]; then
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Homebrew cask staging · would remove ${removed} leftover(s)"
+        else
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Homebrew cask staging · removed ${removed} leftover(s)"
+        fi
+        note_activity
+    fi
+}
+
 clean_homebrew() {
     command -v brew > /dev/null 2>&1 || return 0
     local cleanup_timeout="${MOLE_TIMEOUT_PKG_CLEANUP_SEC:-20}"

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -4562,5 +4562,8 @@ clean_developer_tools() {
             fi
         fi
     done
+    # Leftover cask staging files (interrupted/failed upgrades) can grow to
+    # several GB; clean them independently of the 7-day cleanup throttle.
+    _run_developer_cleanup_step clean_homebrew_tmp_staged || return $?
     _run_developer_cleanup_step clean_homebrew || return $?
 }

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -1703,6 +1703,7 @@ stop_section_spinner() { :; }
 clean_sqlite_temp_files() { :; }
 clean_dev_npm() { echo "npm"; }
 clean_homebrew() { echo "brew"; }
+clean_homebrew_tmp_staged() { :; }
 clean_project_caches() { :; }
 clean_dev_python() { :; }
 clean_dev_go() { :; }

--- a/tests/clean_system_maintenance.bats
+++ b/tests/clean_system_maintenance.bats
@@ -2244,3 +2244,64 @@ EOF
     [ "$status" -eq 0 ] || return 1
     [ "$output" -ge 1 ]
 }
+
+@test "clean_homebrew_tmp_staged removes leftover .staged cask staging trees" {
+    run /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/brew.sh"
+
+TEST_BREW_PREFIX="$HOME/homebrew"
+STAGED_ROOT="$TEST_BREW_PREFIX/var/homebrew/tmp/.caskroom"
+mkdir -p "$STAGED_ROOT/docker-desktop/4.86.0,236216/Docker.app/Contents"
+mkdir -p "$STAGED_ROOT/lark/7.72.9,f0c167f0"
+printf 'payload' > "$STAGED_ROOT/docker-desktop/4.86.0,236216/Docker.app/Contents/Info.plist"
+printf 'payload' > "$STAGED_ROOT/lark/7.72.9,f0c167f0/app"
+ln -s "$STAGED_ROOT/docker-desktop/4.86.0,236216" "$STAGED_ROOT/docker-desktop/4.86.0,236216.staged"
+ln -s "$STAGED_ROOT/lark/7.72.9,f0c167f0" "$STAGED_ROOT/lark/7.72.9,f0c167f0.staged"
+
+pgrep() { return 1; }
+run_with_timeout() { shift; "$@"; }
+brew() {
+    case "${1:-}" in
+        --prefix) printf '%s\n' "$TEST_BREW_PREFIX" ;;
+        *) return 0 ;;
+    esac
+}
+
+clean_homebrew_tmp_staged > "$HOME/staged_cleanup.out" 2>&1
+
+[[ ! -e "$STAGED_ROOT/docker-desktop/4.86.0,236216" ]] || { echo "docker target still present" >&2; exit 1; }
+[[ ! -L "$STAGED_ROOT/docker-desktop/4.86.0,236216.staged" ]] || { echo "docker .staged link still present" >&2; exit 1; }
+[[ ! -e "$STAGED_ROOT/lark/7.72.9,f0c167f0" ]] || { echo "lark target still present" >&2; exit 1; }
+[[ ! -L "$STAGED_ROOT/lark/7.72.9,f0c167f0.staged" ]] || { echo "lark .staged link still present" >&2; exit 1; }
+grep -q "Homebrew cask staging · removed 2 leftover(s)" "$HOME/staged_cleanup.out" || { echo "missing summary: $(cat "$HOME/staged_cleanup.out")" >&2; exit 1; }
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "clean_homebrew_tmp_staged is a no-op without staged leftovers" {
+    run /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/brew.sh"
+
+TEST_BREW_PREFIX="$HOME/homebrew"
+mkdir -p "$TEST_BREW_PREFIX/var/homebrew/tmp/.caskroom/docker-desktop/4.83.0,234302"
+
+pgrep() { return 1; }
+run_with_timeout() { shift; "$@"; }
+brew() {
+    case "${1:-}" in
+        --prefix) printf '%s\n' "$TEST_BREW_PREFIX" ;;
+        *) return 0 ;;
+    esac
+}
+
+clean_homebrew_tmp_staged
+[[ -d "$TEST_BREW_PREFIX/var/homebrew/tmp/.caskroom/docker-desktop/4.83.0,234302" ]] || exit 1
+EOF
+
+    [ "$status" -eq 0 ]
+}

--- a/tests/dev_extended.bats
+++ b/tests/dev_extended.bats
@@ -1774,6 +1774,7 @@ clean_dev_ocaml() { :; }
 clean_xcode_tools() { :; }
 clean_code_editors() { :; }
 clean_homebrew() { :; }
+clean_homebrew_tmp_staged() { :; }
 clean_developer_tools
 EOF
 


### PR DESCRIPTION
## Summary

Homebrew stages cask installs under `$(brew --prefix)/var/homebrew/tmp/.caskroom`. When a cask upgrade is interrupted or fails — e.g. the app is currently running, or the installer is a `.pkg` requiring sudo — Homebrew leaves both the `<version>` directory and its `<version>.staged` symlink behind. These leftovers are **not** touched by `brew cleanup` (which only handles `~/Library/Caches/Homebrew`), so they can accumulate to several GB over time. On a real machine this was observed at **12 GB across 13 casks** (Docker Desktop alone: 3 versions, 6.3 GB).

## Changes

- `lib/clean/brew.sh`: new `clean_homebrew_tmp_staged()`:
  - Resolves `$(brew --prefix)/var/homebrew/tmp/.caskroom`, iterates each cask dir, removes every `<version>.staged` symlink **and** the directory it points to
  - Safety: only ever deletes paths inside the staging root (symlink target is re-validated against it), skips entirely when `brew` is running (never races an in-progress install), and respects the user whitelist and `--dry-run`
  - Uses the project's `safe_remove` / `safe_remove_symlink` wrappers (never raw `rm`)
- `lib/clean/dev.sh`: wired the step into `clean_developer_tools`, **before** `clean_homebrew` so it runs on every clean, independent of the 7-day throttle
- Tests: 2 bats tests in `clean_system_maintenance.bats` (removal + no-op), plus stub updates in `clean_dev_caches.bats` / `dev_extended.bats`

## Why not just brew cleanup?

`brew cleanup` only prunes the download cache and old formula versions; `var/homebrew/tmp/.caskroom` staged leftovers are never visited. The existing `mo installer` also only scans `~/Library/Caches/Homebrew` for `.dmg`/`.pkg` files.

## Verification

- `scripts/check.sh --no-format` passes (go vet, ShellCheck, syntax, function duplication)
- bats tests for the new function pass (locally; the full-file suite hits a local sandbox bulk-delete restriction unrelated to these changes)