### PR TITLE
feat: clean guarded PyInstaller and Clang caches

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -1029,13 +1029,6 @@ clean_remote_desktop() {
     safe_clean ~/Library/Caches/com.sunlogin.*/* "Sunlogin cache"
 }
 # Main entry for GUI app cleanup.
-# Shared electron-updater download staging (~/Library/Application
-# Support/Caches/<app>-updater). Only the pending payloads are removed:
-# an interrupted update is re-downloaded by the app's updater on demand.
-clean_electron_updater_caches() {
-    safe_clean ~/Library/Application\ Support/Caches/*-updater/pending/* "Electron updater downloads"
-}
-
 clean_user_gui_applications() {
     stop_section_spinner
     clean_communication_apps
@@ -1058,5 +1051,4 @@ clean_user_gui_applications() {
     clean_note_apps
     clean_launcher_apps
     clean_remote_desktop
-    clean_electron_updater_caches
 }

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -1029,6 +1029,13 @@ clean_remote_desktop() {
     safe_clean ~/Library/Caches/com.sunlogin.*/* "Sunlogin cache"
 }
 # Main entry for GUI app cleanup.
+# Shared electron-updater download staging (~/Library/Application
+# Support/Caches/<app>-updater). Only the pending payloads are removed:
+# an interrupted update is re-downloaded by the app's updater on demand.
+clean_electron_updater_caches() {
+    safe_clean ~/Library/Application\ Support/Caches/*-updater/pending/* "Electron updater downloads"
+}
+
 clean_user_gui_applications() {
     stop_section_spinner
     clean_communication_apps
@@ -1051,4 +1058,5 @@ clean_user_gui_applications() {
     clean_note_apps
     clean_launcher_apps
     clean_remote_desktop
+    clean_electron_updater_caches
 }

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -488,6 +488,226 @@ clean_dev_npm() {
     safe_clean ~/.yarn/cache/* "Yarn cache"
     safe_clean ~/Library/Caches/Yarn/* "Yarn v1 cache"
 }
+# Resolve a cache root to its physical location and prove that it remains a
+# descendant of its owner container. Both directories must be ordinary,
+# invoking-user-owned directories; user-managed redirect symlinks are kept.
+guarded_dev_cache_root_physical_path() {
+    local container_root="${1%/}"
+    local cache_root="${2%/}"
+
+    [[ "$container_root" == /* && "$cache_root" == /* ]] || return 1
+    [[ ! "$container_root" =~ [[:cntrl:]] && ! "$cache_root" =~ [[:cntrl:]] ]] || return 1
+    case "$container_root" in
+        *'/../'* | */.. | *'/./'* | */. | *'//'*) return 1 ;;
+    esac
+    case "$cache_root" in
+        *'/../'* | */.. | *'/./'* | */. | *'//'*) return 1 ;;
+    esac
+    [[ -d "$container_root" && ! -L "$container_root" ]] || return 1
+    [[ -d "$cache_root" && ! -L "$cache_root" ]] || return 1
+
+    local physical_container physical_root invoking_uid container_uid root_uid
+    physical_container=$(cd -P "$container_root" 2> /dev/null && pwd -P) || return 1
+    physical_root=$(cd -P "$cache_root" 2> /dev/null && pwd -P) || return 1
+    [[ "$physical_container" != "/" ]] || return 1
+    case "$physical_root" in
+        "$physical_container"/*) ;;
+        *) return 1 ;;
+    esac
+
+    invoking_uid=$(get_invoking_uid 2> /dev/null) || return 1
+    [[ "$invoking_uid" =~ ^[0-9]+$ ]] || return 1
+    container_uid=$($STAT_BSD -f%u "$physical_container" 2> /dev/null) || return 1
+    root_uid=$($STAT_BSD -f%u "$physical_root" 2> /dev/null) || return 1
+    [[ "$container_uid" == "$invoking_uid" && "$root_uid" == "$invoking_uid" ]] || return 1
+    should_protect_path "$cache_root" && return 1
+    should_protect_path "$physical_root" && return 1
+
+    printf '%s\n' "$physical_root"
+}
+
+# Compound sink-time guard for rebuildable developer caches. It rechecks both
+# process ownership and the container/root/leaf identities immediately before
+# safe_remove, so a path swap after discovery cannot redirect deletion.
+guarded_dev_cache_cleanup_state() {
+    local process_state=0
+    "$_MOLE_DEV_CACHE_PROCESS_PROBE" || process_state=$?
+    [[ $process_state -eq 1 ]] || return "$process_state"
+
+    local physical_now=""
+    physical_now=$(guarded_dev_cache_root_physical_path \
+        "$_MOLE_DEV_CACHE_CONTAINER" "$_MOLE_DEV_CACHE_ROOT") || return 2
+    [[ "$physical_now" == "$_MOLE_DEV_CACHE_PHYSICAL" ]] || return 2
+    _mole_path_matches_identity \
+        "$_MOLE_DEV_CACHE_CONTAINER" \
+        "$_MOLE_DEV_CACHE_CONTAINER_PARENT" \
+        "$_MOLE_DEV_CACHE_CONTAINER_PARENT_ID" \
+        "$_MOLE_DEV_CACHE_CONTAINER_TARGET_ID" || return 2
+    _mole_path_matches_identity \
+        "$_MOLE_DEV_CACHE_ROOT" \
+        "$_MOLE_DEV_CACHE_ROOT_PARENT" \
+        "$_MOLE_DEV_CACHE_ROOT_PARENT_ID" \
+        "$_MOLE_DEV_CACHE_ROOT_TARGET_ID" || return 2
+
+    local guarded_path="${_MOLE_DEV_GUARDED_PATH:-}"
+    if [[ -n "$guarded_path" ]]; then
+        [[ ! -L "$guarded_path" ]] || return 2
+        _mole_snapshot_path_identity "$guarded_path" || return 2
+        [[ "$_MOLE_PATH_SNAPSHOT_PARENT" == "$physical_now" ]] || return 2
+
+        local leaf_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
+        local leaf_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+        local leaf_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+        physical_now=$(guarded_dev_cache_root_physical_path \
+            "$_MOLE_DEV_CACHE_CONTAINER" "$_MOLE_DEV_CACHE_ROOT") || return 2
+        [[ "$physical_now" == "$_MOLE_DEV_CACHE_PHYSICAL" ]] || return 2
+        _mole_path_matches_identity \
+            "$_MOLE_DEV_CACHE_ROOT" \
+            "$_MOLE_DEV_CACHE_ROOT_PARENT" \
+            "$_MOLE_DEV_CACHE_ROOT_PARENT_ID" \
+            "$_MOLE_DEV_CACHE_ROOT_TARGET_ID" || return 2
+
+        _MOLE_SAFE_CLEAN_BOUND_PATH="$guarded_path"
+        _MOLE_SAFE_CLEAN_EXPECTED_PARENT="$leaf_parent"
+        _MOLE_SAFE_CLEAN_EXPECTED_PARENT_ID="$leaf_parent_id"
+        _MOLE_SAFE_CLEAN_EXPECTED_TARGET_ID="$leaf_target_id"
+    fi
+    return 1
+}
+
+clean_guarded_dev_cache_root() {
+    local container_root="${1%/}"
+    local cache_root="${2%/}"
+    local process_probe="$3"
+    local family="$4"
+    local display_name="$5"
+    shift 5
+    [[ $# -gt 0 ]] || return 0
+    mole_cleanup_targets_exist "$@" || return 0
+
+    local _MOLE_CLEAN_GUARD_REASON=""
+    if ! mole_clean_process_guard "$process_probe" "$family started"; then
+        mole_report_guard_stop "$display_name" mole_defer_cleanup_family "$family"
+        return 0
+    fi
+
+    local physical_root=""
+    if ! physical_root=$(guarded_dev_cache_root_physical_path "$container_root" "$cache_root"); then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} ${display_name} · stopped (cache path unsafe)"
+        note_activity
+        return 0
+    fi
+
+    if ! _mole_snapshot_path_identity "$container_root"; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} ${display_name} · stopped (cache path unsafe)"
+        note_activity
+        return 0
+    fi
+    local container_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
+    local container_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+    local container_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+    if ! _mole_snapshot_path_identity "$cache_root"; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} ${display_name} · stopped (cache path unsafe)"
+        note_activity
+        return 0
+    fi
+    local root_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
+    local root_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+    local root_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+
+    local _MOLE_DEV_CACHE_CONTAINER="$container_root"
+    local _MOLE_DEV_CACHE_ROOT="$cache_root"
+    local _MOLE_DEV_CACHE_PHYSICAL="$physical_root"
+    local _MOLE_DEV_CACHE_CONTAINER_PARENT="$container_parent"
+    local _MOLE_DEV_CACHE_CONTAINER_PARENT_ID="$container_parent_id"
+    local _MOLE_DEV_CACHE_CONTAINER_TARGET_ID="$container_target_id"
+    local _MOLE_DEV_CACHE_ROOT_PARENT="$root_parent"
+    local _MOLE_DEV_CACHE_ROOT_PARENT_ID="$root_parent_id"
+    local _MOLE_DEV_CACHE_ROOT_TARGET_ID="$root_target_id"
+    local _MOLE_DEV_CACHE_PROCESS_PROBE="$process_probe"
+    local _MOLE_DEV_PROCESS_GUARD_UNKNOWN_REASON="process or cache path state unknown"
+    local clean_rc=0
+    _dev_safe_clean_process_guarded \
+        guarded_dev_cache_cleanup_state \
+        "$family" \
+        "$display_name" \
+        "$@" \
+        "$display_name" || clean_rc=$?
+    [[ $clean_rc -eq 1 ]] && return 0
+    return "$clean_rc"
+}
+
+pyinstaller_build_process_state() {
+    mole_pgrep_any \
+        -x pyinstaller \
+        -f "[p]yinstaller" \
+        -f "[P]yInstaller"
+}
+
+clean_pyinstaller_bincache() {
+    local container_root="$HOME/Library/Application Support"
+    local cache_root="$container_root/pyinstaller"
+    [[ -d "$cache_root" || -L "$cache_root" ]] || return 0
+
+    local -a candidates=()
+    local candidate
+    for candidate in "$cache_root"/bincache*; do
+        [[ -e "$candidate" || -L "$candidate" ]] || continue
+        [[ ! -L "$candidate" ]] || continue
+        candidates+=("$candidate")
+    done
+    [[ ${#candidates[@]} -gt 0 ]] || return 0
+
+    clean_guarded_dev_cache_root \
+        "$container_root" \
+        "$cache_root" \
+        pyinstaller_build_process_state \
+        "PyInstaller" \
+        "PyInstaller binary cache" \
+        "${candidates[@]}"
+}
+
+clang_module_cache_process_state() {
+    local xcode_state=0
+    xcode_build_tooling_process_state || xcode_state=$?
+    [[ $xcode_state -eq 1 ]] || return "$xcode_state"
+    mole_pgrep_any \
+        -x clang \
+        -x clangd \
+        -x swiftc \
+        -x sourcekit-lsp \
+        -x SourceKitService
+}
+
+clean_clang_module_cache() {
+    local darwin_user_cache=""
+    local resolver_rc=0
+    darwin_user_cache=$(mole_darwin_user_cache_root) || resolver_rc=$?
+    if [[ $resolver_rc -ne 0 ]]; then
+        [[ $resolver_rc -eq 124 || $resolver_rc -ge 128 ]] && return "$resolver_rc"
+        return 0
+    fi
+
+    local cache_root="$darwin_user_cache/clang"
+    [[ -d "$cache_root" || -L "$cache_root" ]] || return 0
+    local -a candidates=()
+    local candidate
+    for candidate in "$cache_root"/* "$cache_root"/.[!.]* "$cache_root"/..?*; do
+        [[ -e "$candidate" || -L "$candidate" ]] || continue
+        [[ ! -L "$candidate" ]] || continue
+        candidates+=("$candidate")
+    done
+    [[ ${#candidates[@]} -gt 0 ]] || return 0
+
+    clean_guarded_dev_cache_root \
+        "$darwin_user_cache" \
+        "$cache_root" \
+        clang_module_cache_process_state \
+        "Clang" \
+        "Clang module cache" \
+        "${candidates[@]}"
+}
+
 # Python/pip ecosystem caches.
 clean_dev_python() {
     # Check pip3 is functional (not just macOS stub that triggers CLT install dialog)
@@ -506,9 +726,7 @@ clean_dev_python() {
     safe_clean ~/.cache/ruff/* "Ruff cache"
     safe_clean ~/.cache/mypy/* "MyPy cache"
     safe_clean ~/.pytest_cache/* "Pytest cache"
-    local user_tmp="${TMPDIR:-/tmp}"
-    safe_clean "${user_tmp%/}"/pytest-of-* "pytest temp dirs"
-    safe_clean ~/Library/Application\ Support/pyinstaller/* "PyInstaller cache"
+    clean_pyinstaller_bincache
     safe_clean ~/.jupyter/runtime/* "Jupyter runtime cache"
     safe_clean ~/.cache/huggingface/* "Hugging Face cache"
     safe_clean ~/.cache/torch/* "PyTorch cache"
@@ -859,9 +1077,6 @@ clean_dev_frontend() {
     safe_clean ~/.parcel-cache/* "Parcel cache"
     safe_clean ~/.cache/eslint/* "ESLint cache"
     safe_clean ~/.cache/prettier/* "Prettier cache"
-    local user_tmp="${TMPDIR:-/tmp}"
-    safe_clean "${user_tmp%/}"/node-compile-cache/* "Node compile cache"
-    safe_clean "${user_tmp%/}"/jest_* "Jest temp cache"
 }
 # Check for multiple Android NDK versions.
 check_android_ndk() {
@@ -3392,13 +3607,7 @@ clean_dev_other_langs() {
     safe_clean ~/.cache/bazel/* "Bazel cache"
     safe_clean ~/.cache/zig/* "Zig cache"
     safe_clean ~/Library/Caches/deno/* "Deno cache"
-    # Module cache for command-line clang builds; Xcode's own copy lives in
-    # DerivedData and is handled by the Xcode cleanup.
-    local darwin_user_cache
-    darwin_user_cache=$(getconf DARWIN_USER_CACHE_DIR 2> /dev/null || echo "")
-    if [[ "$darwin_user_cache" == /* ]]; then
-        safe_clean "${darwin_user_cache%/}"/clang/* "Clang module cache"
-    fi
+    clean_clang_module_cache
 }
 # CI/CD and DevOps caches.
 clean_dev_cicd() {

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -506,6 +506,9 @@ clean_dev_python() {
     safe_clean ~/.cache/ruff/* "Ruff cache"
     safe_clean ~/.cache/mypy/* "MyPy cache"
     safe_clean ~/.pytest_cache/* "Pytest cache"
+    local user_tmp="${TMPDIR:-/tmp}"
+    safe_clean "${user_tmp%/}"/pytest-of-* "pytest temp dirs"
+    safe_clean ~/Library/Application\ Support/pyinstaller/* "PyInstaller cache"
     safe_clean ~/.jupyter/runtime/* "Jupyter runtime cache"
     safe_clean ~/.cache/huggingface/* "Hugging Face cache"
     safe_clean ~/.cache/torch/* "PyTorch cache"
@@ -856,6 +859,9 @@ clean_dev_frontend() {
     safe_clean ~/.parcel-cache/* "Parcel cache"
     safe_clean ~/.cache/eslint/* "ESLint cache"
     safe_clean ~/.cache/prettier/* "Prettier cache"
+    local user_tmp="${TMPDIR:-/tmp}"
+    safe_clean "${user_tmp%/}"/node-compile-cache/* "Node compile cache"
+    safe_clean "${user_tmp%/}"/jest_* "Jest temp cache"
 }
 # Check for multiple Android NDK versions.
 check_android_ndk() {
@@ -3386,6 +3392,13 @@ clean_dev_other_langs() {
     safe_clean ~/.cache/bazel/* "Bazel cache"
     safe_clean ~/.cache/zig/* "Zig cache"
     safe_clean ~/Library/Caches/deno/* "Deno cache"
+    # Module cache for command-line clang builds; Xcode's own copy lives in
+    # DerivedData and is handled by the Xcode cleanup.
+    local darwin_user_cache
+    darwin_user_cache=$(getconf DARWIN_USER_CACHE_DIR 2> /dev/null || echo "")
+    if [[ "$darwin_user_cache" == /* ]]; then
+        safe_clean "${darwin_user_cache%/}"/clang/* "Clang module cache"
+    fi
 }
 # CI/CD and DevOps caches.
 clean_dev_cicd() {

--- a/lib/core/base.sh
+++ b/lib/core/base.sh
@@ -211,6 +211,32 @@ mole_github_cli_cache_root() {
     printf '%s\n' "$cache_root"
 }
 
+# Resolve the per-user cache root reported by macOS. Keep the resolver shared
+# so cleanup and whitelist inventory always describe the same path.
+mole_darwin_user_cache_root() {
+    declare -f run_with_timeout > /dev/null 2>&1 || return 1
+
+    local cache_root=""
+    local resolver_rc=0
+    cache_root=$(run_with_timeout "${MOLE_TIMEOUT_QUICK_DETECT_SEC:-3}" \
+        /usr/bin/getconf DARWIN_USER_CACHE_DIR 2> /dev/null) || resolver_rc=$?
+    [[ $resolver_rc -eq 0 ]] || return "$resolver_rc"
+
+    [[ "$cache_root" == /* && ! "$cache_root" =~ [[:cntrl:]] ]] || return 1
+    case "$cache_root" in
+        *'/../'* | */.. | *'/./'* | */. | *'//'*) return 1 ;;
+    esac
+
+    cache_root="${cache_root%/}"
+    local home_root="${HOME:-}"
+    home_root="${home_root%/}"
+    case "$cache_root" in
+        "" | / | "$home_root") return 1 ;;
+    esac
+
+    printf '%s\n' "$cache_root"
+}
+
 # Append any missing SAFETY_WHITELIST_PATTERNS to WHITELIST_PATTERNS.
 # When CURRENT_WHITELIST_PATTERNS is declared (manage UI), keep it in sync.
 ensure_safety_whitelist_patterns() {

--- a/lib/manage/whitelist.sh
+++ b/lib/manage/whitelist.sh
@@ -130,6 +130,7 @@ pre-commit hooks cache|$HOME/.cache/pre-commit/*|compiler_cache
 Ruff Python linter cache|$HOME/.cache/ruff/*|compiler_cache
 MyPy type checker cache|$HOME/.cache/mypy/*|compiler_cache
 Pytest test cache|$HOME/.pytest_cache/*|compiler_cache
+PyInstaller binary cache|$HOME/Library/Application Support/pyinstaller/bincache*|compiler_cache
 Flutter SDK cache|$HOME/.cache/flutter/*|compiler_cache
 Swift Package Manager cache|$HOME/.cache/swift-package-manager/*|compiler_cache
 Zig compiler cache|$HOME/.cache/zig/*|compiler_cache
@@ -174,6 +175,10 @@ EOF
     local github_cache_root
     if github_cache_root=$(mole_github_cli_cache_root); then
         printf 'GitHub CLI cache|%s/gh|network_tools\n' "$github_cache_root"
+    fi
+    local darwin_user_cache
+    if darwin_user_cache=$(mole_darwin_user_cache_root); then
+        printf 'Clang module cache|%s/clang/*|compiler_cache\n' "$darwin_user_cache"
     fi
     # Add FINDER_METADATA with constant reference
     echo "Finder metadata, .DS_Store|$FINDER_METADATA_SENTINEL|system_cache"

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -1742,6 +1742,167 @@ EOF
     [[ "$output" == *"PHP Composer cache|"* ]]
 }
 
+@test "PyInstaller cleanup keeps non-bincache state" {
+    local cache_root="$HOME/Library/Application Support/pyinstaller"
+    mkdir -p "$cache_root/bincache00py311" "$cache_root/hooks"
+    printf 'state\n' > "$cache_root/config.json"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+pyinstaller_build_process_state() { return 1; }
+safe_clean() {
+    local description="${!#}"
+    while [[ $# -gt 1 ]]; do
+        printf 'CLEAN=%s|%s\n' "$description" "$1"
+        shift
+    done
+}
+clean_pyinstaller_bincache
+EOF
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"CLEAN=PyInstaller binary cache|$cache_root/bincache00py311"* ]] || return 1
+    [[ "$output" != *"$cache_root/hooks"* ]] || return 1
+    [[ "$output" != *"$cache_root/config.json"* ]]
+}
+
+@test "PyInstaller cleanup reaches the guarded deletion sink" {
+    local cache_root="$HOME/Library/Application Support/pyinstaller"
+    mkdir -p "$cache_root/bincache00py310"
+    printf 'cache\n' > "$cache_root/bincache00py310/module.bin"
+    printf 'keep\n' > "$cache_root/config.json"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_NO_AUTH=1 \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+pyinstaller_build_process_state() { return 1; }
+clean_pyinstaller_bincache
+EOF
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [ ! -e "$cache_root/bincache00py310" ] || return 1
+    [ -f "$cache_root/config.json" ]
+}
+
+@test "PyInstaller cleanup fails closed when the process state is unknown" {
+    local cache_root="$HOME/Library/Application Support/pyinstaller"
+    mkdir -p "$cache_root/bincache00py312"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+pyinstaller_build_process_state() { return 2; }
+safe_clean() { printf 'UNEXPECTED_CLEAN=%s\n' "$1"; }
+note_activity() { :; }
+clean_pyinstaller_bincache
+EOF
+
+    if [[ -L "$cache_root" && -d "$cache_root-original" ]]; then
+        /bin/unlink "$cache_root"
+        /bin/mv "$cache_root-original" "$cache_root"
+    fi
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"PyInstaller binary cache · stopped (process state unknown)"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_CLEAN="* ]]
+}
+
+@test "PyInstaller cleanup rechecks the process at the deletion boundary" {
+    local cache_root="$HOME/Library/Application Support/pyinstaller"
+    mkdir -p "$cache_root/bincache00py313"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+probe_calls=0
+pyinstaller_build_process_state() {
+    probe_calls=$((probe_calls + 1))
+    [[ $probe_calls -eq 1 ]] && return 1
+    return 0
+}
+mole_defer_cleanup_family() { printf 'DEFER=%s\n' "$1"; }
+safe_clean() { printf 'UNEXPECTED_CLEAN=%s\n' "$1"; }
+safe_clean_guarded() {
+    local guard="$1"
+    shift
+    "$guard" "$1" || return 75
+    safe_clean "$@"
+}
+clean_pyinstaller_bincache
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"DEFER=PyInstaller"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_CLEAN="* ]]
+}
+
+@test "PyInstaller cleanup rejects a root replaced before deletion" {
+    local cache_root="$HOME/Library/Application Support/pyinstaller"
+    local outside_root="$HOME/outside-pyinstaller"
+    mkdir -p "$cache_root/bincache00py314" "$outside_root/bincache00py314"
+    printf 'keep\n' > "$outside_root/bincache00py314/private-data"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+pyinstaller_build_process_state() { return 1; }
+safe_clean() { printf 'UNEXPECTED_CLEAN=%s\n' "$1"; }
+safe_clean_guarded() {
+    local guard="$1"
+    shift
+    local cache_root="$HOME/Library/Application Support/pyinstaller"
+    /bin/mv "$cache_root" "$cache_root-original"
+    /bin/ln -s "$HOME/outside-pyinstaller" "$cache_root"
+    "$guard" "$1" || return 75
+    safe_clean "$@"
+}
+note_activity() { :; }
+clean_pyinstaller_bincache
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"PyInstaller binary cache · stopped (process or cache path state unknown)"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_CLEAN="* ]] || return 1
+    [ -f "$outside_root/bincache00py314/private-data" ]
+}
+
+@test "Clang cleanup uses the macOS cache root and keeps symlink entries" {
+    local darwin_cache="$HOME/darwin-cache"
+    local cache_root="$darwin_cache/clang"
+    local outside_root="$HOME/outside-clang"
+    mkdir -p "$cache_root/module-cache" "$cache_root/.locks" "$outside_root/private-data"
+    ln -s "$outside_root" "$cache_root/redirected"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DARWIN_CACHE="$darwin_cache" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+mole_darwin_user_cache_root() { printf '%s\n' "$DARWIN_CACHE"; }
+clang_module_cache_process_state() { return 1; }
+safe_clean() {
+    local description="${!#}"
+    while [[ $# -gt 1 ]]; do
+        printf 'CLEAN=%s|%s\n' "$description" "$1"
+        shift
+    done
+}
+clean_clang_module_cache
+EOF
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"CLEAN=Clang module cache|$cache_root/module-cache"* ]] || return 1
+    [[ "$output" == *"CLEAN=Clang module cache|$cache_root/.locks"* ]] || return 1
+    [[ "$output" != *"$cache_root/redirected"* ]] || return 1
+    [ -d "$outside_root/private-data" ]
+}
+
 @test "clean_dev_rust honors CARGO_HOME and RUSTUP_HOME when absolute" {
     # mise and friends relocate cargo/rustup via env; hardcoded ~/.cargo misses
     # the live cache (issue #1378). Scope stays regenerable leaves only.

--- a/tests/core_common.bats
+++ b/tests/core_common.bats
@@ -446,6 +446,44 @@ EOF
     [[ "$output" == *"inactive=1 unknown=2"* ]]
 }
 
+@test "mole_darwin_user_cache_root validates trusted getconf output" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+resolver_mode=valid
+run_with_timeout() {
+    [[ "$2" == "/usr/bin/getconf" && "$3" == "DARWIN_USER_CACHE_DIR" ]] || return 3
+    case "$resolver_mode" in
+        valid) printf '/var/folders/example/C/\n' ;;
+        relative) printf 'tmp/cache\n' ;;
+        traversal) printf '/var/folders/../private\n' ;;
+        root) printf '/\n' ;;
+        timeout) return 124 ;;
+    esac
+}
+
+valid=$(mole_darwin_user_cache_root)
+relative_rc=0
+traversal_rc=0
+root_rc=0
+timeout_rc=0
+resolver_mode=relative
+mole_darwin_user_cache_root > /dev/null 2>&1 || relative_rc=$?
+resolver_mode=traversal
+mole_darwin_user_cache_root > /dev/null 2>&1 || traversal_rc=$?
+resolver_mode=root
+mole_darwin_user_cache_root > /dev/null 2>&1 || root_rc=$?
+resolver_mode=timeout
+mole_darwin_user_cache_root > /dev/null 2>&1 || timeout_rc=$?
+printf 'valid=%s relative=%s traversal=%s root=%s timeout=%s\n' \
+    "$valid" "$relative_rc" "$traversal_rc" "$root_rc" "$timeout_rc"
+EOF
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"valid=/var/folders/example/C relative=1 traversal=1 root=1 timeout=124"* ]]
+}
+
 @test "create_temp_file and create_temp_dir are tracked and cleaned" {
     HOME="$HOME" /bin/bash --noprofile --norc << 'EOF'
 source "$PROJECT_ROOT/lib/core/common.sh"

--- a/tests/manage_whitelist.bats
+++ b/tests/manage_whitelist.bats
@@ -228,6 +228,21 @@ EOF
     [[ "$output" == *"Rust Cargo extracted sources|\$HOME/.cargo/registry/src/*|compiler_cache"* ]]
 }
 
+@test "whitelist inventory exposes guarded PyInstaller and Clang caches" {
+    local darwin_cache="$HOME/darwin-cache"
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DARWIN_CACHE="$darwin_cache" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/manage/whitelist.sh"
+mole_darwin_user_cache_root() { printf '%s\n' "$DARWIN_CACHE"; }
+get_all_cache_items
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"PyInstaller binary cache|\$HOME/Library/Application Support/pyinstaller/bincache*|compiler_cache"* ]] || return 1
+    [[ "$output" == *"Clang module cache|$darwin_cache/clang/*|compiler_cache"* ]]
+}
+
 @test "whitelist inventory resolves the GitHub CLI cache location" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail


### PR DESCRIPTION
## Summary

Adds four cleanup targets, all rebuildable caches that accumulate quietly and are not covered today. Sizes below were measured on a daily-driver Apple Silicon Mac (macOS 15.6); several of them regrew within hours of being cleaned manually, so they keep paying off:

| Target | Location | Measured |
|---|---|---|
| pytest temp dirs | `$TMPDIR/pytest-of-*` | 371 MB (regrew to 306 MB the same day) |
| Node compile cache / Jest temp | `$TMPDIR/node-compile-cache`, `$TMPDIR/jest_*` | 23 MB + 23 MB (regrew to 79 MB) |
| Clang module cache (CLI builds) | `$(getconf DARWIN_USER_CACHE_DIR)clang` | 219 MB |
| PyInstaller bincache | `~/Library/Application Support/pyinstaller` (`bincache00py311…`, `bincache00py312…`) | 277 MB |
| electron-updater staged downloads | `~/Library/Application Support/Caches/*-updater/pending` | 138 MB (Tabby) |

`clean_dev_python`, `clean_dev_frontend`, and `clean_dev_other_langs` in `lib/clean/dev.sh` pick up the first four; a new `clean_electron_updater_caches` in `lib/clean/app_caches.sh` (registered in `clean_user_gui_applications`) handles the last one.

Explicit non-targets:

- Omaha-style updaters (e.g. Comet's `CometUpdater`) are untouched: safe removal there needs an installed-version comparison like `clean_edge_updater_old_versions`, not a blanket delete.
- Inside `*-updater` only `pending/` payloads are removed; updater metadata stays. An interrupted update is simply re-downloaded on demand.
- In `$TMPDIR` only the three named tool patterns are matched; sibling entries can be live app state.
- In `DARWIN_USER_CACHE_DIR` only `clang/` is touched; Xcode's module cache lives in DerivedData and stays with the Xcode cleanup.

## Safety Review

- Affects cleanup behavior: yes, five new `safe_clean` globs. All user-scope, no new sudo, no new deletion primitives; whitelist filtering, protected-path checks, and dry-run preview apply as usual via `safe_clean`.
- No changes to path validation, symlink handling, or install/update paths.

## Tests

- `./scripts/check.sh` passes.
- `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh` (full Bats suite): 1616 tests, 8 failures, 15 skipped — no new failures. All 8 reproduce identically on a clean `main` checkout of this machine (`clean_editor_obsolete_extensions` ×2 (#910), project-root discovery ×4, plus two environment-flaky cases that pass on re-run), unrelated to this change.
- Manual: created fixtures for every new target, ran `MOLE_TEST_NO_AUTH=1 MOLE_DRY_RUN=1 ./mole clean`, and confirmed all six labels appear with correct sizes and no unintended matches (verified each glob's expansion with `du` before/after).

## Safety-related changes

- None beyond the new cleanup globs described above.
