### PR TITLE
feat(clean): allow tuning system cleanup time budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Prefer a walkthrough? Watch the [Mole tutorial video](https://www.youtube.com/wa
 Mole can remove files, so it validates paths, protects shared and system-owned locations, and asks for confirmation when an action needs it. When Mole cannot prove an item is safe to change, it skips or refuses it.
 
 - `clean`, `uninstall`, `purge`, `installer`, and `remove` can delete files. Review them with `--dry-run` first, and add `--debug` when needed.
+- System cleanup is bounded to 120 seconds so it cannot appear stuck on a slow filesystem. For a one-off run on a healthy but slow disk, set `MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC` between 30 and 600 seconds, for example: `MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC=300 mo clean`.
 - `mo analyze` moves selected items to Trash after confirmation.
 - Cleanup activity is recorded in `~/Library/Logs/mole/operations.log`; review it with `mo history` or disable it with `MO_NO_OPLOG=1`.
 - Protect caches with `mo clean --whitelist`, or maintenance items with `mo optimize --whitelist`.

--- a/lib/clean/system.sh
+++ b/lib/clean/system.sh
@@ -119,6 +119,25 @@ system_cleanup_budget_reached() {
     [[ "$SECONDS" -ge "$deadline" ]]
 }
 
+system_cleanup_budget_seconds() {
+    local requested="${MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC:-120}"
+
+    # Keep this section bounded even when a user needs more time for a slow
+    # but healthy filesystem. The lower bound avoids a deadline that expires
+    # before a useful scan can start; the upper bound prevents a stalled
+    # privileged scan from making clean appear hung indefinitely.
+    if [[ "$requested" =~ ^[0-9]+$ ]] && \
+        (( 10#$requested >= 30 && 10#$requested <= 600 )); then
+        printf '%d\n' "$((10#$requested))"
+        return 0
+    fi
+
+    if declare -F debug_log > /dev/null 2>&1; then
+        debug_log "Ignoring invalid MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC=$requested; using 120s"
+    fi
+    printf '%s\n' 120
+}
+
 report_system_cleanup_budget_reached() {
     echo -e "  ${YELLOW}${ICON_WARNING}${NC} System cleanup · ${GRAY}time limit reached, skipped remaining slow scans${NC}"
     if declare -F note_activity > /dev/null 2>&1; then
@@ -225,8 +244,10 @@ clean_deep_system() {
     stop_section_spinner
     # Keep the section bounded as a whole as well as at each inner scan. A
     # single slow filesystem may consume one inner timeout, but later families
-    # stop once the two-minute section budget is exhausted.
-    local system_cleanup_deadline=$((SECONDS + 120))
+    # stop once the bounded section budget is exhausted.
+    local system_cleanup_budget_sec=""
+    system_cleanup_budget_sec=$(system_cleanup_budget_seconds)
+    local system_cleanup_deadline=$((SECONDS + system_cleanup_budget_sec))
     local cache_cleaned=0
     local cache_status=0
     start_section_spinner "Cleaning system caches..."

--- a/lib/core/timeouts.sh
+++ b/lib/core/timeouts.sh
@@ -19,6 +19,7 @@
 #   PKG_LIST          Package manager listing (brew list, simctl list). ~10s.
 #   PKG_CLEANUP       Cache cleanup commands that walk disks. ~20s.
 #   DISK_VERIFY       Filesystem-level verify/repair operations. ~30s.
+#   SYSTEM_CLEANUP    Whole privileged system-cleanup pass. ~120s.
 #   HINT_SCAN         Non-destructive scan that walks an unbounded user
 #                     directory tree (project-artifact discovery, preference
 #                     plist lint). Per-listing finds are already capped; this is
@@ -64,6 +65,7 @@ readonly MOLE_TIMEOUT_MEDIUM_PROBE_SEC="${MOLE_TIMEOUT_MEDIUM_PROBE_SEC:-5}"
 readonly MOLE_TIMEOUT_PKG_LIST_SEC="${MOLE_TIMEOUT_PKG_LIST_SEC:-10}"
 readonly MOLE_TIMEOUT_PKG_CLEANUP_SEC="${MOLE_TIMEOUT_PKG_CLEANUP_SEC:-20}"
 readonly MOLE_TIMEOUT_DISK_VERIFY_SEC="${MOLE_TIMEOUT_DISK_VERIFY_SEC:-30}"
+readonly MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC="${MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC:-120}"
 readonly MOLE_TIMEOUT_HINT_SCAN_SEC="${MOLE_TIMEOUT_HINT_SCAN_SEC:-15}"
 
 # Clamp a per-command timeout to an overall wall-clock deadline. Kept beside

--- a/tests/clean_core.bats
+++ b/tests/clean_core.bats
@@ -659,6 +659,26 @@ EOF
     [[ "$output" != *"system preview included"* ]]
 }
 
+@test "system cleanup budget defaults safely and accepts a bounded override" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/system.sh"
+
+[[ "$(system_cleanup_budget_seconds)" == "120" ]] || exit 1
+MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC=600
+[[ "$(system_cleanup_budget_seconds)" == "600" ]] || exit 1
+MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC=601
+[[ "$(system_cleanup_budget_seconds)" == "120" ]] || exit 1
+MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC=invalid
+[[ "$(system_cleanup_budget_seconds)" == "120" ]] || exit 1
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+}
+
 @test "MOLE_DRY_RUN enables the complete clean preview without deleting Trash" {
     mkdir -p "$HOME/.Trash"
     printf 'keep\n' > "$HOME/.Trash/env-dry-run-sentinel"


### PR DESCRIPTION
## Summary
- add a bounded `MOLE_TIMEOUT_SYSTEM_CLEANUP_SEC` override for the privileged system-cleanup section
- retain the 120-second default and restrict overrides to 30–600 seconds
- document the one-off slow-filesystem workaround and cover default, valid, and invalid values

The current fixed two-minute budget can be insufficient for a healthy Mac with a large diagnostics tree. A global bound remains necessary so a stalled privileged scan cannot appear hung indefinitely.

## Validation
- `bash -n lib/core/timeouts.sh lib/clean/system.sh`
- direct helper checks for default, 600-second override, and invalid values
- `./scripts/check.sh --format` (formatter unavailable in this environment)

`bats` is not installed in this environment, so the Bats suite could not be invoked here.