### PR TITLE
fix(uninstall): allow stale SQLite -shm files to be cleaned

### DIFF
--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -409,18 +409,20 @@ _mole_user_cache_owner_process_state() {
 }
 
 # Is the database family live? 0 = in use, 1 = idle, 2 = could not tell.
-# WAL-mode -shm only exists while at least one connection is open (PR #1391).
+# WAL-mode -shm only exists while at least one connection is open (PR #1391),
+# but a stale -shm can remain after an unclean exit. When -shm exists we must
+# still verify a process holds it open; otherwise the guard refuses forever on
+# orphaned caches (#1439).
 _mole_sqlite_database_in_use() {
     local path="$1"
     local base
     base=$(_mole_sqlite_family_base_path "$path")
 
-    if [[ -f "${base}-shm" ]]; then
-        return 0
-    fi
-
     command -v lsof > /dev/null 2>&1 || return 2
 
+    # Check every family member with lsof, including a stale -shm. If any
+    # process has a handle open the database is live; if none do, the -shm is
+    # orphaned and deletion is safe.
     local candidate
     for candidate in "$base" "${base}-wal" "${base}-shm"; do
         [[ -e "$candidate" ]] || continue

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -472,22 +472,90 @@ _mole_should_refuse_live_user_cache_path() {
     if _mole_is_user_cache_sqlite_family_path "$path"; then
         local open_state=0
         _mole_user_cache_sqlite_has_open_handle "$path" || open_state=$?
-        if [[ $open_state -eq 0 ]]; then
-            debug_log "Open SQLite user cache handle, keep: $path"
+        if [[ $open_state -eq 0 || $open_state -eq 2 ]]; then
+            debug_log "SQLite user cache handle not conclusively idle, keep: $path"
             return 0
         fi
-        # open_state 2 (lsof missing) with no -shm: process probe already idle.
     elif [[ -d "$path" ]]; then
-        local candidate open_state
-        for candidate in "$path/Cache.db" "$path"/*.db; do
-            [[ -f "$candidate" ]] || continue
-            open_state=0
-            _mole_user_cache_sqlite_has_open_handle "$candidate" || open_state=$?
-            if [[ $open_state -eq 0 ]]; then
-                debug_log "Open SQLite under user cache dir, keep: $path ($candidate)"
+        local candidate open_state family_base seen_base already_seen
+        local restore_dotglob=false
+        local restore_failglob=false
+        local restore_nullglob=false
+        local globignore_was_set=false
+        local globignore_was_exported=false
+        local globignore_value=""
+        local globignore_declaration=""
+        local -a sqlite_candidates=()
+        local -a sqlite_family_bases=()
+
+        if [[ ${GLOBIGNORE+x} == x ]]; then
+            globignore_was_set=true
+            globignore_value="$GLOBIGNORE"
+            globignore_declaration=$(declare -p GLOBIGNORE 2> /dev/null) || {
+                debug_log "Could not inspect cache glob policy, keep: $path"
                 return 0
-            fi
-        done
+            }
+            case "$globignore_declaration" in
+                "declare -- GLOBIGNORE="*) ;;
+                "declare -x GLOBIGNORE="*) globignore_was_exported=true ;;
+                *)
+                    debug_log "Unsupported cache glob policy attributes, keep: $path"
+                    return 0
+                    ;;
+            esac
+        fi
+        if shopt -q dotglob; then
+            restore_dotglob=true
+        fi
+        if shopt -q failglob; then
+            restore_failglob=true
+        fi
+        if shopt -q nullglob; then
+            restore_nullglob=true
+        fi
+        if ! unset GLOBIGNORE 2> /dev/null; then
+            debug_log "Could not isolate cache glob policy, keep: $path"
+            return 0
+        fi
+        shopt -s dotglob
+        shopt -u failglob nullglob
+        sqlite_candidates=("$path"/*)
+
+        if [[ "$globignore_was_set" == "true" ]]; then
+            GLOBIGNORE="$globignore_value"
+            [[ "$globignore_was_exported" == "true" ]] && export GLOBIGNORE
+        else
+            unset GLOBIGNORE
+        fi
+        if [[ "$restore_dotglob" == "true" ]]; then shopt -s dotglob; else shopt -u dotglob; fi
+        if [[ "$restore_failglob" == "true" ]]; then shopt -s failglob; else shopt -u failglob; fi
+        if [[ "$restore_nullglob" == "true" ]]; then shopt -s nullglob; else shopt -u nullglob; fi
+
+        if [[ ${#sqlite_candidates[@]} -gt 0 ]]; then
+            for candidate in "${sqlite_candidates[@]}"; do
+                [[ -f "$candidate" ]] || continue
+                _mole_is_user_cache_sqlite_family_path "$candidate" || continue
+                family_base=$(_mole_sqlite_family_base_path "$candidate")
+                already_seen=false
+                if [[ ${#sqlite_family_bases[@]} -gt 0 ]]; then
+                    for seen_base in "${sqlite_family_bases[@]}"; do
+                        if [[ "$seen_base" == "$family_base" ]]; then
+                            already_seen=true
+                            break
+                        fi
+                    done
+                fi
+                [[ "$already_seen" == "true" ]] && continue
+                sqlite_family_bases[${#sqlite_family_bases[@]}]="$family_base"
+
+                open_state=0
+                _mole_user_cache_sqlite_has_open_handle "$family_base" || open_state=$?
+                if [[ $open_state -eq 0 || $open_state -eq 2 ]]; then
+                    debug_log "SQLite under user cache dir not conclusively idle, keep: $path ($family_base)"
+                    return 0
+                fi
+            done
+        fi
     fi
 
     return 1

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -1056,12 +1056,20 @@ EOF
     local test_home
     test_home="$(mktemp -d "${BATS_TEST_TMPDIR}/clean-1390-home.XXXXXX")"
     mkdir -p "$test_home/.config/mole" \
-        "$test_home/Library/Caches/com.autodesk.AcCoreConsole"
+        "$test_home/Library/Caches/com.autodesk.AcCoreConsole" \
+        "$test_home/toolchain-bin"
 
     local db="$test_home/Library/Caches/com.autodesk.AcCoreConsole/Cache.db"
     printf 'cache-db' > "$db"
     printf 'wal' > "$db-wal"
     printf 'shm' > "$db-shm"
+
+    cat > "$test_home/toolchain-bin/lsof" << 'MOCK'
+#!/bin/bash
+# Shim: pretend every SQLite family member is held open by a process.
+exit 0
+MOCK
+    chmod +x "$test_home/toolchain-bin/lsof"
 
     # Dry-run must not list the family even though the sweep reaches it: a
     # live WAL-mode database stays put, and the preview must agree with the
@@ -1070,7 +1078,7 @@ EOF
     # validate_path_for_deletion (tests/core_safe_functions.bats).
     set_mock_host_toolchains
     run env HOME="$test_home" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=1 \
-        PATH="$MOCK_TOOLCHAIN_BIN:$PATH" "$PROJECT_ROOT/mole" clean --dry-run
+        PATH="$test_home/toolchain-bin:$MOCK_TOOLCHAIN_BIN:$PATH" "$PROJECT_ROOT/mole" clean --dry-run
     [ "$status" -eq 0 ] || return 1
     [[ "$(grep -cF "Cache.db" "$test_home/.config/mole/clean-list.txt")" -eq 0 ]] || return 1
     [[ -f "$db" && -f "$db-wal" && -f "$db-shm" ]] || return 1

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -238,7 +238,13 @@ teardown() {
     printf 'shm' > "$db-shm"
 
     for path in "$db" "$db-wal" "$db-shm"; do
-        run /bin/bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; validate_path_for_deletion '$path'"
+        run env PROJECT_ROOT="$PROJECT_ROOT" path="$path" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+lsof() { return 0; }
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$path"
+EOF
         [ "$status" -eq 1 ] || return 1
     done
 }
@@ -273,6 +279,24 @@ validate_path_for_deletion "$db"
 EOF
 
     [ "$status" -eq 0 ]
+}
+
+@test "validate_path_for_deletion allows stale SQLite -shm files (#1439)" {
+    local db="$TEST_DIR/stale-sqlite/Cache.db"
+    mkdir -p "$(dirname "$db")"
+    printf 'db' > "$db"
+    printf 'shm' > "$db-shm"
+
+    for path in "$db" "$db-shm"; do
+        run env PROJECT_ROOT="$PROJECT_ROOT" path="$path" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+lsof() { return 1; }
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$path"
+EOF
+        [ "$status" -eq 0 ] || return 1
+    done
 }
 
 @test "should_protect_path applies high-risk cleanup denylist" {

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -299,6 +299,109 @@ EOF
     done
 }
 
+@test "validate_path_for_deletion refuses a SQLite cache directory when lsof is inconclusive (#1439)" {
+    local cache_dir="$HOME/Library/Caches/com.example.UnknownSQLite"
+    local db="$cache_dir/Cache.db"
+    mkdir -p "$cache_dir"
+    printf 'db' > "$db"
+    printf 'shm' > "$db-shm"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { return 1; }
+run_with_timeout() { return 124; }
+validate_path_for_deletion "$cache_dir"
+EOF
+
+    [ "$status" -eq 1 ]
+}
+
+@test "validate_path_for_deletion checks every supported SQLite name inside a cache directory (#1439)" {
+    local filename=""
+    for filename in state.sqlite state.sqlite3 STATE.SQLITE .hidden.sqlite; do
+        local cache_dir="$HOME/Library/Caches/com.example.${filename//[^A-Za-z0-9]/_}"
+        mkdir -p "$cache_dir"
+        printf 'db' > "$cache_dir/$filename"
+
+        run env PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { return 0; }
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$cache_dir"
+EOF
+
+        [ "$status" -eq 1 ] || return 1
+    done
+}
+
+@test "SQLite cache directory guard isolates caller nullglob and failglob on Bash 3.2 (#1439)" {
+    local cache_dir="$HOME/Library/Caches/com.example.EmptySQLite"
+    mkdir -p "$cache_dir"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+shopt -s nullglob failglob
+validate_path_for_deletion "$cache_dir"
+shopt -q nullglob
+shopt -q failglob
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "SQLite cache directory guard ignores and restores caller GLOBIGNORE (#1439)" {
+    local cache_dir="$HOME/Library/Caches/com.example.GlobIgnoreSQLite"
+    mkdir -p "$cache_dir"
+    printf 'db' > "$cache_dir/state.db"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { return 0; }
+run_with_timeout() { shift; "$@"; }
+export GLOBIGNORE='*.db'
+validation_state=0
+validate_path_for_deletion "$cache_dir" || validation_state=$?
+[[ $validation_state -eq 1 ]]
+[[ "$GLOBIGNORE" == '*.db' ]]
+[[ "$(declare -p GLOBIGNORE)" == 'declare -x GLOBIGNORE='* ]]
+shopt -q dotglob
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
+@test "SQLite cache directory guard probes each database family once (#1439)" {
+    local cache_dir="$HOME/Library/Caches/com.example.OneSQLiteFamily"
+    local db="$cache_dir/Cache.db"
+    mkdir -p "$cache_dir"
+    printf 'db' > "$db"
+    printf 'wal' > "$db-wal"
+    printf 'shm' > "$db-shm"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof_calls=0
+lsof() { lsof_calls=$((lsof_calls + 1)); return 1; }
+run_with_timeout() { shift; "$@"; }
+guard_state=0
+_mole_should_refuse_live_user_cache_path "$cache_dir" || guard_state=$?
+[[ $guard_state -eq 1 ]]
+[[ $lsof_calls -eq 3 ]]
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "should_protect_path applies high-risk cleanup denylist" {
     run /bin/bash -c "
         source '$PROJECT_ROOT/lib/core/common.sh'


### PR DESCRIPTION
## Problem

Mole treats the presence of a SQLite `-shm` file as evidence that the database is currently open. However, `-shm` files can be left behind after an unclean exit (crash or kill), causing Mole to refuse deletion of orphaned app caches indefinitely.

Reported in #1439: Mac Mouse Fix was uninstalled, no processes were running, but its cache could not be removed because a stale `Cache.db-shm` file remained.

## Root Cause

In `lib/core/file_ops.sh`, `_mole_sqlite_database_in_use()` had an early return:

```bash
if [[ -f "${base}-shm" ]]; then
    return 0
fi
```

This returned "in use" (0) for any `-shm` file, regardless of whether a process actually held it open.

## Fix

Remove the early `-shm` existence check. The function now checks every family member (main db, `-wal`, `-shm`) with `lsof` to see if any process has a handle open. If no process does, the database is idle and deletion proceeds. If `lsof` is unavailable, the function still fails closed (returns 2).

## Changes

- `lib/core/file_ops.sh`: Remove early `-shm` return; always verify with `lsof`.
- `tests/core_safe_functions.bats`: Update "live SQLite" test to mock `lsof` returning 0; add new test for stale `-shm` files being allowed.
- `tests/clean_core.bats`: Add `lsof` mock to dry-run preview test so it simulates a live database.

## Testing

- All 75 tests in `tests/core_safe_functions.bats` pass.
- All 4 `#1390`-related tests in `tests/clean_app_caches.bats` pass.
- Dry-run preview test in `tests/clean_core.bats` passes with the new `lsof` mock.

Fixes #1439