### PR TITLE
fix(purge): exclude node_modules/vendor/Pods from project container detection

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -51,6 +51,12 @@ is_project_container() {
     [[ "$basename" == "Music" ]] && return 1
     [[ "$basename" == "Pictures" ]] && return 1
     [[ "$basename" == "Public" ]] && return 1
+    # Package-manager directories: they contain package.json/composer.json
+    # but are not project containers; deleting their children leaves
+    # packages half-installed and requires a network restore.
+    [[ "$basename" == "node_modules" ]] && return 1
+    [[ "$basename" == "vendor" ]] && return 1
+    [[ "$basename" == "Pods" ]] && return 1
 
     # Single find expression for indicators.
     local -a find_args=("$dir" "-maxdepth" "$max_depth" "(")


### PR DESCRIPTION
## Summary

`is_project_container` in `lib/clean/project.sh` returned `0` for `node_modules` directories because they contain `package.json` (the first entry in `MOLE_PURGE_PROJECT_INDICATORS`). This caused `mo purge` to delete `dist/` and `build/` directories inside individual packages, leaving them half-installed.

## Root Cause

The container exclusion list covers `Library`, `Applications`, `Movies`, `Music`, `Pictures`, `Public`, and dot-directories, but had no entry for `node_modules`, `vendor`, or `Pods`. When `discover_project_dirs` globs `$HOME/*/`, any `node_modules` directory at `$HOME` level is treated as a project container, causing each child package to be scanned as a project root.

## Fix

Add `node_modules`, `vendor`, and `Pods` to the exclusion list in `is_project_container`. This ensures package-manager directories are not treated as project containers, so they fall through to the existing artifact/nested-filtering logic.

## Verification

- `node_modules` at any level is now rejected as a project container
- `vendor` (PHP Composer) and `Pods` (CocoaPods) are excluded for the same reason
- Backward compatible: the existing `is_protected_purge_artifact` logic already handles these as targets

Closes #1459