### PR TITLE
feat(clean): remove old Autodesk Fusion app bundles

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -716,6 +716,172 @@ _autodesk_cache_delete_guard_allows() {
     mole_clean_process_guard autodesk_cache_process_state "Autodesk running"
 }
 
+# Autodesk Fusion's in-app updater keeps every previous app bundle under
+# ~/Library/Application Support/Autodesk/webdeploy/production. An alias named
+# "Autodesk Fusion.app" points at the currently installed version. Bundles
+# newer than that alias are staged for the next launch and must be kept (#1438).
+clean_autodesk_fusion_old_bundles() {
+    local production_dir="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    [[ -d "$production_dir" ]] || return 0
+
+    local current_alias="$production_dir/Autodesk Fusion.app"
+    if [[ ! -e "$current_alias" ]]; then
+        debug_log "Autodesk Fusion old bundles: no current alias at $current_alias"
+        return 0
+    fi
+
+    local current_target=""
+    if [[ -L "$current_alias" ]]; then
+        current_target=$(readlink "$current_alias" 2> /dev/null || true)
+    else
+        # Alias / Finder alias: resolve via AppleScript; fall back to pwd -P
+        # so a missing osascript still finds the real bundle.
+        if command -v osascript > /dev/null 2>&1; then
+            current_target=$(osascript -e "tell application \"Finder\" to POSIX path of (original item of (POSIX file \"$current_alias\" as alias))" 2> /dev/null || true)
+            current_target="${current_target%/}"
+        fi
+        if [[ -z "$current_target" ]]; then
+            current_target=$(cd "$current_alias" 2> /dev/null && pwd -P) || current_target=""
+        fi
+    fi
+    current_target="${current_target%/}"
+    if [[ -z "$current_target" ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (current alias unreadable)"
+        note_activity
+        return 0
+    fi
+
+    # The alias typically points at ".../<hash>/Autodesk Fusion.app"; keep the
+    # hash directory that owns it.
+    local current_dir=""
+    if [[ "$current_target" == "$production_dir"/* ]]; then
+        local rel="${current_target#"$production_dir"/}"
+        current_dir="${rel%%/*}"
+    else
+        current_dir=$(basename "$(dirname "$current_target")")
+    fi
+    if [[ -z "$current_dir" || ! -d "$production_dir/$current_dir" ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (current version missing)"
+        note_activity
+        return 0
+    fi
+
+    local current_mtime
+    current_mtime=$(stat -f%m "$production_dir/$current_dir" 2> /dev/null || echo "0")
+    [[ "$current_mtime" =~ ^[0-9]+$ ]] || current_mtime=0
+
+    # Keep a version newer than current: it is a staged auto-update that the
+    # alias will point at on next launch.
+    local newest_dir=""
+    local newest_mtime=0
+    local dir name mtime
+    for dir in "$production_dir"/*; do
+        [[ -d "$dir" && ! -L "$dir" ]] || continue
+        name=$(basename "$dir")
+        [[ "$name" == "Autodesk Fusion.app" ]] && continue
+        [[ "$name" == "$current_dir" ]] && continue
+        mtime=$(stat -f%m "$dir" 2> /dev/null || echo "0")
+        if [[ "$mtime" =~ ^[0-9]+$ ]] && [[ "$mtime" -gt "$newest_mtime" ]]; then
+            newest_mtime="$mtime"
+            newest_dir="$name"
+        fi
+    done
+    if [[ "$newest_mtime" -le "$current_mtime" ]]; then
+        newest_dir=""
+    elif [[ -n "$newest_dir" ]]; then
+        debug_log "Autodesk Fusion old versions: keeping $newest_dir (staged auto-update newer than $current_dir)"
+    fi
+
+    local -a old_dirs=()
+    for dir in "$production_dir"/*; do
+        [[ -d "$dir" && ! -L "$dir" ]] || continue
+        name=$(basename "$dir")
+        [[ "$name" == "Autodesk Fusion.app" ]] && continue
+        [[ "$name" == "$current_dir" ]] && continue
+        [[ -n "$newest_dir" && "$name" == "$newest_dir" ]] && continue
+        if should_protect_path "$dir" || is_path_whitelisted "$dir"; then
+            continue
+        fi
+        old_dirs+=("$dir")
+    done
+
+    if [[ ${#old_dirs[@]} -eq 0 ]]; then
+        debug_log "Autodesk Fusion old versions: nothing to remove (current=$current_dir)"
+        return 0
+    fi
+
+    local process_state=0
+    autodesk_cache_process_state || process_state=$?
+    if [[ $process_state -ne 1 ]]; then
+        if [[ $process_state -eq 2 ]]; then
+            echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (process state unknown)"
+            note_activity
+        else
+            mole_defer_cleanup_family "Autodesk Fusion"
+        fi
+        return 0
+    fi
+
+    local cleaned_count=0
+    local total_size=0
+    local stopped_reason=""
+    for dir in "${old_dirs[@]}"; do
+        process_state=0
+        autodesk_cache_process_state || process_state=$?
+        if [[ $process_state -ne 1 ]]; then
+            stopped_reason="Autodesk Fusion started"
+            [[ $process_state -eq 2 ]] && stopped_reason="process state unknown"
+            break
+        fi
+        local size_kb=""
+        local size_rc=0
+        size_kb=$(get_path_size_kb "$dir") || size_rc=$?
+        [[ $size_rc -eq 0 ]] || _mole_record_clean_cancellation "$size_rc"
+        [[ $size_rc -eq 0 ]] || return "$size_rc"
+        size_kb="${size_kb:-0}"
+
+        if [[ "$DRY_RUN" == "true" ]]; then
+            if declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
+                record_dry_run_cleanup_target "$dir" "$size_kb" 1 true || continue
+            fi
+            total_size=$((total_size + size_kb))
+            cleaned_count=$((cleaned_count + 1))
+            continue
+        fi
+
+        if safe_remove "$dir" true "$size_kb" > /dev/null 2>&1; then
+            total_size=$((total_size + size_kb))
+            cleaned_count=$((cleaned_count + 1))
+        else
+            debug_log "Autodesk Fusion old version removal failed: $dir"
+        fi
+    done
+
+    if [[ $cleaned_count -gt 0 ]]; then
+        local size_human
+        size_human=$(bytes_to_human "$((total_size * 1024))")
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Autodesk Fusion old versions${NC} · ${YELLOW}${cleaned_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
+        else
+            local line_color
+            line_color=$(cleanup_result_color_kb "$total_size")
+            echo -e "  ${line_color}${ICON_SUCCESS}${NC} Autodesk Fusion old versions${NC} · ${line_color}${cleaned_count} dirs, $size_human${NC}"
+        fi
+        files_cleaned=$((files_cleaned + cleaned_count))
+        total_size_cleaned=$((total_size_cleaned + total_size))
+        total_items=$((total_items + 1))
+        note_activity
+    fi
+    if [[ -n "$stopped_reason" ]]; then
+        if [[ "$stopped_reason" == "process state unknown" ]]; then
+            echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · stopped (${stopped_reason})"
+            note_activity
+        else
+            mole_defer_cleanup_family "Autodesk Fusion"
+        fi
+    fi
+}
+
 # 3D and CAD tools.
 clean_3d_tools() {
     safe_clean ~/Library/Caches/org.blenderfoundation.blender/* "Blender cache"
@@ -751,6 +917,12 @@ clean_3d_tools() {
     fi
 
     safe_clean ~/Library/Caches/com.sketchup.*/* "SketchUp cache"
+
+    # Remove old Autodesk Fusion app bundles left by the in-app updater.
+    # The updater keeps every version under webdeploy/production and leaves an
+    # alias named "Autodesk Fusion.app" pointing at the current one. Delete
+    # every older bundle, keep the current target and any newer staged update.
+    clean_autodesk_fusion_old_bundles
 }
 # Productivity apps.
 clean_productivity_apps() {

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -707,6 +707,10 @@ autodesk_cache_process_state() {
         -f "/AcCoreConsole" \
         -x "ADPClientService" \
         -f "/ADPClientService" \
+        -x "streamer" \
+        -f "/streamer" \
+        -x "Fusion Client Downloader" \
+        -x "Fusion 360 Client Downloader" \
         -f "Autodesk Fusion" \
         -f "Fusion 360" \
         -f "Fusion360"
@@ -716,99 +720,451 @@ _autodesk_cache_delete_guard_allows() {
     mole_clean_process_guard autodesk_cache_process_state "Autodesk running"
 }
 
-# Autodesk Fusion's in-app updater keeps every previous app bundle under
-# ~/Library/Application Support/Autodesk/webdeploy/production. An alias named
-# "Autodesk Fusion.app" points at the currently installed version. Bundles
-# newer than that alias are staged for the next launch and must be kept (#1438).
+# Autodesk Fusion's in-app updater can leave tens of gigabytes of old app
+# bundles under webdeploy/production (#1438 measured 60GB). This is not a
+# generic Autodesk tree cleanup: only direct 40-hex version directories that
+# contain one exact com.autodesk.fusion360 app bundle are eligible. Keep the
+# current, equal-version, newer staged, unrecognized, non-hash, and symlinked
+# entries. Version evidence is stronger than directory mtime, which an updater
+# can preserve or reorder.
+_MOLE_AUTODESK_FUSION_VERSION=""
+_MOLE_AUTODESK_FUSION_APP=""
+_MOLE_AUTODESK_FUSION_PRODUCTION_ROOT=""
+_MOLE_AUTODESK_FUSION_RESOLVED_DIR=""
+_MOLE_AUTODESK_FUSION_RESOLVED_VERSION=""
+_MOLE_AUTODESK_FUSION_CLEANUP_TARGETS=()
+_MOLE_AUTODESK_FUSION_CLEANUP_PARENTS=()
+_MOLE_AUTODESK_FUSION_CLEANUP_PARENT_IDS=()
+_MOLE_AUTODESK_FUSION_CLEANUP_TARGET_IDS=()
+_MOLE_AUTODESK_FUSION_GUARD_REASON=""
+
+_autodesk_fusion_trusted_production_root() {
+    local production_dir="$1"
+    _MOLE_AUTODESK_FUSION_PRODUCTION_ROOT=""
+    [[ -d "$production_dir" && ! -L "$production_dir" ]] || return 1
+
+    local physical_root=""
+    physical_root=$(cd -P "$production_dir" 2> /dev/null && pwd -P) || return 1
+    # Refuse every symlinked ancestor. A lexical path below Application Support
+    # is not containment when webdeploy or production redirects elsewhere.
+    [[ "$physical_root" == "$production_dir" ]] || return 1
+    _MOLE_AUTODESK_FUSION_PRODUCTION_ROOT="$physical_root"
+}
+
+_autodesk_fusion_version_dir_version() {
+    local version_dir="$1"
+    local deadline_seconds="$2"
+    _MOLE_AUTODESK_FUSION_VERSION=""
+    _MOLE_AUTODESK_FUSION_APP=""
+
+    [[ -d "$version_dir" && ! -L "$version_dir" ]] || return 1
+    local app_candidate=""
+    local app_count=0
+    local candidate
+    for candidate in \
+        "$version_dir/Autodesk Fusion.app" \
+        "$version_dir/Autodesk Fusion 360.app"; do
+        [[ -d "$candidate" && ! -L "$candidate" ]] || continue
+        app_candidate="$candidate"
+        app_count=$((app_count + 1))
+    done
+    [[ $app_count -eq 1 ]] || return 1
+
+    local contents_dir="$app_candidate/Contents"
+    local macos_dir="$contents_dir/MacOS"
+    [[ -d "$contents_dir" && ! -L "$contents_dir" ]] || return 1
+    [[ -d "$macos_dir" && ! -L "$macos_dir" ]] || return 1
+    local info_plist="$contents_dir/Info.plist"
+    [[ -f "$info_plist" && ! -L "$info_plist" ]] || return 1
+
+    local probe_timeout=""
+    local probe_rc=0
+    probe_timeout=$(_mole_timeout_with_deadline \
+        "$MOLE_TIMEOUT_QUICK_DETECT_SEC" "$deadline_seconds") || probe_rc=$?
+    [[ $probe_rc -eq 0 ]] || return "$probe_rc"
+
+    local bundle_id=""
+    bundle_id=$(run_with_timeout "$probe_timeout" /usr/bin/plutil \
+        -extract CFBundleIdentifier raw "$info_plist" < /dev/null 2> /dev/null) || probe_rc=$?
+    [[ $probe_rc -eq 124 || $probe_rc -ge 128 ]] && return "$probe_rc"
+    [[ $probe_rc -eq 0 && "$bundle_id" == "com.autodesk.fusion360" ]] || return 1
+
+    probe_timeout=$(_mole_timeout_with_deadline \
+        "$MOLE_TIMEOUT_QUICK_DETECT_SEC" "$deadline_seconds") || probe_rc=$?
+    [[ $probe_rc -eq 0 ]] || return "$probe_rc"
+    local version=""
+    version=$(run_with_timeout "$probe_timeout" /usr/bin/plutil \
+        -extract CFBundleVersion raw "$info_plist" < /dev/null 2> /dev/null) || probe_rc=$?
+    [[ $probe_rc -eq 124 || $probe_rc -ge 128 ]] && return "$probe_rc"
+    [[ $probe_rc -eq 0 && "$version" =~ ^[0-9]+([.][0-9]+)*$ ]] || return 1
+
+    probe_timeout=$(_mole_timeout_with_deadline \
+        "$MOLE_TIMEOUT_QUICK_DETECT_SEC" "$deadline_seconds") || probe_rc=$?
+    [[ $probe_rc -eq 0 ]] || return "$probe_rc"
+    local executable=""
+    executable=$(run_with_timeout "$probe_timeout" /usr/bin/plutil \
+        -extract CFBundleExecutable raw "$info_plist" < /dev/null 2> /dev/null) || probe_rc=$?
+    [[ $probe_rc -eq 124 || $probe_rc -ge 128 ]] && return "$probe_rc"
+    [[ $probe_rc -eq 0 &&
+        ("$executable" == "Autodesk Fusion" || "$executable" == "Autodesk Fusion 360") ]] || return 1
+    local executable_path="$macos_dir/$executable"
+    [[ -f "$executable_path" && -x "$executable_path" && ! -L "$executable_path" ]] || return 1
+
+    _MOLE_AUTODESK_FUSION_VERSION="$version"
+    _MOLE_AUTODESK_FUSION_APP="$app_candidate"
+}
+
+_autodesk_fusion_version_is_older() {
+    local candidate_version="$1"
+    local current_version="$2"
+    [[ "$candidate_version" =~ ^[0-9]+([.][0-9]+)*$ ]] || return 1
+    [[ "$current_version" =~ ^[0-9]+([.][0-9]+)*$ ]] || return 1
+
+    local saved_ifs="$IFS"
+    IFS='.'
+    # shellcheck disable=SC2206 # intentional numeric version split
+    local -a candidate_parts=($candidate_version)
+    # shellcheck disable=SC2206 # intentional numeric version split
+    local -a current_parts=($current_version)
+    IFS="$saved_ifs"
+
+    local count=${#candidate_parts[@]}
+    [[ ${#current_parts[@]} -gt $count ]] && count=${#current_parts[@]}
+    local index candidate_part current_part
+    for ((index = 0; index < count; index++)); do
+        candidate_part="${candidate_parts[$index]:-0}"
+        current_part="${current_parts[$index]:-0}"
+        # Avoid arithmetic overflow on corrupt metadata. Unknown is retained.
+        [[ ${#candidate_part} -le 9 && ${#current_part} -le 9 ]] || return 1
+        if ((10#$candidate_part < 10#$current_part)); then
+            return 0
+        elif ((10#$candidate_part > 10#$current_part)); then
+            return 1
+        fi
+    done
+    return 1
+}
+
+_autodesk_fusion_resolve_current_dir() {
+    local production_root="$1"
+    local deadline_seconds="$2"
+    _MOLE_AUTODESK_FUSION_RESOLVED_DIR=""
+
+    local current_alias="$production_root/Autodesk Fusion.app"
+    [[ -e "$current_alias" || -L "$current_alias" ]] || return 1
+
+    local resolved_target=""
+    local resolve_rc=0
+    if [[ -L "$current_alias" ]]; then
+        [[ -e "$current_alias" ]] || return 1
+        resolved_target=$(cd -P "$current_alias" 2> /dev/null && pwd -P) || return 1
+    else
+        # Resolve a Finder alias through Foundation, not Finder automation. The
+        # static JXA receives the path as argv, so quotes or AppleScript syntax
+        # in a user path cannot become code. Test/no-auth runs never launch it.
+        if [[ "${MOLE_TEST_MODE:-0}" == "1" || "${MOLE_TEST_NO_AUTH:-0}" == "1" ||
+            ! -x /usr/bin/osascript ]]; then
+            return 1
+        fi
+        local resolve_timeout=""
+        resolve_timeout=$(_mole_timeout_with_deadline \
+            "$MOLE_TIMEOUT_QUICK_DETECT_SEC" "$deadline_seconds") || resolve_rc=$?
+        [[ $resolve_rc -eq 0 ]] || return "$resolve_rc"
+        # shellcheck disable=SC2016 # `$` belongs to the JXA bridge, not Bash
+        local jxa_script='ObjC.import("Foundation"); function run(argv) { var url = $.NSURL.fileURLWithPath($(argv[0])); var resolved = $.NSURL.URLByResolvingAliasFileAtURLOptionsError(url, 0, null); if (!resolved) throw new Error("unresolved alias"); return ObjC.unwrap(resolved.path); }'
+        resolved_target=$(run_with_timeout "$resolve_timeout" /usr/bin/osascript \
+            -l JavaScript -e "$jxa_script" "$current_alias" < /dev/null 2> /dev/null) || resolve_rc=$?
+        [[ $resolve_rc -eq 0 ]] || return "$resolve_rc"
+        resolved_target="${resolved_target%/}"
+        [[ -d "$resolved_target" ]] || return 1
+        resolved_target=$(cd -P "$resolved_target" 2> /dev/null && pwd -P) || return 1
+    fi
+
+    local version_dir=""
+    local target_name="${resolved_target##*/}"
+    if [[ "${resolved_target%/*}" == "$production_root" &&
+        "$target_name" =~ ^[0-9a-f]{40}$ ]]; then
+        version_dir="$resolved_target"
+    elif [[ "$target_name" == "Autodesk Fusion.app" ||
+        "$target_name" == "Autodesk Fusion 360.app" ]]; then
+        version_dir="${resolved_target%/*}"
+        local version_name="${version_dir##*/}"
+        [[ "${version_dir%/*}" == "$production_root" &&
+            "$version_name" =~ ^[0-9a-f]{40}$ ]] || return 1
+    else
+        return 1
+    fi
+    [[ -d "$version_dir" && ! -L "$version_dir" ]] || return 1
+
+    _MOLE_AUTODESK_FUSION_RESOLVED_DIR="$version_dir"
+}
+
+_autodesk_fusion_resolve_current_version() {
+    local production_root="$1"
+    local deadline_seconds="$2"
+    _MOLE_AUTODESK_FUSION_RESOLVED_DIR=""
+    _MOLE_AUTODESK_FUSION_RESOLVED_VERSION=""
+
+    local resolve_rc=0
+    _autodesk_fusion_resolve_current_dir \
+        "$production_root" "$deadline_seconds" || resolve_rc=$?
+    [[ $resolve_rc -eq 0 ]] || return "$resolve_rc"
+    local version_dir="$_MOLE_AUTODESK_FUSION_RESOLVED_DIR"
+
+    local version_rc=0
+    _autodesk_fusion_version_dir_version \
+        "$version_dir" "$deadline_seconds" || version_rc=$?
+    [[ $version_rc -eq 0 ]] || return "$version_rc"
+    local version="$_MOLE_AUTODESK_FUSION_VERSION"
+
+    # The updater can switch the alias while plist metadata is being read and
+    # exit before the caller's process recheck. End this resolver with an
+    # alias-only rebind, so its returned directory/version are one stable
+    # observation rather than metadata from an alias target that is no longer
+    # current.
+    resolve_rc=0
+    _autodesk_fusion_resolve_current_dir \
+        "$production_root" "$deadline_seconds" || resolve_rc=$?
+    [[ $resolve_rc -eq 0 ]] || return "$resolve_rc"
+    [[ "$_MOLE_AUTODESK_FUSION_RESOLVED_DIR" == "$version_dir" ]] || return 1
+
+    _MOLE_AUTODESK_FUSION_RESOLVED_DIR="$version_dir"
+    _MOLE_AUTODESK_FUSION_RESOLVED_VERSION="$version"
+}
+
+_autodesk_fusion_materialize_version_dirs() {
+    local production_root="$1"
+    local output_file="$2"
+    local deadline_seconds="$3"
+    : > "$output_file" || return 1
+
+    local scan_timeout=""
+    local scan_rc=0
+    scan_timeout=$(_mole_timeout_with_deadline \
+        "$MOLE_TIMEOUT_MEDIUM_PROBE_SEC" "$deadline_seconds") || scan_rc=$?
+    if [[ $scan_rc -eq 0 ]]; then
+        run_with_timeout "$scan_timeout" find "$production_root" \
+            -mindepth 1 -maxdepth 1 -type d -print0 \
+            < /dev/null > "$output_file" 2> /dev/null || scan_rc=$?
+    fi
+    if [[ $scan_rc -ne 0 ]]; then
+        : > "$output_file" || true
+        return "$scan_rc"
+    fi
+}
+
+_autodesk_fusion_plan_old_versions() {
+    local production_root="$1"
+    local current_dir="$2"
+    local current_version="$3"
+    local deadline_seconds="$4"
+    _MOLE_AUTODESK_FUSION_CLEANUP_TARGETS=()
+    _MOLE_AUTODESK_FUSION_CLEANUP_PARENTS=()
+    _MOLE_AUTODESK_FUSION_CLEANUP_PARENT_IDS=()
+    _MOLE_AUTODESK_FUSION_CLEANUP_TARGET_IDS=()
+
+    local inventory_file=""
+    inventory_file=$(create_temp_file) || return 1
+    local inventory_rc=0
+    _autodesk_fusion_materialize_version_dirs \
+        "$production_root" "$inventory_file" "$deadline_seconds" || inventory_rc=$?
+    if [[ $inventory_rc -ne 0 ]]; then
+        rm -f -- "$inventory_file" 2> /dev/null || true # SAFE: exact tracked temp file created above
+        return "$inventory_rc"
+    fi
+
+    local dir name candidate_version version_rc
+    while IFS= read -r -d '' dir; do
+        if [[ $SECONDS -ge $deadline_seconds ]]; then
+            inventory_rc=124
+            break
+        fi
+        name="${dir##*/}"
+        [[ "$name" =~ ^[0-9a-f]{40}$ ]] || continue
+        [[ "$dir" != "$current_dir" && "${dir%/*}" == "$production_root" ]] || continue
+        [[ -d "$dir" && ! -L "$dir" ]] || continue
+
+        version_rc=0
+        _autodesk_fusion_version_dir_version \
+            "$dir" "$deadline_seconds" || version_rc=$?
+        if [[ $version_rc -eq 124 || $version_rc -ge 128 ]]; then
+            inventory_rc=$version_rc
+            break
+        elif [[ $version_rc -ne 0 ]]; then
+            debug_log "Autodesk Fusion old versions: keeping unverified directory $dir"
+            continue
+        fi
+        candidate_version="$_MOLE_AUTODESK_FUSION_VERSION"
+        _autodesk_fusion_version_is_older \
+            "$candidate_version" "$current_version" || continue
+        if should_protect_path "$dir" || is_path_whitelisted "$dir" ||
+            (declare -f holds_compiled_model_cache > /dev/null 2>&1 && holds_compiled_model_cache "$dir"); then
+            continue
+        fi
+
+        _mole_snapshot_path_identity "$dir" || continue
+        [[ "$_MOLE_PATH_SNAPSHOT_PARENT" == "$production_root" ]] || continue
+        _MOLE_AUTODESK_FUSION_CLEANUP_TARGETS+=("$dir")
+        _MOLE_AUTODESK_FUSION_CLEANUP_PARENTS+=("$_MOLE_PATH_SNAPSHOT_PARENT")
+        _MOLE_AUTODESK_FUSION_CLEANUP_PARENT_IDS+=("$_MOLE_PATH_SNAPSHOT_PARENT_ID")
+        _MOLE_AUTODESK_FUSION_CLEANUP_TARGET_IDS+=("$_MOLE_PATH_SNAPSHOT_TARGET_ID")
+    done < "$inventory_file"
+    rm -f -- "$inventory_file" 2> /dev/null || true # SAFE: exact tracked temp file created above
+
+    if [[ $inventory_rc -ne 0 ]]; then
+        _MOLE_AUTODESK_FUSION_CLEANUP_TARGETS=()
+        _MOLE_AUTODESK_FUSION_CLEANUP_PARENTS=()
+        _MOLE_AUTODESK_FUSION_CLEANUP_PARENT_IDS=()
+        _MOLE_AUTODESK_FUSION_CLEANUP_TARGET_IDS=()
+        return "$inventory_rc"
+    fi
+}
+
+_autodesk_fusion_guard_current_is_unchanged() {
+    local _MOLE_AUTODESK_FUSION_RESOLVED_DIR=""
+    local _MOLE_AUTODESK_FUSION_RESOLVED_VERSION=""
+    local resolve_rc=0
+    _autodesk_fusion_resolve_current_version \
+        "$_MOLE_AUTODESK_FUSION_GUARD_ROOT" \
+        "$_MOLE_AUTODESK_FUSION_GUARD_DEADLINE" || resolve_rc=$?
+    if [[ $resolve_rc -ne 0 ]]; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="current version unknown"
+        [[ $resolve_rc -eq 124 || $resolve_rc -ge 128 ]] && return "$resolve_rc"
+        return 1
+    fi
+    if [[ "$_MOLE_AUTODESK_FUSION_RESOLVED_DIR" != "$_MOLE_AUTODESK_FUSION_GUARD_CURRENT_DIR" ||
+        "$_MOLE_AUTODESK_FUSION_RESOLVED_VERSION" != "$_MOLE_AUTODESK_FUSION_GUARD_CURRENT_VERSION" ]]; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="current version changed"
+        return 1
+    fi
+}
+
+_autodesk_fusion_delete_guard_allows() {
+    local target="$1"
+    _MOLE_AUTODESK_FUSION_GUARD_REASON=""
+
+    local _MOLE_CLEAN_GUARD_REASON=""
+    if ! mole_clean_process_guard \
+        autodesk_cache_process_state "Autodesk started"; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="$_MOLE_CLEAN_GUARD_REASON"
+        return 1
+    fi
+
+    local _MOLE_AUTODESK_FUSION_PRODUCTION_ROOT=""
+    if ! _autodesk_fusion_trusted_production_root \
+        "$_MOLE_AUTODESK_FUSION_GUARD_ROOT"; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="production root changed"
+        return 1
+    fi
+
+    local current_rc=0
+    _autodesk_fusion_guard_current_is_unchanged || current_rc=$?
+    [[ $current_rc -eq 0 ]] || return "$current_rc"
+
+    local name="${target##*/}"
+    if [[ ! "$name" =~ ^[0-9a-f]{40}$ || "${target%/*}" != "$_MOLE_AUTODESK_FUSION_GUARD_ROOT" ||
+        "$target" == "$_MOLE_AUTODESK_FUSION_GUARD_CURRENT_DIR" || ! -d "$target" || -L "$target" ]]; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="candidate changed"
+        return 1
+    fi
+
+    local version_rc=0
+    _autodesk_fusion_version_dir_version \
+        "$target" "$_MOLE_AUTODESK_FUSION_GUARD_DEADLINE" || version_rc=$?
+    if [[ $version_rc -ne 0 ]]; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="candidate identity changed"
+        [[ $version_rc -eq 124 || $version_rc -ge 128 ]] && return "$version_rc"
+        return 1
+    fi
+    if ! _autodesk_fusion_version_is_older \
+        "$_MOLE_AUTODESK_FUSION_VERSION" \
+        "$_MOLE_AUTODESK_FUSION_GUARD_CURRENT_VERSION"; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="retention changed"
+        return 1
+    fi
+    if should_protect_path "$target" || is_path_whitelisted "$target" ||
+        (declare -f holds_compiled_model_cache > /dev/null 2>&1 && holds_compiled_model_cache "$target"); then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="policy changed"
+        return 1
+    fi
+
+    # Metadata probes above are bounded, but the updater can start during any
+    # one of them. Rebind its tri-state immediately before the final identity
+    # check; that identity remains the last operation before safe_remove's rm.
+    _MOLE_CLEAN_GUARD_REASON=""
+    if ! mole_clean_process_guard \
+        autodesk_cache_process_state "Autodesk started"; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="$_MOLE_CLEAN_GUARD_REASON"
+        return 1
+    fi
+
+    # The updater may atomically switch the alias and exit during any earlier
+    # metadata, policy, or process probe. Make current resolution the last
+    # external-state check, immediately before the target identity binding.
+    current_rc=0
+    _autodesk_fusion_guard_current_is_unchanged || current_rc=$?
+    [[ $current_rc -eq 0 ]] || return "$current_rc"
+
+    # Make the object/parent identity check the last guard operation so a
+    # replacement during the metadata probes is rejected at the sink.
+    if ! _mole_path_matches_identity \
+        "$target" \
+        "$_MOLE_AUTODESK_FUSION_GUARD_PARENT" \
+        "$_MOLE_AUTODESK_FUSION_GUARD_PARENT_ID" \
+        "$_MOLE_AUTODESK_FUSION_GUARD_TARGET_ID"; then
+        _MOLE_AUTODESK_FUSION_GUARD_REASON="candidate replaced"
+        return 1
+    fi
+}
+
 clean_autodesk_fusion_old_bundles() {
     local production_dir="$HOME/Library/Application Support/Autodesk/webdeploy/production"
     [[ -d "$production_dir" ]] || return 0
+    local cleanup_deadline=$((SECONDS + 60))
 
-    local current_alias="$production_dir/Autodesk Fusion.app"
-    if [[ ! -e "$current_alias" ]]; then
-        debug_log "Autodesk Fusion old bundles: no current alias at $current_alias"
-        return 0
-    fi
-
-    local current_target=""
-    if [[ -L "$current_alias" ]]; then
-        current_target=$(readlink "$current_alias" 2> /dev/null || true)
-    else
-        # Alias / Finder alias: resolve via AppleScript; fall back to pwd -P
-        # so a missing osascript still finds the real bundle.
-        if command -v osascript > /dev/null 2>&1; then
-            current_target=$(osascript -e "tell application \"Finder\" to POSIX path of (original item of (POSIX file \"$current_alias\" as alias))" 2> /dev/null || true)
-            current_target="${current_target%/}"
-        fi
-        if [[ -z "$current_target" ]]; then
-            current_target=$(cd "$current_alias" 2> /dev/null && pwd -P) || current_target=""
-        fi
-    fi
-    current_target="${current_target%/}"
-    if [[ -z "$current_target" ]]; then
-        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (current alias unreadable)"
+    local _MOLE_AUTODESK_FUSION_PRODUCTION_ROOT=""
+    if ! _autodesk_fusion_trusted_production_root "$production_dir"; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (production root not trusted)"
         note_activity
         return 0
     fi
+    local production_root="$_MOLE_AUTODESK_FUSION_PRODUCTION_ROOT"
 
-    # The alias typically points at ".../<hash>/Autodesk Fusion.app"; keep the
-    # hash directory that owns it.
-    local current_dir=""
-    if [[ "$current_target" == "$production_dir"/* ]]; then
-        local rel="${current_target#"$production_dir"/}"
-        current_dir="${rel%%/*}"
-    else
-        current_dir=$(basename "$(dirname "$current_target")")
-    fi
-    if [[ -z "$current_dir" || ! -d "$production_dir/$current_dir" ]]; then
-        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (current version missing)"
+    local _MOLE_AUTODESK_FUSION_RESOLVED_DIR=""
+    local _MOLE_AUTODESK_FUSION_RESOLVED_VERSION=""
+    local current_rc=0
+    _autodesk_fusion_resolve_current_version \
+        "$production_root" "$cleanup_deadline" || current_rc=$?
+    if [[ $current_rc -eq 124 ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (current version probe timed out)"
+        note_activity
+        return 0
+    elif [[ $current_rc -ge 128 ]]; then
+        return "$current_rc"
+    elif [[ $current_rc -ne 0 ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (current version unknown)"
         note_activity
         return 0
     fi
+    local current_dir="$_MOLE_AUTODESK_FUSION_RESOLVED_DIR"
+    local current_version="$_MOLE_AUTODESK_FUSION_RESOLVED_VERSION"
 
-    local current_mtime
-    current_mtime=$(stat -f%m "$production_dir/$current_dir" 2> /dev/null || echo "0")
-    [[ "$current_mtime" =~ ^[0-9]+$ ]] || current_mtime=0
-
-    # Keep a version newer than current: it is a staged auto-update that the
-    # alias will point at on next launch.
-    local newest_dir=""
-    local newest_mtime=0
-    local dir name mtime
-    for dir in "$production_dir"/*; do
-        [[ -d "$dir" && ! -L "$dir" ]] || continue
-        name=$(basename "$dir")
-        [[ "$name" == "Autodesk Fusion.app" ]] && continue
-        [[ "$name" == "$current_dir" ]] && continue
-        mtime=$(stat -f%m "$dir" 2> /dev/null || echo "0")
-        if [[ "$mtime" =~ ^[0-9]+$ ]] && [[ "$mtime" -gt "$newest_mtime" ]]; then
-            newest_mtime="$mtime"
-            newest_dir="$name"
-        fi
-    done
-    if [[ "$newest_mtime" -le "$current_mtime" ]]; then
-        newest_dir=""
-    elif [[ -n "$newest_dir" ]]; then
-        debug_log "Autodesk Fusion old versions: keeping $newest_dir (staged auto-update newer than $current_dir)"
-    fi
-
-    local -a old_dirs=()
-    for dir in "$production_dir"/*; do
-        [[ -d "$dir" && ! -L "$dir" ]] || continue
-        name=$(basename "$dir")
-        [[ "$name" == "Autodesk Fusion.app" ]] && continue
-        [[ "$name" == "$current_dir" ]] && continue
-        [[ -n "$newest_dir" && "$name" == "$newest_dir" ]] && continue
-        if should_protect_path "$dir" || is_path_whitelisted "$dir"; then
-            continue
-        fi
-        old_dirs+=("$dir")
-    done
-
-    if [[ ${#old_dirs[@]} -eq 0 ]]; then
-        debug_log "Autodesk Fusion old versions: nothing to remove (current=$current_dir)"
+    local plan_rc=0
+    _autodesk_fusion_plan_old_versions \
+        "$production_root" "$current_dir" "$current_version" \
+        "$cleanup_deadline" || plan_rc=$?
+    if [[ $plan_rc -eq 124 ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (inventory timed out)"
+        note_activity
+        return 0
+    elif [[ $plan_rc -ge 128 ]]; then
+        return "$plan_rc"
+    elif [[ $plan_rc -ne 0 ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · skipped (inventory incomplete)"
+        note_activity
         return 0
     fi
+    [[ ${#_MOLE_AUTODESK_FUSION_CLEANUP_TARGETS[@]} -gt 0 ]] || return 0
 
     local process_state=0
     autodesk_cache_process_state || process_state=$?
@@ -823,24 +1179,62 @@ clean_autodesk_fusion_old_bundles() {
     fi
 
     local cleaned_count=0
+    local failed_count=0
     local total_size=0
     local stopped_reason=""
-    for dir in "${old_dirs[@]}"; do
-        process_state=0
-        autodesk_cache_process_state || process_state=$?
-        if [[ $process_state -ne 1 ]]; then
-            stopped_reason="Autodesk Fusion started"
-            [[ $process_state -eq 2 ]] && stopped_reason="process state unknown"
+    local index dir size_kb size_rc size_timeout guard_rc remove_rc
+    for ((index = 0; index < ${#_MOLE_AUTODESK_FUSION_CLEANUP_TARGETS[@]}; index++)); do
+        dir="${_MOLE_AUTODESK_FUSION_CLEANUP_TARGETS[$index]}"
+        local _MOLE_AUTODESK_FUSION_GUARD_ROOT="$production_root"
+        local _MOLE_AUTODESK_FUSION_GUARD_CURRENT_DIR="$current_dir"
+        local _MOLE_AUTODESK_FUSION_GUARD_CURRENT_VERSION="$current_version"
+        local _MOLE_AUTODESK_FUSION_GUARD_DEADLINE="$cleanup_deadline"
+        local _MOLE_AUTODESK_FUSION_GUARD_PARENT="${_MOLE_AUTODESK_FUSION_CLEANUP_PARENTS[$index]}"
+        local _MOLE_AUTODESK_FUSION_GUARD_PARENT_ID="${_MOLE_AUTODESK_FUSION_CLEANUP_PARENT_IDS[$index]}"
+        local _MOLE_AUTODESK_FUSION_GUARD_TARGET_ID="${_MOLE_AUTODESK_FUSION_CLEANUP_TARGET_IDS[$index]}"
+
+        guard_rc=0
+        _autodesk_fusion_delete_guard_allows "$dir" || guard_rc=$?
+        if [[ $guard_rc -eq 124 ]]; then
+            stopped_reason="verification timed out"
+            break
+        elif [[ $guard_rc -ge 128 ]]; then
+            return "$guard_rc"
+        elif [[ $guard_rc -ne 0 ]]; then
+            stopped_reason="$_MOLE_AUTODESK_FUSION_GUARD_REASON"
             break
         fi
-        local size_kb=""
-        local size_rc=0
-        size_kb=$(get_path_size_kb "$dir") || size_rc=$?
-        [[ $size_rc -eq 0 ]] || _mole_record_clean_cancellation "$size_rc"
-        [[ $size_rc -eq 0 ]] || return "$size_rc"
-        size_kb="${size_kb:-0}"
 
-        if [[ "$DRY_RUN" == "true" ]]; then
+        size_timeout=""
+        size_rc=0
+        size_timeout=$(_mole_timeout_with_deadline \
+            "$MOLE_TIMEOUT_DISK_VERIFY_SEC" "$cleanup_deadline") || size_rc=$?
+        if [[ $size_rc -eq 0 ]]; then
+            size_kb=$(get_path_size_kb "$dir" "$size_timeout") || size_rc=$?
+        fi
+        if [[ $size_rc -eq 124 ]]; then
+            stopped_reason="size probe timed out"
+            break
+        elif [[ $size_rc -ge 128 ]]; then
+            return "$size_rc"
+        elif [[ $size_rc -ne 0 || ! "$size_kb" =~ ^[0-9]+$ ]]; then
+            failed_count=$((failed_count + 1))
+            continue
+        fi
+
+        guard_rc=0
+        _autodesk_fusion_delete_guard_allows "$dir" || guard_rc=$?
+        if [[ $guard_rc -eq 124 ]]; then
+            stopped_reason="verification timed out"
+            break
+        elif [[ $guard_rc -ge 128 ]]; then
+            return "$guard_rc"
+        elif [[ $guard_rc -ne 0 ]]; then
+            stopped_reason="$_MOLE_AUTODESK_FUSION_GUARD_REASON"
+            break
+        fi
+
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
             if declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
                 record_dry_run_cleanup_target "$dir" "$size_kb" 1 true || continue
             fi
@@ -849,10 +1243,26 @@ clean_autodesk_fusion_old_bundles() {
             continue
         fi
 
-        if safe_remove "$dir" true "$size_kb" > /dev/null 2>&1; then
+        remove_rc=0
+        local _MOLE_SAFE_REMOVE_FINAL_GUARD="_autodesk_fusion_delete_guard_allows"
+        safe_remove "$dir" true "$size_kb" "$cleanup_deadline" \
+            "$_MOLE_AUTODESK_FUSION_GUARD_PARENT" \
+            "$_MOLE_AUTODESK_FUSION_GUARD_PARENT_ID" \
+            "$_MOLE_AUTODESK_FUSION_GUARD_TARGET_ID" \
+            > /dev/null 2>&1 || remove_rc=$?
+        if [[ $remove_rc -eq 0 ]]; then
             total_size=$((total_size + size_kb))
             cleaned_count=$((cleaned_count + 1))
+        elif [[ $remove_rc -eq 124 ]]; then
+            stopped_reason="removal timed out"
+            break
+        elif [[ $remove_rc -ge 128 ]]; then
+            return "$remove_rc"
+        elif [[ -n "$_MOLE_AUTODESK_FUSION_GUARD_REASON" ]]; then
+            stopped_reason="$_MOLE_AUTODESK_FUSION_GUARD_REASON"
+            break
         else
+            failed_count=$((failed_count + 1))
             debug_log "Autodesk Fusion old version removal failed: $dir"
         fi
     done
@@ -860,25 +1270,25 @@ clean_autodesk_fusion_old_bundles() {
     if [[ $cleaned_count -gt 0 ]]; then
         local size_human
         size_human=$(bytes_to_human "$((total_size * 1024))")
-        if [[ "$DRY_RUN" == "true" ]]; then
+        if [[ "${DRY_RUN:-false}" == "true" ]]; then
             echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Autodesk Fusion old versions${NC} · ${YELLOW}${cleaned_count} dirs, $(colorize_human_size "$size_human") ${YELLOW}dry${NC}"
         else
             local line_color
             line_color=$(cleanup_result_color_kb "$total_size")
             echo -e "  ${line_color}${ICON_SUCCESS}${NC} Autodesk Fusion old versions${NC} · ${line_color}${cleaned_count} dirs, $size_human${NC}"
         fi
-        files_cleaned=$((files_cleaned + cleaned_count))
-        total_size_cleaned=$((total_size_cleaned + total_size))
-        total_items=$((total_items + 1))
+        files_cleaned=$((${files_cleaned:-0} + cleaned_count))
+        total_size_cleaned=$((${total_size_cleaned:-0} + total_size))
+        total_items=$((${total_items:-0} + 1))
+        note_activity
+    fi
+    if [[ $failed_count -gt 0 ]]; then
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · ${failed_count} failed"
         note_activity
     fi
     if [[ -n "$stopped_reason" ]]; then
-        if [[ "$stopped_reason" == "process state unknown" ]]; then
-            echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · stopped (${stopped_reason})"
-            note_activity
-        else
-            mole_defer_cleanup_family "Autodesk Fusion"
-        fi
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Autodesk Fusion old versions · stopped (${stopped_reason})"
+        note_activity
     fi
 }
 

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -1024,9 +1024,15 @@ safe_remove() {
     # returns non-zero to refuse.
     local final_sink_guard="${_MOLE_SAFE_REMOVE_FINAL_GUARD:-}"
     if [[ -n "$final_sink_guard" ]] && declare -f "$final_sink_guard" > /dev/null 2>&1; then
-        if ! "$final_sink_guard" "$path"; then
+        local final_sink_guard_rc=0
+        "$final_sink_guard" "$path" || final_sink_guard_rc=$?
+        if [[ $final_sink_guard_rc -ne 0 ]]; then
             debug_log "Refusing removal after the final sink guard denied: $path"
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "SKIPPED" "$path" "sink guard denied"
+            if [[ $final_sink_guard_rc -eq 124 || $final_sink_guard_rc -ge 128 ]]; then
+                _mole_record_clean_cancellation "$final_sink_guard_rc"
+                return "$final_sink_guard_rc"
+            fi
             return 1
         fi
     fi

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -1404,3 +1404,91 @@ INNER
     [ "$status" -eq 0 ]
     [[ ! -e "$db" ]]
 }
+
+@test "clean_autodesk_fusion_old_bundles removes old versions, keeps current and staged" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    mkdir -p "$prod/hash-current" "$prod/hash-old" "$prod/hash-newer"
+    ln -s "$prod/hash-current" "$prod/Autodesk Fusion.app"
+
+    # Make hash-newer actually newer than current.
+    touch -t 202001010000 "$prod/hash-current"
+    touch -t 201901010000 "$prod/hash-old"
+    touch -t 202101010000 "$prod/hash-newer"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+get_path_size_kb() { echo "1024"; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+safe_remove() { echo "REMOVE:$1"; rm -rf "$1"; }
+note_activity() { :; }
+debug_log() { :; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ]
+    [[ ! -d "$prod/hash-old" ]] || return 1
+    [[ -d "$prod/hash-current" ]]
+    [[ -d "$prod/hash-newer" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles skips when Autodesk is running" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    mkdir -p "$prod/hash-current" "$prod/hash-old"
+    ln -s "$prod/hash-current" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 0; }
+get_path_size_kb() { echo "1024"; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; }
+mole_defer_cleanup_family() { echo "DEFER:$1"; }
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DEFER:Autodesk Fusion"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ -d "$prod/hash-old" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles skips when current alias is broken" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    mkdir -p "$prod/hash-old"
+    # Alias points to a directory that does not exist.
+    ln -s "$prod/hash-missing" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; }
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ -d "$prod/hash-old" ]]
+}

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -26,6 +26,21 @@ teardown_file() {
     fi
 }
 
+make_fusion_version_dir() {
+    local version_dir="$1"
+    local version="$2"
+    local bundle_id="${3:-com.autodesk.fusion360}"
+    local app_name="${4:-Autodesk Fusion.app}"
+    local info_plist="$version_dir/$app_name/Contents/Info.plist"
+    mkdir -p "$(dirname "$info_plist")" "$version_dir/$app_name/Contents/MacOS"
+    /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string $bundle_id" \
+        -c "Add :CFBundleVersion string $version" \
+        -c "Add :CFBundleExecutable string Autodesk Fusion" \
+        "$info_plist" > /dev/null
+    touch "$version_dir/$app_name/Contents/MacOS/Autodesk Fusion"
+    chmod +x "$version_dir/$app_name/Contents/MacOS/Autodesk Fusion"
+}
+
 @test "clean_xcode_tools skips derived data when Xcode running" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
@@ -1405,25 +1420,27 @@ INNER
     [[ ! -e "$db" ]]
 }
 
-@test "clean_autodesk_fusion_old_bundles removes old versions, keeps current and staged" {
+@test "clean_autodesk_fusion_old_bundles removes only strictly older versions and keeps every staged version" {
     local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
-    mkdir -p "$prod/hash-current" "$prod/hash-old" "$prod/hash-newer"
-    ln -s "$prod/hash-current" "$prod/Autodesk Fusion.app"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    local staged_one="$prod/cccccccccccccccccccccccccccccccccccccccc"
+    local staged_two="$prod/dddddddddddddddddddddddddddddddddddddddd"
+    local equal="$prod/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    make_fusion_version_dir "$staged_one" "2.0.300"
+    make_fusion_version_dir "$staged_two" "3.0.1"
+    make_fusion_version_dir "$equal" "2.0.200"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
 
-    # Make hash-newer actually newer than current.
-    touch -t 202001010000 "$prod/hash-current"
-    touch -t 201901010000 "$prod/hash-old"
-    touch -t 202101010000 "$prod/hash-newer"
-
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=0 /bin/bash --noprofile --norc << 'INNER'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
 pgrep() { return 1; }
 get_path_size_kb() { echo "1024"; }
-should_protect_path() { return 1; }
-is_path_whitelisted() { return 1; }
-safe_remove() { echo "REMOVE:$1"; rm -rf "$1"; }
 note_activity() { :; }
 debug_log() { :; }
 files_cleaned=0
@@ -1433,17 +1450,90 @@ DRY_RUN=false
 clean_autodesk_fusion_old_bundles
 INNER
 
-    [ "$status" -eq 0 ]
-    [[ ! -d "$prod/hash-old" ]] || return 1
-    [[ -d "$prod/hash-current" ]]
-    [[ -d "$prod/hash-newer" ]]
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ ! -d "$old" ]] || return 1
+    [[ -d "$current" && -d "$staged_one" && -d "$staged_two" && -d "$equal" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles preserves non-hash and unverified siblings" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    local wrong_id="$prod/cccccccccccccccccccccccccccccccccccccccc"
+    local no_app="$prod/dddddddddddddddddddddddddddddddddddddddd"
+    local no_executable="$prod/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    local non_hash="$prod/cache"
+    local external="$HOME/fusion-external-version"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    make_fusion_version_dir "$wrong_id" "2.0.50" "com.example.not-fusion"
+    make_fusion_version_dir "$no_executable" "2.0.25"
+    rm "$no_executable/Autodesk Fusion.app/Contents/MacOS/Autodesk Fusion"
+    mkdir -p "$no_app/config" "$non_hash"
+    make_fusion_version_dir "$non_hash" "2.0.1"
+    make_fusion_version_dir "$external" "2.0.1"
+    ln -s "$external" "$prod/ffffffffffffffffffffffffffffffffffffffff"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=0 /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+get_path_size_kb() { echo "1"; }
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ] || return 1
+    [[ ! -d "$old" ]] || return 1
+    [[ -d "$wrong_id" && -d "$no_app" && -d "$no_executable" && -d "$non_hash" && -L "$prod/ffffffffffffffffffffffffffffffffffffffff" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles refuses a symlinked production root" {
+    local autodesk="$HOME/Library/Application Support/Autodesk"
+    local external="$HOME/outside-fusion-production"
+    rm -rf "$autodesk" "$external"
+    mkdir -p "$autodesk/webdeploy" "$external"
+    local current="$external/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$external/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$external/Autodesk Fusion.app"
+    ln -s "$external" "$autodesk/webdeploy/production"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"production root not trusted"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ -d "$old" ]]
 }
 
 @test "clean_autodesk_fusion_old_bundles skips when Autodesk is running" {
     local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
     rm -rf "$HOME/Library/Application Support/Autodesk"
-    mkdir -p "$prod/hash-current" "$prod/hash-old"
-    ln -s "$prod/hash-current" "$prod/Autodesk Fusion.app"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
 set -euo pipefail
@@ -1451,9 +1541,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
 pgrep() { return 0; }
 get_path_size_kb() { echo "1024"; }
-should_protect_path() { return 1; }
-is_path_whitelisted() { return 1; }
-safe_remove() { echo "UNEXPECTED_REMOVE:$1"; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
 mole_defer_cleanup_family() { echo "DEFER:$1"; }
 note_activity() { :; }
 debug_log() { :; }
@@ -1461,34 +1549,517 @@ DRY_RUN=false
 clean_autodesk_fusion_old_bundles
 INNER
 
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"DEFER:Autodesk Fusion"* ]] || return 1
     [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
-    [[ -d "$prod/hash-old" ]]
+    [[ -d "$old" ]]
 }
 
-@test "clean_autodesk_fusion_old_bundles skips when current alias is broken" {
+@test "clean_autodesk_fusion_old_bundles skips while the Autodesk streamer updater is running" {
     local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
     rm -rf "$HOME/Library/Application Support/Autodesk"
-    mkdir -p "$prod/hash-old"
-    # Alias points to a directory that does not exist.
-    ln -s "$prod/hash-missing" "$prod/Autodesk Fusion.app"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
-pgrep() { return 1; }
-should_protect_path() { return 1; }
-is_path_whitelisted() { return 1; }
-safe_remove() { echo "UNEXPECTED_REMOVE:$1"; }
+pgrep() { [[ "$*" == *streamer* ]]; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
+mole_defer_cleanup_family() { echo "DEFER:$1"; }
 note_activity() { :; }
 debug_log() { :; }
 DRY_RUN=false
 clean_autodesk_fusion_old_bundles
 INNER
 
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"DEFER:Autodesk Fusion"* ]] || return 1
     [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
-    [[ -d "$prod/hash-old" ]]
+    [[ -d "$old" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles skips when Autodesk process state is unknown" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+autodesk_cache_process_state() { return 2; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"skipped (process state unknown)"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles skips when current alias is broken" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Autodesk Fusion.app" \
+        "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"current version unknown"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles stops when the current alias changes during sizing" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=0 /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+get_path_size_kb() {
+    local alias="$HOME/Library/Application Support/Autodesk/webdeploy/production/Autodesk Fusion.app"
+    rm "$alias"
+    ln -s "$1/Autodesk Fusion.app" "$alias"
+    echo "1"
+}
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"stopped (current version changed)"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles stops when Autodesk starts during sizing" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=0 /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+marker="$HOME/autodesk-started"
+pgrep() { [[ -e "$marker" ]]; }
+get_path_size_kb() { : > "$marker"; echo "1"; }
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"stopped (Autodesk started)"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles rejects a candidate replaced during sizing" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk" "$HOME/fusion-replacement"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    local replacement="$HOME/fusion-replacement"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    make_fusion_version_dir "$replacement" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=0 /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+old="$HOME/Library/Application Support/Autodesk/webdeploy/production/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+pgrep() { return 1; }
+get_path_size_kb() {
+    mv "$old" "$HOME/original-old-fusion"
+    mv "$HOME/fusion-replacement" "$old"
+    echo "1"
+}
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+INNER
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"stopped (candidate replaced)"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles reports a failed removal and continues" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old_one="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    local old_two="$prod/cccccccccccccccccccccccccccccccccccccccc"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old_one" "2.0.100"
+    make_fusion_version_dir "$old_two" "2.0.150"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+old_one="$HOME/Library/Application Support/Autodesk/webdeploy/production/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+pgrep() { return 1; }
+get_path_size_kb() { echo "1"; }
+safe_remove() {
+    if [[ "$1" == "$old_one" ]]; then
+        return 1
+    fi
+    command rm -rf "$1"
+}
+note_activity() { :; }
+debug_log() { :; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+DRY_RUN=false
+clean_autodesk_fusion_old_bundles
+printf 'COUNTS:%s:%s:%s\n' "$files_cleaned" "$total_size_cleaned" "$total_items"
+INNER
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"1 failed"* ]] || return 1
+    [[ "$output" == *"COUNTS:1:1:1"* ]] || return 1
+    [[ -d "$old_one" && ! -d "$old_two" ]]
+}
+
+@test "clean_autodesk_fusion_old_bundles propagates a final sink interrupt" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_CURRENT_COMMAND=clean /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+pgrep() { return 1; }
+get_path_size_kb() { echo "1"; }
+guard_calls=0
+_autodesk_fusion_delete_guard_allows() {
+    guard_calls=$((guard_calls + 1))
+    [[ $guard_calls -lt 3 ]] && return 0
+    _MOLE_AUTODESK_FUSION_GUARD_REASON="interrupted"
+    return 130
+}
+note_activity() { :; }
+debug_log() { :; }
+DRY_RUN=false
+MOLE_CLEAN_CANCEL_STATUS=0
+set +e
+clean_autodesk_fusion_old_bundles
+cleanup_rc=$?
+set -e
+printf 'RC:%s CANCEL:%s CALLS:%s\n' \
+    "$cleanup_rc" "$MOLE_CLEAN_CANCEL_STATUS" "$guard_calls"
+[[ $cleanup_rc -eq 130 ]]
+INNER
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC:130 CANCEL:130 CALLS:3"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "Autodesk Fusion final guard catches the streamer starting during metadata probes" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+marker="$HOME/streamer-started"
+autodesk_cache_process_state() { [[ -e "$marker" ]]; }
+_autodesk_fusion_resolve_current_version() {
+    _MOLE_AUTODESK_FUSION_RESOLVED_DIR="$current"
+    _MOLE_AUTODESK_FUSION_RESOLVED_VERSION="2.0.200"
+    : > "$marker"
+}
+_mole_snapshot_path_identity "$old"
+_MOLE_AUTODESK_FUSION_GUARD_ROOT="$prod"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_DIR="$current"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_VERSION="2.0.200"
+_MOLE_AUTODESK_FUSION_GUARD_DEADLINE=$((SECONDS + 10))
+_MOLE_AUTODESK_FUSION_GUARD_PARENT="$_MOLE_PATH_SNAPSHOT_PARENT"
+_MOLE_AUTODESK_FUSION_GUARD_PARENT_ID="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+_MOLE_AUTODESK_FUSION_GUARD_TARGET_ID="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+set +e
+_autodesk_fusion_delete_guard_allows "$old"
+guard_rc=$?
+set -e
+printf 'RC:%s REASON:%s\n' "$guard_rc" "$_MOLE_AUTODESK_FUSION_GUARD_REASON"
+INNER
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC:1 REASON:Autodesk started"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "Autodesk Fusion final guard catches the current alias switching during candidate probes" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+alias_path="$prod/Autodesk Fusion.app"
+pgrep() { return 1; }
+plutil_counter="$HOME/plutil-counter"
+: > "$plutil_counter"
+run_with_timeout() {
+    shift
+    if [[ "$1" == "/usr/bin/plutil" ]]; then
+        local plutil_calls
+        plutil_calls=$(wc -l < "$plutil_counter")
+        plutil_calls=$((plutil_calls + 1))
+        printf '%s\n' "$plutil_calls" >> "$plutil_counter"
+        if [[ $plutil_calls -eq 4 ]]; then
+            rm "$alias_path"
+            ln -s "$old/Autodesk Fusion.app" "$alias_path"
+        fi
+    fi
+    "$@"
+}
+_mole_snapshot_path_identity "$old"
+_MOLE_AUTODESK_FUSION_GUARD_ROOT="$prod"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_DIR="$current"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_VERSION="2.0.200"
+_MOLE_AUTODESK_FUSION_GUARD_DEADLINE=$((SECONDS + 10))
+_MOLE_AUTODESK_FUSION_GUARD_PARENT="$_MOLE_PATH_SNAPSHOT_PARENT"
+_MOLE_AUTODESK_FUSION_GUARD_PARENT_ID="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+_MOLE_AUTODESK_FUSION_GUARD_TARGET_ID="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+set +e
+_autodesk_fusion_delete_guard_allows "$old"
+guard_rc=$?
+set -e
+plutil_calls=$(wc -l < "$plutil_counter" | tr -d '[:space:]')
+printf 'RC:%s REASON:%s PLUTIL:%s\n' \
+    "$guard_rc" "$_MOLE_AUTODESK_FUSION_GUARD_REASON" "$plutil_calls"
+INNER
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC:1 REASON:current version changed"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "Autodesk Fusion final guard catches the current alias switching during its final process probe" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+alias_path="$prod/Autodesk Fusion.app"
+process_calls=0
+autodesk_cache_process_state() {
+    process_calls=$((process_calls + 1))
+    if [[ $process_calls -eq 2 ]]; then
+        rm "$alias_path"
+        ln -s "$old/Autodesk Fusion.app" "$alias_path"
+    fi
+    return 1
+}
+_mole_snapshot_path_identity "$old"
+_MOLE_AUTODESK_FUSION_GUARD_ROOT="$prod"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_DIR="$current"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_VERSION="2.0.200"
+_MOLE_AUTODESK_FUSION_GUARD_DEADLINE=$((SECONDS + 10))
+_MOLE_AUTODESK_FUSION_GUARD_PARENT="$_MOLE_PATH_SNAPSHOT_PARENT"
+_MOLE_AUTODESK_FUSION_GUARD_PARENT_ID="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+_MOLE_AUTODESK_FUSION_GUARD_TARGET_ID="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+set +e
+_autodesk_fusion_delete_guard_allows "$old"
+guard_rc=$?
+set -e
+printf 'RC:%s REASON:%s PROCESS:%s\n' \
+    "$guard_rc" "$_MOLE_AUTODESK_FUSION_GUARD_REASON" "$process_calls"
+INNER
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC:1 REASON:current version changed PROCESS:2"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "Autodesk Fusion final current resolver rebinds the alias after metadata probes" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    local old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    make_fusion_version_dir "$current" "2.0.200"
+    make_fusion_version_dir "$old" "2.0.100"
+    ln -s "$current/Autodesk Fusion.app" "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+old="$prod/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+alias_path="$prod/Autodesk Fusion.app"
+pgrep() { return 1; }
+plutil_counter="$HOME/final-resolver-plutil-counter"
+: > "$plutil_counter"
+run_with_timeout() {
+    shift
+    if [[ "$1" == "/usr/bin/plutil" ]]; then
+        local plutil_calls
+        plutil_calls=$(wc -l < "$plutil_counter")
+        plutil_calls=$((plutil_calls + 1))
+        printf '%s\n' "$plutil_calls" >> "$plutil_counter"
+        if [[ $plutil_calls -eq 7 ]]; then
+            rm "$alias_path"
+            ln -s "$old/Autodesk Fusion.app" "$alias_path"
+        fi
+    fi
+    "$@"
+}
+_mole_snapshot_path_identity "$old"
+_MOLE_AUTODESK_FUSION_GUARD_ROOT="$prod"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_DIR="$current"
+_MOLE_AUTODESK_FUSION_GUARD_CURRENT_VERSION="2.0.200"
+_MOLE_AUTODESK_FUSION_GUARD_DEADLINE=$((SECONDS + 10))
+_MOLE_AUTODESK_FUSION_GUARD_PARENT="$_MOLE_PATH_SNAPSHOT_PARENT"
+_MOLE_AUTODESK_FUSION_GUARD_PARENT_ID="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+_MOLE_AUTODESK_FUSION_GUARD_TARGET_ID="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+set +e
+_autodesk_fusion_delete_guard_allows "$old"
+guard_rc=$?
+set -e
+plutil_calls=$(wc -l < "$plutil_counter" | tr -d '[:space:]')
+printf 'RC:%s REASON:%s PLUTIL:%s\n' \
+    "$guard_rc" "$_MOLE_AUTODESK_FUSION_GUARD_REASON" "$plutil_calls"
+INNER
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"RC:1 REASON:current version unknown PLUTIL:9"* ]] || return 1
+    [[ -d "$old" ]]
+}
+
+@test "Finder alias resolver passes the alias path as inert argv" {
+    local prod="$HOME/Library/Application Support/Autodesk/webdeploy/production"
+    rm -rf "$HOME/Library/Application Support/Autodesk"
+    local current="$prod/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    make_fusion_version_dir "$current" "2.0.200"
+    touch "$prod/Autodesk Fusion.app"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+alias_path="$HOME/Library/Application Support/Autodesk/webdeploy/production/Autodesk Fusion.app"
+target="$HOME/Library/Application Support/Autodesk/webdeploy/production/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Autodesk Fusion.app"
+run_with_timeout() {
+    shift
+    if [[ "$1" == "/usr/bin/osascript" ]]; then
+        [[ "${!#}" == "$alias_path" ]] || return 79
+        printf '%s\n' "$target"
+        return 0
+    fi
+    "$@"
+}
+_autodesk_fusion_resolve_current_version \
+    "$HOME/Library/Application Support/Autodesk/webdeploy/production" \
+    "$((SECONDS + 10))"
+printf 'CURRENT:%s|%s\n' \
+    "$_MOLE_AUTODESK_FUSION_RESOLVED_DIR" \
+    "$_MOLE_AUTODESK_FUSION_RESOLVED_VERSION"
+INNER
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"CURRENT:$current|2.0.200"* ]]
 }

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -49,6 +49,38 @@ EOF
     [[ -z "$(ls -A "$MOLE_TEST_TRASH_DIR" 2> /dev/null || true)" ]]
 }
 
+@test "safe_remove final sink guard preserves timeout and signal cancellation" {
+    local victim="$SANDBOX/final-guard-victim"
+    mkdir -p "$victim"
+    : > "$victim/keep.txt"
+
+    run /bin/bash --noprofile --norc <<EOF
+$(prelude)
+export MOLE_CURRENT_COMMAND=clean
+guard_rc=0
+final_guard() { return "\$guard_rc"; }
+_MOLE_SAFE_REMOVE_FINAL_GUARD=final_guard
+for guard_rc in 124 130; do
+    MOLE_CLEAN_CANCEL_STATUS=0
+    set +e
+    safe_remove "$victim" true 1
+    actual_rc=\$?
+    set -e
+    printf 'GUARD:%s ACTUAL:%s CANCEL:%s\n' \
+        "\$guard_rc" "\$actual_rc" "\$MOLE_CLEAN_CANCEL_STATUS"
+done
+[[ -d "$victim" ]]
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"GUARD:124 ACTUAL:124 CANCEL:124"* ]] || return 1
+    [[ "$output" == *"GUARD:130 ACTUAL:130 CANCEL:130"* ]] || return 1
+    [[ -d "$victim" ]]
+}
+
 @test "mole_delete trash mode moves the target instead of rm -rf" {
     local victim="$SANDBOX/victim_trash"
     mkdir -p "$victim"


### PR DESCRIPTION
## Problem

Autodesk Fusion's in-app updater can leave previous app bundles under `~/Library/Application Support/Autodesk/webdeploy/production`. Each release lives in a hash-named folder and the `Autodesk Fusion.app` alias identifies the current version. The reporter accumulated about 60 GB of old bundles (#1438).

## Solution

Add `clean_autodesk_fusion_old_bundles`, called from `clean_3d_tools`, with deletion evidence bound at every stage:

1. Resolve and stabilize the current Fusion alias inside the real production root; fail closed when it is missing, changes, or escapes containment.
2. Consider only direct lowercase 40-hex version directories containing a verified Fusion bundle, exact bundle ID, numeric bundle version, and executable.
3. Keep the current version, equal versions, every newer staged version, symlinks, and anything unrecognized. Remove only strictly older verified versions.
4. Recheck Autodesk/updater process state, current-alias identity, candidate metadata, parent identity, and target identity at the final deletion sink.
5. Preserve timeout/signal cancellation and report partial removal failures accurately.

## Testing

- Full Bats suite: 1,647 passed, 6 existing environment-dependent skips, 0 failures.
- Relevant cleanup and file-operation suites on the latest-main merge tree: 338/338 passed.
- Go, integration, installation, formatting, ShellCheck, syntax, and duplication checks passed.

Closes #1438
