### PR TITLE
feat(clean): add --trash and confirm system caches on interactive runs

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -442,10 +442,24 @@ read_clean_sudo_password_remainder() {
     printf -v "$__remainder_var" '%s' "$remainder"
 }
 
+# Seam for the interactive check so the authorization policy can be covered
+# without allocating a pty.
+clean_stdin_is_tty() {
+    [[ -t 0 ]]
+}
+
 prompt_for_system_clean() {
+    local sudo_cached="${1:-false}"
     local prompt_attempt=0
+    local prompt_line="System caches need sudo."
+    if [[ "$sudo_cached" == "true" ]]; then
+        # A cached timestamp settles who the user is, not whether this run was
+        # meant to sweep system caches. Keep asking; only the password step is
+        # already done.
+        prompt_line="System caches, admin access already active."
+    fi
     while true; do
-        echo -ne "${PURPLE}${ICON_ARROW}${NC} System caches need sudo. ${GREEN}Enter${NC} continue, ${GRAY}Space${NC} skip: "
+        echo -ne "${PURPLE}${ICON_ARROW}${NC} ${prompt_line} ${GREEN}Enter${NC} continue, ${GRAY}Space${NC} skip: "
 
         local choice
         choice=$(read_clean_sudo_choice)
@@ -1432,6 +1446,8 @@ start_cleanup() {
     export MOLE_CLEAN_SIZING_TIMEOUTS
     MOLE_CLEAN_REMOVAL_TIMEOUTS=0
     export MOLE_CLEAN_REMOVAL_TIMEOUTS
+    MOLE_CLEAN_TRASH_FAILURES=0
+    export MOLE_CLEAN_TRASH_FAILURES
     log_operation_session_start "clean"
     DRY_RUN_SEEN_IDENTITIES=()
     DRY_RUN_TOTAL_PARTIAL=false
@@ -1455,6 +1471,11 @@ start_cleanup() {
 
     echo -e "${PURPLE_BOLD}Clean Your Mac${NC}"
     echo ""
+
+    if [[ "${MOLE_CLEAN_TRASH:-0}" == "1" && "$DRY_RUN" != "true" ]]; then
+        echo -e "${GREEN}${ICON_SUCCESS}${NC} Trash mode, removals stay restorable, space frees up when you empty the Trash"
+        echo ""
+    fi
 
     if [[ "$DRY_RUN" != "true" && -t 0 ]]; then
         echo -e "${GRAY}${ICON_WARNING} Use --dry-run to preview, --whitelist to manage protected paths${NC}"
@@ -1483,18 +1504,22 @@ start_cleanup() {
         return
     fi
 
-    if [[ -t 0 ]]; then
-        if adopt_sudo_session; then
-            SYSTEM_CLEAN=true
-            echo -e "${GREEN}${ICON_SUCCESS}${NC} Admin access already available"
-            echo ""
-        else
-            prompt_for_system_clean
-        fi
+    local sudo_cached=false
+    adopt_sudo_session && sudo_cached=true
+
+    if clean_stdin_is_tty; then
+        # Confirm the privileged sweep on every interactive run. A sudo
+        # timestamp the user established for something else authenticates them;
+        # it does not say this run was meant to delete outside $HOME. The
+        # adopted session above still spares them the password and still keeps
+        # later privileged calls from prompting mid-spinner (#1084).
+        prompt_for_system_clean "$sudo_cached"
     else
+        # No terminal to ask, so the #1084 contract stands unchanged:
+        # credentials the caller already established are reused for the run.
         echo ""
         echo "Running in non-interactive mode"
-        if adopt_sudo_session; then
+        if [[ "$sudo_cached" == "true" ]]; then
             SYSTEM_CLEAN=true
             echo "  ${ICON_LIST} System-level cleanup enabled, sudo session active"
         else
@@ -1950,6 +1975,12 @@ perform_cleanup() {
         summary_details+=("${GRAY}${ICON_WARNING}${NC} ${MOLE_CLEAN_REMOVAL_TIMEOUTS} item(s) exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s removal budget and may be only partly removed. Run clean again, or raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} for slower disks.")
     fi
 
+    # Trash mode never downgrades to a permanent delete, so a failed move
+    # leaves the item in place. Say so: silence here would read as "cleaned".
+    if [[ ${MOLE_CLEAN_TRASH_FAILURES:-0} -gt 0 ]]; then
+        summary_details+=("${GRAY}${ICON_WARNING}${NC} ${MOLE_CLEAN_TRASH_FAILURES} item(s) could not be moved to the Trash and were left in place. Run ${GRAY}mo clean${NC} without ${GRAY}--trash${NC} to remove them permanently.")
+    fi
+
     if [[ $had_errexit -eq 1 ]]; then
         set -e
     fi
@@ -1990,6 +2021,9 @@ main() {
             "--dry-run" | "-n")
                 DRY_RUN=true
                 export MOLE_DRY_RUN=1
+                ;;
+            "--trash")
+                export MOLE_CLEAN_TRASH=1
                 ;;
             "--external")
                 shift

--- a/bin/completion.sh
+++ b/bin/completion.sh
@@ -11,7 +11,7 @@ for entry in "${MOLE_COMMANDS[@]}"; do
     command_names+=("${entry%%:*}")
 done
 command_words="${command_names[*]}"
-clean_option_words="--dry-run -n --external --whitelist --debug --help -h"
+clean_option_words="--dry-run -n --trash --external --whitelist --debug --help -h"
 analyze_option_words="--json --help -h"
 history_option_words="--json --limit --help -h"
 purge_option_words="--paths --dry-run -n --include-empty --debug --help -h"

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -844,6 +844,58 @@ _mole_record_clean_cancellation() {
     fi
 }
 
+# ============================================================================
+# Cache-clean Trash routing (mo clean --trash)
+# ============================================================================
+
+# Cache cleanup deletes permanently by default. `mo clean --trash` opts into a
+# recoverable sweep: every deletion that would have been an rm -rf becomes a
+# Trash move instead. The guarantee only means something if it holds for the
+# whole run, so the switch lives here at the shared sink rather than at the
+# ~40 call sites in lib/clean.
+_mole_clean_trash_mode() {
+    [[ "${MOLE_CLEAN_TRASH:-0}" == "1" ]]
+}
+
+# Route one already-validated path to the Trash on behalf of safe_remove and
+# safe_sudo_remove. Never falls back to a permanent delete: a trash-mode run
+# that silently deleted something outright would break the only promise the
+# flag makes. Timeouts (124) and signals (128+) propagate unchanged so callers
+# keep their existing cancellation semantics.
+_mole_clean_trash_sink() {
+    local path="$1"
+    local needs_sudo="$2"
+    local size_human="$3"
+    local expected_parent="${4:-}"
+    local expected_parent_id="${5:-}"
+    local expected_target_id="${6:-}"
+
+    local trash_rc=0
+    _mole_move_to_trash "$path" "$needs_sudo" \
+        "$expected_parent" "$expected_parent_id" "$expected_target_id" || trash_rc=$?
+
+    if [[ $trash_rc -eq 0 ]]; then
+        log_operation "${MOLE_CURRENT_COMMAND:-clean}" "TRASHED" "$path" "$size_human"
+        return 0
+    fi
+
+    if [[ $trash_rc -eq 124 ]]; then
+        log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "trash move timed out"
+        MOLE_CLEAN_REMOVAL_TIMEOUTS=$((${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} + 1))
+        return 124
+    fi
+    if [[ $trash_rc -ge 128 ]]; then
+        _mole_record_clean_cancellation "$trash_rc"
+        return "$trash_rc"
+    fi
+
+    debug_log "Trash move failed, refusing permanent delete: $path"
+    log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "trash unavailable"
+    MOLE_CLEAN_TRASH_FAILURES=$((${MOLE_CLEAN_TRASH_FAILURES:-0} + 1))
+    export MOLE_CLEAN_TRASH_FAILURES
+    return 1
+}
+
 # Safe wrapper around rm -rf with validation
 safe_remove() {
     local path="$1"
@@ -1029,6 +1081,16 @@ safe_remove() {
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "SKIPPED" "$path" "sink guard denied"
             return 1
         fi
+    fi
+
+    # Trash mode short-circuit. Everything above this line (path validation,
+    # the final identity re-check, the sink guard) is mode-independent and has
+    # already run; only the last action differs.
+    if _mole_clean_trash_mode; then
+        local trash_sink_rc=0
+        _mole_clean_trash_sink "$path" false "$size_human" \
+            "$expected_parent" "$expected_parent_id" "$expected_target_id" || trash_sink_rc=$?
+        return "$trash_sink_rc"
     fi
 
     # Perform the deletion
@@ -1451,6 +1513,17 @@ safe_sudo_remove() {
         log_operation "${MOLE_CURRENT_COMMAND:-clean}" "SKIPPED" "$path" "identity changed"
         return 1
     fi
+    # Trash mode short-circuit, matching safe_remove. Root-owned cache paths
+    # are moved into the invoking user's Trash by the same privileged mover
+    # uninstall already uses, so a `--trash` run stays recoverable even for the
+    # sudo sections.
+    if _mole_clean_trash_mode; then
+        local trash_sink_rc=0
+        _mole_clean_trash_sink "$path" true "$size_human" \
+            "$expected_parent" "$expected_parent_id" "$expected_target_id" || trash_sink_rc=$?
+        return "$trash_sink_rc"
+    fi
+
     local remove_timeout=""
     local section_deadline_spent=0
     remove_timeout=$(_mole_timeout_with_deadline "$MOLE_TIMEOUT_DISK_VERIFY_SEC" \
@@ -2793,7 +2866,11 @@ safe_sudo_find_delete() {
         fi
         # -type f never emits symlinks; a path that is one now was swapped
         # after find saw it, and the single-file path refuses those.
-        if [[ "$type_filter" == "f" && "${MOLE_DRY_RUN:-0}" != "1" && ! -L "$match" ]]; then
+        # Trash mode also takes the single-file path: the batch deletes with a
+        # privileged xargs rm, which has no Trash equivalent, and routing each
+        # match through safe_sudo_remove is what keeps the run recoverable.
+        if [[ "$type_filter" == "f" && "${MOLE_DRY_RUN:-0}" != "1" && ! -L "$match" ]] &&
+            ! _mole_clean_trash_mode; then
             local identity_timeout=""
             local match_identity=""
             local identity_rc=0

--- a/lib/core/help.sh
+++ b/lib/core/help.sh
@@ -7,10 +7,17 @@ show_clean_help() {
     echo ""
     echo "Options:"
     echo "  --dry-run, -n     Preview cleanup without making changes"
+    echo "  --trash           Move removals to the Trash instead of deleting them"
     echo "  --external PATH   Clean OS metadata from a mounted external volume"
     echo "  --whitelist       Manage protected paths"
     echo "  --debug           Show detailed operation logs"
     echo "  -h, --help        Show this help message"
+    echo ""
+    echo "Cleanup deletes permanently by default. --trash keeps the run"
+    echo "recoverable and never falls back to a permanent delete."
+    echo ""
+    echo "System caches are confirmed on every interactive run, even when a sudo"
+    echo "session is already active."
 }
 
 show_installer_help() {

--- a/lib/manage/update.sh
+++ b/lib/manage/update.sh
@@ -970,6 +970,7 @@ show_help() {
     echo
     printf "  %s%-28s%s %s\n" "$GREEN" "mo clean --dry-run" "$NC" "Preview cleanup"
     printf "  %s%-28s%s %s\n" "$GREEN" "mo clean --whitelist" "$NC" "Manage protected caches"
+    printf "  %s%-28s%s %s\n" "$GREEN" "mo clean --trash" "$NC" "Clean into the Trash, restorable"
 
     printf "  %s%-28s%s %s\n" "$GREEN" "mo optimize --dry-run" "$NC" "Preview optimization"
     printf "  %s%-28s%s %s\n" "$GREEN" "mo optimize --whitelist" "$NC" "Manage protected items"

--- a/tests/clean_system_confirm.bats
+++ b/tests/clean_system_confirm.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+# Tests for the system-cache confirmation in bin/clean.sh.
+#
+# A cached sudo timestamp authenticates the user; it does not say this run was
+# meant to sweep system caches, so an interactive run is asked every time. The
+# non-interactive contract from #1084 is unchanged: credentials the caller
+# already established are reused for the whole run.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+setup() {
+    SANDBOX="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-clean-confirm.XXXXXX")"
+    export SANDBOX
+    export MOLE_TEST_MODE=1
+    export MOLE_TEST_NO_AUTH=1
+}
+
+teardown() {
+    rm -rf "$SANDBOX"
+}
+
+source_clean() {
+    cat <<EOF
+set -euo pipefail
+export HOME="$SANDBOX/home"
+mkdir -p "\$HOME"
+export MOLE_TEST_MODE=1
+export MOLE_TEST_NO_AUTH=1
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+EOF
+}
+
+@test "an interactive run with a cached sudo session is still asked" {
+    run /bin/bash --noprofile --norc <<EOF
+$(source_clean)
+clean_stdin_is_tty() { return 0; }
+adopt_sudo_session() { return 0; }
+prompt_for_system_clean() { echo "PROMPTED cached=\$1"; SYSTEM_CLEAN=false; }
+start_cleanup < /dev/null
+echo "SYSTEM_CLEAN=\$SYSTEM_CLEAN"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    # The prompt appears, and it knows the password step is already done.
+    [[ "$output" == *"PROMPTED cached=true"* ]] || return 1
+    [[ "$output" == *"SYSTEM_CLEAN=false"* ]] || return 1
+}
+
+@test "an interactive run without a cached session is asked the same way" {
+    run /bin/bash --noprofile --norc <<EOF
+$(source_clean)
+clean_stdin_is_tty() { return 0; }
+adopt_sudo_session() { return 1; }
+prompt_for_system_clean() { echo "PROMPTED cached=\$1"; SYSTEM_CLEAN=false; }
+start_cleanup < /dev/null
+echo "SYSTEM_CLEAN=\$SYSTEM_CLEAN"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"PROMPTED cached=false"* ]] || return 1
+}
+
+@test "the prompt says admin access is already active when it is" {
+    run /bin/bash --noprofile --norc <<EOF
+$(source_clean)
+read_clean_sudo_choice() { echo "SPACE"; }
+prompt_for_system_clean true
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"admin access already active"* ]] || return 1
+    [[ "$output" != *"need sudo"* ]] || return 1
+}
+
+@test "a non-interactive run still reuses an established sudo session (#1084)" {
+    run /bin/bash --noprofile --norc <<EOF
+$(source_clean)
+clean_stdin_is_tty() { return 1; }
+adopt_sudo_session() { return 0; }
+start_cleanup < /dev/null
+echo "SYSTEM_CLEAN=\$SYSTEM_CLEAN"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"SYSTEM_CLEAN=true"* ]] || return 1
+    [[ "$output" == *"sudo session active"* ]] || return 1
+}
+
+@test "a non-interactive run without sudo skips system cleanup" {
+    run /bin/bash --noprofile --norc <<EOF
+$(source_clean)
+clean_stdin_is_tty() { return 1; }
+adopt_sudo_session() { return 1; }
+start_cleanup < /dev/null
+echo "SYSTEM_CLEAN=\$SYSTEM_CLEAN"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"SYSTEM_CLEAN=false"* ]] || return 1
+    [[ "$output" == *"requires sudo"* ]] || return 1
+}

--- a/tests/clean_trash_mode.bats
+++ b/tests/clean_trash_mode.bats
@@ -1,0 +1,192 @@
+#!/usr/bin/env bats
+
+# Tests for `mo clean --trash` (MOLE_CLEAN_TRASH=1).
+#
+# Cache cleanup deletes permanently by default; trash mode swaps the final
+# action in safe_remove / safe_sudo_remove for a Trash move. The contract under
+# test is that the swap happens everywhere and that a failed move is never
+# downgraded to a permanent delete. MOLE_TEST_TRASH_DIR keeps Finder and
+# AppleScript out of the run.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+setup() {
+    SANDBOX="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-clean-trash.XXXXXX")"
+    export SANDBOX
+    export MOLE_TEST_TRASH_DIR="$SANDBOX/Trash"
+    export MOLE_TEST_NO_AUTH=1
+    unset MOLE_CLEAN_TRASH
+    unset MOLE_DRY_RUN
+}
+
+teardown() {
+    rm -rf "$SANDBOX"
+}
+
+prelude() {
+    cat <<EOF
+set -euo pipefail
+export HOME="$SANDBOX/home"
+mkdir -p "\$HOME"
+export MOLE_TEST_TRASH_DIR="$MOLE_TEST_TRASH_DIR"
+export MOLE_TEST_NO_AUTH=1
+export MOLE_CURRENT_COMMAND=clean
+source "$PROJECT_ROOT/lib/core/common.sh"
+EOF
+}
+
+source_clean() {
+    cat <<EOF
+set -euo pipefail
+export HOME="$SANDBOX/home"
+mkdir -p "\$HOME"
+export MOLE_TEST_MODE=1
+export MOLE_TEST_NO_AUTH=1
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+start_inline_spinner() { :; }
+stop_inline_spinner() { :; }
+note_activity() { :; }
+EOF
+}
+
+@test "safe_remove moves the target to the Trash when MOLE_CLEAN_TRASH=1" {
+    local victim="$SANDBOX/cache_dir"
+    mkdir -p "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+export MOLE_CLEAN_TRASH=1
+safe_remove "$victim"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ ! -e "$victim" ]] || return 1
+    [[ -n "$(ls -A "$MOLE_TEST_TRASH_DIR" 2> /dev/null || true)" ]] || return 1
+}
+
+@test "safe_remove deletes permanently by default and leaves the Trash empty" {
+    local victim="$SANDBOX/cache_default"
+    mkdir -p "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+safe_remove "$victim"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ ! -e "$victim" ]] || return 1
+    [[ -z "$(ls -A "$MOLE_TEST_TRASH_DIR" 2> /dev/null || true)" ]] || return 1
+}
+
+@test "safe_remove refuses a permanent delete when the Trash is unavailable" {
+    local victim="$SANDBOX/cache_no_trash"
+    mkdir -p "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    # With the harness Trash cleared and MOLE_TEST_NO_AUTH=1 every Trash
+    # route fails. The target must survive rather than fall back to rm -rf.
+    run /bin/bash --noprofile --norc <<EOF
+set -euo pipefail
+unset MOLE_TEST_TRASH_DIR
+export HOME="$SANDBOX/home"
+mkdir -p "\$HOME"
+export MOLE_TEST_NO_AUTH=1
+export MOLE_CURRENT_COMMAND=clean
+source "$PROJECT_ROOT/lib/core/common.sh"
+export MOLE_CLEAN_TRASH=1
+safe_remove "$victim"
+EOF
+
+    [ "$status" -ne 0 ] || return 1
+    [[ -d "$victim" ]] || return 1
+    [[ -f "$victim/data.txt" ]] || return 1
+}
+
+@test "trash mode records TRASHED rather than REMOVED in the operations log" {
+    local victim="$SANDBOX/cache_logged"
+    mkdir -p "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+export MOLE_CLEAN_TRASH=1
+safe_remove "$victim"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+
+    local log="$SANDBOX/home/Library/Logs/mole/operations.log"
+    [[ -f "$log" ]] || return 1
+    grep -q "TRASHED $victim" "$log" || return 1
+    ! grep -q "REMOVED $victim" "$log" || return 1
+}
+
+@test "dry-run in trash mode touches nothing" {
+    local victim="$SANDBOX/cache_dry"
+    mkdir -p "$victim"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+export MOLE_CLEAN_TRASH=1
+export MOLE_DRY_RUN=1
+safe_remove "$victim"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ -d "$victim" ]] || return 1
+    [[ -z "$(ls -A "$MOLE_TEST_TRASH_DIR" 2> /dev/null || true)" ]] || return 1
+}
+
+@test "safe_clean routes through the Trash in trash mode" {
+    local victim="$SANDBOX/pipeline_cache"
+    mkdir -p "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(source_clean)
+export MOLE_TEST_TRASH_DIR="$MOLE_TEST_TRASH_DIR"
+export MOLE_CLEAN_TRASH=1
+start_section "Developer tools"
+safe_clean "$victim" "Test cache"
+end_section
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ ! -e "$victim" ]] || return 1
+    [[ -n "$(ls -A "$MOLE_TEST_TRASH_DIR" 2> /dev/null || true)" ]] || return 1
+}
+
+@test "safe_clean leaves items in place when the Trash is unavailable" {
+    local victim="$SANDBOX/pipeline_no_trash"
+    mkdir -p "$victim"
+    printf 'payload' > "$victim/data.txt"
+
+    # Clear the harness Trash so every Trash route fails; `run` would
+    # otherwise inherit the directory setup() exported.
+    run /bin/bash --noprofile --norc <<EOF
+$(source_clean)
+unset MOLE_TEST_TRASH_DIR
+export MOLE_CLEAN_TRASH=1
+start_section "Developer tools"
+safe_clean "$victim" "Test cache"
+end_section
+echo "failures=\${MOLE_CLEAN_TRASH_FAILURES:-0}"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ -f "$victim/data.txt" ]] || return 1
+    # The summary reads off this counter, so a silent failure would look clean.
+    [[ "$output" == *"failures=1"* ]] || return 1
+}

--- a/tests/completion.bats
+++ b/tests/completion.bats
@@ -89,7 +89,7 @@ setup() {
 @test "completion bash includes current clean, analyze, history, and purge options only" {
 	run "$PROJECT_ROOT/bin/completion.sh" bash
 	[ "$status" -eq 0 ]
-	[[ "$output" == *"--dry-run -n --external --whitelist --debug --help -h"* ]] || return 1
+	[[ "$output" == *"--dry-run -n --trash --external --whitelist --debug --help -h"* ]] || return 1
 	[[ "$output" == *"--json --help -h"* ]] || return 1
 	[[ "$output" == *"--json --limit --help -h"* ]] || return 1
 	[[ "$output" == *"--paths --dry-run -n --include-empty --debug --help -h"* ]] || return 1


### PR DESCRIPTION
## Why

`mo clean` is the only Mole command that deletes permanently — `mo uninstall`
has routed through the Trash since #723 — and on an interactive run it enabled
the privileged sweep from a cached sudo timestamp without asking.

This PR closes both gaps. They are separable; happy to split if you prefer.

## `mo clean --trash`

Opt-in recoverable cleanup. The switch sits at the shared sink (`safe_remove`
and `safe_sudo_remove`), after path validation, the final identity re-check and
the sink guard have all run, so only the last action differs — no call site in
`lib/clean` changes and no future one can forget to honour it.

- **Never downgrades.** A failed Trash move leaves the item in place rather
  than falling back to `rm -rf`; the run summary reports how many were left
  behind, so silence cannot read as "cleaned".
- **Covers the sudo sections** via the same privileged mover `mole_delete`
  already uses for root-owned app bundles.
- `safe_sudo_find_delete` drops back to its single-file path in trash mode —
  the privileged `xargs rm` batch has no Trash equivalent.
- Removals log as `TRASHED`, which `mo history` already counts and renders.

## System caches confirmed on interactive runs

`start_cleanup` called `adopt_sudo_session` and, on success, set
`SYSTEM_CLEAN=true` with no prompt. A timestamp the user established for
something else authenticates them; it does not say this run was meant to delete
outside `$HOME`.

The session is still adopted first, so the confirmation costs a keypress rather
than a password, and every later privileged call still stays out of the spinner.
The prompt says "admin access already active" when it is.

**#1084 is unaffected.** That issue asked for credentials entered once to be
reused for the whole run instead of prompting mid-spinner, and that contract is
untouched — including the non-interactive path, which has no terminal to ask.
`tests/clean_core.bats` "mo clean adopts cached sudo before system cleanup
(#1084)" passes unmodified.

## Testing

- `tests/clean_trash_mode.bats` (7) — routing, the no-fallback guarantee, the
  `TRASHED` log line, dry-run, and the same two through `safe_clean`.
- `tests/clean_system_confirm.bats` (5) — interactive with and without a cached
  session, the prompt wording, and both non-interactive paths.
- `tests/completion.bats` snapshot updated for the new flag.
- `shellcheck` and `shfmt -i 4 -ci -sr` clean; full `./scripts/test.sh`
  compared against a pristine `main` checkout.

No Go code touched.
