### PR TITLE
fix(purge): honor user whitelist entries

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -37,6 +37,8 @@ IS_M_SERIES=$([[ "$(uname -m)" == "arm64" ]] && echo "true" || echo "false")
 MOLE_USER_HOME="$(get_invoking_home)"
 [[ -n "$MOLE_USER_HOME" ]] || MOLE_USER_HOME="$HOME"
 
+load_mole_whitelist "$MOLE_USER_HOME"
+
 CLEAN_PREVIEW_FINAL_FILE="$MOLE_USER_HOME/.config/mole/clean-list.txt"
 CLEAN_PREVIEW_STAGING_FILE=""
 CLEAN_PREVIEW_LEDGER_FILE=""
@@ -66,81 +68,6 @@ readonly PROTECTED_SW_DOMAINS=(
     "linear.app"
     "excalidraw.com"
 )
-
-declare -a WHITELIST_PATTERNS=()
-WHITELIST_WARNINGS=()
-if [[ -f "$MOLE_USER_HOME/.config/mole/whitelist" ]]; then
-    while IFS= read -r line; do
-        # shellcheck disable=SC2295
-        line="${line#"${line%%[![:space:]]*}"}"
-        # shellcheck disable=SC2295
-        line="${line%"${line##*[![:space:]]}"}"
-        [[ -z "$line" || "$line" =~ ^# ]] && continue
-
-        [[ "$line" == ~* ]] && line="${line/#~/$MOLE_USER_HOME}"
-        line="${line//\$HOME/$MOLE_USER_HOME}"
-        line="${line//\$\{HOME\}/$MOLE_USER_HOME}"
-        if [[ "$line" =~ \.\. ]]; then
-            WHITELIST_WARNINGS+=("Path traversal not allowed: $line")
-            continue
-        fi
-
-        if [[ "$line" != "$FINDER_METADATA_SENTINEL" ]]; then
-            if [[ "$line" =~ [[:cntrl:]] ]]; then
-                WHITELIST_WARNINGS+=("Invalid path format: $line")
-                continue
-            fi
-
-            if [[ "$line" != /* ]]; then
-                WHITELIST_WARNINGS+=("Must be absolute path: $line")
-                continue
-            fi
-        fi
-
-        if [[ "$line" =~ // ]]; then
-            WHITELIST_WARNINGS+=("Consecutive slashes: $line")
-            continue
-        fi
-
-        case "$line" in
-            / | /System | /System/* | /bin | /bin/* | /sbin | /sbin/* | /usr/bin | /usr/bin/* | /usr/sbin | /usr/sbin/* | /etc | /etc/* | /var/db | /var/db/*)
-                WHITELIST_WARNINGS+=("Protected system path: $line")
-                continue
-                ;;
-        esac
-
-        duplicate="false"
-        if [[ ${#WHITELIST_PATTERNS[@]} -gt 0 ]]; then
-            for existing in "${WHITELIST_PATTERNS[@]}"; do
-                if [[ "$line" == "$existing" ]]; then
-                    duplicate="true"
-                    break
-                fi
-            done
-        fi
-        [[ "$duplicate" == "true" ]] && continue
-        WHITELIST_PATTERNS+=("$line")
-    done < "$MOLE_USER_HOME/.config/mole/whitelist"
-else
-    WHITELIST_PATTERNS=("${DEFAULT_WHITELIST_PATTERNS[@]}")
-fi
-
-# Expand whitelist patterns once to avoid repeated tilde expansion in hot loops.
-expand_whitelist_patterns() {
-    if [[ ${#WHITELIST_PATTERNS[@]} -gt 0 ]]; then
-        local -a EXPANDED_PATTERNS
-        EXPANDED_PATTERNS=()
-        for pattern in "${WHITELIST_PATTERNS[@]}"; do
-            local expanded="${pattern/#\~/$MOLE_USER_HOME}"
-            EXPANDED_PATTERNS+=("$expanded")
-        done
-        WHITELIST_PATTERNS=("${EXPANDED_PATTERNS[@]}")
-    fi
-}
-expand_whitelist_patterns
-# Existing user files replace defaults entirely; re-apply hard safety entries
-# (FINDER_METADATA and future SAFETY_WHITELIST_PATTERNS) so they still protect.
-ensure_safety_whitelist_patterns
 
 prepare_clean_preview_file() {
     EXPORT_LIST_FILE="$CLEAN_PREVIEW_FINAL_FILE"

--- a/bin/purge.sh
+++ b/bin/purge.sh
@@ -23,6 +23,10 @@ trap 'trap - EXIT; cleanup; exit 130' INT TERM
 source "$SCRIPT_DIR/../lib/core/log.sh"
 source "$SCRIPT_DIR/../lib/clean/project.sh"
 
+# Purge ends at safe_remove just like clean, so initialize the invoking user's
+# whitelist before project discovery or the interactive selection begins.
+load_mole_whitelist
+
 # Configuration
 CURRENT_SECTION=""
 

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -221,6 +221,97 @@ ensure_safety_whitelist_patterns() {
     done
 }
 
+# Load and validate the invoking user's clean whitelist. Both `clean` and
+# `purge` use safe_remove as their final deletion sink, so they must share the
+# same source of WHITELIST_PATTERNS before either command starts scanning.
+# Keeping this here also makes the validation rules independent of a command
+# entrypoint, which prevents a new cleanup command from silently skipping the
+# whitelist initialization (see #1427).
+load_mole_whitelist() {
+    local whitelist_home="${1:-}"
+    if [[ -z "$whitelist_home" ]]; then
+        whitelist_home=$(get_invoking_home)
+    fi
+    [[ -n "$whitelist_home" ]] || whitelist_home="${HOME:-}"
+    MOLE_USER_HOME="$whitelist_home"
+
+    WHITELIST_PATTERNS=()
+    WHITELIST_WARNINGS=()
+
+    local whitelist_file="$MOLE_USER_HOME/.config/mole/whitelist"
+    if [[ -f "$whitelist_file" ]]; then
+        local line duplicate existing
+        while IFS= read -r line; do
+            # shellcheck disable=SC2295
+            line="${line#"${line%%[![:space:]]*}"}"
+            # shellcheck disable=SC2295
+            line="${line%"${line##*[![:space:]]}"}"
+            [[ -z "$line" || "$line" =~ ^# ]] && continue
+
+            [[ "$line" == ~* ]] && line="${line/#~/$MOLE_USER_HOME}"
+            line="${line//\$HOME/$MOLE_USER_HOME}"
+            line="${line//\$\{HOME\}/$MOLE_USER_HOME}"
+            if [[ "$line" =~ \.\. ]]; then
+                WHITELIST_WARNINGS+=("Path traversal not allowed: $line")
+                continue
+            fi
+
+            if [[ "$line" != "$FINDER_METADATA_SENTINEL" ]]; then
+                if [[ "$line" =~ [[:cntrl:]] ]]; then
+                    WHITELIST_WARNINGS+=("Invalid path format: $line")
+                    continue
+                fi
+
+                if [[ "$line" != /* ]]; then
+                    WHITELIST_WARNINGS+=("Must be absolute path: $line")
+                    continue
+                fi
+            fi
+
+            if [[ "$line" =~ // ]]; then
+                WHITELIST_WARNINGS+=("Consecutive slashes: $line")
+                continue
+            fi
+
+            case "$line" in
+                / | /System | /System/* | /bin | /bin/* | /sbin | /sbin/* | /usr/bin | /usr/bin/* | /usr/sbin | /usr/sbin/* | /etc | /etc/* | /var/db | /var/db/*)
+                    WHITELIST_WARNINGS+=("Protected system path: $line")
+                    continue
+                    ;;
+            esac
+
+            duplicate="false"
+            if [[ ${#WHITELIST_PATTERNS[@]} -gt 0 ]]; then
+                for existing in "${WHITELIST_PATTERNS[@]}"; do
+                    if [[ "$line" == "$existing" ]]; then
+                        duplicate="true"
+                        break
+                    fi
+                done
+            fi
+            [[ "$duplicate" == "true" ]] && continue
+            WHITELIST_PATTERNS+=("$line")
+        done < "$whitelist_file"
+    elif [[ ${#DEFAULT_WHITELIST_PATTERNS[@]} -gt 0 ]]; then
+        WHITELIST_PATTERNS=("${DEFAULT_WHITELIST_PATTERNS[@]}")
+    fi
+
+    # Expand patterns once, before hot cleanup loops call is_path_whitelisted.
+    if [[ ${#WHITELIST_PATTERNS[@]} -gt 0 ]]; then
+        local -a expanded_patterns=()
+        local pattern expanded
+        for pattern in "${WHITELIST_PATTERNS[@]}"; do
+            expanded="${pattern/#\~/$MOLE_USER_HOME}"
+            expanded_patterns+=("$expanded")
+        done
+        WHITELIST_PATTERNS=("${expanded_patterns[@]}")
+    fi
+
+    # Existing user files replace convenience defaults; hard safety entries
+    # remain enforced for every command that loads this shared policy.
+    ensure_safety_whitelist_patterns
+}
+
 # ============================================================================
 # BSD Stat Compatibility
 # ============================================================================

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1406,6 +1406,51 @@ EOF
 	[ -d "$HOME/.cache/mole" ] || [ -d "${XDG_CACHE_HOME:-$HOME/.cache}/mole" ]
 }
 
+@test "mo purge skips whitelisted project artifacts (#1427)" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+
+protected="$HOME/www/protected/node_modules"
+unprotected="$HOME/www/unprotected/node_modules"
+mkdir -p "$protected" "$unprotected" "$HOME/.config/mole" "$HOME/.cache/mole"
+printf 'keep\n' > "$protected/keep.js"
+printf 'remove\n' > "$unprotected/remove.js"
+touch "$HOME/www/protected/package.json" "$HOME/www/unprotected/package.json"
+touch -t 202001010101 \
+    "$protected/keep.js" "$protected" "$HOME/www/protected/package.json" "$HOME/www/protected" \
+    "$unprotected/remove.js" "$unprotected" "$HOME/www/unprotected/package.json" "$HOME/www/unprotected"
+printf '%s\n' "$protected" > "$HOME/.config/mole/whitelist"
+
+export MOLE_SKIP_MAIN=1
+export MOLE_TEST_NO_AUTH=1
+source "$PROJECT_ROOT/bin/purge.sh"
+PURGE_SEARCH_PATHS=("$HOME/www")
+scan_purge_targets() {
+    printf '%s\n' "$protected" "$unprotected" > "$2"
+}
+get_dir_size_kb() { echo 1; }
+get_file_mtime() { echo 1577836800; }
+is_recently_modified() { return 1; }
+purge_target_activity_still_safe() { return 0; }
+
+start_purge
+clean_project_artifacts </dev/null
+
+protected_loaded=false
+for pattern in "${WHITELIST_PATTERNS[@]}"; do
+    if [[ "$pattern" == "$protected" ]]; then
+        protected_loaded=true
+        break
+    fi
+done
+[[ "$protected_loaded" == "true" ]] || exit 1
+[[ -d "$protected" ]] || exit 1
+[[ ! -e "$unprotected" ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ] || { echo "$output"; return 1; }
+}
+
 # .NET bin directory detection tests
 @test "is_dotnet_bin_dir: finds .NET context in parent directory with Debug dir" {
 	mkdir -p "$HOME/www/dotnet-app/bin/Debug"


### PR DESCRIPTION
## Summary

- centralize validated whitelist loading in the shared core policy
- initialize the invoking user's whitelist before `mo purge` scans and reuse the same loader from `mo clean`
- add a regression test proving a whitelisted project artifact survives purge while an unwhitelisted artifact is removed

## Root cause

`bin/purge.sh` sourced the project cleanup helpers but never populated `WHITELIST_PATTERNS`. The downstream `safe_remove` guard was correct, but it received an empty whitelist.

Fixes #1427

## Validation

- `./scripts/check.sh --format`
- `bash -n lib/core/base.sh bin/clean.sh bin/purge.sh lib/clean/project.sh tests/purge.bats`
- `shellcheck lib/core/base.sh bin/clean.sh bin/purge.sh`
- `MOLE_TEST_NO_AUTH=1 bats tests/purge.bats tests/manage_whitelist.bats` (108/108)
- full suite attempted; remaining failures are environment-bound system probes, permissions, TTY, and network/cache setup rather than this change