### PR TITLE
fix(analyze): refresh local snapshot count

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -105,6 +105,7 @@ func newModel(path string, isOverview bool) model {
 		multiSelected:       make(map[string]bool),
 		largeMultiSelected:  make(map[string]bool),
 		liveSortMode:        liveScanSortModeFromEnv(),
+		snapshotRunner:      runLocalSnapshotCommand,
 	}
 
 	if isOverview {

--- a/cmd/analyze/model.go
+++ b/cmd/analyze/model.go
@@ -161,6 +161,8 @@ type model struct {
 	lastTotalFiles      int64           // Total files from previous scan (for progress bar)
 	diskFree            int64           // Free disk space for the analyzed volume
 	localSnapshotCount  int             // Read-only Time Machine snapshot count for overview context
+	snapshotProbeID     int64
+	snapshotRunner      localSnapshotCommandRunner
 	viewNeedsRefresh    bool
 	// Top-files (T) view incremental filter. largeFilesAll is the full,
 	// size-ranked list; largeFiles is the view actually rendered and acted on,

--- a/cmd/analyze/snapshots.go
+++ b/cmd/analyze/snapshots.go
@@ -14,29 +14,36 @@ import (
 const localSnapshotProbeTimeout = 3 * time.Second
 
 type localSnapshotMsg struct {
-	count int
-	err   error
+	probeID int64
+	count   int
+	err     error
 }
 
 type localSnapshotCommandRunner func(context.Context, string, ...string) ([]byte, error)
 
-func detectLocalSnapshotsCmd() tea.Cmd {
-	return localSnapshotProbeCmd(func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		return exec.CommandContext(ctx, name, args...).Output()
-	})
+func runLocalSnapshotCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
 }
 
-func localSnapshotProbeCmd(run localSnapshotCommandRunner) tea.Cmd {
+func (m model) detectLocalSnapshotsCmd() tea.Cmd {
+	run := m.snapshotRunner
+	if run == nil {
+		run = runLocalSnapshotCommand
+	}
+	return localSnapshotProbeCmd(run, m.snapshotProbeID)
+}
+
+func localSnapshotProbeCmd(run localSnapshotCommandRunner, probeID int64) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), localSnapshotProbeTimeout)
 		defer cancel()
 
 		output, err := run(ctx, "/usr/bin/tmutil", "listlocalsnapshotdates", "/")
 		if err != nil {
-			return localSnapshotMsg{err: err}
+			return localSnapshotMsg{probeID: probeID, err: err}
 		}
 
-		return localSnapshotMsg{count: parseLocalSnapshotCount(output)}
+		return localSnapshotMsg{probeID: probeID, count: parseLocalSnapshotCount(output)}
 	}
 }
 

--- a/cmd/analyze/snapshots_test.go
+++ b/cmd/analyze/snapshots_test.go
@@ -136,6 +136,53 @@ func TestOverviewRefreshReprobesLocalSnapshots(t *testing.T) {
 	}
 }
 
+func TestOverviewRefreshResultSurvivesDrillDown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	m := newModel("/", true)
+	m.snapshotRunner = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("Snapshot dates:\n"), nil
+	}
+	m.localSnapshotCount = 4
+	refreshedModel, refreshCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+	refreshed := refreshedModel.(model)
+	refreshMsg := localSnapshotMsgFromBatch(t, refreshCmd)
+
+	refreshed.entries = []dirEntry{{Name: "child", Path: t.TempDir(), Size: 1, IsDir: true}}
+	drilledModel, _ := refreshed.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	drilled := drilledModel.(model)
+	if drilled.inOverviewMode() {
+		t.Fatal("enter key left model in overview mode")
+	}
+
+	updatedModel, _ := drilled.Update(refreshMsg)
+	backModel, _ := updatedModel.(model).Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if got := backModel.(model).localSnapshotCount; got != 0 {
+		t.Fatalf("refresh completed during drill-down left snapshot count at %d", got)
+	}
+}
+
+func TestEnteringOverviewProbesLocalSnapshots(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	m := newModel(t.TempDir(), false)
+	m.snapshotRunner = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("Snapshot dates:\n2026-08-27-101500\n"), nil
+	}
+
+	overviewModel, overviewCmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	overview := overviewModel.(model)
+	if !overview.inOverviewMode() {
+		t.Fatal("escape key did not enter overview mode")
+	}
+
+	msg := localSnapshotMsgFromBatch(t, overviewCmd)
+	updatedModel, _ := overview.Update(msg)
+	if got := updatedModel.(model).localSnapshotCount; got != 1 {
+		t.Fatalf("entering overview stored snapshot count %d, want 1", got)
+	}
+}
+
 func localSnapshotMsgFromBatch(t *testing.T, cmd tea.Cmd) localSnapshotMsg {
 	t.Helper()
 	if cmd == nil {

--- a/cmd/analyze/snapshots_test.go
+++ b/cmd/analyze/snapshots_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestParseLocalSnapshotCount(t *testing.T) {
@@ -63,7 +65,7 @@ func TestLocalSnapshotProbeUsesBoundedReadOnlyTMUtilQuery(t *testing.T) {
 		return []byte("Snapshot dates:\n2026-08-26-091500\n2026-08-26-101500\n"), nil
 	}
 
-	msg := localSnapshotProbeCmd(runner)().(localSnapshotMsg)
+	msg := localSnapshotProbeCmd(runner, 0)().(localSnapshotMsg)
 	if msg.err != nil || msg.count != 2 {
 		t.Fatalf("snapshot probe result = %#v, want count 2", msg)
 	}
@@ -80,7 +82,7 @@ func TestLocalSnapshotProbeReportsCommandFailure(t *testing.T) {
 	wantErr := errors.New("tmutil unavailable")
 	msg := localSnapshotProbeCmd(func(context.Context, string, ...string) ([]byte, error) {
 		return nil, wantErr
-	})().(localSnapshotMsg)
+	}, 0)().(localSnapshotMsg)
 	if !errors.Is(msg.err, wantErr) || msg.count != 0 {
 		t.Fatalf("snapshot probe result = %#v, want command error", msg)
 	}
@@ -101,6 +103,59 @@ func TestOverviewStoresSuccessfulLocalSnapshotCount(t *testing.T) {
 	if got := updated.(model).localSnapshotCount; got != 3 {
 		t.Fatalf("failed refresh changed snapshot count to %d, want 3", got)
 	}
+}
+
+func TestOverviewRefreshReprobesLocalSnapshots(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	m := newModel("/", true)
+	m.snapshotRunner = func(context.Context, string, ...string) ([]byte, error) {
+		return []byte("Snapshot dates:\n"), nil
+	}
+	m.localSnapshotCount = 4
+	firstUpdated, firstCmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+	first := firstUpdated.(model)
+	firstMsg := localSnapshotMsgFromBatch(t, firstCmd)
+
+	secondUpdated, secondCmd := first.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+	second := secondUpdated.(model)
+	secondMsg := localSnapshotMsgFromBatch(t, secondCmd)
+	if firstMsg.probeID == secondMsg.probeID {
+		t.Fatalf("consecutive refreshes reused snapshot probe ID %d", firstMsg.probeID)
+	}
+
+	staleUpdated, _ := second.Update(firstMsg)
+	stale := staleUpdated.(model)
+	if stale.localSnapshotCount != 4 {
+		t.Fatalf("stale probe changed snapshot count to %d, want 4", stale.localSnapshotCount)
+	}
+
+	currentUpdated, _ := stale.Update(secondMsg)
+	if got := currentUpdated.(model).localSnapshotCount; got != 0 {
+		t.Fatalf("current successful zero-count refresh left snapshot count at %d", got)
+	}
+}
+
+func localSnapshotMsgFromBatch(t *testing.T, cmd tea.Cmd) localSnapshotMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatalf("overview refresh command = nil, want a command batch")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("overview refresh command returned %T, want tea.BatchMsg", msg)
+	}
+	for _, batchCmd := range batch {
+		if batchCmd == nil {
+			continue
+		}
+		if msg, ok := batchCmd().(localSnapshotMsg); ok {
+			return msg
+		}
+	}
+	t.Fatalf("overview refresh batch did not re-probe local snapshots")
+	return localSnapshotMsg{}
 }
 
 func TestOverviewViewExplainsLocalSnapshotOnlySpace(t *testing.T) {

--- a/cmd/analyze/update.go
+++ b/cmd/analyze/update.go
@@ -489,7 +489,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case localSnapshotMsg:
-		if m.inOverviewMode() && msg.probeID == m.snapshotProbeID && msg.err == nil {
+		if msg.probeID == m.snapshotProbeID && msg.err == nil {
 			m.localSnapshotCount = msg.count
 		}
 		return m, nil
@@ -1129,9 +1129,9 @@ func (m *model) switchToOverviewMode() tea.Cmd {
 	cmd := m.scheduleOverviewScans()
 	if cmd == nil {
 		m.status = "Ready"
-		return nil
+		return m.detectLocalSnapshotsCmd()
 	}
-	return tea.Batch(cmd, tickCmd())
+	return tea.Batch(cmd, m.detectLocalSnapshotsCmd(), tickCmd())
 }
 
 func (m model) enterSelectedDir() (tea.Model, tea.Cmd) {

--- a/cmd/analyze/update.go
+++ b/cmd/analyze/update.go
@@ -67,7 +67,7 @@ func (m *model) scheduleOverviewScans() tea.Cmd {
 
 func (m model) Init() tea.Cmd {
 	if m.inOverviewMode() {
-		return tea.Batch(m.scheduleOverviewScans(), detectLocalSnapshotsCmd())
+		return tea.Batch(m.scheduleOverviewScans(), m.detectLocalSnapshotsCmd())
 	}
 	return tea.Batch(m.scanCmd(m.path), tickCmd())
 }
@@ -489,7 +489,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case localSnapshotMsg:
-		if m.inOverviewMode() && msg.err == nil {
+		if m.inOverviewMode() && msg.probeID == m.snapshotProbeID && msg.err == nil {
 			m.localSnapshotCount = msg.count
 		}
 		return m, nil
@@ -681,7 +681,8 @@ func (m model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 			m.status = "Refreshing..."
 			m.overviewScanning = true
-			return m, tea.Batch(m.scheduleOverviewScans(), tickCmd())
+			m.snapshotProbeID++
+			return m, tea.Batch(m.scheduleOverviewScans(), m.detectLocalSnapshotsCmd(), tickCmd())
 		}
 
 		invalidateCacheTree(m.path)


### PR DESCRIPTION
## Summary

- re-run the bounded, read-only Time Machine snapshot probe when the overview is refreshed with `R`/`r`
- tag probes with a generation so an older initial or refresh result cannot overwrite a newer refresh
- preserve the last known count on probe failure while allowing a successful zero result to clear it

This completes the TUI refresh lifecycle for the snapshot notice added in #1467. The scope intentionally stays inside the existing overview UI; it does not add JSON fields, estimate snapshot sizes, or perform snapshot cleanup.

## Verification

- focused regression failed before the refresh probe was scheduled, then passed
- `go test -race ./cmd/analyze -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `./scripts/check.sh`
- `MOLE_TEST_NO_AUTH=1 ./scripts/test.sh`: 1720 tests, 1 failure, 6 skipped; the sole unrelated `clean_dev_caches.bats` mdfind failure reproduces unchanged on exact base `608d5d04`
