### PR TITLE
fix(analyze): surface local snapshot space

### DIFF
--- a/cmd/analyze/model.go
+++ b/cmd/analyze/model.go
@@ -160,6 +160,7 @@ type model struct {
 	totalFiles          int64           // Total files found in current/last scan
 	lastTotalFiles      int64           // Total files from previous scan (for progress bar)
 	diskFree            int64           // Free disk space for the analyzed volume
+	localSnapshotCount  int             // Read-only Time Machine snapshot count for overview context
 	viewNeedsRefresh    bool
 	// Top-files (T) view incremental filter. largeFilesAll is the full,
 	// size-ranked list; largeFiles is the view actually rendered and acted on,

--- a/cmd/analyze/snapshots.go
+++ b/cmd/analyze/snapshots.go
@@ -1,0 +1,54 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const localSnapshotProbeTimeout = 3 * time.Second
+
+type localSnapshotMsg struct {
+	count int
+	err   error
+}
+
+type localSnapshotCommandRunner func(context.Context, string, ...string) ([]byte, error)
+
+func detectLocalSnapshotsCmd() tea.Cmd {
+	return localSnapshotProbeCmd(func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return exec.CommandContext(ctx, name, args...).Output()
+	})
+}
+
+func localSnapshotProbeCmd(run localSnapshotCommandRunner) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), localSnapshotProbeTimeout)
+		defer cancel()
+
+		output, err := run(ctx, "/usr/bin/tmutil", "listlocalsnapshotdates", "/")
+		if err != nil {
+			return localSnapshotMsg{err: err}
+		}
+
+		return localSnapshotMsg{count: parseLocalSnapshotCount(output)}
+	}
+}
+
+// parseLocalSnapshotCount ignores tmutil's localized heading and counts only
+// the documented YYYY-MM-DD-HHMMSS snapshot-date rows. Snapshot sizes are
+// intentionally not inferred because tmutil does not expose retained bytes.
+func parseLocalSnapshotCount(data []byte) int {
+	count := 0
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if _, err := time.Parse("2006-01-02-150405", strings.TrimSpace(line)); err == nil {
+			count++
+		}
+	}
+	return count
+}

--- a/cmd/analyze/snapshots_test.go
+++ b/cmd/analyze/snapshots_test.go
@@ -1,0 +1,146 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseLocalSnapshotCount(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   int
+	}{
+		{
+			name: "counts documented snapshot dates",
+			output: `Snapshot dates for volume group containing disk /:
+2026-08-26-091500
+2026-08-26-101500
+`,
+			want: 2,
+		},
+		{
+			name:   "ignores a localized heading with no snapshots",
+			output: "本地快照日期：\n",
+			want:   0,
+		},
+		{
+			name: "ignores snapshot names and malformed dates",
+			output: `Snapshots for volume group containing disk /:
+com.apple.os.update-MSUPrepareUpdate
+2026-99-99-999999
+`,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLocalSnapshotCount([]byte(tt.output))
+			if got != tt.want {
+				t.Fatalf("parseLocalSnapshotCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalSnapshotProbeUsesBoundedReadOnlyTMUtilQuery(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+	runner := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > localSnapshotProbeTimeout {
+			t.Fatalf("snapshot probe context deadline = %v, want a live %s budget", deadline, localSnapshotProbeTimeout)
+		}
+		return []byte("Snapshot dates:\n2026-08-26-091500\n2026-08-26-101500\n"), nil
+	}
+
+	msg := localSnapshotProbeCmd(runner)().(localSnapshotMsg)
+	if msg.err != nil || msg.count != 2 {
+		t.Fatalf("snapshot probe result = %#v, want count 2", msg)
+	}
+	if gotName != "/usr/bin/tmutil" {
+		t.Fatalf("snapshot probe command = %q, want /usr/bin/tmutil", gotName)
+	}
+	wantArgs := []string{"listlocalsnapshotdates", "/"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("snapshot probe args = %#v, want %#v", gotArgs, wantArgs)
+	}
+}
+
+func TestLocalSnapshotProbeReportsCommandFailure(t *testing.T) {
+	wantErr := errors.New("tmutil unavailable")
+	msg := localSnapshotProbeCmd(func(context.Context, string, ...string) ([]byte, error) {
+		return nil, wantErr
+	})().(localSnapshotMsg)
+	if !errors.Is(msg.err, wantErr) || msg.count != 0 {
+		t.Fatalf("snapshot probe result = %#v, want command error", msg)
+	}
+}
+
+func TestOverviewStoresSuccessfulLocalSnapshotCount(t *testing.T) {
+	m := model{path: "/", isOverview: true}
+	updated, cmd := m.Update(localSnapshotMsg{count: 3})
+	if cmd != nil {
+		t.Fatalf("snapshot update command = %v, want nil", cmd)
+	}
+	got := updated.(model)
+	if got.localSnapshotCount != 3 {
+		t.Fatalf("snapshot count = %d, want 3", got.localSnapshotCount)
+	}
+
+	updated, _ = got.Update(localSnapshotMsg{count: 9, err: errors.New("bad output")})
+	if got := updated.(model).localSnapshotCount; got != 3 {
+		t.Fatalf("failed refresh changed snapshot count to %d, want 3", got)
+	}
+}
+
+func TestOverviewViewExplainsLocalSnapshotOnlySpace(t *testing.T) {
+	m := model{
+		path:               "/",
+		isOverview:         true,
+		localSnapshotCount: 2,
+		entries:            []dirEntry{{Name: "Home", Path: "/tmp/home", Size: 1, IsDir: true}},
+	}
+
+	view := m.View()
+	for _, want := range []string{"2 Time Machine local snapshots", "snapshot-only space is not listed below"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected overview snapshot notice %q, got:\n%s", want, view)
+		}
+	}
+}
+
+func TestOverviewViewUsesSingularSnapshotLabel(t *testing.T) {
+	m := model{
+		path:               "/",
+		isOverview:         true,
+		localSnapshotCount: 1,
+		entries:            []dirEntry{{Name: "Home", Path: "/tmp/home", Size: 1, IsDir: true}},
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "1 Time Machine local snapshot") || strings.Contains(view, "1 Time Machine local snapshots") {
+		t.Fatalf("expected singular snapshot notice, got:\n%s", view)
+	}
+}
+
+func TestOverviewViewOmitsSnapshotNoticeWhenNoneDetected(t *testing.T) {
+	m := model{
+		path:       "/",
+		isOverview: true,
+		entries:    []dirEntry{{Name: "Home", Path: "/tmp/home", Size: 1, IsDir: true}},
+	}
+
+	if view := m.View(); strings.Contains(view, "Time Machine local snapshot") {
+		t.Fatalf("expected no snapshot notice, got:\n%s", view)
+	}
+}

--- a/cmd/analyze/update.go
+++ b/cmd/analyze/update.go
@@ -67,7 +67,7 @@ func (m *model) scheduleOverviewScans() tea.Cmd {
 
 func (m model) Init() tea.Cmd {
 	if m.inOverviewMode() {
-		return m.scheduleOverviewScans()
+		return tea.Batch(m.scheduleOverviewScans(), detectLocalSnapshotsCmd())
 	}
 	return tea.Batch(m.scanCmd(m.path), tickCmd())
 }
@@ -486,6 +486,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			cmd := m.scheduleOverviewScans()
 			return m, cmd
+		}
+		return m, nil
+	case localSnapshotMsg:
+		if m.inOverviewMode() && msg.err == nil {
+			m.localSnapshotCount = msg.count
 		}
 		return m, nil
 	case tickMsg:

--- a/cmd/analyze/view.go
+++ b/cmd/analyze/view.go
@@ -26,6 +26,14 @@ func (m model) View() string {
 			freeLabel = fmt.Sprintf("  %s(%s free)%s", colorGray, humanizeBytes(m.diskFree), colorReset)
 		}
 		fmt.Fprintf(&b, "%sAnalyze Disk%s%s\n", colorPurpleBold, colorReset, freeLabel)
+		if m.localSnapshotCount > 0 {
+			snapshotLabel := "snapshot"
+			if m.localSnapshotCount != 1 {
+				snapshotLabel = "snapshots"
+			}
+			fmt.Fprintf(&b, "%s%d Time Machine local %s · snapshot-only space is not listed below%s\n",
+				colorGray, m.localSnapshotCount, snapshotLabel, colorReset)
+		}
 		if m.overviewScanning {
 			if allOverviewEntriesPending(m.entries) {
 				fmt.Fprintf(&b, "%sSelect a location to explore:%s  ", colorGray, colorReset)


### PR DESCRIPTION
## Summary

- detect Time Machine local snapshots asynchronously in the Analyze overview
- show their count and explain that snapshot-only space is outside the file scan
- keep the probe read-only and bounded, without estimating retained bytes

## Verification

- `./scripts/check.sh`
- `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh` — 1702 tests, 0 failures, 5 skipped
- `go test -race ./cmd/analyze`

Closes #1466
