### PR TITLE
fix(clean): treat CLT-only simctl absence as a normal skip

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -2628,11 +2628,13 @@ _resolve_simctl_developer_dir() {
     fi
 
     local selected_developer_dir=""
+    local selected_is_clt=false
     if command -v xcode-select > /dev/null 2>&1; then
         selected_developer_dir=$(xcode-select -p 2> /dev/null || true)
     fi
     case "$selected_developer_dir" in
         /Library/Developer/CommandLineTools | /Library/Developer/CommandLineTools/)
+            selected_is_clt=true
             ;;
         "")
             return 1
@@ -2650,6 +2652,7 @@ _resolve_simctl_developer_dir() {
 
     local -a candidates=()
     local app_root candidate_app candidate_developer_dir
+    local xcode_app_found=false
     local nullglob_was_set=0
     shopt -q nullglob && nullglob_was_set=1
     shopt -s nullglob
@@ -2657,6 +2660,7 @@ _resolve_simctl_developer_dir() {
         [[ -d "$app_root" ]] || continue
         for candidate_app in "$app_root"/Xcode*.app; do
             [[ -d "$candidate_app" ]] || continue
+            xcode_app_found=true
             candidate_developer_dir="$candidate_app/Contents/Developer"
             if _simctl_developer_dir_is_usable "$candidate_developer_dir"; then
                 candidates+=("$candidate_developer_dir")
@@ -2665,6 +2669,12 @@ _resolve_simctl_developer_dir() {
     done
     if [[ $nullglob_was_set -eq 0 ]]; then
         shopt -u nullglob
+    fi
+
+    if [[ "$selected_is_clt" == true && "$xcode_app_found" == false ]]; then
+        _MOLE_SIMCTL_RESOLUTION_STATUS="clt-only"
+        debug_log "Standalone Command Line Tools selected; no Xcode app is installed"
+        return 1
     fi
 
     if [[ ${#candidates[@]} -eq 1 ]]; then
@@ -2736,6 +2746,8 @@ clean_dev_mobile() {
         elif [[ "$_MOLE_SIMCTL_RESOLUTION_STATUS" == "explicit-invalid" ]]; then
             echo -e "  ${GRAY}${ICON_WARNING}${NC} Xcode unavailable simulators · DEVELOPER_DIR has no simctl"
             note_activity
+        elif [[ "$_MOLE_SIMCTL_RESOLUTION_STATUS" == "clt-only" ]]; then
+            debug_log "Skipping unavailable simulator cleanup without a full Xcode installation"
         elif [[ "$_MOLE_SIMCTL_RESOLUTION_STATUS" == "ready" ]]; then
             debug_log "Checking for unavailable Xcode simulators"
             debug_log "Resolved simctl DEVELOPER_DIR: $_MOLE_SIMCTL_DEVELOPER_DIR"

--- a/tests/dev_extended.bats
+++ b/tests/dev_extended.bats
@@ -2072,6 +2072,7 @@ EOF
     mkdir -p "$tmp_bin"
     cat > "$tmp_bin/xcrun" << 'XEOF'
 #!/bin/bash
+printf '%s\n' "$*" >> "$SIMCTL_CALL_LOG"
 exit 1
 XEOF
     cat > "$tmp_bin/xcode-select" << 'XEOF'
@@ -2080,7 +2081,9 @@ printf '/Library/Developer/CommandLineTools\n'
 XEOF
     chmod +x "$tmp_bin/xcrun" "$tmp_bin/xcode-select"
 
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" PATH="$tmp_bin:$PATH" /bin/bash --noprofile --norc << 'EOF'
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" PATH="$tmp_bin:$PATH" \
+        SIMCTL_CALL_LOG="$HOME/simctl-unavailable.log" \
+        /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
@@ -2095,14 +2098,19 @@ clean_xcode_xctest_devices() { :; }
 clean_xcode_device_support() { echo "DEVICE_SUPPORT:$2"; }
 safe_clean() { echo "SAFE_CLEAN:$2"; }
 safe_clean_guarded() { echo "SAFE_CLEAN_GUARDED:$1:${*: -1}"; }
-note_activity() { :; }
+note_activity() { echo "ACTIVITY"; }
 debug_log() { :; }
 
 clean_dev_mobile
+echo "RESOLUTION_STATUS:$_MOLE_SIMCTL_RESOLUTION_STATUS"
 EOF
 
     [ "$status" -eq 0 ] || return 1
-    [[ "$output" == *"simctl could not be resolved"* ]] || return 1
+    [[ "$output" == *"RESOLUTION_STATUS:clt-only"* ]] || return 1
+    [[ "$output" != *"simctl could not be resolved"* ]] || return 1
+    [[ "$output" != *"Xcode unavailable simulators"* ]] || return 1
+    [[ "$output" != *"ACTIVITY"* ]] || return 1
+    [[ ! -e "$HOME/simctl-unavailable.log" ]] || return 1
     [[ "$output" == *"DEVICE_SUPPORT:iOS DeviceSupport"* ]] || return 1
     [[ "$output" == *"SAFE_CLEAN_GUARDED:_coresimulator_delete_guard_allows:Simulator runtime cache"* ]] || return 1
     [[ "$output" == *"SAFE_CLEAN_GUARDED:_xcode_delete_guard_allows:Xcode Interface Builder cache"* ]] || return 1


### PR DESCRIPTION
## Summary

- classify the standard Command Line Tools-only setup before invoking `xcrun`
- skip the error-like simulator warning and activity accounting when no `Xcode*.app` exists in the supported application roots
- keep explicit `DEVELOPER_DIR`, usable Xcode discovery, ambiguous installs, and later developer cleanup behavior unchanged

Fixes #1462

## Testing

- `./scripts/check.sh --format`
- `MOLE_TEST_NO_AUTH=1 bats tests/dev_extended.bats` (85 passed)
- full suite: 1691 tests, with 3 failures outside the changed surface; both browser-clean failures passed isolated reruns, while the existing `clean_dev_caches` mdfind case reproduced in isolation