### PR TITLE
Speed up clean and purge scans

### DIFF
--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -576,15 +576,19 @@ clean_project_caches() {
 
     local scan_index
     for ((scan_index = 0; scan_index < ${#root_matches_files[@]}; scan_index++)); do
-        root_matches_file="${root_matches_files[$scan_index]}"
-        local scan_rc="${scan_statuses[$scan_index]:-1}"
-        if [[ $scan_rc -ge 128 ]]; then
+        local preflight_rc="${scan_statuses[$scan_index]:-1}"
+        if [[ $preflight_rc -ge 128 ]]; then
             local pending_file
             for pending_file in "${root_matches_files[@]}"; do
                 rm -f "$pending_file"
             done
-            return "$scan_rc"
+            return "$preflight_rc"
         fi
+    done
+
+    for ((scan_index = 0; scan_index < ${#root_matches_files[@]}; scan_index++)); do
+        root_matches_file="${root_matches_files[$scan_index]}"
+        local scan_rc="${scan_statuses[$scan_index]:-1}"
         if [[ $scan_rc -ne 0 ]]; then
             failed_scan_count=$((failed_scan_count + 1))
             rm -f "$root_matches_file"

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -445,7 +445,7 @@ clean_python_bytecode_cache_group() {
             dry_run_paths+=("$cache_dir")
             dry_run_sizes+=("$size_kb")
         else
-            if ! safe_remove "$cache_dir" true; then
+            if ! safe_remove "$cache_dir" true "$size_kb"; then
                 continue
             fi
         fi

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -515,29 +515,65 @@ clean_python_bytecode_cache_group() {
 clean_project_caches() {
     stop_inline_spinner 2> /dev/null || true
 
+    if [[ -t 1 ]]; then
+        MOLE_SPINNER_PREFIX="  "
+        start_inline_spinner "Searching project caches..."
+    fi
+
     local -a scan_roots=()
     local root
     while IFS= read -r root; do
         [[ -n "$root" ]] && scan_roots+=("$root")
     done < <(discover_project_cache_roots)
 
-    [[ ${#scan_roots[@]} -eq 0 ]] && return 0
-
-    if [[ -t 1 ]]; then
-        MOLE_SPINNER_PREFIX="  "
-        start_inline_spinner "Searching project caches..."
-    fi
-
-    for root in "${scan_roots[@]}"; do
-        local root_matches_file
-        root_matches_file=$(create_temp_file)
-        local scan_rc=0
-        scan_project_cache_root "$root" "$root_matches_file" || scan_rc=$?
-
+    if [[ ${#scan_roots[@]} -eq 0 ]]; then
         if [[ -t 1 ]]; then
             stop_inline_spinner
         fi
+        return 0
+    fi
 
+    local -a root_matches_files=()
+    local -a scan_pids=()
+    local -a scan_statuses=()
+    local max_scan_jobs
+    max_scan_jobs=$(get_optimal_parallel_jobs io)
+    if ! [[ "$max_scan_jobs" =~ ^[0-9]+$ ]] || [[ "$max_scan_jobs" -lt 1 ]]; then
+        max_scan_jobs=1
+    elif [[ "$max_scan_jobs" -gt 4 ]]; then
+        max_scan_jobs=4
+    fi
+
+    _wait_for_project_cache_scan_batch() {
+        local scan_pid
+        for scan_pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
+            local scan_rc=0
+            wait "$scan_pid" 2> /dev/null || scan_rc=$?
+            scan_statuses+=("$scan_rc")
+        done
+        scan_pids=()
+    }
+
+    for root in "${scan_roots[@]}"; do
+        local root_matches_file
+        root_matches_file=$(create_temp_file) || continue
+        root_matches_files+=("$root_matches_file")
+        scan_project_cache_root "$root" "$root_matches_file" < /dev/null &
+        scan_pids+=($!)
+        if [[ ${#scan_pids[@]} -ge $max_scan_jobs ]]; then
+            _wait_for_project_cache_scan_batch
+        fi
+    done
+    _wait_for_project_cache_scan_batch
+
+    if [[ -t 1 ]]; then
+        stop_inline_spinner
+    fi
+
+    local scan_index
+    for ((scan_index = 0; scan_index < ${#root_matches_files[@]}; scan_index++)); do
+        root_matches_file="${root_matches_files[$scan_index]}"
+        local scan_rc="${scan_statuses[$scan_index]:-1}"
         if [[ $scan_rc -ne 0 ]]; then
             rm -f "$root_matches_file"
             continue
@@ -546,15 +582,12 @@ clean_project_caches() {
         local process_rc=0
         process_project_cache_matches "$root_matches_file" || process_rc=$?
         rm -f "$root_matches_file"
-        [[ $process_rc -eq 0 ]] || return "$process_rc"
-
-        if [[ -t 1 ]]; then
-            MOLE_SPINNER_PREFIX="  "
-            start_inline_spinner "Searching project caches..."
+        if [[ $process_rc -ne 0 ]]; then
+            local pending_file
+            for pending_file in "${root_matches_files[@]}"; do
+                rm -f "$pending_file"
+            done
+            return "$process_rc"
         fi
     done
-
-    if [[ -t 1 ]]; then
-        stop_inline_spinner
-    fi
 }

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -2,8 +2,10 @@
 # Cache Cleanup Module
 set -euo pipefail
 
+_MOLE_CACHES_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_MOLE_CACHES_MODULE_PATH="$_MOLE_CACHES_MODULE_DIR/${BASH_SOURCE[0]##*/}"
 # shellcheck disable=SC1091
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/purge_shared.sh"
+source "$_MOLE_CACHES_MODULE_DIR/purge_shared.sh"
 # Preflight TCC prompts once to avoid mid-run interruptions.
 check_tcc_permissions() {
     [[ -t 1 ]] || return 0
@@ -242,11 +244,32 @@ pycache_has_bytecode() {
     [[ ${#bytecode_files[@]} -gt 0 ]]
 }
 
+_process_project_cache_scan_file() {
+    local root="$1"
+    local scan_file="$2"
+    local processed_file="$3"
+
+    while IFS= read -r match_path; do
+        [[ -z "$match_path" ]] && continue
+        # Skip __pycache__ dirs with no .pyc/.pyo files (empty or already cleaned)
+        if [[ "${match_path##*/}" == "__pycache__" ]]; then
+            pycache_has_bytecode "$match_path" || continue
+        fi
+        local project_root=""
+        project_root=$(project_cache_group_root "$root" "$match_path")
+        [[ -z "$project_root" ]] && project_root="$root"
+        printf '%s\t%s\n' "$project_root" "$match_path" >> "$processed_file"
+    done < "$scan_file"
+}
+
 # Scan a project root for supported build caches while pruning heavy subtrees.
 scan_project_cache_root() {
     local root="$1"
     local output_file="$2"
     local scan_timeout="${MOLE_PROJECT_CACHE_SCAN_TIMEOUT:-6}"
+    if [[ ! "$scan_timeout" =~ ^[0-9]+(\.[0-9]+)?$ || "$scan_timeout" =~ ^0+(\.0+)?$ ]]; then
+        scan_timeout=6
+    fi
     [[ -d "$root" ]] || return 0
     : > "$output_file"
 
@@ -259,18 +282,25 @@ scan_project_cache_root() {
         -print
     )
 
+    local scan_budget
+    scan_budget=$(mole_purge_timeout_budget_seconds "$scan_timeout" 6)
+    local scan_deadline=$((SECONDS + scan_budget))
+    local stage_timeout=""
     local status=0
     local scan_file
     scan_file=$(create_temp_file) || return 1
     local processed_file
     processed_file=$(create_temp_file) || {
-        rm -f "$scan_file"
+        rm -f "$scan_file" # SAFE: exact scratch file created by create_temp_file above
         return 1
     }
-    run_with_timeout "$scan_timeout" "${find_args[@]}" > "$scan_file" 2> /dev/null || status=$?
+    stage_timeout=$(_mole_timeout_with_deadline "$scan_timeout" "$scan_deadline") || status=$?
+    if [[ $status -eq 0 ]]; then
+        run_with_timeout "$stage_timeout" "${find_args[@]}" > "$scan_file" 2> /dev/null || status=$?
+    fi
 
     if [[ $status -ne 0 ]]; then
-        rm -f "$scan_file" "$processed_file"
+        rm -f "$scan_file" "$processed_file" # SAFE: exact scratch files created by create_temp_file above
         if [[ $status -eq 124 ]]; then
             debug_log "Project cache scan timed out: $root"
         else
@@ -280,21 +310,28 @@ scan_project_cache_root() {
     fi
 
     if [[ -s "$scan_file" ]]; then
-        while IFS= read -r match_path; do
-            [[ -z "$match_path" ]] && continue
-            # Skip __pycache__ dirs with no .pyc/.pyo files (empty or already cleaned)
-            if [[ "${match_path##*/}" == "__pycache__" ]]; then
-                pycache_has_bytecode "$match_path" || continue
-            fi
-            local project_root=""
-            project_root=$(project_cache_group_root "$root" "$match_path")
-            [[ -z "$project_root" ]] && project_root="$root"
-            printf '%s\t%s\n' "$project_root" "$match_path" >> "$processed_file"
-        done < "$scan_file"
+        stage_timeout=$(_mole_timeout_with_deadline "$scan_timeout" "$scan_deadline") || status=$?
+        if [[ $status -eq 0 ]]; then
+            # shellcheck disable=SC2016 # The child shell expands its own positional parameters.
+            run_with_timeout "$stage_timeout" /bin/bash --noprofile --norc -c '
+                set -euo pipefail
+                source "$1"
+                _process_project_cache_scan_file "$2" "$3" "$4"
+            ' _ "$_MOLE_CACHES_MODULE_PATH" "$root" "$scan_file" "$processed_file" || status=$?
+        fi
     fi
-    rm -f "$scan_file"
+    rm -f "$scan_file" # SAFE: exact scratch file created by create_temp_file above
+    if [[ $status -ne 0 ]]; then
+        rm -f "$processed_file" # SAFE: exact scratch file created by create_temp_file above
+        if [[ $status -eq 124 ]]; then
+            debug_log "Project cache post-processing timed out: $root"
+        else
+            debug_log "Project cache post-processing failed (${status}): $root"
+        fi
+        return "$status"
+    fi
     if ! mv "$processed_file" "$output_file"; then
-        rm -f "$processed_file"
+        rm -f "$processed_file" # SAFE: exact scratch file created by create_temp_file above
         return 1
     fi
 
@@ -537,6 +574,10 @@ clean_project_caches() {
     local -a scan_pids=()
     local -a scan_statuses=()
     local failed_scan_count=0
+    local scan_interrupt_status=0
+    local previous_scan_int_trap=""
+    local previous_scan_term_trap=""
+    local scan_traps_installed=false
     local max_scan_jobs
     max_scan_jobs=$(get_optimal_parallel_jobs io)
     if ! [[ "$max_scan_jobs" =~ ^[0-9]+$ ]] || [[ "$max_scan_jobs" -lt 1 ]]; then
@@ -546,32 +587,97 @@ clean_project_caches() {
     fi
 
     _wait_for_project_cache_scan_batch() {
-        local scan_pid
-        for scan_pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
+        local scan_index scan_pid
+        for ((scan_index = 0; scan_index < ${#scan_pids[@]}; scan_index++)); do
+            scan_pid="${scan_pids[$scan_index]}"
             local scan_rc=0
             wait "$scan_pid" 2> /dev/null || scan_rc=$?
             scan_statuses+=("$scan_rc")
+            if [[ $scan_rc -ge 128 ]]; then
+                local remaining_index
+                for ((remaining_index = scan_index + 1; remaining_index < ${#scan_pids[@]}; remaining_index++)); do
+                    kill "${scan_pids[$remaining_index]}" 2> /dev/null || true
+                done
+                for ((remaining_index = scan_index + 1; remaining_index < ${#scan_pids[@]}; remaining_index++)); do
+                    wait "${scan_pids[$remaining_index]}" 2> /dev/null || true
+                done
+                scan_pids=()
+                return "$scan_rc"
+            fi
         done
         scan_pids=()
     }
 
+    # shellcheck disable=SC2329 # Invoked by the signal trap below.
+    _cleanup_project_cache_scan_workers() {
+        local scan_pid
+        for scan_pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
+            kill "$scan_pid" 2> /dev/null || true
+        done
+        for scan_pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
+            wait "$scan_pid" 2> /dev/null || true
+        done
+        scan_pids=()
+    }
+
+    # shellcheck disable=SC2329 # Invoked by the signal trap below.
+    _handle_project_cache_scan_interrupt() {
+        local interrupt_status="$1"
+        if [[ $scan_interrupt_status -lt 128 ]]; then
+            scan_interrupt_status="$interrupt_status"
+        fi
+        _cleanup_project_cache_scan_workers
+    }
+
+    _restore_project_cache_scan_traps() {
+        [[ "$scan_traps_installed" == "true" ]] || return 0
+        trap - INT TERM
+        scan_traps_installed=false
+        # eval: restore caller traps captured by $(trap -p)
+        [[ -n "$previous_scan_int_trap" ]] && eval "$previous_scan_int_trap"
+        [[ -n "$previous_scan_term_trap" ]] && eval "$previous_scan_term_trap"
+        return 0
+    }
+
+    previous_scan_int_trap=$(trap -p INT || true)
+    previous_scan_term_trap=$(trap -p TERM || true)
+    trap '_handle_project_cache_scan_interrupt 130' INT
+    trap '_handle_project_cache_scan_interrupt 143' TERM
+    scan_traps_installed=true
+
     for root in "${scan_roots[@]}"; do
+        [[ $scan_interrupt_status -ge 128 ]] && break
         local root_matches_file
         if ! root_matches_file=$(create_temp_file); then
             failed_scan_count=$((failed_scan_count + 1))
             continue
         fi
         root_matches_files+=("$root_matches_file")
+        [[ $scan_interrupt_status -ge 128 ]] && break
         scan_project_cache_root "$root" "$root_matches_file" < /dev/null &
-        scan_pids+=($!)
+        scan_pids+=("$!")
         if [[ ${#scan_pids[@]} -ge $max_scan_jobs ]]; then
-            _wait_for_project_cache_scan_batch
+            _wait_for_project_cache_scan_batch || scan_interrupt_status=$?
+            if [[ $scan_interrupt_status -ge 128 ]]; then
+                break
+            fi
         fi
     done
-    _wait_for_project_cache_scan_batch
+    if [[ $scan_interrupt_status -lt 128 ]]; then
+        _wait_for_project_cache_scan_batch || scan_interrupt_status=$?
+    fi
+    _restore_project_cache_scan_traps
 
     if [[ -t 1 ]]; then
         stop_inline_spinner
+    fi
+
+    if [[ $scan_interrupt_status -ge 128 ]]; then
+        local pending_file
+        for pending_file in "${root_matches_files[@]}"; do
+            rm -f "$pending_file" # SAFE: exact scratch file created by create_temp_file above
+        done
+        return "$scan_interrupt_status"
     fi
 
     local scan_index

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -536,6 +536,7 @@ clean_project_caches() {
     local -a root_matches_files=()
     local -a scan_pids=()
     local -a scan_statuses=()
+    local failed_scan_count=0
     local max_scan_jobs
     max_scan_jobs=$(get_optimal_parallel_jobs io)
     if ! [[ "$max_scan_jobs" =~ ^[0-9]+$ ]] || [[ "$max_scan_jobs" -lt 1 ]]; then
@@ -556,7 +557,10 @@ clean_project_caches() {
 
     for root in "${scan_roots[@]}"; do
         local root_matches_file
-        root_matches_file=$(create_temp_file) || continue
+        if ! root_matches_file=$(create_temp_file); then
+            failed_scan_count=$((failed_scan_count + 1))
+            continue
+        fi
         root_matches_files+=("$root_matches_file")
         scan_project_cache_root "$root" "$root_matches_file" < /dev/null &
         scan_pids+=($!)
@@ -574,7 +578,15 @@ clean_project_caches() {
     for ((scan_index = 0; scan_index < ${#root_matches_files[@]}; scan_index++)); do
         root_matches_file="${root_matches_files[$scan_index]}"
         local scan_rc="${scan_statuses[$scan_index]:-1}"
+        if [[ $scan_rc -ge 128 ]]; then
+            local pending_file
+            for pending_file in "${root_matches_files[@]}"; do
+                rm -f "$pending_file"
+            done
+            return "$scan_rc"
+        fi
         if [[ $scan_rc -ne 0 ]]; then
+            failed_scan_count=$((failed_scan_count + 1))
             rm -f "$root_matches_file"
             continue
         fi
@@ -590,4 +602,15 @@ clean_project_caches() {
             return "$process_rc"
         fi
     done
+
+    if [[ $failed_scan_count -gt 0 ]]; then
+        local scan_noun="root scans"
+        if [[ $failed_scan_count -eq 1 ]]; then
+            scan_noun="root scan"
+        fi
+        echo -e "  ${GRAY}${ICON_WARNING}${NC} Project caches · skipped ${failed_scan_count} slow/incomplete ${scan_noun}"
+        if declare -f note_activity > /dev/null 2>&1; then
+            note_activity
+        fi
+    fi
 }

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -248,6 +248,7 @@ scan_project_cache_root() {
     local output_file="$2"
     local scan_timeout="${MOLE_PROJECT_CACHE_SCAN_TIMEOUT:-6}"
     [[ -d "$root" ]] || return 0
+    : > "$output_file"
 
     local -a find_args=(
         find -P "$root" -maxdepth 9 -mount
@@ -259,11 +260,26 @@ scan_project_cache_root() {
     )
 
     local status=0
-    local tmp_file
-    tmp_file=$(create_temp_file)
-    run_with_timeout "$scan_timeout" "${find_args[@]}" > "$tmp_file" 2> /dev/null || status=$?
+    local scan_file
+    scan_file=$(create_temp_file) || return 1
+    local processed_file
+    processed_file=$(create_temp_file) || {
+        rm -f "$scan_file"
+        return 1
+    }
+    run_with_timeout "$scan_timeout" "${find_args[@]}" > "$scan_file" 2> /dev/null || status=$?
 
-    if [[ -s "$tmp_file" ]]; then
+    if [[ $status -ne 0 ]]; then
+        rm -f "$scan_file" "$processed_file"
+        if [[ $status -eq 124 ]]; then
+            debug_log "Project cache scan timed out: $root"
+        else
+            debug_log "Project cache scan failed (${status}): $root"
+        fi
+        return "$status"
+    fi
+
+    if [[ -s "$scan_file" ]]; then
         while IFS= read -r match_path; do
             [[ -z "$match_path" ]] && continue
             # Skip __pycache__ dirs with no .pyc/.pyo files (empty or already cleaned)
@@ -273,15 +289,13 @@ scan_project_cache_root() {
             local project_root=""
             project_root=$(project_cache_group_root "$root" "$match_path")
             [[ -z "$project_root" ]] && project_root="$root"
-            printf '%s\t%s\n' "$project_root" "$match_path" >> "$output_file"
-        done < "$tmp_file"
+            printf '%s\t%s\n' "$project_root" "$match_path" >> "$processed_file"
+        done < "$scan_file"
     fi
-    rm -f "$tmp_file"
-
-    if [[ $status -eq 124 ]]; then
-        debug_log "Project cache scan timed out: $root"
-    elif [[ $status -ne 0 ]]; then
-        debug_log "Project cache scan failed (${status}): $root"
+    rm -f "$scan_file"
+    if ! mv "$processed_file" "$output_file"; then
+        rm -f "$processed_file"
+        return 1
     fi
 
     return 0
@@ -517,10 +531,16 @@ clean_project_caches() {
     for root in "${scan_roots[@]}"; do
         local root_matches_file
         root_matches_file=$(create_temp_file)
-        scan_project_cache_root "$root" "$root_matches_file"
+        local scan_rc=0
+        scan_project_cache_root "$root" "$root_matches_file" || scan_rc=$?
 
         if [[ -t 1 ]]; then
             stop_inline_spinner
+        fi
+
+        if [[ $scan_rc -ne 0 ]]; then
+            rm -f "$root_matches_file"
+            continue
         fi
 
         local process_rc=0

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -565,6 +565,7 @@ scan_purge_targets() {
             "--min-depth" "$min_depth"
             "--max-depth" "$max_depth"
             "--threads" "8"
+            "--prune"
             "--exclude" ".git"
             "--exclude" "Library"
             "--exclude" ".Trash"
@@ -583,6 +584,10 @@ scan_purge_targets() {
             "--exclude" ".Trash"
             "--exclude" "Applications"
         )
+        local purge_target
+        for purge_target in "${PURGE_TARGETS[@]}"; do
+            fd_tag_args+=("--exclude" "$purge_target")
+        done
 
         # Trust fd when it exits successfully, including an empty result set.
         # Empty scans are common in healthy project trees; falling back to find
@@ -641,7 +646,7 @@ scan_purge_targets() {
 
         if [[ $find_status -eq 0 ]]; then
             run_with_timeout "$_scan_timeout" find "$search_path" -mindepth "$cachedir_tag_min_depth" -maxdepth "$cachedir_tag_max_depth" \
-                \( "${prune_expr[@]}" \) -prune -o \
+                \( -type d \( \( "${prune_expr[@]}" \) -o \( "${target_expr[@]}" \) \) \) -prune -o \
                 -type f -name "$MOLE_CACHEDIR_TAG_NAME" -print \
                 2> /dev/null > "$tag_output" || find_status=$?
         fi

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -827,10 +827,11 @@ _mole_purge_final_remove_guard() {
     purge_target_activity_still_safe "$path" "${_MOLE_PURGE_FINAL_WAS_RECENT:-true}"
 }
 
-# Args: $1 - path
+# Args: $1 - path, $2 - optional shared deadline in SECONDS
 # Get directory size in KB.
 get_dir_size_kb() {
     local path="$1"
+    local deadline="${2:-}"
     if [[ ! -d "$path" ]]; then
         echo "0"
         return
@@ -839,6 +840,13 @@ get_dir_size_kb() {
     local timeout_seconds="${MO_PURGE_SIZE_TIMEOUT_SEC:-15}"
     if [[ ! "$timeout_seconds" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
         timeout_seconds=15
+    fi
+    if [[ -n "$deadline" ]]; then
+        timeout_seconds=$(_mole_timeout_with_deadline "$timeout_seconds" "$deadline") || {
+            debug_log "Size calculation budget exhausted before: $path"
+            echo "TIMEOUT"
+            return
+        }
     fi
 
     local du_output=""
@@ -1675,6 +1683,11 @@ clean_project_artifacts() {
     # filesystem cache, making du timeout and display "unknown" sizes.
     local -a _size_tmpfiles=()
     local -a _size_pids=()
+    local _size_total_timeout="$MOLE_TIMEOUT_DISK_VERIFY_SEC"
+    if [[ ! "$_size_total_timeout" =~ ^([2-9]|[1-9][0-9]+)$ ]]; then
+        _size_total_timeout=30
+    fi
+    local _size_deadline=$((SECONDS + _size_total_timeout))
     local _max_size_jobs
     _max_size_jobs=$(get_optimal_parallel_jobs io)
     if ! [[ "$_max_size_jobs" =~ ^[0-9]+$ ]] || [[ "$_max_size_jobs" -lt 1 ]]; then
@@ -1712,7 +1725,11 @@ clean_project_artifacts() {
         _stmp=$(mktemp)
         register_temp_file "$_stmp"
         _size_tmpfiles+=("$_stmp")
-        (get_dir_size_kb "$_sz_item" > "$_stmp" 2> /dev/null) < /dev/null &
+        if [[ $SECONDS -ge $_size_deadline ]]; then
+            printf 'TIMEOUT\n' > "$_stmp"
+            continue
+        fi
+        (get_dir_size_kb "$_sz_item" "$_size_deadline" > "$_stmp" 2> /dev/null) < /dev/null &
         _size_pids+=($!)
 
         if [[ ${#_size_pids[@]} -ge $_max_size_jobs ]]; then

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -538,7 +538,12 @@ scan_purge_targets() {
         local deadline="$2"
         if [[ -f "$input_file" ]]; then
             local process_status=0
-            filter_nested_artifacts < "$input_file" |
+            local nested_filter_timeout=""
+            nested_filter_timeout=$(_mole_timeout_with_deadline "$scan_timeout" "$deadline") || process_status=$?
+            if [[ $process_status -ne 0 ]]; then
+                return "$process_status"
+            fi
+            filter_nested_artifacts "$nested_filter_timeout" < "$input_file" |
                 (
                     while IFS= read -r item; do
                         if [[ $SECONDS -ge $deadline ]]; then
@@ -708,11 +713,9 @@ scan_purge_targets() {
 # Filter out nested artifacts (e.g. node_modules inside node_modules, .build inside build).
 # Optimized: Sort paths to put parents before children, then filter in single pass.
 filter_nested_artifacts() {
-    # 1. Append trailing slash to each path (to ensure /foo/bar starts with /foo/)
-    # 2. Sort to group parents and children (LC_COLLATE=C ensures standard sorting)
-    # 3. Use awk to filter out paths that start with the previous kept path
-    # 4. Remove trailing slash
-    sed 's|[^/]$|&/|' | LC_COLLATE=C sort | awk '
+    local timeout_seconds="${1:-}"
+    # shellcheck disable=SC2016 # Awk expands its own variables.
+    local nested_filter_program='
         BEGIN { last_kept = "" }
         {
             current = $0
@@ -723,7 +726,26 @@ filter_nested_artifacts() {
                 last_kept = current
             }
         }
-    ' | sed 's|/$||'
+    '
+    # shellcheck disable=SC2016 # The child shell expands its own positional parameters.
+    local -a filter_command=(
+        /bin/bash -o pipefail -c
+        'sed "$1" | LC_COLLATE=C sort | awk "$2" | sed "$3"'
+        _
+        's|[^/]$|&/|'
+        "$nested_filter_program"
+        's|/$||'
+    )
+
+    # 1. Append trailing slash to each path (to ensure /foo/bar starts with /foo/)
+    # 2. Sort to group parents and children (LC_COLLATE=C ensures standard sorting)
+    # 3. Use awk to filter out paths that start with the previous kept path
+    # 4. Remove trailing slash
+    if [[ -n "$timeout_seconds" ]]; then
+        run_with_timeout "$timeout_seconds" "${filter_command[@]}"
+    else
+        "${filter_command[@]}"
+    fi
 }
 
 filter_protected_artifacts() {
@@ -920,6 +942,10 @@ get_dir_size_kb() {
         debug_log "Size calculation returned invalid output: $path"
         echo "ERROR"
     fi
+}
+
+_mole_purge_size_budget_seconds() {
+    mole_purge_timeout_budget_seconds "${1:-$MOLE_TIMEOUT_DISK_VERIFY_SEC}" 30
 }
 
 # Resolve the owning project for a purge artifact. Monorepo indicators take
@@ -1464,6 +1490,10 @@ clean_project_artifacts() {
         for pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
             kill "$pid" 2> /dev/null || true
         done
+        for pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
+            wait "$pid" 2> /dev/null || true
+        done
+        scan_pids=()
         # Clean up temp files
         for temp in "${scan_temps[@]+"${scan_temps[@]}"}"; do
             rm -f "$temp" "${temp}.targets" "${temp}.tags" "${temp}.processed" 2> /dev/null || true
@@ -1479,6 +1509,19 @@ clean_project_artifacts() {
     previous_term_trap=$(trap -p TERM || true)
     trap cleanup_scan INT TERM
     trap_installed_by_this_call=true
+    _restore_purge_scan_traps() {
+        [[ "$trap_installed_by_this_call" == "true" ]] || return 0
+        trap - INT TERM
+        trap_installed_by_this_call=false
+        local saved_int_trap="$previous_int_trap"
+        local saved_term_trap="$previous_term_trap"
+        previous_int_trap=""
+        previous_term_trap=""
+        # eval: restore caller traps captured by $(trap -p)
+        [[ -n "$saved_int_trap" ]] && eval "$saved_int_trap"
+        [[ -n "$saved_term_trap" ]] && eval "$saved_term_trap"
+        return 0
+    }
     local -a scan_statuses=()
     local -a scan_root_parents=()
     local -a scan_root_parent_ids=()
@@ -1490,6 +1533,7 @@ clean_project_artifacts() {
     local -a failed_scan_roots=()
     local -a failed_scan_statuses=()
     local failed_scan_count=0
+    local scan_interrupt_status=0
     local max_scan_jobs
     max_scan_jobs=$(get_optimal_parallel_jobs io)
     if ! [[ "$max_scan_jobs" =~ ^[0-9]+$ ]] || [[ "$max_scan_jobs" -lt 1 ]]; then
@@ -1499,8 +1543,9 @@ clean_project_artifacts() {
     fi
 
     _wait_for_purge_scan_batch() {
-        local pid
-        for pid in "${scan_pids[@]+"${scan_pids[@]}"}"; do
+        local scan_index pid
+        for ((scan_index = 0; scan_index < ${#scan_pids[@]}; scan_index++)); do
+            pid="${scan_pids[$scan_index]}"
             local scan_status=0
             if wait "$pid" 2> /dev/null; then
                 scan_status=0
@@ -1508,6 +1553,17 @@ clean_project_artifacts() {
                 scan_status=$?
             fi
             scan_statuses+=("$scan_status")
+            if [[ $scan_status -ge 128 ]]; then
+                local remaining_index
+                for ((remaining_index = scan_index + 1; remaining_index < ${#scan_pids[@]}; remaining_index++)); do
+                    kill "${scan_pids[$remaining_index]}" 2> /dev/null || true
+                done
+                for ((remaining_index = scan_index + 1; remaining_index < ${#scan_pids[@]}; remaining_index++)); do
+                    wait "${scan_pids[$remaining_index]}" 2> /dev/null || true
+                done
+                scan_pids=()
+                return "$scan_status"
+            fi
         done
         scan_pids=()
     }
@@ -1516,6 +1572,7 @@ clean_project_artifacts() {
     # Keep root-level concurrency bounded because each fd scan has its own
     # worker pool. Batches preserve launch-order alignment with scan_statuses.
     for path in "${PURGE_SEARCH_PATHS[@]}"; do
+        [[ $scan_interrupt_status -ge 128 ]] && break
         if [[ -d "$path" ]]; then
             if ! _mole_snapshot_path_identity "$path"; then
                 failed_scan_count=$((failed_scan_count + 1))
@@ -1558,11 +1615,29 @@ clean_project_artifacts() {
             local scan_pid=$!
             scan_pids+=("$scan_pid")
             if [[ ${#scan_pids[@]} -ge $max_scan_jobs ]]; then
-                _wait_for_purge_scan_batch
+                _wait_for_purge_scan_batch || scan_interrupt_status=$?
+                [[ $scan_interrupt_status -ge 128 ]] && break
             fi
         fi
     done
-    _wait_for_purge_scan_batch
+    if [[ $scan_interrupt_status -lt 128 ]]; then
+        _wait_for_purge_scan_batch || scan_interrupt_status=$?
+    fi
+
+    if [[ $scan_interrupt_status -ge 128 ]]; then
+        local interrupted_stats_dir="${XDG_CACHE_HOME:-$HOME/.cache}/mole"
+        rm -f "$interrupted_stats_dir/purge_scanning" 2> /dev/null || true
+        local interrupted_temp
+        for interrupted_temp in "${scan_temps[@]+"${scan_temps[@]}"}"; do
+            rm -f "$interrupted_temp" "${interrupted_temp}.targets" \
+                "${interrupted_temp}.tags" "${interrupted_temp}.processed" 2> /dev/null || true
+        done
+        _restore_purge_scan_traps
+        if [[ -t 1 ]]; then
+            stop_inline_spinner
+        fi
+        return "$scan_interrupt_status"
+    fi
 
     # Stop the scanning monitor (removes purge_scanning file to signal completion)
     local stats_dir="${XDG_CACHE_HOME:-$HOME/.cache}/mole"
@@ -1628,12 +1703,7 @@ clean_project_artifacts() {
     fi
     rm -f "$dedupe_output"
     # Restore caller traps after this function completes.
-    if [[ "$trap_installed_by_this_call" == "true" ]]; then
-        trap - INT TERM
-        # eval: restore caller traps captured by $(trap -p)
-        [[ -n "$previous_int_trap" ]] && eval "$previous_int_trap"
-        [[ -n "$previous_term_trap" ]] && eval "$previous_term_trap"
-    fi
+    _restore_purge_scan_traps
     if [[ $failed_scan_count -gt 0 ]]; then
         local root_text="root"
         [[ $failed_scan_count -ne 1 ]] && root_text="roots"
@@ -1778,10 +1848,8 @@ clean_project_artifacts() {
     # filesystem cache, making du timeout and display "unknown" sizes.
     local -a _size_tmpfiles=()
     local -a _size_pids=()
-    local _size_total_timeout="$MOLE_TIMEOUT_DISK_VERIFY_SEC"
-    if [[ ! "$_size_total_timeout" =~ ^([2-9]|[1-9][0-9]+)$ ]]; then
-        _size_total_timeout=30
-    fi
+    local _size_total_timeout
+    _size_total_timeout=$(_mole_purge_size_budget_seconds "$MOLE_TIMEOUT_DISK_VERIFY_SEC")
     local _size_deadline=$((SECONDS + _size_total_timeout))
     local _max_size_jobs
     _max_size_jobs=$(get_optimal_parallel_jobs io)
@@ -1815,7 +1883,51 @@ clean_project_artifacts() {
         fi
     }
 
+    local _size_previous_int_trap=""
+    local _size_previous_term_trap=""
+    local _size_interrupt_status=0
+    local _size_traps_installed=false
+    # shellcheck disable=SC2329 # Invoked by the signal trap below.
+    _cleanup_purge_size_workers() {
+        local size_pid
+        for size_pid in "${_size_pids[@]+"${_size_pids[@]}"}"; do
+            kill "$size_pid" 2> /dev/null || true
+        done
+        for size_pid in "${_size_pids[@]+"${_size_pids[@]}"}"; do
+            wait "$size_pid" 2> /dev/null || true
+        done
+        _size_pids=()
+    }
+    # shellcheck disable=SC2329 # Invoked by the signal trap below.
+    _handle_purge_size_interrupt() {
+        local interrupt_status="$1"
+        if [[ $_size_interrupt_status -lt 128 ]]; then
+            _size_interrupt_status="$interrupt_status"
+        fi
+        _cleanup_purge_size_workers
+    }
+    _restore_purge_size_traps() {
+        [[ "$_size_traps_installed" == "true" ]] || return 0
+        trap - INT TERM
+        _size_traps_installed=false
+        local saved_int_trap="$_size_previous_int_trap"
+        local saved_term_trap="$_size_previous_term_trap"
+        _size_previous_int_trap=""
+        _size_previous_term_trap=""
+        # eval: restore caller traps captured by $(trap -p)
+        [[ -n "$saved_int_trap" ]] && eval "$saved_int_trap"
+        [[ -n "$saved_term_trap" ]] && eval "$saved_term_trap"
+        return 0
+    }
+
+    _size_previous_int_trap=$(trap -p INT || true)
+    _size_previous_term_trap=$(trap -p TERM || true)
+    trap '_handle_purge_size_interrupt 130' INT
+    trap '_handle_purge_size_interrupt 143' TERM
+    _size_traps_installed=true
+
     for _sz_item in "${safe_to_clean[@]}"; do
+        [[ $_size_interrupt_status -ge 128 ]] && break
         local _stmp
         _stmp=$(mktemp)
         register_temp_file "$_stmp"
@@ -1829,11 +1941,27 @@ clean_project_artifacts() {
 
         if [[ ${#_size_pids[@]} -ge $_max_size_jobs ]]; then
             _reap_one_size_pid
+            [[ $_size_interrupt_status -ge 128 ]] && break
         fi
     done
-    for _spid in "${_size_pids[@]+"${_size_pids[@]}"}"; do
-        wait "$_spid" 2> /dev/null || true
-    done
+    if [[ $_size_interrupt_status -lt 128 ]]; then
+        for _spid in "${_size_pids[@]+"${_size_pids[@]}"}"; do
+            wait "$_spid" 2> /dev/null || true
+        done
+        _size_pids=()
+    fi
+    _restore_purge_size_traps
+
+    if [[ $_size_interrupt_status -ge 128 ]]; then
+        local interrupted_size_temp
+        for interrupted_size_temp in "${_size_tmpfiles[@]+"${_size_tmpfiles[@]}"}"; do
+            rm -f "$interrupted_size_temp" 2> /dev/null || true # SAFE: exact scratch file created by mktemp above
+        done
+        if [[ -t 1 ]]; then
+            stop_inline_spinner
+        fi
+        return "$_size_interrupt_status"
+    fi
 
     local -a menu_options=()
     local -a item_paths=()

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -388,12 +388,12 @@ is_php_project_root() {
 
 # Decide whether a "bin" directory is a .NET directory
 is_dotnet_bin_dir() {
-    local path="$1"
-    [[ "$(basename "$path")" == "bin" ]] || return 1
+    local path="${1%/}"
+    [[ "${path##*/}" == "bin" ]] || return 1
 
     # Check if parent directory has a .csproj/.fsproj/.vbproj file
-    local parent_dir
-    parent_dir="$(dirname "$path")"
+    local parent_dir="${path%/*}"
+    [[ -n "$parent_dir" ]] || parent_dir="/"
     find "$parent_dir" -maxdepth 1 \( -name "*.csproj" -o -name "*.fsproj" -o -name "*.vbproj" \) 2> /dev/null | grep -q . || return 1
 
     # Check if bin directory contains Debug/ or Release/ subdirectories
@@ -406,12 +406,11 @@ is_dotnet_bin_dir() {
 # Expects path to be a vendor directory (basename == vendor)
 # Strategy: Only clean PHP Composer vendor, protect all others
 is_protected_vendor_dir() {
-    local path="$1"
-    local base
-    base=$(basename "$path")
+    local path="${1%/}"
+    local base="${path##*/}"
     [[ "$base" == "vendor" ]] || return 1
-    local parent_dir
-    parent_dir=$(dirname "$path")
+    local parent_dir="${path%/*}"
+    [[ -n "$parent_dir" ]] || parent_dir="/"
 
     # PHP Composer vendor can be safely regenerated with 'composer install'
     # Do NOT protect it (return 1 = not protected = can be cleaned)
@@ -435,9 +434,8 @@ is_protected_vendor_dir() {
 
 # Check if an artifact should be protected from purge
 is_protected_purge_artifact() {
-    local path="$1"
-    local base
-    base=$(basename "$path")
+    local path="${1%/}"
+    local base="${path##*/}"
 
     case "$base" in
         bin)

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -512,21 +512,22 @@ scan_purge_targets() {
         local input_file="$1"
         if [[ -f "$input_file" ]]; then
             local process_status=0
-            (
-                while IFS= read -r item; do
-                    # Check if we should abort (scanning file removed by Ctrl+C)
-                    if [[ ! -f "$stats_dir/purge_scanning" ]]; then
-                        exit 130
-                    fi
+            filter_nested_artifacts < "$input_file" |
+                (
+                    while IFS= read -r item; do
+                        # Check if we should abort (scanning file removed by Ctrl+C)
+                        if [[ ! -f "$stats_dir/purge_scanning" ]]; then
+                            exit 130
+                        fi
 
-                    if [[ -n "$item" ]] && is_safe_project_artifact "$item" "$search_path"; then
-                        echo "$item"
-                        # Update scanning path to show current project directory
-                        local project_dir="${item%/*}"
-                        echo "$project_dir" > "$stats_dir/purge_scanning" 2> /dev/null || true
-                    fi
-                done < "$input_file"
-            ) | filter_nested_artifacts | filter_protected_artifacts > "$processed_output" || process_status=$?
+                        if [[ -n "$item" ]] && is_safe_project_artifact "$item" "$search_path"; then
+                            echo "$item"
+                            # Update scanning path to show current project directory
+                            local project_dir="${item%/*}"
+                            echo "$project_dir" > "$stats_dir/purge_scanning" 2> /dev/null || true
+                        fi
+                    done
+                ) | filter_protected_artifacts > "$processed_output" || process_status=$?
 
             if [[ $process_status -ne 0 ]]; then
                 rm -f "$processed_output" 2> /dev/null || true

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -294,6 +294,25 @@ is_purge_project_root() {
 
 # Args: $1 - path to check
 # Safe cleanup requires the path be inside a project directory.
+is_safe_project_artifact_under_root() {
+    local path="${1%/}"
+    local search_path="${2%/}"
+
+    [[ "$path" == /* && "$search_path" == /* && "$search_path" != "/" ]] || return 1
+    [[ "$path" == "$search_path/"* ]] || return 1
+
+    local relative_path="${path#"$search_path"/}"
+    local relative_without_slashes="${relative_path//\//}"
+    local depth=$((${#relative_path} - ${#relative_without_slashes}))
+    if [[ $depth -lt 1 ]]; then
+        # Allow direct-child artifacts only when the search path is itself
+        # a project root (single-project mode).
+        is_purge_project_root "$search_path"
+        return $?
+    fi
+    return 0
+}
+
 is_safe_project_artifact() {
     local path="$1"
     local search_path="$2"
@@ -331,19 +350,7 @@ is_safe_project_artifact() {
         return 1
     fi
 
-    # Must not be a direct child of the search root.
-    local relative_path="${path#"$search_path"/}"
-    local _rel_stripped="${relative_path//\//}"
-    local depth=$((${#relative_path} - ${#_rel_stripped}))
-    if [[ $depth -lt 1 ]]; then
-        # Allow direct-child artifacts only when the search path is itself
-        # a project root (single-project mode).
-        if is_purge_project_root "$search_path"; then
-            return 0
-        fi
-        return 1
-    fi
-    return 0
+    is_safe_project_artifact_under_root "$path" "$search_path"
 }
 
 # Revalidate a selected artifact against the configured scan roots immediately
@@ -356,8 +363,19 @@ is_safe_configured_purge_artifact() {
     [[ ${#PURGE_SEARCH_PATHS[@]} -gt 0 ]] || return 1
 
     local search_path
+    # Ordinary configured roots retain their lexical prefix in scan results.
+    # Check those roots first so one candidate does not resolve every unrelated
+    # root physically. The second pass preserves support for symlink aliases.
     for search_path in "${PURGE_SEARCH_PATHS[@]}"; do
         [[ -n "$search_path" ]] || continue
+        [[ "$search_path" == "/" || "$path" == "${search_path%/}/"* ]] || continue
+        if is_safe_project_artifact "$path" "$search_path"; then
+            return 0
+        fi
+    done
+    for search_path in "${PURGE_SEARCH_PATHS[@]}"; do
+        [[ -n "$search_path" ]] || continue
+        [[ "$search_path" != "/" && "$path" != "${search_path%/}/"* ]] || continue
         if is_safe_project_artifact "$path" "$search_path"; then
             return 0
         fi
@@ -817,14 +835,36 @@ purge_target_activity_still_safe() {
     [[ "$_PURGE_ACTIVITY_STATE" == "old" || "$_PURGE_ACTIVITY_STATE" == "uncertain" ]]
 }
 
-# Final safe_remove hook for purge. Candidate identity is checked separately by
-# safe_remove; this hook rebinds the policy that depends on current contents so
-# a project cannot become active or protected in the last pre-delete window.
+# Final safe_remove hook for purge. The caller supplies the exact scan-root and
+# candidate identities through dynamically scoped locals. Recheck them after
+# the stateful activity probe so no filesystem walk separates identity proof
+# from safe_remove's deletion sink.
 _mole_purge_final_remove_guard() {
     local path="$1"
     is_safe_configured_purge_artifact "$path" || return 1
     is_protected_purge_artifact "$path" && return 1
-    purge_target_activity_still_safe "$path" "${_MOLE_PURGE_FINAL_WAS_RECENT:-true}"
+    purge_target_activity_still_safe "$path" "${_MOLE_PURGE_FINAL_WAS_RECENT:-true}" || return 1
+
+    _mole_path_matches_identity \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT:-}" \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT_PARENT:-}" \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT_PARENT_ID:-}" \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT_TARGET_ID:-}" || return 1
+    _mole_path_matches_identity \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL:-}" \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL_PARENT:-}" \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL_PARENT_ID:-}" \
+        "${_MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL_TARGET_ID:-}" || return 1
+    _mole_path_matches_identity \
+        "$path" \
+        "${_MOLE_PURGE_FINAL_EXPECTED_PARENT:-}" \
+        "${_MOLE_PURGE_FINAL_EXPECTED_PARENT_ID:-}" \
+        "${_MOLE_PURGE_FINAL_EXPECTED_TARGET_ID:-}" || return 1
+
+    local current_physical_path="${_MOLE_PATH_SNAPSHOT_PARENT%/}/${path##*/}"
+    [[ "$_MOLE_PATH_SNAPSHOT_PARENT" == "/" ]] && current_physical_path="/${path##*/}"
+    is_safe_project_artifact_under_root \
+        "$current_physical_path" "${_MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL:-}"
 }
 
 # Args: $1 - path, $2 - optional shared deadline in SECONDS
@@ -1406,6 +1446,7 @@ clean_project_artifacts() {
     local -a safe_expected_parents=()
     local -a safe_expected_parent_ids=()
     local -a safe_expected_target_ids=()
+    local -a safe_scan_root_indexes=()
     local previous_int_trap=""
     local previous_term_trap=""
     local trap_installed_by_this_call=false
@@ -1442,6 +1483,10 @@ clean_project_artifacts() {
     local -a scan_root_parents=()
     local -a scan_root_parent_ids=()
     local -a scan_root_target_ids=()
+    local -a scan_root_physical_paths=()
+    local -a scan_root_physical_parents=()
+    local -a scan_root_physical_parent_ids=()
+    local -a scan_root_physical_target_ids=()
     local -a failed_scan_roots=()
     local -a failed_scan_statuses=()
     local failed_scan_count=0
@@ -1479,13 +1524,35 @@ clean_project_artifacts() {
                 debug_log "Purge scan root identity unavailable: $path"
                 continue
             fi
+            local scan_root_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
+            local scan_root_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+            local scan_root_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+            local scan_root_physical_path=""
+            scan_root_physical_path=$(cd -P "$path" 2> /dev/null && pwd -P) || {
+                failed_scan_count=$((failed_scan_count + 1))
+                failed_scan_roots+=("$path")
+                failed_scan_statuses+=("1")
+                debug_log "Purge scan root physical path unavailable: $path"
+                continue
+            }
+            if ! _mole_snapshot_path_identity "$scan_root_physical_path"; then
+                failed_scan_count=$((failed_scan_count + 1))
+                failed_scan_roots+=("$path")
+                failed_scan_statuses+=("1")
+                debug_log "Purge scan root physical identity unavailable: $path"
+                continue
+            fi
             local scan_output
             scan_output=$(mktemp)
             scan_temps+=("$scan_output")
             scan_roots+=("$path")
-            scan_root_parents+=("$_MOLE_PATH_SNAPSHOT_PARENT")
-            scan_root_parent_ids+=("$_MOLE_PATH_SNAPSHOT_PARENT_ID")
-            scan_root_target_ids+=("$_MOLE_PATH_SNAPSHOT_TARGET_ID")
+            scan_root_parents+=("$scan_root_parent")
+            scan_root_parent_ids+=("$scan_root_parent_id")
+            scan_root_target_ids+=("$scan_root_target_id")
+            scan_root_physical_paths+=("$scan_root_physical_path")
+            scan_root_physical_parents+=("$_MOLE_PATH_SNAPSHOT_PARENT")
+            scan_root_physical_parent_ids+=("$_MOLE_PATH_SNAPSHOT_PARENT_ID")
+            scan_root_physical_target_ids+=("$_MOLE_PATH_SNAPSHOT_TARGET_ID")
             # Launch scan in background for true parallelism
             scan_purge_targets "$path" "$scan_output" < /dev/null &
             local scan_pid=$!
@@ -1523,6 +1590,15 @@ clean_project_artifacts() {
             scan_status=1
             scan_statuses[scan_index]=1
             debug_log "Purge scan root changed before results were collected: ${scan_roots[$scan_index]}"
+        fi
+        if [[ $scan_status -eq 0 ]] && ! _mole_path_matches_identity \
+            "${scan_root_physical_paths[$scan_index]}" \
+            "${scan_root_physical_parents[$scan_index]}" \
+            "${scan_root_physical_parent_ids[$scan_index]}" \
+            "${scan_root_physical_target_ids[$scan_index]}"; then
+            scan_status=1
+            scan_statuses[scan_index]=1
+            debug_log "Purge scan root target changed before results were collected: ${scan_roots[$scan_index]}"
         fi
         if [[ $scan_status -eq 0 && ! -f "$scan_output" ]]; then
             scan_status=1
@@ -1596,17 +1672,42 @@ clean_project_artifacts() {
         _activity_total_timeout="$MOLE_TIMEOUT_HINT_SCAN_SEC"
     fi
     local _PURGE_ACTIVITY_DEADLINE_EPOCH=$((_now_epoch + _activity_total_timeout))
-    for item in "${all_found_items[@]}"; do
+    local candidate_index
+    for ((candidate_index = 0; candidate_index < ${#all_found_items[@]}; candidate_index++)); do
+        item="${all_found_items[$candidate_index]}"
         local candidate_bound=false
         local candidate_parent=""
         local candidate_parent_id=""
         local candidate_target_id=""
         local root_index
+        local scan_root
+        local -a candidate_root_indexes=()
         for ((root_index = 0; root_index < ${#scan_roots[@]}; root_index++)); do
             [[ ${scan_statuses[$root_index]:-1} -eq 0 ]] || continue
-            if ! is_safe_project_artifact "$item" "${scan_roots[$root_index]}"; then
-                continue
+            scan_root="${scan_roots[$root_index]}"
+            if [[ "$scan_root" == "/" || "$item" == "${scan_root%/}/"* ]]; then
+                candidate_root_indexes+=("$root_index")
             fi
+        done
+        # A scan root may be a symlink while fd/find reports the physical path.
+        # Fall back to the full physical containment check only for that rare
+        # alias case; normal candidates stay on their lexical roots.
+        if [[ ${#candidate_root_indexes[@]} -eq 0 ]]; then
+            for ((root_index = 0; root_index < ${#scan_roots[@]}; root_index++)); do
+                [[ ${scan_statuses[$root_index]:-1} -eq 0 ]] || continue
+                candidate_root_indexes+=("$root_index")
+            done
+        fi
+        if [[ ! -d "$item" || -L "$item" ]] || ! _mole_snapshot_path_identity "$item"; then
+            continue
+        fi
+        candidate_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
+        candidate_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+        candidate_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+        local candidate_physical_path="${candidate_parent%/}/${item##*/}"
+        [[ "$candidate_parent" == "/" ]] && candidate_physical_path="/${item##*/}"
+        local candidate_scan_root_index=-1
+        for root_index in "${candidate_root_indexes[@]}"; do
             if ! _mole_path_matches_identity \
                 "${scan_roots[$root_index]}" \
                 "${scan_root_parents[$root_index]}" \
@@ -1614,29 +1715,22 @@ clean_project_artifacts() {
                 "${scan_root_target_ids[$root_index]}"; then
                 continue
             fi
-            if [[ ! -d "$item" || -L "$item" ]] || ! _mole_snapshot_path_identity "$item"; then
-                continue
-            fi
-            candidate_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
-            candidate_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
-            candidate_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
-            # Bind the candidate only while both endpoints still match the
-            # completed scan. Rechecking the root after the candidate snapshot
-            # closes a replacement between those two observations.
             if ! _mole_path_matches_identity \
-                "${scan_roots[$root_index]}" \
-                "${scan_root_parents[$root_index]}" \
-                "${scan_root_parent_ids[$root_index]}" \
-                "${scan_root_target_ids[$root_index]}"; then
+                "${scan_root_physical_paths[$root_index]}" \
+                "${scan_root_physical_parents[$root_index]}" \
+                "${scan_root_physical_parent_ids[$root_index]}" \
+                "${scan_root_physical_target_ids[$root_index]}"; then
                 continue
             fi
             if ! _mole_path_matches_identity \
                 "$item" "$candidate_parent" "$candidate_parent_id" "$candidate_target_id"; then
                 continue
             fi
-            if ! is_safe_project_artifact "$item" "${scan_roots[$root_index]}"; then
+            if ! is_safe_project_artifact_under_root \
+                "$candidate_physical_path" "${scan_root_physical_paths[$root_index]}"; then
                 continue
             fi
+            candidate_scan_root_index="$root_index"
             candidate_bound=true
             break
         done
@@ -1669,6 +1763,7 @@ clean_project_artifacts() {
         safe_expected_parents+=("$candidate_parent")
         safe_expected_parent_ids+=("$candidate_parent_id")
         safe_expected_target_ids+=("$candidate_target_id")
+        safe_scan_root_indexes+=("$candidate_scan_root_index")
     done
     if [[ -t 1 ]]; then
         stop_inline_spinner
@@ -1750,6 +1845,7 @@ clean_project_artifacts() {
     local -a item_expected_parents=()
     local -a item_expected_parent_ids=()
     local -a item_expected_target_ids=()
+    local -a item_scan_root_indexes=()
     # Helper to get artifact display name
     # For duplicate artifact names within same project, include parent directory for context
     get_artifact_display_name() {
@@ -1926,6 +2022,7 @@ clean_project_artifacts() {
         item_expected_parents+=("${safe_expected_parents[$item_index]}")
         item_expected_parent_ids+=("${safe_expected_parent_ids[$item_index]}")
         item_expected_target_ids+=("${safe_expected_target_ids[$item_index]}")
+        item_scan_root_indexes+=("${safe_scan_root_indexes[$item_index]}")
         # Build human-readable age label (bash 3.2 compatible, no assoc arrays).
         local _mod_time _age_secs _age_d
         _mod_time=$(get_file_mtime "$item" 2> /dev/null || echo "0")
@@ -2076,6 +2173,7 @@ clean_project_artifacts() {
         local -a sorted_item_expected_parents=()
         local -a sorted_item_expected_parent_ids=()
         local -a sorted_item_expected_target_ids=()
+        local -a sorted_item_scan_root_indexes=()
 
         for idx in "${sorted_indices[@]}"; do
             sorted_menu_options+=("${menu_options[idx]}")
@@ -2091,6 +2189,7 @@ clean_project_artifacts() {
             sorted_item_expected_parents+=("${item_expected_parents[idx]}")
             sorted_item_expected_parent_ids+=("${item_expected_parent_ids[idx]}")
             sorted_item_expected_target_ids+=("${item_expected_target_ids[idx]}")
+            sorted_item_scan_root_indexes+=("${item_scan_root_indexes[idx]}")
         done
 
         # Replace original arrays with sorted versions
@@ -2107,6 +2206,7 @@ clean_project_artifacts() {
         item_expected_parents=("${sorted_item_expected_parents[@]}")
         item_expected_parent_ids=("${sorted_item_expected_parent_ids[@]}")
         item_expected_target_ids=("${sorted_item_expected_target_ids[@]}")
+        item_scan_root_indexes=("${sorted_item_scan_root_indexes[@]}")
     fi
     if [[ -t 1 ]]; then
         stop_inline_spinner
@@ -2237,12 +2337,33 @@ clean_project_artifacts() {
         local expected_parent="${item_expected_parents[idx]}"
         local expected_parent_id="${item_expected_parent_ids[idx]}"
         local expected_target_id="${item_expected_target_ids[idx]}"
+        local expected_scan_root_index="${item_scan_root_indexes[idx]}"
+        local expected_scan_root="${scan_roots[$expected_scan_root_index]}"
+        local expected_scan_root_physical="${scan_root_physical_paths[$expected_scan_root_index]}"
+        if ! _mole_path_matches_identity \
+            "$expected_scan_root" \
+            "${scan_root_parents[$expected_scan_root_index]}" \
+            "${scan_root_parent_ids[$expected_scan_root_index]}" \
+            "${scan_root_target_ids[$expected_scan_root_index]}"; then
+            echo -e "${YELLOW}${ICON_WARNING}${NC} Skipped $display_item_path (scan root changed after review)"
+            continue
+        fi
+        if ! _mole_path_matches_identity \
+            "$expected_scan_root_physical" \
+            "${scan_root_physical_parents[$expected_scan_root_index]}" \
+            "${scan_root_physical_parent_ids[$expected_scan_root_index]}" \
+            "${scan_root_physical_target_ids[$expected_scan_root_index]}"; then
+            echo -e "${YELLOW}${ICON_WARNING}${NC} Skipped $display_item_path (scan root target changed after review)"
+            continue
+        fi
         if ! _mole_path_matches_identity \
             "$item_path" "$expected_parent" "$expected_parent_id" "$expected_target_id"; then
             echo -e "${YELLOW}${ICON_WARNING}${NC} Skipped $display_item_path (path changed after review)"
             continue
         fi
-        if ! is_safe_configured_purge_artifact "$item_path"; then
+        local current_item_physical_path="${_MOLE_PATH_SNAPSHOT_PARENT%/}/${item_path##*/}"
+        [[ "$_MOLE_PATH_SNAPSHOT_PARENT" == "/" ]] && current_item_physical_path="/${item_path##*/}"
+        if ! is_safe_project_artifact_under_root "$current_item_physical_path" "$expected_scan_root_physical"; then
             debug_log "Skipping purge target outside configured safe roots: ${item_path:-<empty>}"
             continue
         fi
@@ -2260,6 +2381,17 @@ clean_project_artifacts() {
         local removal_recorded=false
         if [[ -e "$item_path" ]]; then
             local _MOLE_PURGE_FINAL_WAS_RECENT="${item_recent_flags[idx]:-true}"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT="$expected_scan_root"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT_PARENT="${scan_root_parents[$expected_scan_root_index]}"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT_PARENT_ID="${scan_root_parent_ids[$expected_scan_root_index]}"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT_TARGET_ID="${scan_root_target_ids[$expected_scan_root_index]}"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL="$expected_scan_root_physical"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL_PARENT="${scan_root_physical_parents[$expected_scan_root_index]}"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL_PARENT_ID="${scan_root_physical_parent_ids[$expected_scan_root_index]}"
+            local _MOLE_PURGE_FINAL_SCAN_ROOT_PHYSICAL_TARGET_ID="${scan_root_physical_target_ids[$expected_scan_root_index]}"
+            local _MOLE_PURGE_FINAL_EXPECTED_PARENT="$expected_parent"
+            local _MOLE_PURGE_FINAL_EXPECTED_PARENT_ID="$expected_parent_id"
+            local _MOLE_PURGE_FINAL_EXPECTED_TARGET_ID="$expected_target_id"
             local _MOLE_SAFE_REMOVE_FINAL_GUARD="_mole_purge_final_remove_guard"
             if safe_remove "$item_path" true "$size_kb" "" \
                 "$expected_parent" "$expected_parent_id" "$expected_target_id"; then

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -490,13 +490,22 @@ scan_purge_targets() {
 
     local cachedir_tag_min_depth=$((min_depth + 1))
     local cachedir_tag_max_depth=$((max_depth + 1))
+    local scan_timeout="${MO_PURGE_SCAN_TIMEOUT_SEC:-60}"
+    [[ "$scan_timeout" =~ ^[1-9][0-9]*$ ]] || scan_timeout=60
+    [[ "$scan_timeout" -ge 2 ]] || scan_timeout=2
+    local scan_deadline=$((SECONDS + scan_timeout))
+    local scan_stage_timeout=""
 
     # Update current scanning path
     local stats_dir="${XDG_CACHE_HOME:-$HOME/.cache}/mole"
     echo "$search_path" > "$stats_dir/purge_scanning" 2> /dev/null || true
 
     emit_valid_cachedir_tag_dirs() {
+        local deadline="$1"
         while IFS= read -r tag_file; do
+            if [[ $SECONDS -ge $deadline ]]; then
+                return 124
+            fi
             [[ -n "$tag_file" ]] || continue
             local cache_dir="${tag_file%/*}"
             if [[ -n "$cache_dir" ]] && mole_dir_has_cachedir_tag "$cache_dir"; then
@@ -508,11 +517,15 @@ scan_purge_targets() {
     # Helper to process raw results
     process_scan_results() {
         local input_file="$1"
+        local deadline="$2"
         if [[ -f "$input_file" ]]; then
             local process_status=0
             filter_nested_artifacts < "$input_file" |
                 (
                     while IFS= read -r item; do
+                        if [[ $SECONDS -ge $deadline ]]; then
+                            exit 124
+                        fi
                         # Check if we should abort (scanning file removed by Ctrl+C)
                         if [[ ! -f "$stats_dir/purge_scanning" ]]; then
                             exit 130
@@ -525,7 +538,7 @@ scan_purge_targets() {
                             echo "$project_dir" > "$stats_dir/purge_scanning" 2> /dev/null || true
                         fi
                     done
-                ) | filter_protected_artifacts > "$processed_output" || process_status=$?
+                ) | filter_protected_artifacts "$deadline" > "$processed_output" || process_status=$?
 
             if [[ $process_status -ne 0 ]]; then
                 rm -f "$processed_output" 2> /dev/null || true
@@ -591,19 +604,24 @@ scan_purge_targets() {
         # Trust fd when it exits successfully, including an empty result set.
         # Empty scans are common in healthy project trees; falling back to find
         # doubles the scan cost and can make "nothing to clean" feel slow.
-        local _scan_timeout="${MO_PURGE_SCAN_TIMEOUT_SEC:-60}"
         local fd_status=0
-        run_with_timeout "$_scan_timeout" fd "${fd_args[@]}" "$pattern" "$search_path" \
-            2> /dev/null > "$target_output" || fd_status=$?
+        scan_stage_timeout=$(_mole_timeout_with_deadline "$scan_timeout" "$scan_deadline") || fd_status=$?
         if [[ $fd_status -eq 0 ]]; then
-            run_with_timeout "$_scan_timeout" fd "${fd_tag_args[@]}" "^${MOLE_CACHEDIR_TAG_NAME}$" "$search_path" \
+            run_with_timeout "$scan_stage_timeout" fd "${fd_args[@]}" "$pattern" "$search_path" \
+                2> /dev/null > "$target_output" || fd_status=$?
+        fi
+        if [[ $fd_status -eq 0 ]]; then
+            scan_stage_timeout=$(_mole_timeout_with_deadline "$scan_timeout" "$scan_deadline") || fd_status=$?
+        fi
+        if [[ $fd_status -eq 0 ]]; then
+            run_with_timeout "$scan_stage_timeout" fd "${fd_tag_args[@]}" "^${MOLE_CACHEDIR_TAG_NAME}$" "$search_path" \
                 2> /dev/null > "$tag_output" || fd_status=$?
         fi
         if [[ $fd_status -eq 0 ]]; then
-            emit_valid_cachedir_tag_dirs < "$tag_output" >> "$target_output" || fd_status=$?
+            emit_valid_cachedir_tag_dirs "$scan_deadline" < "$tag_output" >> "$target_output" || fd_status=$?
         fi
         if [[ $fd_status -eq 0 ]]; then
-            process_scan_results "$target_output" || fd_status=$?
+            process_scan_results "$target_output" "$scan_deadline" || fd_status=$?
         fi
         if [[ $fd_status -eq 0 ]]; then
             debug_log "Using fd for scanning"
@@ -636,24 +654,29 @@ scan_purge_targets() {
 
         # Use plain `find` here for compatibility with environments where
         # `command find` behaves inconsistently in this complex expression.
-        local _scan_timeout="${MO_PURGE_SCAN_TIMEOUT_SEC:-60}"
         local find_status=0
-        run_with_timeout "$_scan_timeout" find "$search_path" -mindepth "$min_depth" -maxdepth "$max_depth" -type d \
-            \( "${prune_expr[@]}" \) -prune -o \
-            \( "${target_expr[@]}" \) -print -prune \
-            2> /dev/null > "$target_output" || find_status=$?
+        scan_stage_timeout=$(_mole_timeout_with_deadline "$scan_timeout" "$scan_deadline") || find_status=$?
+        if [[ $find_status -eq 0 ]]; then
+            run_with_timeout "$scan_stage_timeout" find "$search_path" -mindepth "$min_depth" -maxdepth "$max_depth" -type d \
+                \( "${prune_expr[@]}" \) -prune -o \
+                \( "${target_expr[@]}" \) -print -prune \
+                2> /dev/null > "$target_output" || find_status=$?
+        fi
 
         if [[ $find_status -eq 0 ]]; then
-            run_with_timeout "$_scan_timeout" find "$search_path" -mindepth "$cachedir_tag_min_depth" -maxdepth "$cachedir_tag_max_depth" \
+            scan_stage_timeout=$(_mole_timeout_with_deadline "$scan_timeout" "$scan_deadline") || find_status=$?
+        fi
+        if [[ $find_status -eq 0 ]]; then
+            run_with_timeout "$scan_stage_timeout" find "$search_path" -mindepth "$cachedir_tag_min_depth" -maxdepth "$cachedir_tag_max_depth" \
                 \( -type d \( \( "${prune_expr[@]}" \) -o \( "${target_expr[@]}" \) \) \) -prune -o \
                 -type f -name "$MOLE_CACHEDIR_TAG_NAME" -print \
                 2> /dev/null > "$tag_output" || find_status=$?
         fi
         if [[ $find_status -eq 0 ]]; then
-            emit_valid_cachedir_tag_dirs < "$tag_output" >> "$target_output" || find_status=$?
+            emit_valid_cachedir_tag_dirs "$scan_deadline" < "$tag_output" >> "$target_output" || find_status=$?
         fi
         if [[ $find_status -eq 0 ]]; then
-            process_scan_results "$target_output" || find_status=$?
+            process_scan_results "$target_output" "$scan_deadline" || find_status=$?
         fi
 
         cleanup_scan_outputs
@@ -686,7 +709,11 @@ filter_nested_artifacts() {
 }
 
 filter_protected_artifacts() {
+    local deadline="${1:-}"
     while IFS= read -r item; do
+        if [[ "$deadline" =~ ^[0-9]+$ && $SECONDS -ge $deadline ]]; then
+            return 124
+        fi
         if ! is_protected_purge_artifact "$item"; then
             echo "$item"
         fi

--- a/lib/clean/purge_shared.sh
+++ b/lib/clean/purge_shared.sh
@@ -105,6 +105,26 @@ readonly MOLE_PURGE_PROJECT_INDICATORS=(
 readonly MOLE_CACHEDIR_TAG_NAME="CACHEDIR.TAG"
 readonly MOLE_CACHEDIR_TAG_SIGNATURE="Signature: 8a477f597d28d172789f06886806bc55"
 
+# Normalize an integer or fractional timeout into the whole-second budget used
+# by SECONDS. Shared by clean's project-cache scan and purge's size pool so both
+# keep fractional overrides without duplicating deadline arithmetic.
+mole_purge_timeout_budget_seconds() {
+    local fallback_seconds="${2:-30}"
+    [[ "$fallback_seconds" =~ ^[1-9][0-9]*$ ]] || fallback_seconds=30
+    local timeout_seconds="${1:-$fallback_seconds}"
+    if [[ ! "$timeout_seconds" =~ ^[0-9]+(\.[0-9]+)?$ || "$timeout_seconds" =~ ^0+(\.0+)?$ ]]; then
+        timeout_seconds="$fallback_seconds"
+    fi
+
+    local timeout_whole="${timeout_seconds%%.*}"
+    local timeout_budget=$((10#$timeout_whole))
+    if [[ "$timeout_seconds" == *.* && "${timeout_seconds#*.}" =~ [1-9] ]]; then
+        timeout_budget=$((timeout_budget + 1))
+    fi
+    [[ $timeout_budget -ge 2 ]] || timeout_budget=2
+    printf '%s\n' "$timeout_budget"
+}
+
 # High-noise targets intentionally excluded from quick hint scans in mo clean.
 readonly MOLE_PURGE_QUICK_HINT_EXCLUDED_TARGETS=(
     "bin"

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -2183,7 +2183,11 @@ clean_application_support_logs() {
                         fi
                     fi
                     if [[ "$DRY_RUN" != "true" ]]; then
-                        safe_remove "$item" true > /dev/null 2>&1 || true
+                        if [[ "$item_size_known" == "true" ]]; then
+                            safe_remove "$item" true "$item_size_kb" > /dev/null 2>&1 || true
+                        else
+                            safe_remove "$item" true > /dev/null 2>&1 || true
+                        fi
                     fi
                 done < <(command find "$candidate" -mindepth 1 -maxdepth 1 -print0 2> /dev/null || true)
                 if [[ "$item_found" == "true" ]]; then
@@ -2270,7 +2274,11 @@ clean_application_support_logs() {
                         fi
                     fi
                     if [[ "$DRY_RUN" != "true" ]]; then
-                        safe_remove "$item" true > /dev/null 2>&1 || true
+                        if [[ "$item_size_known" == "true" ]]; then
+                            safe_remove "$item" true "$item_size_kb" > /dev/null 2>&1 || true
+                        else
+                            safe_remove "$item" true > /dev/null 2>&1 || true
+                        fi
                     fi
                 done < <(command find "$candidate" -mindepth 1 -maxdepth 1 -print0 2> /dev/null || true)
                 if [[ "$item_found" == "true" ]]; then

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -1301,7 +1301,7 @@ clean_group_container_caches() {
                         candidate_size_kb=$((candidate_size_kb + item_size))
                         continue
                     fi
-                    if safe_remove "$item" true 2> /dev/null; then
+                    if safe_remove "$item" true "$item_size" 2> /dev/null; then
                         candidate_changed=true
                         candidate_size_kb=$((candidate_size_kb + item_size))
                     fi

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -1865,6 +1865,27 @@ _mole_path_requires_direct_trash() {
     return 1
 }
 
+# Refresh the process evidence for one Trash target, then rebind its physical
+# identity. The process table may be reused during discovery, but a distinct app
+# can start before a later item reaches the move sink; stale evidence must never
+# authorize that move.
+_mole_trash_target_still_safe() {
+    local path="$1"
+    local expected_parent="${2:-}"
+    local expected_parent_id="${3:-}"
+    local expected_target_id="${4:-}"
+
+    _mole_reset_process_snapshot
+    if _mole_should_refuse_live_user_cache_path "$path"; then
+        debug_log "Skipped Trash move after live user cache appeared: $path"
+        log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "SKIPPED" "$path" "live user cache"
+        return 1
+    fi
+
+    _mole_bound_path_matches "$path" "$expected_parent" \
+        "$expected_parent_id" "$expected_target_id"
+}
+
 # Finder's Trash API can move package-installed app bundles that macOS App
 # Management blocks from a direct mv. Run it only as the invoking user and only
 # for an exact one-level /Applications/*.app target selected above.
@@ -1876,7 +1897,7 @@ _mole_move_app_to_trash_via_finder() {
     local finder_rc=0
 
     _mole_path_is_application_bundle "$path" || return 1
-    _mole_bound_path_matches "$path" "$expected_parent" \
+    _mole_trash_target_still_safe "$path" "$expected_parent" \
         "$expected_parent_id" "$expected_target_id" || return 1
 
     run_with_timeout "$MOLE_TIMEOUT_DISK_VERIFY_SEC" osascript - "$path" > /dev/null 2>&1 << 'APPLESCRIPT' || finder_rc=$?
@@ -1911,7 +1932,7 @@ _mole_move_to_trash() {
     if [[ -n "${MOLE_TEST_TRASH_DIR:-}" ]]; then
         mkdir -p "$MOLE_TEST_TRASH_DIR" 2> /dev/null || return 1
         local dest="$MOLE_TEST_TRASH_DIR/$(basename "$path").$$.$(date +%s 2> /dev/null || echo 0)"
-        _mole_bound_path_matches "$path" "$expected_parent" \
+        _mole_trash_target_still_safe "$path" "$expected_parent" \
             "$expected_parent_id" "$expected_target_id" || return 1
         mv "$path" "$dest" 2> /dev/null
         return $?
@@ -1949,7 +1970,7 @@ _mole_move_to_trash() {
     # Prefer the `trash` CLI (Homebrew formula) for normal user-owned paths.
     if command -v trash > /dev/null 2>&1; then
         local trash_rc=0
-        _mole_bound_path_matches "$path" "$expected_parent" \
+        _mole_trash_target_still_safe "$path" "$expected_parent" \
             "$expected_parent_id" "$expected_target_id" || return 1
         run_with_timeout "$MOLE_TIMEOUT_DISK_VERIFY_SEC" \
             trash "$path" > /dev/null 2>&1 || trash_rc=$?
@@ -1959,7 +1980,7 @@ _mole_move_to_trash() {
 
     # AppleScript fallback. Pass the path via argv so special chars (quotes,
     # backslashes) cannot break out of the quoted string.
-    _mole_bound_path_matches "$path" "$expected_parent" \
+    _mole_trash_target_still_safe "$path" "$expected_parent" \
         "$expected_parent_id" "$expected_target_id" || return 1
     run_with_timeout "$MOLE_TIMEOUT_DISK_VERIFY_SEC" \
         osascript - "$path" > /dev/null 2>&1 << 'APPLESCRIPT'
@@ -2179,7 +2200,7 @@ _mole_move_path_to_user_trash() {
         fi
 
         local stage_move_rc=0
-        _mole_bound_path_matches "$path" "$expected_parent" \
+        _mole_trash_target_still_safe "$path" "$expected_parent" \
             "$expected_parent_id" "$expected_target_id" || return 1
         sudo -n /bin/mv "$path" "$stage_path" 2> /dev/null || stage_move_rc=$?
         if [[ $stage_move_rc -ne 0 ]]; then
@@ -2248,7 +2269,7 @@ _mole_move_path_to_user_trash() {
             sudo -n /bin/rmdir "$stage_dir" 2> /dev/null || true
         fi
     else
-        _mole_bound_path_matches "$path" "$expected_parent" \
+        _mole_trash_target_still_safe "$path" "$expected_parent" \
             "$expected_parent_id" "$expected_target_id" || return 1
         move_output=$(mv -n "$path" "$dest" 2>&1) || move_rc=$?
     fi
@@ -2374,7 +2395,7 @@ _mole_move_to_trash_batch() {
         local dest
         for ((index = 0; index < ${#paths[@]}; index++)); do
             p="${paths[$index]}"
-            _mole_path_matches_identity \
+            _mole_trash_target_still_safe \
                 "$p" \
                 "${expected_parents[$index]}" \
                 "${expected_parent_ids[$index]}" \
@@ -2408,7 +2429,10 @@ _mole_move_to_trash_batch() {
         _MOLE_TRASH_MOVE_EXPECTED_PARENT="${expected_parents[$index]}"
         _MOLE_TRASH_MOVE_EXPECTED_PARENT_ID="${expected_parent_ids[$index]}"
         _MOLE_TRASH_MOVE_EXPECTED_TARGET_ID="${expected_target_ids[$index]}"
-        if _mole_move_path_to_user_trash "$p" false; then
+        if _mole_move_path_to_user_trash "$p" false \
+            "${expected_parents[$index]}" \
+            "${expected_parent_ids[$index]}" \
+            "${expected_target_ids[$index]}"; then
             _MOLE_TRASH_BATCH_MOVED_PATHS+=("$p")
         else
             failed=1

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -239,6 +239,12 @@ _mole_sqlite_family_base_path() {
 _MOLE_PROCESS_TABLE=""
 _MOLE_PROCESS_TABLE_STATE=""
 
+_mole_reset_process_snapshot() {
+    _MOLE_PROCESS_TABLE=""
+    _MOLE_PROCESS_TABLE_STATE=""
+    _MOLE_USER_CACHE_OWNER_STATE_CACHE=""
+}
+
 _mole_load_process_table() {
     if [[ -n "${_MOLE_PROCESS_TABLE_STATE:-}" ]]; then
         [[ "$_MOLE_PROCESS_TABLE_STATE" == "ok" ]] || return 1
@@ -1055,6 +1061,7 @@ safe_remove() {
     # Recheck live-owner / open-SQLite state after size probing: a helper can
     # launch while du is walking the tree (same race class as the compiled
     # model cache check above).
+    _mole_reset_process_snapshot
     if _mole_should_refuse_live_user_cache_path "$path"; then
         debug_log "Skipped removal after live user cache appeared: $path"
         log_operation "${MOLE_CURRENT_COMMAND:-clean}" "SKIPPED" "$path" "live user cache"

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -954,14 +954,6 @@ safe_remove() {
         return 1
     fi
 
-    # Live reverse-DNS caches under ~/Library/Caches (#1390): refuse while the
-    # owning process is running or an open SQLite handle is proven. Final sink
-    # so both safe_clean and direct safe_remove callers are covered.
-    if _mole_should_refuse_live_user_cache_path "$path"; then
-        log_operation "${MOLE_CURRENT_COMMAND:-clean}" "SKIPPED" "$path" "live user cache"
-        return 1
-    fi
-
     # Dry-run mode: log but don't delete
     if [[ "${MOLE_DRY_RUN:-0}" == "1" ]]; then
         local dry_record_rc=0

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -239,10 +239,9 @@ _mole_sqlite_family_base_path() {
 _MOLE_PROCESS_TABLE=""
 _MOLE_PROCESS_TABLE_STATE=""
 
-_mole_process_table() {
+_mole_load_process_table() {
     if [[ -n "${_MOLE_PROCESS_TABLE_STATE:-}" ]]; then
         [[ "$_MOLE_PROCESS_TABLE_STATE" == "ok" ]] || return 1
-        printf '%s\n' "$_MOLE_PROCESS_TABLE"
         return 0
     fi
 
@@ -310,7 +309,6 @@ _mole_process_table() {
 
     _MOLE_PROCESS_TABLE="$filtered"
     _MOLE_PROCESS_TABLE_STATE="ok"
-    printf '%s\n' "$_MOLE_PROCESS_TABLE"
     return 0
 }
 
@@ -346,11 +344,11 @@ _mole_user_cache_owner_process_state() {
         *"${cache_token}2|"*) return 2 ;;
     esac
 
-    local table=""
-    if ! table=$(_mole_process_table); then
+    if ! _mole_load_process_table; then
         # An unreadable process table is not proof the owner is idle.
         return 2
     fi
+    local table="$_MOLE_PROCESS_TABLE"
 
     # Feed the table by here-string, never through a pipe. `grep -q` exits on
     # its first match, and the printf still writing into that closed pipe takes

--- a/tests/clean_dev_caches.bats
+++ b/tests/clean_dev_caches.bats
@@ -61,6 +61,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
 DRY_RUN=false
 run_with_timeout() { shift; "$@"; }
+github_cli_process_state() { return 1; }
 is_path_whitelisted() { return 1; }
 should_protect_path() { return 1; }
 clean_tool_cache() {
@@ -91,6 +92,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
 DRY_RUN=true
 run_with_timeout() { shift; "$@"; }
+github_cli_process_state() { return 1; }
 is_path_whitelisted() { return 1; }
 should_protect_path() { return 1; }
 start_section_spinner() { :; }
@@ -172,6 +174,7 @@ set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
 DRY_RUN=false
+github_cli_process_state() { return 1; }
 is_path_whitelisted() { return 1; }
 should_protect_path() { return 1; }
 note_activity() { :; }
@@ -206,6 +209,7 @@ set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
 DRY_RUN=false
+github_cli_process_state() { return 1; }
 is_path_whitelisted() { return 1; }
 should_protect_path() { return 1; }
 note_activity() { :; }
@@ -314,6 +318,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
 DRY_RUN=false
 run_with_timeout() { shift; "$@"; }
+github_cli_process_state() { return 1; }
 is_path_whitelisted() { return 1; }
 should_protect_path() { return 1; }
 start_section_spinner() { :; }
@@ -356,6 +361,7 @@ source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/dev.sh"
 DRY_RUN=false
 run_with_timeout() { shift; "$@"; }
+github_cli_process_state() { return 1; }
 is_path_whitelisted() { return 1; }
 should_protect_path() { return 1; }
 start_section_spinner() { :; }

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -663,8 +663,32 @@ EOF
     elapsed=$(printf '%s\n' "$output" | awk -F= '/ELAPSED=/{print $2}' | tail -1)
     [[ "$elapsed" =~ ^[0-9]+$ ]] || return 1
     (( elapsed < 5 ))
+    [[ "$output" == *"Project caches · skipped 1 slow/incomplete root scan"* ]] || return 1
 
 	rm -rf "$HOME/.config/mole" "$HOME/SlowProjects" "$fake_bin"
+}
+
+@test "clean_project_caches propagates an interrupted root scan" {
+	local scan_home="$HOME/interrupted-project-scan"
+	mkdir -p "$scan_home/root"
+
+	run env HOME="$scan_home" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+discover_project_cache_roots() { printf '%s\n' "$HOME/root"; }
+scan_project_cache_root() {
+	: > "$2"
+	return 130
+}
+process_project_cache_matches() { printf 'UNEXPECTED_PROCESS\n'; }
+clean_rc=0
+clean_project_caches || clean_rc=$?
+printf 'RC=%s\n' "$clean_rc"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "RC=130" ]] || return 1
 }
 
 @test "scan_project_cache_root discards partial output when its producer times out" {

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -392,6 +392,7 @@ EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"REMOVE=$cache_dir SILENT=true SIZE=321"* ]] || return 1
+	rm -rf "$HOME/Projects"
 }
 
 @test "pycache_has_bytecode checks direct bytecode files without spawning find" {
@@ -618,7 +619,31 @@ EOF
     [[ "$elapsed" =~ ^[0-9]+$ ]] || return 1
     (( elapsed < 5 ))
 
-    rm -rf "$HOME/.config/mole" "$HOME/SlowProjects" "$fake_bin"
+	rm -rf "$HOME/.config/mole" "$HOME/SlowProjects" "$fake_bin"
+}
+
+@test "scan_project_cache_root discards partial output when its producer times out" {
+	mkdir -p "$HOME/Projects/app/.next/cache"
+	touch "$HOME/Projects/app/package.json"
+	local output_file
+	output_file=$(mktemp)
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" OUTPUT_FILE="$output_file" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+run_with_timeout() {
+	printf '%s\n' "$HOME/Projects/app/.next"
+	return 124
+}
+scan_rc=0
+scan_project_cache_root "$HOME/Projects" "$OUTPUT_FILE" || scan_rc=$?
+printf 'STATUS=%s SIZE=%s\n' "$scan_rc" "$(wc -c < "$OUTPUT_FILE" | tr -d ' ')"
+EOF
+
+	rm -rf "$HOME/Projects" "$output_file"
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "STATUS=124 SIZE=0" ]] || return 1
 }
 
 @test "scan_project_cache_root prunes conda and site-packages" {

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -691,6 +691,30 @@ EOF
 	[[ "$output" == "RC=130" ]] || return 1
 }
 
+@test "clean_project_caches processes no roots when a later scan is interrupted" {
+	local scan_home="$HOME/interrupted-project-scan-batch"
+	mkdir -p "$scan_home/root-1" "$scan_home/root-2"
+
+	run env HOME="$scan_home" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+discover_project_cache_roots() { printf '%s\n' "$HOME/root-1" "$HOME/root-2"; }
+scan_project_cache_root() {
+	: > "$2"
+	[[ "$1" == "$HOME/root-1" ]] && return 0
+	return 130
+}
+process_project_cache_matches() { touch "$HOME/processed"; }
+clean_rc=0
+clean_project_caches || clean_rc=$?
+printf 'RC=%s PROCESSED=%s\n' "$clean_rc" "$([[ -e "$HOME/processed" ]] && printf yes || printf no)"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "RC=130 PROCESSED=no" ]] || return 1
+}
+
 @test "scan_project_cache_root discards partial output when its producer times out" {
 	mkdir -p "$HOME/Projects/app/.next/cache"
 	touch "$HOME/Projects/app/package.json"

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -370,7 +370,28 @@ EOF
     [[ "$output" == *"Python bytecode cache"* ]] || return 1
     [[ "$output" == *"1 dirs"* ]] || return 1
 
-    rm -rf "$HOME/Projects"
+	rm -rf "$HOME/Projects"
+}
+
+@test "clean_python_bytecode_cache_group reuses its exact size at removal" {
+	local cache_dir="$HOME/Projects/python-app/pkg/__pycache__"
+	mkdir -p "$cache_dir"
+	touch "$cache_dir/module.pyc"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" CACHE_DIR="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+DRY_RUN=false
+get_path_size_kb() { printf '321\n'; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+safe_remove() { printf 'REMOVE=%s SILENT=%s SIZE=%s\n' "$1" "$2" "$3"; }
+clean_python_bytecode_cache_group "$HOME/Projects/python-app" "$CACHE_DIR"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"REMOVE=$cache_dir SILENT=true SIZE=321"* ]] || return 1
 }
 
 @test "pycache_has_bytecode checks direct bytecode files without spawning find" {

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -551,7 +551,52 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Next.js build cache|$HOME/go/src/github.com/example/demo/.next/cache/test.cache"* ]] || return 1
 
-    rm -rf "$HOME/go"
+	rm -rf "$HOME/go"
+}
+
+@test "clean_project_caches scans independent roots concurrently within its bound" {
+	local scan_home="$HOME/concurrent-project-scans"
+	mkdir -p "$scan_home/root-1" "$scan_home/root-2" "$scan_home/root-3" "$scan_home/root-4"
+
+	run env HOME="$scan_home" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+discover_project_cache_roots() {
+	printf '%s\n' "$HOME/root-1" "$HOME/root-2" "$HOME/root-3" "$HOME/root-4"
+}
+get_optimal_parallel_jobs() { printf '2\n'; }
+scan_project_cache_root() {
+	: > "$2"
+	touch "$HOME/active-${1##*/}"
+	while [[ ! -e "$HOME/release-scans" ]]; do
+		sleep 0.02
+	done
+	rm -f "$HOME/active-${1##*/}"
+}
+process_project_cache_matches() { :; }
+
+(
+	for _ in {1..100}; do
+		active_count=$(command find "$HOME" -maxdepth 1 -name 'active-*' | wc -l | tr -d ' ')
+		if [[ "$active_count" -ge 2 ]]; then
+			printf '%s\n' "$active_count" > "$HOME/observed-concurrency"
+			touch "$HOME/release-scans"
+			exit 0
+		fi
+		sleep 0.02
+	done
+	exit 1
+) &
+monitor_pid=$!
+
+clean_project_caches
+wait "$monitor_pid"
+printf 'CONCURRENCY=%s\n' "$(cat "$HOME/observed-concurrency")"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "CONCURRENCY=2" ]] || return 1
 }
 
 @test "discover_project_cache_roots dedupes aliased roots by filesystem identity" {

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -577,6 +577,7 @@ scan_project_cache_root() {
 process_project_cache_matches() { :; }
 
 (
+	trap 'touch "$HOME/release-scans"' EXIT
 	for _ in {1..100}; do
 		active_count=$(command find "$HOME" -maxdepth 1 -name 'active-*' | wc -l | tr -d ' ')
 		if [[ "$active_count" -ge 2 ]]; then
@@ -715,6 +716,79 @@ EOF
 	[[ "$output" == "RC=130 PROCESSED=no" ]] || return 1
 }
 
+@test "clean_project_caches stops launching roots after an interrupted batch" {
+	local scan_home="$HOME/interrupted-project-scan-launch"
+	mkdir -p "$scan_home/root-1" "$scan_home/root-2" "$scan_home/root-3"
+
+	run env HOME="$scan_home" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+discover_project_cache_roots() {
+	printf '%s\n' "$HOME/root-1" "$HOME/root-2" "$HOME/root-3"
+}
+get_optimal_parallel_jobs() { printf '1\n'; }
+scan_project_cache_root() {
+	: > "$2"
+	printf '%s\n' "${1##*/}" >> "$HOME/scanned"
+	[[ "${1##*/}" == "root-1" ]] && return 130
+	return 0
+}
+process_project_cache_matches() { printf 'UNEXPECTED_PROCESS\n'; }
+clean_rc=0
+clean_project_caches || clean_rc=$?
+printf 'RC=%s SCANNED=%s\n' "$clean_rc" "$(paste -sd, "$HOME/scanned")"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "RC=130 SCANNED=root-1" ]] || return 1
+}
+
+@test "clean_project_caches kills active root scans when its parent receives TERM" {
+	local scan_home="$HOME/terminated-project-scans"
+	mkdir -p "$scan_home/root"
+	local driver="$scan_home/driver.sh"
+
+	cat > "$driver" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+discover_project_cache_roots() { printf '%s\n' "$HOME/root"; }
+get_optimal_parallel_jobs() { printf '1\n'; }
+scan_project_cache_root() {
+	: > "$2"
+	touch "$HOME/worker-started"
+	trap 'exit 143' TERM
+	sleep 1
+	touch "$HOME/worker-survived"
+}
+process_project_cache_matches() { :; }
+clean_project_caches
+EOF
+	chmod +x "$driver"
+
+	run env HOME="$scan_home" PROJECT_ROOT="$PROJECT_ROOT" DRIVER="$driver" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+/bin/bash "$DRIVER" &
+parent_pid=$!
+for _ in {1..100}; do
+	[[ -e "$HOME/worker-started" ]] && break
+	sleep 0.02
+done
+[[ -e "$HOME/worker-started" ]] || exit 1
+kill -TERM "$parent_pid"
+parent_rc=0
+wait "$parent_pid" || parent_rc=$?
+sleep 0.1
+printf 'PARENT_RC=%s WORKER_SURVIVED=%s\n' \
+	"$parent_rc" "$([[ -e "$HOME/worker-survived" ]] && printf yes || printf no)"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "PARENT_RC=143 WORKER_SURVIVED=no" ]] || return 1
+}
+
 @test "scan_project_cache_root discards partial output when its producer times out" {
 	mkdir -p "$HOME/Projects/app/.next/cache"
 	touch "$HOME/Projects/app/package.json"
@@ -737,6 +811,45 @@ EOF
 	rm -rf "$HOME/Projects" "$output_file"
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == "STATUS=124 SIZE=0" ]] || return 1
+}
+
+@test "scan_project_cache_root bounds grouping within the shared deadline" {
+	mkdir -p "$HOME/Projects"
+	local fake_bin
+	fake_bin="$(mktemp -d "$HOME/project-cache-postprocess.XXXXXX")"
+	cat > "$fake_bin/find" <<'EOF'
+#!/bin/bash
+for i in $(seq 1 1000); do
+	printf '%s\n' "$HOME/Projects/app-$i/.next"
+done
+EOF
+	cat > "$fake_bin/dirname" <<'EOF'
+#!/bin/bash
+sleep 0.02
+/usr/bin/dirname "$@"
+EOF
+	chmod +x "$fake_bin/find" "$fake_bin/dirname"
+	local output_file
+	output_file=$(mktemp)
+
+	run env HOME="$HOME" PATH="$fake_bin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" OUTPUT_FILE="$output_file" \
+		MOLE_PROJECT_CACHE_SCAN_TIMEOUT=2 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+SECONDS=0
+scan_rc=0
+scan_project_cache_root "$HOME/Projects" "$OUTPUT_FILE" || scan_rc=$?
+printf 'STATUS=%s ELAPSED=%s BYTES=%s\n' \
+	"$scan_rc" "$SECONDS" "$(wc -c < "$OUTPUT_FILE" | tr -d ' ')"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	local elapsed
+	elapsed=$(printf '%s\n' "$output" | sed -n 's/.*ELAPSED=\([0-9][0-9]*\).*/\1/p')
+	[[ "$output" == STATUS=124*" BYTES=0" ]] || return 1
+	[[ "$elapsed" =~ ^[0-9]+$ ]] || return 1
+	((elapsed < 4))
 }
 
 @test "scan_project_cache_root prunes conda and site-packages" {

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -794,7 +794,42 @@ EOF
     local total_kb
     total_kb=$(printf '%s\n' "$output" | sed -n 's/.*TOTAL_KB=\([0-9][0-9]*\).*/\1/p' | tail -1)
     [[ -n "$total_kb" ]] || return 1
-    [[ "$total_kb" -ge 2 ]]
+	[[ "$total_kb" -ge 2 ]]
+}
+
+@test "clean_application_support_logs reuses exact item sizes at removal" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+update_progress_if_needed() { return 1; }
+should_protect_data() { return 1; }
+is_critical_system_component() { return 1; }
+app_support_item_size_bytes() { printf '2048\n'; }
+safe_remove() { printf 'REMOVE=%s SILENT=%s SIZE=%s\n' "$1" "$2" "${3:-missing}" >> "$HOME/remove-calls"; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+app_item="$HOME/Library/Application Support/TestApp/Code Cache/nested"
+group_item="$HOME/Library/Group Containers/group.com.apple.contentdelivery/Logs/event.log"
+mkdir -p "$app_item" "${group_item%/*}"
+printf 'log\n' > "$group_item"
+
+clean_application_support_logs
+grep -Fx "REMOVE=$app_item SILENT=true SIZE=2" "$HOME/remove-calls"
+grep -Fx "REMOVE=$group_item SILENT=true SIZE=2" "$HOME/remove-calls"
+command rm -rf "$HOME/Library/Application Support/TestApp" \
+    "$HOME/Library/Group Containers/group.com.apple.contentdelivery" \
+    "$HOME/remove-calls"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"REMOVE=$HOME/Library/Application Support/TestApp/Code Cache/nested SILENT=true SIZE=2"* ]] || return 1
+	[[ "$output" == *"REMOVE=$HOME/Library/Group Containers/group.com.apple.contentdelivery/Logs/event.log SILENT=true SIZE=2"* ]] || return 1
 }
 
 @test "clean_application_support_logs uses bulk clean for large Application Support directories" {

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -989,7 +989,34 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Group Containers logs/caches"* ]] || return 1
-    [[ "$output" == *"PASS"* ]]
+	[[ "$output" == *"PASS"* ]]
+}
+
+@test "clean_group_container_caches reuses exact item sizes at removal" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+should_protect_data() { return 1; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+get_path_size_kb() { printf '77\n'; }
+safe_remove() { printf 'REMOVE=%s SILENT=%s SIZE=%s\n' "$1" "$2" "$3"; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+item="$HOME/Library/Group Containers/group.com.example.tool/Library/Caches/cache.db"
+mkdir -p "${item%/*}"
+printf 'cache\n' > "$item"
+clean_group_container_caches
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"REMOVE=$HOME/Library/Group Containers/group.com.example.tool/Library/Caches/cache.db SILENT=true SIZE=77"* ]] || return 1
 }
 
 @test "clean_handoff_pasteboard_cache removes stale items and keeps fresh ones (#1178)" {

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -636,6 +636,26 @@ SCRIPT
     [[ "$output" != *"UNEXPECTED_REGISTER"* ]]
 }
 
+@test "safe_remove dry-run performs one live-cache eligibility check" {
+    local target_dir="$TEST_DIR/cache-eligibility"
+    mkdir -p "$target_dir"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+guard_calls=0
+_mole_should_refuse_live_user_cache_path() {
+    guard_calls=$((guard_calls + 1))
+    return 1
+}
+MOLE_DRY_RUN=1 safe_remove "$TARGET_DIR" true 1
+printf 'CALLS=%s EXISTS=%s\n' "$guard_calls" "$(test -d "$TARGET_DIR" && echo yes || echo no)"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == "CALLS=1 EXISTS=yes" ]] || return 1
+}
+
 @test "safe_remove in silent mode suppresses error output" {
     run /bin/bash -c "source '$PROJECT_ROOT/lib/core/common.sh'; safe_remove '/System/test' true 2>&1"
     [ "$status" -eq 1 ]

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -636,13 +636,14 @@ SCRIPT
     [[ "$output" != *"UNEXPECTED_REGISTER"* ]]
 }
 
-@test "safe_remove dry-run performs one live-cache eligibility check" {
+@test "safe_remove dry-run exercises the production preview eligibility path" {
     local target_dir="$TEST_DIR/cache-eligibility"
     mkdir -p "$target_dir"
 
     run env PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/bin/clean.sh"
 guard_calls=0
 _mole_should_refuse_live_user_cache_path() {
     guard_calls=$((guard_calls + 1))
@@ -653,7 +654,7 @@ printf 'CALLS=%s EXISTS=%s\n' "$guard_calls" "$(test -d "$TARGET_DIR" && echo ye
 EOF
 
     [ "$status" -eq 0 ] || return 1
-    [[ "$output" == "CALLS=1 EXISTS=yes" ]] || return 1
+	[[ "$output" == *"CALLS=2 EXISTS=yes"* ]] || return 1
 }
 
 @test "safe_remove in silent mode suppresses error output" {
@@ -744,7 +745,7 @@ set -u
 case "${1:-}" in
     rm)
         printf 'sudo-rm %s\n' "$*" >> "$MOLE_SUDO_RM_TRACE"
-        exec sleep 4
+        exec sleep 8
         ;;
     *)
         exit 99
@@ -755,7 +756,7 @@ MOCK
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" \
         PATH="$mock_bin:$PATH" MOLE_SUDO_RM_TRACE="$trace" \
-        MOLE_TIMEOUT_DISK_VERIFY_SEC=1 MO_NO_OPLOG=1 \
+        MOLE_TIMEOUT_DISK_VERIFY_SEC=2 MO_NO_OPLOG=1 \
         MOLE_TEST_MODE=0 MOLE_TEST_NO_AUTH=0 /bin/bash --noprofile --norc <<'SCRIPT'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -775,7 +776,7 @@ SCRIPT
     [[ "$(< "$trace")" == *"sudo-rm rm -rf $target_dir"* ]] || return 1
     local elapsed="${output##*ELAPSED=}"
     [[ "$elapsed" =~ ^[0-9]+$ ]] || return 1
-    [ "$elapsed" -lt 3 ]
+    [ "$elapsed" -lt 5 ]
     [ -e "$target_dir/data" ]
 }
 
@@ -2262,6 +2263,7 @@ EOF
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 ps_calls=$(mktemp)
+rm_calls=$(mktemp)
 ps() {
 	printf 'call\n' >> "$ps_calls"
 	call_count=$(wc -l < "$ps_calls" | tr -d ' ')
@@ -2279,18 +2281,23 @@ TABLE
 lsof() { return 1; }
 get_path_size_kb() { printf '1\n'; }
 oplog_enabled() { return 0; }
-rm() { printf 'UNEXPECTED_REMOVE\n'; return 99; }
+rm() { printf 'call\n' >> "$rm_calls"; return 99; }
 
 remove_rc=0
 safe_remove "$TARGET_FILE" true || remove_rc=$?
 call_count=$(wc -l < "$ps_calls" | tr -d ' ')
-command rm -f "$ps_calls"
-printf 'RC=%s CALLS=%s EXISTS=%s\n' \
-	"$remove_rc" "$call_count" "$(test -f "$TARGET_FILE" && echo yes || echo no)"
+rm_call_count=$(wc -l < "$rm_calls" | tr -d ' ')
+command rm -f "$ps_calls" "$rm_calls"
+printf 'RC=%s CALLS=%s EXISTS=%s RM_CALLS=%s\n' \
+	"$remove_rc" "$call_count" "$(test -f "$TARGET_FILE" && echo yes || echo no)" \
+	"$rm_call_count"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
-	[[ "$output" == "RC=1 CALLS=2 EXISTS=yes" ]] || return 1
+	[[ "$output" == *"RC=1 CALLS=2 EXISTS=yes RM_CALLS=0"* ]] || {
+		echo "$output"
+		return 1
+	}
 }
 
 # Mole's own size probe runs `du` over the very directory it is judging, so the

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -2243,13 +2243,54 @@ _mole_user_cache_owner_process_state "com.example.First" || first_state=$?
 second_state=0
 _mole_user_cache_owner_process_state "com.example.Second" || second_state=$?
 call_count=$(wc -l < "$ps_calls" | tr -d ' ')
-rm -f "$ps_calls"
+command rm -f "$ps_calls"
 printf 'FIRST=%s SECOND=%s CALLS=%s STATE=%s\n' \
 	"$first_state" "$second_state" "$call_count" "$_MOLE_PROCESS_TABLE_STATE"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == "FIRST=0 SECOND=1 CALLS=1 STATE=ok" ]] || return 1
+}
+
+@test "safe_remove refreshes process evidence at the final deletion boundary" {
+	local cache_dir="$HOME/Library/Caches/com.example.LateHelper"
+	local target_file="$cache_dir/Cache.db"
+	mkdir -p "$cache_dir"
+	touch "$target_file"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_FILE="$target_file" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+ps_calls=$(mktemp)
+ps() {
+	printf 'call\n' >> "$ps_calls"
+	call_count=$(wc -l < "$ps_calls" | tr -d ' ')
+	if [[ $call_count -eq 1 ]]; then
+		cat <<'TABLE'
+  PID  PPID COMM             ARGS
+TABLE
+	else
+		cat <<'TABLE'
+  PID  PPID COMM             ARGS
+  901     1 /Applications/Example.app/Contents/MacOS/LateHelper /Applications/Example.app/Contents/MacOS/LateHelper com.example.LateHelper
+TABLE
+	fi
+}
+lsof() { return 1; }
+get_path_size_kb() { printf '1\n'; }
+oplog_enabled() { return 0; }
+rm() { printf 'UNEXPECTED_REMOVE\n'; return 99; }
+
+remove_rc=0
+safe_remove "$TARGET_FILE" true || remove_rc=$?
+call_count=$(wc -l < "$ps_calls" | tr -d ' ')
+command rm -f "$ps_calls"
+printf 'RC=%s CALLS=%s EXISTS=%s\n' \
+	"$remove_rc" "$call_count" "$(test -f "$TARGET_FILE" && echo yes || echo no)"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "RC=1 CALLS=2 EXISTS=yes" ]] || return 1
 }
 
 # Mole's own size probe runs `du` over the very directory it is judging, so the

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -2203,7 +2203,33 @@ EOF
         echo "$output"
         return 1
     }
-    [[ "$output" == *"HELPER=0"* ]]
+	[[ "$output" == *"HELPER=0"* ]]
+}
+
+@test "cache owner probes reuse one process table snapshot" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/file_ops.sh"
+ps_calls=$(mktemp)
+ps() {
+	printf 'call\n' >> "$ps_calls"
+	cat <<'TABLE'
+  PID  PPID COMM             ARGS
+  601     1 /Applications/Example.app/Contents/MacOS/Example /Applications/Example.app/Contents/MacOS/Example com.example.First
+TABLE
+}
+first_state=0
+_mole_user_cache_owner_process_state "com.example.First" || first_state=$?
+second_state=0
+_mole_user_cache_owner_process_state "com.example.Second" || second_state=$?
+call_count=$(wc -l < "$ps_calls" | tr -d ' ')
+rm -f "$ps_calls"
+printf 'FIRST=%s SECOND=%s CALLS=%s STATE=%s\n' \
+	"$first_state" "$second_state" "$call_count" "$_MOLE_PROCESS_TABLE_STATE"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "FIRST=0 SECOND=1 CALLS=1 STATE=ok" ]] || return 1
 }
 
 # Mole's own size probe runs `du` over the very directory it is judging, so the

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1289,14 +1289,58 @@ _mole_timeout_with_deadline() {
 scan_status=0
 scan_purge_targets "$HOME/www" "$SCAN_OUTPUT" || scan_status=$?
 printf 'STATUS=%s CALLS=%s\n' "$scan_status" "$(cat "$HOME/deadline-calls")"
-[[ "$scan_status" -eq 124 ]]
-[[ ! -s "$SCAN_OUTPUT" ]]
-[[ ! -e "$HOME/find-called" ]]
+[[ "$scan_status" -eq 124 ]] || exit 1
+[[ ! -s "$SCAN_OUTPUT" ]] || exit 1
+[[ ! -e "$HOME/find-called" ]] || exit 1
 EOF
 
 	rm -f "$scan_output"
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == "STATUS=124 CALLS=3" ]] || return 1
+}
+
+@test "scan_purge_targets: bounds nested filtering within the shared deadline" {
+	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules"
+	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"
+
+	local mock_bin="$HOME/mock-slow-nested-filter"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/find" <<'EOF'
+#!/bin/bash
+args=" $* "
+if [[ "$args" != *" -type f "* ]]; then
+	printf '%s\n' "$HOME/www/test-project/node_modules"
+fi
+EOF
+	chmod +x "$mock_bin/find"
+	cat > "$mock_bin/sort" <<'EOF'
+#!/bin/bash
+sleep 4
+/usr/bin/sort "$@"
+EOF
+	chmod +x "$mock_bin/sort"
+
+	local scan_output
+	scan_output="$(mktemp)"
+
+	run env HOME="$HOME" PATH="$mock_bin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" SCAN_OUTPUT="$scan_output" \
+		MO_USE_FIND=1 MO_PURGE_SCAN_TIMEOUT_SEC=2 /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+SECONDS=0
+scan_status=0
+scan_purge_targets "$HOME/www" "$SCAN_OUTPUT" || scan_status=$?
+printf 'STATUS=%s ELAPSED=%s BYTES=%s\n' \
+	"$scan_status" "$SECONDS" "$(wc -c < "$SCAN_OUTPUT" | tr -d ' ')"
+EOF
+
+	rm -f "$scan_output"
+	[ "$status" -eq 0 ] || return 1
+	local elapsed
+	elapsed=$(printf '%s\n' "$output" | sed -n 's/.*ELAPSED=\([0-9][0-9]*\).*/\1/p')
+	[[ "$output" == STATUS=124*" BYTES=0" ]] || return 1
+	[[ "$elapsed" =~ ^[0-9]+$ ]] || return 1
+	((elapsed < 4))
 }
 
 @test "is_recently_modified: detects recent projects" {
@@ -1499,6 +1543,71 @@ EOF
 	[[ "$output" == "TIMEOUT" ]] || return 1
 }
 
+@test "purge size pass preserves a fractional timeout override" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+printf 'BUDGET=%s\n' "$(_mole_purge_size_budget_seconds 2.5)"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "BUDGET=3" ]] || return 1
+}
+
+@test "purge size pass kills active workers when its parent receives TERM" {
+	local purge_home="$HOME/terminated-purge-sizes"
+	local artifact="$purge_home/www/app/node_modules"
+	mkdir -p "$artifact" "$purge_home/.cache/mole"
+	touch "$purge_home/www/app/package.json"
+	local driver="$purge_home/driver.sh"
+
+	cat > "$driver" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+artifact="$HOME/www/app/node_modules"
+PURGE_SEARCH_PATHS=("$HOME/www")
+get_optimal_parallel_jobs() { printf '1\n'; }
+scan_purge_targets() { printf '%s\n' "$artifact" > "$2"; }
+is_recently_modified() {
+	_PURGE_ACTIVITY_STATE=old
+	return 1
+}
+get_dir_size_kb() {
+	touch "$HOME/size-worker-started"
+	trap 'exit 143' TERM
+	sleep 1
+	touch "$HOME/size-worker-survived"
+	printf '1\n'
+}
+safe_remove() { return 0; }
+MOLE_DRY_RUN=1 clean_project_artifacts </dev/null
+EOF
+	chmod +x "$driver"
+
+	run env HOME="$purge_home" PROJECT_ROOT="$PROJECT_ROOT" DRIVER="$driver" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+/bin/bash "$DRIVER" &
+parent_pid=$!
+for _ in {1..100}; do
+	[[ -e "$HOME/size-worker-started" ]] && break
+	sleep 0.02
+done
+[[ -e "$HOME/size-worker-started" ]] || exit 1
+kill -TERM "$parent_pid"
+parent_rc=0
+wait "$parent_pid" || parent_rc=$?
+sleep 0.1
+printf 'PARENT_RC=%s WORKER_SURVIVED=%s\n' \
+	"$parent_rc" "$([[ -e "$HOME/size-worker-survived" ]] && printf yes || printf no)"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "PARENT_RC=143 WORKER_SURVIVED=no" ]] || return 1
+}
+
 @test "clean_project_artifacts: restores caller INT/TERM traps" {
 	result=$(/bin/bash -c "
         set -euo pipefail
@@ -1586,6 +1695,34 @@ EOF
 	[[ "$output" == *"(status 7)"* ]] || return 1
 	[[ "$output" == *"REMOVE:$HOME/www/good-project/node_modules"* ]] || return 1
 	[[ "$output" != *"REMOVE:$HOME/dev/failed-project/node_modules"* ]] || return 1
+}
+
+@test "clean_project_artifacts stops launching roots after an interrupted scan" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+first_root="$HOME/root-1"
+second_root="$HOME/root-2"
+third_root="$HOME/root-3"
+mkdir -p "$first_root" "$second_root" "$third_root" "$HOME/.cache/mole"
+PURGE_SEARCH_PATHS=("$first_root" "$second_root" "$third_root")
+get_optimal_parallel_jobs() { printf '1\n'; }
+scan_purge_targets() {
+	: > "$2"
+	printf '%s\n' "${1##*/}" >> "$HOME/scanned-roots"
+	[[ "$1" == "$first_root" ]] && return 130
+	return 0
+}
+
+clean_rc=0
+clean_project_artifacts </dev/null || clean_rc=$?
+printf 'RC=%s SCANNED=%s\n' "$clean_rc" "$(paste -sd, "$HOME/scanned-roots")"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "RC=130 SCANNED=root-1" ]] || return 1
 }
 
 @test "clean_project_artifacts preserves nested candidates merged from overlapping roots" {
@@ -2071,6 +2208,7 @@ is_recently_modified() {
 	return 1
 }
 activity_calls=0
+rm_trace="$HOME/target-rm-reached"
 purge_target_activity_still_safe() {
 	activity_calls=$((activity_calls + 1))
 	if [[ $activity_calls -eq 2 ]]; then
@@ -2081,7 +2219,7 @@ purge_target_activity_still_safe() {
 }
 rm() {
 	if [[ "$*" == *"$artifact"* ]]; then
-		printf 'TARGET_RM_REACHED:%s\n' "$*"
+		printf 'TARGET_RM_REACHED:%s\n' "$*" > "$rm_trace"
 		return 0
 	fi
 	command /bin/rm "$@"
@@ -2092,11 +2230,11 @@ clean_project_artifacts </dev/null
 printf 'ACTIVITY_CALLS=%s\n' "$activity_calls"
 [[ -d "$original_artifact" ]] || exit 1
 [[ -d "$artifact" ]] || exit 1
+[[ ! -e "$rm_trace" ]] || exit 1
 EOF
 
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"ACTIVITY_CALLS=2"* ]] || return 1
-	[[ "$output" != *"TARGET_RM_REACHED:"* ]] || return 1
 }
 
 @test "clean_project_artifacts: non-interactive dry-run shows cloud marker and preserves artifact" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1576,10 +1576,11 @@ is_recently_modified() {
 	return 1
 }
 get_dir_size_kb() {
-	touch "$HOME/size-worker-started"
-	trap 'exit 143' TERM
-	sleep 1
-	touch "$HOME/size-worker-survived"
+	/bin/sh -c 'printf "%s\n" "$PPID" > "$1"' _ "$HOME/size-worker-pid"
+	trap 'touch "$HOME/size-worker-terminated"; exit 143' TERM
+	while [[ ! -e "$HOME/release-size-worker" ]]; do
+		sleep 0.05
+	done
 	printf '1\n'
 }
 safe_remove() { return 0; }
@@ -1592,20 +1593,39 @@ set -euo pipefail
 /bin/bash "$DRIVER" &
 parent_pid=$!
 for _ in {1..100}; do
-	[[ -e "$HOME/size-worker-started" ]] && break
-	sleep 0.02
+	[[ -s "$HOME/size-worker-pid" ]] && break
+	sleep 0.05
 done
-[[ -e "$HOME/size-worker-started" ]] || exit 1
+[[ -s "$HOME/size-worker-pid" ]] || exit 1
+worker_pid=$(< "$HOME/size-worker-pid")
+(
+	sleep 10
+	touch "$HOME/size-watchdog-fired"
+	kill -KILL "$parent_pid" "$worker_pid" 2> /dev/null || true
+) &
+watchdog_pid=$!
 kill -TERM "$parent_pid"
 parent_rc=0
 wait "$parent_pid" || parent_rc=$?
-sleep 0.1
-printf 'PARENT_RC=%s WORKER_SURVIVED=%s\n' \
-	"$parent_rc" "$([[ -e "$HOME/size-worker-survived" ]] && printf yes || printf no)"
+kill "$watchdog_pid" 2> /dev/null || true
+wait "$watchdog_pid" 2> /dev/null || true
+worker_alive=no
+if kill -0 "$worker_pid" 2> /dev/null; then
+	worker_alive=yes
+	touch "$HOME/release-size-worker"
+	kill -TERM "$worker_pid" 2> /dev/null || true
+fi
+printf 'PARENT_RC=%s WORKER_ALIVE=%s WORKER_TERMINATED=%s WATCHDOG=%s\n' \
+	"$parent_rc" "$worker_alive" \
+	"$([[ -e "$HOME/size-worker-terminated" ]] && printf yes || printf no)" \
+	"$([[ -e "$HOME/size-watchdog-fired" ]] && printf yes || printf no)"
 EOF
 
 	[ "$status" -eq 0 ] || return 1
-	[[ "$output" == "PARENT_RC=143 WORKER_SURVIVED=no" ]] || return 1
+	[[ "$output" == "PARENT_RC=143 WORKER_ALIVE=no WORKER_TERMINATED=yes WATCHDOG=no" ]] || {
+		echo "$output"
+		return 1
+	}
 }
 
 @test "clean_project_artifacts: restores caller INT/TERM traps" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1090,6 +1090,44 @@ EOF
 	[[ "$output" == "$HOME/www/test-project/node_modules" ]] || return 1
 }
 
+@test "scan_purge_targets: removes nested candidates before physical safety checks" {
+	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules/nested/dist"
+	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"
+
+	local mock_bin="$HOME/mock-nested-fd"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/fd" <<'EOF'
+#!/bin/bash
+args=" $* "
+if [[ "$args" == *" --type d "* ]]; then
+    printf '%s\n' \
+        "$HOME/www/test-project/node_modules" \
+        "$HOME/www/test-project/node_modules/nested/dist"
+fi
+EOF
+	chmod +x "$mock_bin/fd"
+
+	local scan_output
+	scan_output="$(mktemp)"
+
+	run env HOME="$HOME" PATH="$mock_bin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" SCAN_OUTPUT="$scan_output" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+is_safe_project_artifact() {
+    printf '%s\n' "$1" >> "$HOME/safety-calls"
+    return 0
+}
+scan_purge_targets "$HOME/www" "$SCAN_OUTPUT"
+grep -Fx "$HOME/www/test-project/node_modules" "$SCAN_OUTPUT"
+[[ "$(wc -l < "$HOME/safety-calls" | tr -d ' ')" -eq 1 ]]
+EOF
+
+	rm -f "$scan_output"
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "$HOME/www/test-project/node_modules" ]] || return 1
+}
+
 @test "scan_purge_targets: discards a failed find target scan prefix" {
 	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules"
 	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1598,16 +1598,22 @@ for _ in {1..100}; do
 done
 [[ -s "$HOME/size-worker-pid" ]] || exit 1
 worker_pid=$(< "$HOME/size-worker-pid")
-(
-	sleep 10
-	touch "$HOME/size-watchdog-fired"
-	kill -KILL "$parent_pid" "$worker_pid" 2> /dev/null || true
-) &
+/usr/bin/perl -e '
+	my ($done, $fired, $parent, $worker) = @ARGV;
+	for (1 .. 10) {
+		exit 0 if -e $done;
+		sleep 1;
+	}
+	open my $marker, ">", $fired or exit 2;
+	close $marker;
+	kill 9, $parent, $worker;
+' "$HOME/size-parent-finished" "$HOME/size-watchdog-fired" \
+	"$parent_pid" "$worker_pid" &
 watchdog_pid=$!
 kill -TERM "$parent_pid"
 parent_rc=0
 wait "$parent_pid" || parent_rc=$?
-kill "$watchdog_pid" 2> /dev/null || true
+touch "$HOME/size-parent-finished"
 wait "$watchdog_pid" 2> /dev/null || true
 worker_alive=no
 if kill -0 "$worker_pid" 2> /dev/null; then

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -167,6 +167,43 @@ EOF
 	[[ "$result" == "BLOCKED" ]]
 }
 
+@test "is_safe_configured_purge_artifact checks a lexical owner before unrelated roots" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+PURGE_SEARCH_PATHS=("$HOME/unrelated" "$HOME/projects")
+is_safe_project_artifact() {
+	printf '%s\n' "$2" >> "$HOME/safety-roots"
+	[[ "$2" == "$HOME/projects" ]]
+}
+is_safe_configured_purge_artifact "$HOME/projects/app/node_modules"
+printf 'CALLS=%s ROOT=%s\n' \
+	"$(wc -l < "$HOME/safety-roots" | tr -d ' ')" \
+	"$(cat "$HOME/safety-roots")"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "CALLS=1 ROOT=$HOME/projects" ]] || return 1
+}
+
+@test "is_safe_configured_purge_artifact preserves physical alias fallback" {
+	mkdir -p "$HOME/www/real/proj/node_modules"
+	touch "$HOME/www/real/proj/package.json"
+	ln -s "$HOME/www/real" "$HOME/www/link"
+
+	result=$(/bin/bash -c "
+        source '$PROJECT_ROOT/lib/clean/project.sh'
+        PURGE_SEARCH_PATHS=('$HOME/www/link/proj')
+        if is_safe_configured_purge_artifact '$HOME/www/real/proj/node_modules'; then
+            echo 'ALLOWED'
+        else
+            echo 'BLOCKED'
+        fi
+    ")
+
+	[[ "$result" == "ALLOWED" ]]
+}
+
 @test "compact_purge_scan_path keeps the tail of long purge paths visible" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_SKIP_MAIN=1 /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -1551,6 +1588,92 @@ EOF
 	[[ "$output" != *"REMOVE:$HOME/dev/failed-project/node_modules"* ]] || return 1
 }
 
+@test "clean_project_artifacts preserves nested candidates merged from overlapping roots" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+outer_root="$HOME/projects"
+inner_root="$outer_root/app"
+parent_artifact="$inner_root/node_modules"
+nested_artifact="$parent_artifact/package/.cache"
+mkdir -p "$nested_artifact" "$HOME/.cache/mole"
+touch "$inner_root/package.json"
+PURGE_SEARCH_PATHS=("$outer_root" "$inner_root")
+get_optimal_parallel_jobs() { echo 1; }
+scan_purge_targets() {
+	if [[ "$1" == "$outer_root" ]]; then
+		printf '%s\n' "$parent_artifact" > "$2"
+	else
+		printf '%s\n' "$nested_artifact" > "$2"
+	fi
+}
+get_dir_size_kb() { echo 4; }
+is_recently_modified() {
+	_PURGE_ACTIVITY_STATE=old
+	return 1
+}
+purge_target_activity_still_safe() { return 0; }
+safe_remove() { printf 'REMOVE:%s\n' "$1"; }
+
+export MOLE_DRY_RUN=1
+clean_project_artifacts </dev/null
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"REMOVE:$HOME/projects/app/node_modules"* ]] || return 1
+	[[ "$output" == *"REMOVE:$HOME/projects/app/node_modules/package/.cache"* ]] || return 1
+}
+
+@test "clean_project_artifacts binds candidates without probing unrelated roots" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+unrelated_root="$HOME/unrelated"
+owner_root="$HOME/projects"
+artifact="$owner_root/app/node_modules"
+mkdir -p "$unrelated_root" "$artifact" "$HOME/.cache/mole"
+touch "$owner_root/app/package.json"
+PURGE_SEARCH_PATHS=("$unrelated_root" "$owner_root")
+get_optimal_parallel_jobs() { echo 1; }
+scan_purge_targets() {
+	: > "$2"
+	if [[ "$1" == "$owner_root" ]]; then
+		printf '%s\n' "$artifact" > "$2"
+	fi
+	return 0
+}
+is_safe_project_artifact_under_root() {
+	printf '%s\n' "$2" >> "$HOME/safety-roots"
+	[[ "$2" == "$owner_root" ]]
+}
+get_dir_size_kb() { echo 4; }
+is_recently_modified() {
+	_PURGE_ACTIVITY_STATE=old
+	return 1
+}
+purge_target_activity_still_safe() { return 0; }
+safe_remove() { return 0; }
+
+export MOLE_DRY_RUN=1
+clean_project_artifacts </dev/null
+if grep -Fx "$unrelated_root" "$HOME/safety-roots"; then
+	printf 'UNRELATED_PROBED\n'
+	exit 1
+fi
+owner_calls=$(grep -Fxc "$owner_root" "$HOME/safety-roots")
+printf 'OWNER_CALLS=%s\n' "$owner_calls"
+[[ "$owner_calls" -ge 1 && "$owner_calls" -le 4 ]]
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"OWNER_CALLS="* ]] || return 1
+	[[ "$output" != *"UNRELATED_PROBED"* ]] || return 1
+}
+
 @test "clean_project_artifacts: bounds concurrent root scans" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -1850,6 +1973,48 @@ EOF
 	[ "$status" -eq 0 ] || return 1
 }
 
+@test "clean_project_artifacts rejects results when a symlink root target is replaced" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+configured_root="$HOME/www"
+physical_root="$HOME/www-target"
+original_root="$HOME/www-original"
+artifact="$configured_root/project/node_modules"
+mkdir -p "$physical_root/project/node_modules" "$HOME/.cache/mole"
+touch "$physical_root/project/package.json"
+/bin/rmdir "$configured_root"
+ln -s "$physical_root" "$configured_root"
+
+PURGE_SEARCH_PATHS=("$configured_root")
+scan_purge_targets() {
+	printf '%s\n' "$artifact" > "$2"
+	mv "$physical_root" "$original_root"
+	mkdir -p "$physical_root/project/node_modules"
+	touch "$physical_root/project/package.json"
+}
+safe_remove() {
+	printf 'UNEXPECTED_REMOVE:%s\n' "$1"
+	return 1
+}
+
+clean_project_artifacts </dev/null
+
+[[ -L "$configured_root" ]] || exit 1
+[[ -d "$original_root/project/node_modules" ]] || exit 1
+[[ -d "$physical_root/project/node_modules" ]] || exit 1
+/bin/rm "$configured_root"
+mv "$physical_root" "$configured_root"
+/bin/rm -rf "$original_root"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"Skipped 1 project scan root because scanning did not complete"* ]] || return 1
+	[[ "$output" != *"UNEXPECTED_REMOVE:"* ]] || return 1
+}
+
 @test "clean_project_artifacts refuses a replacement at the selected artifact leaf" {
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -1883,6 +2048,55 @@ clean_project_artifacts </dev/null
 EOF
 
 	[ "$status" -eq 0 ] || return 1
+}
+
+@test "clean_project_artifacts rechecks identity after the final activity probe" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+configured_root="$HOME/www"
+artifact="$configured_root/project/node_modules"
+original_artifact="$configured_root/project/node_modules-original"
+replacement="$HOME/replacement-node-modules"
+mkdir -p "$artifact" "$replacement" "$HOME/.cache/mole"
+touch "$configured_root/project/package.json"
+
+PURGE_SEARCH_PATHS=("$configured_root")
+scan_purge_targets() { printf '%s\n' "$artifact" > "$2"; }
+get_dir_size_kb() { echo 1; }
+is_recently_modified() {
+	_PURGE_ACTIVITY_STATE=old
+	return 1
+}
+activity_calls=0
+purge_target_activity_still_safe() {
+	activity_calls=$((activity_calls + 1))
+	if [[ $activity_calls -eq 2 ]]; then
+		mv "$artifact" "$original_artifact"
+		mv "$replacement" "$artifact"
+	fi
+	return 0
+}
+rm() {
+	if [[ "$*" == *"$artifact"* ]]; then
+		printf 'TARGET_RM_REACHED:%s\n' "$*"
+		return 0
+	fi
+	command /bin/rm "$@"
+}
+
+clean_project_artifacts </dev/null
+
+printf 'ACTIVITY_CALLS=%s\n' "$activity_calls"
+[[ -d "$original_artifact" ]] || exit 1
+[[ -d "$artifact" ]] || exit 1
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"ACTIVITY_CALLS=2"* ]] || return 1
+	[[ "$output" != *"TARGET_RM_REACHED:"* ]] || return 1
 }
 
 @test "clean_project_artifacts: non-interactive dry-run shows cloud marker and preserves artifact" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1443,6 +1443,25 @@ EOF
 	[[ "$result" == "ERROR" ]]
 }
 
+@test "get_dir_size_kb: returns TIMEOUT when the shared size budget is exhausted" {
+	mkdir -p "$HOME/www/budget-project/node_modules"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/project.sh"
+_mole_timeout_with_deadline() { return 124; }
+run_with_timeout() {
+	printf 'unexpected du call\n' >&2
+	return 99
+}
+get_dir_size_kb "$HOME/www/budget-project/node_modules" "$((SECONDS + 30))"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "TIMEOUT" ]] || return 1
+}
+
 @test "clean_project_artifacts: restores caller INT/TERM traps" {
 	result=$(/bin/bash -c "
         set -euo pipefail

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1182,16 +1182,8 @@ EOF
 	mkdir -p "$mock_bin"
 	cat > "$mock_bin/find" <<'EOF'
 #!/bin/bash
-result_type=""
-while [[ $# -gt 0 ]]; do
-	if [[ "$1" == "-type" && $# -gt 1 ]]; then
-		result_type="$2"
-		break
-	fi
-	shift
-done
-
-if [[ "$result_type" == "d" ]]; then
+args=" $* "
+if [[ "$args" != *" -type f "* ]]; then
 	printf '%s\n' "$HOME/www/test-project/node_modules"
 	exit 0
 fi
@@ -1218,6 +1210,56 @@ EOF
 	rm -f "$scan_output"
 	[ "$status" -eq 0 ] || return 1
 	[[ "$output" == *"STATUS=9"* ]] || return 1
+}
+
+@test "scan_purge_targets: shares one deadline across fd stages and fallback" {
+	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules"
+	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"
+
+	local mock_bin="$HOME/mock-shared-scan-deadline"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/fd" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$HOME/www/test-project/node_modules"
+EOF
+	chmod +x "$mock_bin/fd"
+	cat > "$mock_bin/find" <<'EOF'
+#!/bin/bash
+printf 'find-called\n' >> "$HOME/find-called"
+exit 0
+EOF
+	chmod +x "$mock_bin/find"
+
+	local scan_output
+	scan_output="$(mktemp)"
+
+	run env HOME="$HOME" PATH="$mock_bin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" SCAN_OUTPUT="$scan_output" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+
+_mole_timeout_with_deadline() {
+	local calls=0
+	[[ -f "$HOME/deadline-calls" ]] && calls="$(cat "$HOME/deadline-calls")"
+	calls=$((calls + 1))
+	printf '%s\n' "$calls" > "$HOME/deadline-calls"
+	if [[ $calls -gt 1 ]]; then
+		return 124
+	fi
+	printf '5\n'
+}
+
+scan_status=0
+scan_purge_targets "$HOME/www" "$SCAN_OUTPUT" || scan_status=$?
+printf 'STATUS=%s CALLS=%s\n' "$scan_status" "$(cat "$HOME/deadline-calls")"
+[[ "$scan_status" -eq 124 ]]
+[[ ! -s "$SCAN_OUTPUT" ]]
+[[ ! -e "$HOME/find-called" ]]
+EOF
+
+	rm -f "$scan_output"
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "STATUS=124 CALLS=3" ]] || return 1
 }
 
 @test "is_recently_modified: detects recent projects" {

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -790,6 +790,20 @@ EOF
 	[[ "$result" == "NOT_PROTECTED" ]]
 }
 
+@test "is_protected_purge_artifact avoids basename and dirname subprocesses" {
+	mkdir -p "$HOME/dotnet-app/bin/Debug"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+basename() { return 99; }
+dirname() { return 99; }
+is_protected_purge_artifact "$HOME/dotnet-app/bin"
+EOF
+
+	[ "$status" -eq 0 ]
+}
+
 # Integration tests
 @test "scan_purge_targets: skips Rails vendor directory" {
 	mkdir -p "$HOME/www/rails-app/vendor/javascript"

--- a/tests/purge.bats
+++ b/tests/purge.bats
@@ -1045,6 +1045,51 @@ EOF
 	[ "$status" -eq 0 ]
 }
 
+@test "scan_purge_targets: prunes matched artifacts from target and tag scans" {
+	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules"
+	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"
+
+	local mock_bin="$HOME/mock-pruned-fd"
+	mkdir -p "$mock_bin"
+	cat > "$mock_bin/fd" <<'EOF'
+#!/bin/bash
+args=" $* "
+case "$args" in
+    *" --type d "*)
+        [[ "$args" == *" --prune "* ]] || exit 9
+        printf '%s\n' "$HOME/www/test-project/node_modules"
+        ;;
+    *" --type f "*)
+        [[ "$args" == *" --exclude node_modules "* ]] || exit 10
+        ;;
+    *) exit 11 ;;
+esac
+EOF
+	chmod +x "$mock_bin/fd"
+	cat > "$mock_bin/find" <<'EOF'
+#!/bin/bash
+printf 'find-called\n' >> "$HOME/find-called"
+exit 12
+EOF
+	chmod +x "$mock_bin/find"
+
+	local scan_output
+	scan_output="$(mktemp)"
+
+	run env HOME="$HOME" PATH="$mock_bin:$PATH" PROJECT_ROOT="$PROJECT_ROOT" SCAN_OUTPUT="$scan_output" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/project.sh"
+scan_purge_targets "$HOME/www" "$SCAN_OUTPUT"
+[[ ! -e "$HOME/find-called" ]] || exit 1
+grep -Fx "$HOME/www/test-project/node_modules" "$SCAN_OUTPUT"
+EOF
+
+	rm -f "$scan_output"
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == "$HOME/www/test-project/node_modules" ]] || return 1
+}
+
 @test "scan_purge_targets: discards a failed find target scan prefix" {
 	mkdir -p "$HOME/.config/mole" "$HOME/www/test-project/node_modules"
 	printf '%s\n' "$HOME/www" > "$HOME/.config/mole/purge_paths"

--- a/tests/timeout_tty_foreground.bats
+++ b/tests/timeout_tty_foreground.bats
@@ -43,7 +43,7 @@ setup() {
 	run grep -nF "scan_purge_targets \"\$path\" \"\$scan_output\" < /dev/null &" "$PROJECT_ROOT/lib/clean/project.sh"
 	[ "$status" -eq 0 ] || return 1
 
-	run grep -nF "(get_dir_size_kb \"\$_sz_item\" > \"\$_stmp\" 2> /dev/null) < /dev/null &" "$PROJECT_ROOT/lib/clean/project.sh"
+	run grep -nF "(get_dir_size_kb \"\$_sz_item\" \"\$_size_deadline\" > \"\$_stmp\" 2> /dev/null) < /dev/null &" "$PROJECT_ROOT/lib/clean/project.sh"
 	[ "$status" -eq 0 ] || return 1
 }
 

--- a/tests/uninstall_remove_file_list.bats
+++ b/tests/uninstall_remove_file_list.bats
@@ -114,7 +114,42 @@ EOF
     # Audit log records one ok line per moved path.
     local ok_lines
     ok_lines=$(awk -F'\t' '$4 == "ok" && $2 == "trash"' "$MOLE_DELETE_LOG" | wc -l | tr -d ' ')
-    [ "$ok_lines" -eq 5 ]
+	[ "$ok_lines" -eq 5 ]
+}
+
+@test "Trash batches refresh live-owner evidence before each move" {
+	local first_cache="$HOME/Library/Caches/com.example.One"
+	local second_cache="$HOME/Library/Caches/com.example.Two"
+	mkdir -p "$first_cache" "$second_cache" "$HOME/.cache/mole"
+	printf 'one\n' > "$first_cache/data"
+	printf 'two\n' > "$second_cache/data"
+	local ps_count="$SANDBOX/ps-count"
+	: > "$ps_count"
+
+	run env PROJECT_ROOT="$PROJECT_ROOT" PS_COUNT="$ps_count" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+ps() {
+	printf 'x' >> "$PS_COUNT"
+	local calls
+	calls=$(wc -c < "$PS_COUNT" | tr -d ' ')
+	printf '  PID  PPID COMM ARGS\n'
+	if [[ $calls -ge 2 ]]; then
+		printf '9000 1 /Applications/ExampleTwo /Applications/ExampleTwo --bundle com.example.Two\n'
+	fi
+}
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+remove_file_list "$(printf '%s\n%s\n' \
+	"$HOME/Library/Caches/com.example.One" \
+	"$HOME/Library/Caches/com.example.Two")" false
+printf 'PS_CALLS=%s ONE=%s TWO=%s\n' \
+	"$(wc -c < "$PS_COUNT" | tr -d ' ')" \
+	"$([[ -e "$HOME/Library/Caches/com.example.One" ]] && printf yes || printf no)" \
+	"$([[ -e "$HOME/Library/Caches/com.example.Two" ]] && printf yes || printf no)"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[[ "$output" == *"PS_CALLS=3 ONE=no TWO=yes"* ]] || return 1
 }
 
 @test "remove_file_list preserves unmoved paths when the guarded batch helper fails" {


### PR DESCRIPTION
Clean and purge were doing a lot of repeated filesystem work on larger project trees. This pr prunes nested purge hits earlier, reuses scan, size and process evidence, and runs independent project cache scans concurrently while keeping partial timeout output out of deletion paths.

On my machine clean --dry-run went from a median 87.15s to 76.43s. In a controlled fixture with identical candidates it went from 25.87s to 21.35s. The largest purge root scan went from 30.10s to 9.81s, and the full purge dry-run now completes in about 286-297s where main did not finish within 608s.

Purge still revalidates the configured root, physical root, candidate identity and recent activity at the final removal boundary.