### PR TITLE
fix(clean): preserve live container cache trees

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -258,27 +258,34 @@ append_dry_run_cleanup_target() {
 # prepared ledger retain the legacy in-memory duplicate check.
 record_dry_run_cleanup_target() {
     local path="$1"
-    if declare -f should_protect_path > /dev/null 2>&1 && should_protect_path "$path" 2> /dev/null; then
-        return 1
-    fi
-    if declare -f is_path_whitelisted > /dev/null 2>&1 && is_path_whitelisted "$path" 2> /dev/null; then
-        return 1
-    fi
-    if declare -f holds_compiled_model_cache > /dev/null 2>&1 && holds_compiled_model_cache "$path" 2> /dev/null; then
-        return 1
-    fi
-    # Keep preview eligibility identical to real cleanup (#1390 / PR #1391).
-    if declare -f _mole_should_refuse_live_user_cache_path > /dev/null 2>&1 &&
-        _mole_should_refuse_live_user_cache_path "$path"; then
-        return 1
-    fi
-    if declare -f _mole_is_sqlite_database_path > /dev/null 2>&1 &&
-        _mole_is_sqlite_database_path "$path" &&
-        declare -f _mole_sqlite_database_in_use > /dev/null 2>&1; then
-        local sqlite_state=0
-        _mole_sqlite_database_in_use "$path" || sqlite_state=$?
-        if [[ $sqlite_state -eq 0 || $sqlite_state -eq 2 ]]; then
+    if [[ "${_MOLE_DRY_RUN_TARGET_PREVALIDATED:-false}" != "true" ]]; then
+        if declare -f should_protect_path > /dev/null 2>&1 && should_protect_path "$path" 2> /dev/null; then
             return 1
+        fi
+        if declare -f is_path_whitelisted > /dev/null 2>&1 && is_path_whitelisted "$path" 2> /dev/null; then
+            return 1
+        fi
+        if declare -f holds_compiled_model_cache > /dev/null 2>&1 && holds_compiled_model_cache "$path" 2> /dev/null; then
+            return 1
+        fi
+        # Keep preview eligibility identical to real cleanup (#1390 / PR #1391).
+        if declare -f _mole_should_refuse_live_user_cache_path > /dev/null 2>&1; then
+            local live_cache_state=0
+            _mole_should_refuse_live_user_cache_path "$path" || live_cache_state=$?
+            if [[ $live_cache_state -eq 0 || $live_cache_state -eq 2 ]]; then
+                return 1
+            fi
+            [[ $live_cache_state -ge 128 ]] && return "$live_cache_state"
+        fi
+        if declare -f _mole_is_sqlite_database_path > /dev/null 2>&1 &&
+            _mole_is_sqlite_database_path "$path" &&
+            declare -f _mole_sqlite_database_in_use > /dev/null 2>&1; then
+            local sqlite_state=0
+            _mole_sqlite_database_in_use "$path" || sqlite_state=$?
+            if [[ $sqlite_state -eq 0 || $sqlite_state -eq 2 ]]; then
+                return 1
+            fi
+            [[ $sqlite_state -ge 128 ]] && return "$sqlite_state"
         fi
     fi
 

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -1792,6 +1792,8 @@ clean_remote_desktop() {
 }
 # Main entry for GUI app cleanup.
 clean_user_gui_applications() {
+    # Product and media App Container rows share one recursive-handle budget.
+    local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
     stop_section_spinner
     clean_communication_apps
     clean_dingtalk

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -954,6 +954,9 @@ clean_app_caches() {
     local precise_size_limit="${MOLE_CONTAINER_CACHE_PRECISE_SIZE_LIMIT:-64}"
     [[ "$precise_size_limit" =~ ^[0-9]+$ ]] || precise_size_limit=64
     local precise_size_used=0
+    # Recursive lsof probes fail closed after one cumulative section budget;
+    # candidate count cannot multiply the per-command timeout into minutes.
+    local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
 
     local _ng_state
     _ng_state=$(shopt -p nullglob || true)
@@ -1114,6 +1117,13 @@ process_container_cache() {
                 total_size_partial=true
             fi
 
+            # Dry-run bypasses safe_remove, so ask the same deletion funnel
+            # immediately before registering this preview candidate.
+            _mole_reset_process_snapshot
+            if ! validate_path_for_deletion "$item" 2> /dev/null; then
+                continue
+            fi
+
             if declare -f register_dry_run_cleanup_target > /dev/null 2>&1; then
                 register_dry_run_cleanup_target "$item" || continue
             fi
@@ -1185,6 +1195,7 @@ clean_group_container_caches() {
     local total_size_partial=false
     local cleaned_count=0
     local found_any=false
+    local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
 
     local container_dir
     local _nullglob_state
@@ -1273,6 +1284,10 @@ clean_group_container_caches() {
                         continue
                     fi
                     if [[ "$DRY_RUN" == "true" ]] && declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
+                        _mole_reset_process_snapshot
+                        if ! validate_path_for_deletion "$item" 2> /dev/null; then
+                            continue
+                        fi
                         record_dry_run_cleanup_target "$item" 0 1 false || continue
                     fi
                     candidate_changed=true
@@ -1294,6 +1309,10 @@ clean_group_container_caches() {
                     [[ $size_rc -eq 0 ]] || return "$size_rc"
                     [[ "$item_size" =~ ^[0-9]+$ ]] || item_size=0
                     if [[ "$DRY_RUN" == "true" ]]; then
+                        _mole_reset_process_snapshot
+                        if ! validate_path_for_deletion "$item" 2> /dev/null; then
+                            continue
+                        fi
                         if declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
                             record_dry_run_cleanup_target "$item" "$item_size" 1 true || continue
                         fi

--- a/lib/clean/user.sh
+++ b/lib/clean/user.sh
@@ -893,6 +893,9 @@ directory_has_entries() {
 }
 
 clean_app_caches() {
+    # Every App Container handle probe in this section shares one wall-clock
+    # budget, including the explicit Apple cache rows before the generic scan.
+    local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
     start_section_spinner "Scanning app caches..."
 
     # macOS system caches (merged from clean_macos_system_caches)
@@ -954,10 +957,6 @@ clean_app_caches() {
     local precise_size_limit="${MOLE_CONTAINER_CACHE_PRECISE_SIZE_LIMIT:-64}"
     [[ "$precise_size_limit" =~ ^[0-9]+$ ]] || precise_size_limit=64
     local precise_size_used=0
-    # Recursive lsof probes fail closed after one cumulative section budget;
-    # candidate count cannot multiply the per-command timeout into minutes.
-    local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
-
     local _ng_state
     _ng_state=$(shopt -p nullglob || true)
     shopt -s nullglob
@@ -1080,83 +1079,14 @@ process_container_cache() {
     item_count=$(cache_top_level_entry_count_capped "$cache_dir" 101)
     [[ "$item_count" =~ ^[0-9]+$ ]] || item_count=0
     [[ "$item_count" -eq 0 ]] && return 0
-
-    if [[ "$DRY_RUN" == "true" ]]; then
-        local _nullglob_state
-        local _dotglob_state
-        _nullglob_state=$(shopt -p nullglob || true)
-        _dotglob_state=$(shopt -p dotglob || true)
-        shopt -s nullglob dotglob
-
-        local item
-        for item in "$cache_dir"/*; do
-            [[ -e "$item" ]] || continue
-            [[ -L "$item" ]] && continue
-            if holds_compiled_model_cache "$item"; then
-                continue
-            fi
-            if should_protect_path "$item" 2> /dev/null || is_path_whitelisted "$item" 2> /dev/null; then
-                continue
-            fi
-            local item_size_kb=0
-            local size_known=false
-            if [[ "$precise_size_used" -lt "$precise_size_limit" ]]; then
-                local size_rc=0
-                item_size_kb=$(get_path_size_kb "$item" 2> /dev/null) || size_rc=$?
-                if [[ $size_rc -ne 0 ]]; then
-                    _mole_record_clean_cancellation "$size_rc"
-                    # eval: restore shopt state captured by $(shopt -p)
-                    eval "$_nullglob_state"
-                    eval "$_dotglob_state"
-                    return "$size_rc"
-                fi
-                [[ "$item_size_kb" =~ ^[0-9]+$ ]] || item_size_kb=0
-                precise_size_used=$((precise_size_used + 1))
-                size_known=true
-            else
-                total_size_partial=true
-            fi
-
-            # Dry-run bypasses safe_remove, so ask the same deletion funnel
-            # immediately before registering this preview candidate.
-            _mole_reset_process_snapshot
-            if ! validate_path_for_deletion "$item" 2> /dev/null; then
-                continue
-            fi
-
-            if declare -f register_dry_run_cleanup_target > /dev/null 2>&1; then
-                register_dry_run_cleanup_target "$item" || continue
-            fi
-
-            if declare -f append_dry_run_cleanup_target > /dev/null 2>&1; then
-                append_dry_run_cleanup_target "$item" "$item_size_kb" 1 "$size_known"
-            fi
-            total_size=$((total_size + item_size_kb))
-            cleaned_count=$((cleaned_count + 1))
-            found_any=true
-        done
-
-        # eval: restore shopt state captured by $(shopt -p)
-        eval "$_nullglob_state"
-        eval "$_dotglob_state"
-        return 0
-    fi
-
-    if [[ "$item_count" -le 100 && "$precise_size_used" -lt "$precise_size_limit" ]]; then
-        local size=""
-        local size_rc=0
-        size=$(get_path_size_kb "$cache_dir" 2> /dev/null) || size_rc=$?
-        [[ $size_rc -eq 0 ]] || _mole_record_clean_cancellation "$size_rc"
-        [[ $size_rc -eq 0 ]] || return "$size_rc"
-        [[ "$size" =~ ^[0-9]+$ ]] || size=0
-        total_size=$((total_size + size))
-        precise_size_used=$((precise_size_used + 1))
-    else
+    local measure_item_sizes=true
+    if [[ "$item_count" -gt 100 ]]; then
+        # Large containers are intentionally cleanup-only: one du per child
+        # turns a bounded cache sweep into another long recursive scan.
+        measure_item_sizes=false
         total_size_partial=true
     fi
 
-    found_any=true
-    cleaned_count=$((cleaned_count + 1))
     local _nullglob_state
     local _dotglob_state
     _nullglob_state=$(shopt -p nullglob || true)
@@ -1175,7 +1105,52 @@ process_container_cache() {
         if should_protect_path "$item" 2> /dev/null || is_path_whitelisted "$item" 2> /dev/null; then
             continue
         fi
-        safe_remove "$item" true || true
+
+        local item_size_kb=0
+        local size_known=false
+        if [[ "$measure_item_sizes" == "true" && "$precise_size_used" -lt "$precise_size_limit" ]]; then
+            local size_rc=0
+            item_size_kb=$(get_path_size_kb "$item" 2> /dev/null) || size_rc=$?
+            if [[ $size_rc -ne 0 ]]; then
+                _mole_record_clean_cancellation "$size_rc"
+                # eval: restore shopt state captured by $(shopt -p)
+                eval "$_nullglob_state"
+                eval "$_dotglob_state"
+                return "$size_rc"
+            fi
+            [[ "$item_size_kb" =~ ^[0-9]+$ ]] || item_size_kb=0
+            precise_size_used=$((precise_size_used + 1))
+            size_known=true
+        elif [[ "$measure_item_sizes" == "true" ]]; then
+            total_size_partial=true
+        fi
+
+        local action_rc=0
+        if [[ "$DRY_RUN" == "true" ]]; then
+            # Dry-run and real mode share this candidate loop. Preview probes
+            # once here; real mode probes once at safe_remove's final sink.
+            _mole_reset_process_snapshot
+            validate_path_for_deletion "$item" 2> /dev/null || action_rc=$?
+            if [[ $action_rc -eq 0 ]] && declare -f register_dry_run_cleanup_target > /dev/null 2>&1; then
+                register_dry_run_cleanup_target "$item" || action_rc=$?
+            fi
+            if [[ $action_rc -eq 0 ]] && declare -f append_dry_run_cleanup_target > /dev/null 2>&1; then
+                append_dry_run_cleanup_target "$item" "$item_size_kb" 1 "$size_known" || action_rc=$?
+            fi
+        else
+            safe_remove "$item" true "$item_size_kb" || action_rc=$?
+        fi
+        if [[ $action_rc -ge 128 ]]; then
+            _mole_record_clean_cancellation "$action_rc"
+            # eval: restore shopt state captured by $(shopt -p)
+            eval "$_nullglob_state"
+            eval "$_dotglob_state"
+            return "$action_rc"
+        fi
+        [[ $action_rc -eq 0 ]] || continue
+        total_size=$((total_size + item_size_kb))
+        cleaned_count=$((cleaned_count + 1))
+        found_any=true
     done
     # eval: restore shopt state captured by $(shopt -p)
     eval "$_nullglob_state"
@@ -1198,8 +1173,8 @@ clean_group_container_caches() {
     local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
 
     local container_dir
-    local _nullglob_state
-    _nullglob_state=$(shopt -p nullglob || true)
+    local group_nullglob_state
+    group_nullglob_state=$(shopt -p nullglob || true)
     shopt -s nullglob
 
     for container_dir in "$group_containers_dir"/*; do
@@ -1269,66 +1244,79 @@ clean_group_container_caches() {
 
             local candidate_size_kb=0
             local candidate_changed=false
-            local _nullglob_state
-            local _dotglob_state
-            _nullglob_state=$(shopt -p nullglob || true)
-            _dotglob_state=$(shopt -p dotglob || true)
+            local candidate_nullglob_state
+            local candidate_dotglob_state
+            candidate_nullglob_state=$(shopt -p nullglob || true)
+            candidate_dotglob_state=$(shopt -p dotglob || true)
             shopt -s nullglob dotglob
 
+            local candidate_size_known=true
             if [[ "$quick_count" -gt 100 ]]; then
                 total_size_partial=true
-                for item in "$candidate"/*; do
-                    [[ -e "$item" ]] || continue
-                    [[ -L "$item" ]] && continue
-                    if should_protect_path "$item" 2> /dev/null || is_path_whitelisted "$item" 2> /dev/null; then
-                        continue
-                    fi
-                    if [[ "$DRY_RUN" == "true" ]] && declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
-                        _mole_reset_process_snapshot
-                        if ! validate_path_for_deletion "$item" 2> /dev/null; then
-                            continue
-                        fi
-                        record_dry_run_cleanup_target "$item" 0 1 false || continue
-                    fi
-                    candidate_changed=true
-                    if [[ "$DRY_RUN" != "true" ]]; then
-                        safe_remove "$item" true 2> /dev/null || true
-                    fi
-                done
-            else
-                for item in "$candidate"/*; do
-                    [[ -e "$item" ]] || continue
-                    [[ -L "$item" ]] && continue
-                    if should_protect_path "$item" 2> /dev/null || is_path_whitelisted "$item" 2> /dev/null; then
-                        continue
-                    fi
-                    local item_size=""
+                candidate_size_known=false
+            fi
+            for item in "$candidate"/*; do
+                [[ -e "$item" ]] || continue
+                [[ -L "$item" ]] && continue
+                if should_protect_path "$item" 2> /dev/null ||
+                    is_path_whitelisted "$item" 2> /dev/null ||
+                    holds_compiled_model_cache "$item" 2> /dev/null; then
+                    continue
+                fi
+
+                local item_size=0
+                if [[ "$candidate_size_known" == "true" ]]; then
                     local size_rc=0
                     item_size=$(get_path_size_kb "$item" 2> /dev/null) || size_rc=$?
                     [[ $size_rc -eq 0 ]] || _mole_record_clean_cancellation "$size_rc"
-                    [[ $size_rc -eq 0 ]] || return "$size_rc"
+                    if [[ $size_rc -ne 0 ]]; then
+                        # eval: restore shopt state captured by $(shopt -p)
+                        eval "$candidate_nullglob_state"
+                        eval "$candidate_dotglob_state"
+                        eval "$group_nullglob_state"
+                        return "$size_rc"
+                    fi
                     [[ "$item_size" =~ ^[0-9]+$ ]] || item_size=0
-                    if [[ "$DRY_RUN" == "true" ]]; then
-                        _mole_reset_process_snapshot
-                        if ! validate_path_for_deletion "$item" 2> /dev/null; then
-                            continue
-                        fi
-                        if declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
-                            record_dry_run_cleanup_target "$item" "$item_size" 1 true || continue
-                        fi
-                        candidate_changed=true
-                        candidate_size_kb=$((candidate_size_kb + item_size))
-                        continue
+                fi
+
+                local action_rc=0
+                if [[ "$DRY_RUN" == "true" ]]; then
+                    _mole_reset_process_snapshot
+                    # Match real safe_remove ordering: a compiled-model cache
+                    # that appeared during sizing is rejected before the
+                    # recursive lsof probe can consume this section's budget.
+                    if holds_compiled_model_cache "$item" 2> /dev/null; then
+                        action_rc=1
                     fi
-                    if safe_remove "$item" true "$item_size" 2> /dev/null; then
-                        candidate_changed=true
-                        candidate_size_kb=$((candidate_size_kb + item_size))
+                    if [[ $action_rc -eq 0 ]]; then
+                        validate_path_for_deletion "$item" 2> /dev/null || action_rc=$?
                     fi
-                done
-            fi
+                    if [[ $action_rc -eq 0 ]] && declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
+                        # The path, whitelist, compiled-model, live-owner, and
+                        # SQLite guards have all run after sizing. Avoid only
+                        # repeating that complete eligibility pass.
+                        local _MOLE_DRY_RUN_TARGET_PREVALIDATED=true
+                        record_dry_run_cleanup_target \
+                            "$item" "$item_size" 1 "$candidate_size_known" || action_rc=$?
+                    fi
+                else
+                    safe_remove "$item" true "$item_size" 2> /dev/null || action_rc=$?
+                fi
+                if [[ $action_rc -ge 128 ]]; then
+                    _mole_record_clean_cancellation "$action_rc"
+                    # eval: restore shopt state captured by $(shopt -p)
+                    eval "$candidate_nullglob_state"
+                    eval "$candidate_dotglob_state"
+                    eval "$group_nullglob_state"
+                    return "$action_rc"
+                fi
+                [[ $action_rc -eq 0 ]] || continue
+                candidate_changed=true
+                candidate_size_kb=$((candidate_size_kb + item_size))
+            done
             # eval: restore shopt state captured by $(shopt -p)
-            eval "$_nullglob_state"
-            eval "$_dotglob_state"
+            eval "$candidate_nullglob_state"
+            eval "$candidate_dotglob_state"
 
             if [[ "$candidate_changed" == "true" ]]; then
                 total_size=$((total_size + candidate_size_kb))
@@ -1338,7 +1326,7 @@ clean_group_container_caches() {
         done
     done
     # eval: restore shopt state captured by $(shopt -p)
-    eval "$_nullglob_state"
+    eval "$group_nullglob_state"
 
     stop_section_spinner
 
@@ -1838,6 +1826,8 @@ clean_cloud_storage() {
 
 # Office app caches.
 clean_office_applications() {
+    # Bound every explicit Office App Container probe as one section.
+    local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
     if [[ "${MO_DEBUG:-0}" == "1" ]]; then
         echo "[DEBUG] Cleaning office application caches..." >&2
     fi
@@ -1865,6 +1855,7 @@ clean_office_applications() {
 
 # Virtualization caches.
 clean_utm_caches() {
+    local _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
     if pgrep -x "UTM" > /dev/null 2>&1; then
         debug_log "Skipping UTM caches while UTM is running"
         return 0

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -161,26 +161,54 @@ _mole_is_active_powerlog_database_path() {
 # under one cache directory does not fork pgrep once per leaf file. Bash 3.2
 # has no associative arrays, so the cache is a pipe-delimited string.
 
-_mole_user_library_caches_prefix() {
-    printf '%s\n' "${HOME%/}/Library/Caches"
+_mole_user_cache_scope() {
+    local path="$1"
+    local normalized="${path%/}"
+    local library_root="${HOME%/}/Library"
+    local remainder=""
+    local component=""
+    local suffix=""
+    local scope_type=""
+
+    case "$normalized" in
+        "$library_root/Caches"/*)
+            remainder="${normalized#"$library_root/Caches"/}"
+            component="${remainder%%/*}"
+            scope_type="standard"
+            ;;
+        "$library_root/Containers"/*)
+            remainder="${normalized#"$library_root/Containers"/}"
+            component="${remainder%%/*}"
+            suffix="${remainder#"$component"}"
+            case "$suffix" in
+                /Data/Library/Caches | /Data/Library/Caches/*) scope_type="container" ;;
+                *) return 1 ;;
+            esac
+            ;;
+        "$library_root/Group Containers"/*)
+            remainder="${normalized#"$library_root/Group Containers"/}"
+            component="${remainder%%/*}"
+            suffix="${remainder#"$component"}"
+            case "$suffix" in
+                /Caches | /Caches/* | /Library/Caches | /Library/Caches/*) scope_type="container" ;;
+                *) return 1 ;;
+            esac
+            ;;
+        *) return 1 ;;
+    esac
+
+    # Reverse-DNS style only (com.vendor.app). Named trees such as Homebrew
+    # stay outside this gate; they have their own process probes. The separator
+    # is excluded so the caller can split this Bash-3.2-compatible record.
+    [[ "$component" == *.* && "$component" != .* && "$component" != *"|"* ]] || return 1
+    printf '%s|%s\n' "$component" "$scope_type"
+    return 0
 }
 
 _mole_user_cache_owner_component() {
-    local path="$1"
-    local prefix
-    prefix=$(_mole_user_library_caches_prefix)
-    local normalized="${path%/}"
-    case "$normalized" in
-        "$prefix"/*) ;;
-        *) return 1 ;;
-    esac
-    local remainder="${normalized#"$prefix"/}"
-    local component="${remainder%%/*}"
-    # Reverse-DNS style only (com.vendor.app). Named trees such as Homebrew
-    # stay outside this gate; they have their own process probes.
-    [[ "$component" == *.* && "$component" != .* ]] || return 1
-    printf '%s\n' "$component"
-    return 0
+    local scope=""
+    scope=$(_mole_user_cache_scope "$1") || return 1
+    printf '%s\n' "${scope%%|*}"
 }
 
 # SQLite main file or -wal / -shm / -journal companion. Case-insensitive so a
@@ -471,11 +499,58 @@ _mole_user_cache_sqlite_has_open_handle() {
     return "$state"
 }
 
-# Return 0 when deletion must be refused (live owner or open SQLite handle).
+# Is any process holding the exact container-cache file, or a descendant of
+# the directory, open? 0 = in use, 1 = conclusively idle, 2 = could not tell.
+_mole_container_cache_has_open_handle() {
+    local path="$1"
+    command -v lsof > /dev/null 2>&1 || return 2
+    declare -f run_with_timeout > /dev/null 2>&1 || return 2
+    [[ -e "$path" ]] || return 1
+
+    if [[ -n "${_MOLE_CONTAINER_CACHE_PROBE_DEADLINE+x}" &&
+        -z "$_MOLE_CONTAINER_CACHE_PROBE_DEADLINE" ]]; then
+        _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=$((SECONDS + MOLE_TIMEOUT_MEDIUM_PROBE_SEC))
+    fi
+    local probe_timeout=""
+    if ! probe_timeout=$(_mole_timeout_with_deadline "$MOLE_TIMEOUT_QUICK_DETECT_SEC" \
+        "${_MOLE_CONTAINER_CACHE_PROBE_DEADLINE:-}"); then
+        debug_log "Container cache handle probe budget exhausted, keep: $path"
+        return 2
+    fi
+    local lsof_rc=0
+    local records=""
+    if [[ -d "$path" ]]; then
+        records=$(run_with_timeout "$probe_timeout" \
+            lsof -F pfn +D "$path" < /dev/null 2>&1) || lsof_rc=$?
+    else
+        records=$(run_with_timeout "$probe_timeout" \
+            lsof -F pfn -- "$path" < /dev/null 2>&1) || lsof_rc=$?
+    fi
+
+    if [[ $lsof_rc -eq 0 ]]; then
+        return 0
+    fi
+    # A recursive walk may report one open record and still fail on another
+    # descendant. Field output starts with p/f/n; warning prose does not.
+    if [[ -n "$records" ]] && LC_ALL=C grep -qE '^[pfn]' <<< "$records"; then
+        return 0
+    fi
+    # Only status 1 with completely empty output is a conclusive no-match for
+    # this snapshot. It is not an ownership lease: safe_remove minimizes the
+    # unavoidable reopen window by taking this snapshot at the final sink.
+    # Missing lsof/timeout helper, timeout, signal, traversal warning, or other
+    # error is unknown and must not authorize deletion.
+    [[ $lsof_rc -eq 1 && -z "$records" ]] || return 2
+    return 1
+}
+
+# Return 0 when deletion must be refused (live owner or open cache handle).
 _mole_should_refuse_live_user_cache_path() {
     local path="$1"
-    local owner=""
-    owner=$(_mole_user_cache_owner_component "$path") || return 1
+    local scope=""
+    scope=$(_mole_user_cache_scope "$path") || return 1
+    local owner="${scope%%|*}"
+    local scope_type="${scope#*|}"
 
     local process_state=0
     _mole_user_cache_owner_process_state "$owner" || process_state=$?
@@ -488,9 +563,25 @@ _mole_should_refuse_live_user_cache_path() {
         return 0
     fi
 
-    # Process is conclusively idle. Still refuse SQLite family members that
-    # another process has open, or that still expose a WAL -shm (PR #1391).
-    if _mole_is_user_cache_sqlite_family_path "$path"; then
+    # Container ids and helper process names need not correspond (for example,
+    # a team-prefixed Group Container used by SkyComputerUseService). Inspect
+    # every open descendant instead of treating process-name silence as idle.
+    if [[ "$scope_type" == "container" ]]; then
+        # A real safe_remove defers this comparatively expensive recursive
+        # probe to its final-sink recheck. Nothing mutates the target between
+        # initial validation and that boundary. Dry-run and direct validators
+        # do not set this dynamic-scope flag and still probe here.
+        if [[ "${_MOLE_DEFER_CONTAINER_HANDLE_PROBE:-false}" == "true" ]]; then
+            return 1
+        fi
+        local container_open_state=0
+        _mole_container_cache_has_open_handle "$path" || container_open_state=$?
+        if [[ $container_open_state -eq 0 || $container_open_state -eq 2 ]]; then
+            debug_log "Container cache handle not conclusively idle, keep: $path"
+            return 0
+        fi
+    # Standard reverse-DNS caches retain the narrower SQLite-family probe.
+    elif _mole_is_user_cache_sqlite_family_path "$path"; then
         local open_state=0
         _mole_user_cache_sqlite_has_open_handle "$path" || open_state=$?
         if [[ $open_state -eq 0 || $open_state -eq 2 ]]; then
@@ -920,6 +1011,7 @@ safe_remove() {
     local expected_parent="${5:-}"
     local expected_parent_id="${6:-}"
     local expected_target_id="${7:-}"
+    local _MOLE_DEFER_CONTAINER_HANDLE_PROBE=false
 
     local pending_clean_cancel="${MOLE_CLEAN_CANCEL_STATUS:-0}"
     if [[ "${MOLE_CURRENT_COMMAND:-}" == "clean" &&
@@ -929,11 +1021,17 @@ safe_remove() {
 
     # Validate path. Silent cleanup callers still need the same policy result,
     # but should not print one validation warning per skipped cache item.
+    # Real cleanup performs its recursive container-handle probe once, at the
+    # final sink below. Dry-run returns before that boundary, so it probes now.
+    if [[ "${MOLE_DRY_RUN:-0}" != "1" ]]; then
+        _MOLE_DEFER_CONTAINER_HANDLE_PROBE=true
+    fi
     if [[ "$silent" == "true" ]]; then
         validate_path_for_deletion "$path" 2> /dev/null || return 1
     elif ! validate_path_for_deletion "$path"; then
         return 1
     fi
+    _MOLE_DEFER_CONTAINER_HANDLE_PROBE=false
 
     # Honor the user whitelist here, not just in safe_clean. safe_remove is
     # called directly by several clean/optimize flows (Xcode DerivedData,

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -499,17 +499,45 @@ _mole_user_cache_sqlite_has_open_handle() {
     return "$state"
 }
 
+# Identity captured by the most recent conclusively idle container-cache
+# probe. safe_remove rebinds it immediately before rm so a rename-and-recreate
+# cannot turn an idle snapshot of the old object into permission for the new
+# object at the same path.
+_MOLE_CONTAINER_CACHE_PROBE_PARENT=""
+_MOLE_CONTAINER_CACHE_PROBE_PARENT_ID=""
+_MOLE_CONTAINER_CACHE_PROBE_TARGET_ID=""
+
+_mole_container_cache_probe_deadline() {
+    local timeout_seconds="${MOLE_TIMEOUT_MEDIUM_PROBE_SEC:-5}"
+    if [[ ! "$timeout_seconds" =~ ^[0-9]+(\.[0-9]+)?$ ||
+        "$timeout_seconds" =~ ^0+(\.0+)?$ ]]; then
+        timeout_seconds=5
+    fi
+    local timeout_whole="${timeout_seconds%%.*}"
+    local timeout_budget=$((10#$timeout_whole))
+    if [[ "$timeout_seconds" == *.* && "${timeout_seconds#*.}" =~ [1-9] ]]; then
+        timeout_budget=$((timeout_budget + 1))
+    fi
+    [[ $timeout_budget -ge 2 ]] || timeout_budget=2
+    printf '%s\n' "$((SECONDS + timeout_budget))"
+}
+
 # Is any process holding the exact container-cache file, or a descendant of
-# the directory, open? 0 = in use, 1 = conclusively idle, 2 = could not tell.
+# the directory, open? 0 = in use, 1 = conclusively idle, 2 = could not tell;
+# signal statuses are preserved so clean can stop instead of treating an
+# interrupted safety probe as an ordinary skipped item.
 _mole_container_cache_has_open_handle() {
     local path="$1"
+    _MOLE_CONTAINER_CACHE_PROBE_PARENT=""
+    _MOLE_CONTAINER_CACHE_PROBE_PARENT_ID=""
+    _MOLE_CONTAINER_CACHE_PROBE_TARGET_ID=""
     command -v lsof > /dev/null 2>&1 || return 2
     declare -f run_with_timeout > /dev/null 2>&1 || return 2
     [[ -e "$path" ]] || return 1
 
     if [[ -n "${_MOLE_CONTAINER_CACHE_PROBE_DEADLINE+x}" &&
         -z "$_MOLE_CONTAINER_CACHE_PROBE_DEADLINE" ]]; then
-        _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=$((SECONDS + MOLE_TIMEOUT_MEDIUM_PROBE_SEC))
+        _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=$(_mole_container_cache_probe_deadline)
     fi
     local probe_timeout=""
     if ! probe_timeout=$(_mole_timeout_with_deadline "$MOLE_TIMEOUT_QUICK_DETECT_SEC" \
@@ -517,6 +545,13 @@ _mole_container_cache_has_open_handle() {
         debug_log "Container cache handle probe budget exhausted, keep: $path"
         return 2
     fi
+    # Bind the exact parent and target objects around lsof. The path can be
+    # renamed and recreated while the recursive probe is running.
+    _mole_snapshot_path_identity "$path" || return 2
+    local expected_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
+    local expected_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+    local expected_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+
     local lsof_rc=0
     local records=""
     if [[ -d "$path" ]]; then
@@ -527,6 +562,9 @@ _mole_container_cache_has_open_handle() {
             lsof -F pfn -- "$path" < /dev/null 2>&1) || lsof_rc=$?
     fi
 
+    if [[ $lsof_rc -ge 128 ]]; then
+        return "$lsof_rc"
+    fi
     if [[ $lsof_rc -eq 0 ]]; then
         return 0
     fi
@@ -541,12 +579,23 @@ _mole_container_cache_has_open_handle() {
     # Missing lsof/timeout helper, timeout, signal, traversal warning, or other
     # error is unknown and must not authorize deletion.
     [[ $lsof_rc -eq 1 && -z "$records" ]] || return 2
+    if ! _mole_path_matches_identity \
+        "$path" "$expected_parent" "$expected_parent_id" "$expected_target_id"; then
+        debug_log "Container cache identity changed during handle probe, keep: $path"
+        return 2
+    fi
+    _MOLE_CONTAINER_CACHE_PROBE_PARENT="$expected_parent"
+    _MOLE_CONTAINER_CACHE_PROBE_PARENT_ID="$expected_parent_id"
+    _MOLE_CONTAINER_CACHE_PROBE_TARGET_ID="$expected_target_id"
     return 1
 }
 
 # Return 0 when deletion must be refused (live owner or open cache handle).
 _mole_should_refuse_live_user_cache_path() {
     local path="$1"
+    _MOLE_CONTAINER_CACHE_PROBE_PARENT=""
+    _MOLE_CONTAINER_CACHE_PROBE_PARENT_ID=""
+    _MOLE_CONTAINER_CACHE_PROBE_TARGET_ID=""
     local scope=""
     scope=$(_mole_user_cache_scope "$path") || return 1
     local owner="${scope%%|*}"
@@ -576,6 +625,9 @@ _mole_should_refuse_live_user_cache_path() {
         fi
         local container_open_state=0
         _mole_container_cache_has_open_handle "$path" || container_open_state=$?
+        if [[ $container_open_state -ge 128 ]]; then
+            return "$container_open_state"
+        fi
         if [[ $container_open_state -eq 0 || $container_open_state -eq 2 ]]; then
             debug_log "Container cache handle not conclusively idle, keep: $path"
             return 0
@@ -884,9 +936,15 @@ validate_path_for_deletion() {
 
     # Live reverse-DNS user caches (process + SQLite handle). Covers Autodesk
     # helpers and every other com.vendor tree under ~/Library/Caches (#1390).
-    if _mole_should_refuse_live_user_cache_path "$policy_path"; then
+    local live_cache_guard_rc=0
+    _mole_should_refuse_live_user_cache_path "$policy_path" || live_cache_guard_rc=$?
+    if [[ $live_cache_guard_rc -eq 0 ]]; then
         debug_log "Path validation: live user cache kept: $policy_path"
         return 1
+    fi
+    if [[ $live_cache_guard_rc -ge 128 ]]; then
+        _mole_record_clean_cancellation "$live_cache_guard_rc"
+        return "$live_cache_guard_rc"
     fi
 
     # General SQLite family gate from PR #1391: refuse any in-use database even
@@ -958,9 +1016,11 @@ _record_file_ops_dry_run_target() {
 
     local size_kb=0
     local size_known=true
+    local eligibility_still_current=true
     if [[ -n "$precomputed_size_kb" && "$precomputed_size_kb" =~ ^[0-9]+$ ]]; then
         size_kb="$precomputed_size_kb"
     else
+        eligibility_still_current=false
         local measured_size=""
         local measure_rc=0
         measured_size=$(get_path_size_kb "$path" 2> /dev/null) || measure_rc=$?
@@ -979,11 +1039,14 @@ _record_file_ops_dry_run_target() {
         fi
     fi
 
+    # A precomputed size means validate_path_for_deletion was the last
+    # meaningful probe. If this helper measured after validation, rerun the
+    # recorder guards: an owner can open the cache while du is walking it.
+    local _MOLE_DRY_RUN_TARGET_PREVALIDATED="$eligibility_still_current"
     local record_rc=0
     record_dry_run_cleanup_target \
         "$path" "$size_kb" 1 "$size_known" || record_rc=$?
-    [[ $record_rc -eq 124 || $record_rc -ge 128 ]] && return "$record_rc"
-    return 0
+    return "$record_rc"
 }
 
 # Preserve the first timeout or signal observed by a clean deletion sink. Some
@@ -1012,6 +1075,9 @@ safe_remove() {
     local expected_parent_id="${6:-}"
     local expected_target_id="${7:-}"
     local _MOLE_DEFER_CONTAINER_HANDLE_PROBE=false
+    local container_probe_parent=""
+    local container_probe_parent_id=""
+    local container_probe_target_id=""
 
     local pending_clean_cancel="${MOLE_CLEAN_CANCEL_STATUS:-0}"
     if [[ "${MOLE_CURRENT_COMMAND:-}" == "clean" &&
@@ -1021,14 +1087,30 @@ safe_remove() {
 
     # Validate path. Silent cleanup callers still need the same policy result,
     # but should not print one validation warning per skipped cache item.
-    # Real cleanup performs its recursive container-handle probe once, at the
-    # final sink below. Dry-run returns before that boundary, so it probes now.
-    if [[ "${MOLE_DRY_RUN:-0}" != "1" ]]; then
+    # Real cleanup performs its recursive container-handle probe once at the
+    # final sink below. A dry-run with no precomputed size likewise defers that
+    # one expensive probe until after sizing, where the preview recorder runs
+    # the complete eligibility pass. Pre-sized dry-runs probe here once.
+    local dry_run_sizes_before_preview=false
+    if [[ "${MOLE_DRY_RUN:-0}" == "1" &&
+        (! "$precomputed_size_kb" =~ ^[0-9]+$) ]] &&
+        declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
+        dry_run_sizes_before_preview=true
+    fi
+    if [[ "${MOLE_DRY_RUN:-0}" != "1" || "$dry_run_sizes_before_preview" == "true" ]]; then
         _MOLE_DEFER_CONTAINER_HANDLE_PROBE=true
     fi
+    local validation_rc=0
     if [[ "$silent" == "true" ]]; then
-        validate_path_for_deletion "$path" 2> /dev/null || return 1
-    elif ! validate_path_for_deletion "$path"; then
+        validate_path_for_deletion "$path" 2> /dev/null || validation_rc=$?
+    else
+        validate_path_for_deletion "$path" || validation_rc=$?
+    fi
+    if [[ $validation_rc -ne 0 ]]; then
+        if [[ $validation_rc -ge 128 ]]; then
+            _mole_record_clean_cancellation "$validation_rc"
+            return "$validation_rc"
+        fi
         return 1
     fi
     _MOLE_DEFER_CONTAINER_HANDLE_PROBE=false
@@ -1067,6 +1149,7 @@ safe_remove() {
             _mole_record_clean_cancellation "$dry_record_rc"
             return "$dry_record_rc"
         fi
+        [[ $dry_record_rc -eq 0 ]] || return "$dry_record_rc"
         if [[ "${MO_DEBUG:-}" == "1" ]]; then
             local file_type="file"
             [[ -d "$path" ]] && file_type="directory"
@@ -1160,11 +1243,20 @@ safe_remove() {
     # launch while du is walking the tree (same race class as the compiled
     # model cache check above).
     _mole_reset_process_snapshot
-    if _mole_should_refuse_live_user_cache_path "$path"; then
+    local live_cache_guard_rc=0
+    _mole_should_refuse_live_user_cache_path "$path" || live_cache_guard_rc=$?
+    if [[ $live_cache_guard_rc -eq 0 ]]; then
         debug_log "Skipped removal after live user cache appeared: $path"
         log_operation "${MOLE_CURRENT_COMMAND:-clean}" "SKIPPED" "$path" "live user cache"
         return 1
     fi
+    if [[ $live_cache_guard_rc -ge 128 ]]; then
+        _mole_record_clean_cancellation "$live_cache_guard_rc"
+        return "$live_cache_guard_rc"
+    fi
+    container_probe_parent="$_MOLE_CONTAINER_CACHE_PROBE_PARENT"
+    container_probe_parent_id="$_MOLE_CONTAINER_CACHE_PROBE_PARENT_ID"
+    container_probe_target_id="$_MOLE_CONTAINER_CACHE_PROBE_TARGET_ID"
 
     if [[ -n "$expected_parent" ]] && ! _mole_path_matches_identity \
         "$path" "$expected_parent" "$expected_parent_id" "$expected_target_id"; then
@@ -1193,6 +1285,14 @@ safe_remove() {
             fi
             return 1
         fi
+    fi
+
+    if [[ -n "$container_probe_parent" ]] && ! _mole_path_matches_identity \
+        "$path" "$container_probe_parent" "$container_probe_parent_id" \
+        "$container_probe_target_id"; then
+        debug_log "Refusing removal after container cache identity changed: $path"
+        log_operation "${MOLE_CURRENT_COMMAND:-clean}" "SKIPPED" "$path" "identity changed"
+        return 1
     fi
 
     # Perform the deletion
@@ -1974,14 +2074,26 @@ _mole_trash_target_still_safe() {
     local expected_target_id="${4:-}"
 
     _mole_reset_process_snapshot
-    if _mole_should_refuse_live_user_cache_path "$path"; then
+    local live_cache_guard_rc=0
+    _mole_should_refuse_live_user_cache_path "$path" || live_cache_guard_rc=$?
+    if [[ $live_cache_guard_rc -eq 0 ]]; then
         debug_log "Skipped Trash move after live user cache appeared: $path"
         log_operation "${MOLE_CURRENT_COMMAND:-uninstall}" "SKIPPED" "$path" "live user cache"
         return 1
     fi
+    if [[ $live_cache_guard_rc -ge 128 ]]; then
+        _mole_record_clean_cancellation "$live_cache_guard_rc"
+        return "$live_cache_guard_rc"
+    fi
 
-    _mole_bound_path_matches "$path" "$expected_parent" \
-        "$expected_parent_id" "$expected_target_id"
+    if [[ -n "$expected_parent" ]]; then
+        _mole_bound_path_matches "$path" "$expected_parent" \
+            "$expected_parent_id" "$expected_target_id"
+        return $?
+    fi
+    _mole_bound_path_matches "$path" "$_MOLE_CONTAINER_CACHE_PROBE_PARENT" \
+        "$_MOLE_CONTAINER_CACHE_PROBE_PARENT_ID" \
+        "$_MOLE_CONTAINER_CACHE_PROBE_TARGET_ID"
 }
 
 # Finder's Trash API can move package-installed app bundles that macOS App

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -733,7 +733,9 @@ EOF
 }
 
 @test "clean_app_caches skips expensive size scans for large sandboxed caches" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=true /bin/bash --noprofile --norc << 'EOF'
+    local large_home
+    large_home=$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-large-container.XXXXXX")
+    run env HOME="$large_home" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/user.sh"
@@ -745,24 +747,28 @@ safe_clean() { :; }
 should_protect_data() { return 1; }
 is_critical_system_component() { return 1; }
 get_path_size_kb() {
-    echo "SHOULD_NOT_SIZE_SCAN"
-    return 0
+    printf 'SIZE:%s\n' "$1" >> "$size_trace"
+    printf '7\n'
 }
+safe_remove() { return 0; }
 files_cleaned=0
 total_size_cleaned=0
 total_items=0
 
+size_trace="$HOME/size-trace"
 mkdir -p "$HOME/Library/Containers/com.example.large/Data/Library/Caches"
 for i in $(seq 1 101); do
     touch "$HOME/Library/Containers/com.example.large/Data/Library/Caches/file-$i.tmp"
 done
 
 clean_app_caches
+printf 'SIZE_CALLS=%s\n' "$(wc -l < "$size_trace" 2> /dev/null || printf '0')"
 EOF
 
+    rm -rf "$large_home"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Sandboxed app caches"* ]] || return 1
-    [[ "$output" != *"SHOULD_NOT_SIZE_SCAN"* ]]
+    [[ "$output" == *"SIZE_CALLS=0"* ]]
 }
 
 @test "clean_application_support_logs counts nested directory contents in dry-run size summary" {
@@ -1104,6 +1110,182 @@ EOF
     [[ "$output" == *"PREVIEW=$idle_target"* ]] || return 1
 }
 
+@test "clean_group_container_caches dry run omits compiled model cache parents (#1471)" {
+    local model_home
+    model_home=$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-model-group.XXXXXX")
+    local model_parent="$model_home/Library/Group Containers/TEAM.com.example.shared/Library/Caches/Vision"
+    local idle_target="$model_home/Library/Group Containers/TEAM.com.example.shared/Library/Caches/ZIdle"
+    run env HOME="$model_home" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
+        model_parent="$model_parent" idle_target="$idle_target" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+should_protect_data() { return 1; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+_mole_user_cache_owner_process_state() { return 1; }
+_mole_timeout_with_deadline() {
+    [[ ! -f "$exhausted_marker" ]] || return 1
+    printf '2\n'
+}
+lsof() {
+    case "$*" in
+        *"+D $model_parent"*)
+            touch "$exhausted_marker"
+            return 1
+            ;;
+        *"+D $idle_target"*) return 1 ;;
+        *) return 2 ;;
+    esac
+}
+run_with_timeout() { shift; "$@"; }
+get_path_size_kb() { printf '7\n'; }
+register_dry_run_cleanup_target() { printf 'REGISTER=%s\n' "$1"; }
+append_dry_run_cleanup_target() { printf 'APPEND=%s\n' "$1"; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+exhausted_marker="$HOME/compiled-probe-spent-budget"
+mkdir -p "$model_parent/com.apple.e5rt.e5bundlecache"
+mkdir -p "$idle_target"
+printf 'model\n' > "$model_parent/com.apple.e5rt.e5bundlecache/model.bin"
+printf 'idle\n' > "$idle_target/state.json"
+clean_group_container_caches
+printf 'FILES=%s SIZE=%s ITEMS=%s EXISTS=%s\n' \
+    "$files_cleaned" "$total_size_cleaned" "$total_items" \
+    "$(test -d "$model_parent" && echo yes || echo no)"
+EOF
+
+    rm -rf "$model_home"
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"FILES=1 SIZE=7 ITEMS=1 EXISTS=yes"* ]] || return 1
+    [[ "$output" != *"REGISTER=$model_parent"* ]] || return 1
+    [[ "$output" != *"APPEND=$model_parent"* ]] || return 1
+    [[ "$output" == *"REGISTER=$idle_target"* ]] || return 1
+    [[ "$output" == *"APPEND=$idle_target"* ]] || return 1
+    [[ "$output" == *"Group Containers logs/caches"* ]] || return 1
+}
+
+@test "explicit App Container cleanup families expose one cumulative probe deadline (#1471)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+bytes_to_human() { printf '0B\n'; }
+directory_has_entries() { return 1; }
+clean_support_app_data() { :; }
+safe_clean() {
+    case "${*: -1}" in
+        "Wallpaper agent cache" | "Microsoft Word container cache" | "UTM sandbox cache")
+            [[ -n "${_MOLE_CONTAINER_CACHE_PROBE_DEADLINE+x}" ]] || {
+                printf 'MISSING=%s\n' "${*: -1}"
+                return 99
+            }
+            if [[ -z "$_MOLE_CONTAINER_CACHE_PROBE_DEADLINE" ]]; then
+                _MOLE_CONTAINER_CACHE_PROBE_DEADLINE=4242
+            elif [[ "$_MOLE_CONTAINER_CACHE_PROBE_DEADLINE" != "4242" ]]; then
+                printf 'RESET=%s:%s\n' "${*: -1}" "$_MOLE_CONTAINER_CACHE_PROBE_DEADLINE"
+                return 99
+            fi
+            printf 'SCOPED=%s\n' "${*: -1}"
+            ;;
+    esac
+}
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+clean_app_caches
+clean_office_applications
+clean_utm_caches
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"SCOPED=Wallpaper agent cache"* ]] || return 1
+    [[ "$output" == *"SCOPED=Microsoft Word container cache"* ]] || return 1
+    [[ "$output" == *"SCOPED=UTM sandbox cache"* ]] || return 1
+    [[ "$output" != *"MISSING="* ]] || return 1
+    [[ "$output" != *"RESET="* ]] || return 1
+}
+
+@test "process_container_cache counts only items safe_remove actually removed (#1471)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+should_protect_data() { return 1; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+holds_compiled_model_cache() { return 1; }
+get_path_size_kb() { printf '7\n'; }
+safe_remove() { return 1; }
+
+container="$HOME/Library/Containers/com.example.Failed"
+target="$container/Data/Library/Caches/Live"
+mkdir -p "$target"
+printf 'live\n' > "$target/state.json"
+total_size=0
+total_size_partial=false
+cleaned_count=0
+found_any=false
+precise_size_limit=64
+precise_size_used=0
+process_container_cache "$container"
+printf 'FOUND=%s CLEANED=%s SIZE=%s EXISTS=%s\n' \
+    "$found_any" "$cleaned_count" "$total_size" \
+    "$(test -d "$target" && echo yes || echo no)"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"FOUND=false CLEANED=0 SIZE=0 EXISTS=yes"* ]] || return 1
+}
+
+@test "clean_group_container_caches does not report or count an all-refused large candidate (#1471)" {
+    local refused_home
+    refused_home=$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-refused-group.XXXXXX")
+    run env HOME="$refused_home" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+should_protect_data() { return 1; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+safe_remove() { return 1; }
+get_path_size_kb() { printf 'UNEXPECTED_SIZE\n'; return 99; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+candidate="$HOME/Library/Group Containers/group.com.example.refused/Library/Caches"
+mkdir -p "$candidate"
+for i in $(seq 1 101); do
+    printf 'live\n' > "$candidate/item-$i.jsonl"
+done
+clean_group_container_caches
+remaining=$(find "$candidate" -type f | wc -l | tr -d ' ')
+printf 'FILES=%s SIZE=%s ITEMS=%s REMAINING=%s\n' \
+    "$files_cleaned" "$total_size_cleaned" "$total_items" "$remaining"
+EOF
+
+    rm -rf "$refused_home"
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"FILES=0 SIZE=0 ITEMS=0 REMAINING=101"* ]] || return 1
+    [[ "$output" != *"Group Containers logs/caches"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_SIZE"* ]] || return 1
+}
+
 @test "clean_handoff_pasteboard_cache removes stale items and keeps fresh ones (#1178)" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
@@ -1238,6 +1420,9 @@ start_section_spinner() { :; }
 stop_section_spinner() { :; }
 bytes_to_human() { echo "0B"; }
 note_activity() { :; }
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { return 1; }
+run_with_timeout() { shift; "$@"; }
 files_cleaned=0
 total_size_cleaned=0
 total_items=0
@@ -1305,7 +1490,10 @@ EOF
 }
 
 @test "clean_group_container_caches does not report when only whitelisted items exist" {
-    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc << 'EOF'
+    local whitelist_home="$HOME/group-only-whitelisted"
+    mkdir -p "$whitelist_home"
+
+    run env HOME="$whitelist_home" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/clean/user.sh"

--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -1054,6 +1054,56 @@ EOF
 	[[ "$output" == *"REMOVE=$HOME/Library/Group Containers/group.com.example.tool/Library/Caches/cache.db SILENT=true SIZE=77"* ]] || return 1
 }
 
+@test "clean_group_container_caches dry run omits a live nested non-SQLite cache (#1471)" {
+    local live_target="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/ComputerUse"
+    local idle_target="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/IdleCache"
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=true \
+        live_target="$live_target" idle_target="$idle_target" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/user.sh"
+start_section_spinner() { :; }
+stop_section_spinner() { :; }
+note_activity() { :; }
+should_protect_data() { return 1; }
+should_protect_path() { return 1; }
+is_path_whitelisted() { return 1; }
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() {
+    printf '%s\n' "$*" >> "$lsof_trace"
+    case "$*" in
+        *"+D $live_target"*)
+            printf 'p901\nf5\nn%s\n' "$live_file"
+            return 0
+            ;;
+        *"+D $idle_target"*) return 1 ;;
+        *) return 2 ;;
+    esac
+}
+run_with_timeout() { shift; "$@"; }
+get_path_size_kb() { printf '77\n'; }
+record_dry_run_cleanup_target() { printf 'PREVIEW=%s\n' "$1"; }
+files_cleaned=0
+total_size_cleaned=0
+total_items=0
+
+live_file="$live_target/segments/current/events.jsonl"
+lsof_trace="$HOME/container-lsof-trace"
+mkdir -p "${live_file%/*}"
+mkdir -p "$idle_target"
+printf 'event\n' > "$live_file"
+printf 'idle\n' > "$idle_target/state.json"
+clean_group_container_caches
+test -f "$live_file" || exit 1
+grep -qF "+D $live_target" "$lsof_trace" || exit 1
+grep -qF "+D $idle_target" "$lsof_trace" || exit 1
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" != *"PREVIEW=$live_target"* ]] || return 1
+    [[ "$output" == *"PREVIEW=$idle_target"* ]] || return 1
+}
+
 @test "clean_handoff_pasteboard_cache removes stale items and keeps fresh ones (#1178)" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" DRY_RUN=false /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -442,7 +442,7 @@ EOF
     printf 'event\n' > "$cache_dir/segments/events.jsonl"
 
     local probe_rc
-    for probe_rc in 2 124 130; do
+    for probe_rc in 2 124; do
         run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" probe_rc="$probe_rc" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -500,6 +500,95 @@ validate_path_for_deletion "$cache_dir"
 EOF
     [ "$status" -eq 1 ] || return 1
     [[ "$output" != *"UNEXPECTED_"* ]] || return 1
+}
+
+@test "container cache probe accepts fractional cumulative timeout overrides (#1471)" {
+    local cache_dir="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/Fractional"
+    local lsof_trace="$HOME/fractional-lsof-trace"
+    mkdir -p "$cache_dir"
+    printf 'idle\n' > "$cache_dir/state.json"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" \
+        lsof_trace="$lsof_trace" MOLE_TIMEOUT_MEDIUM_PROBE_SEC=2.5 \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { printf 'call\n' >> "$lsof_trace"; return 1; }
+run_with_timeout() { shift; "$@"; }
+_MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
+validate_path_for_deletion "$cache_dir"
+printf 'DEADLINE=%s\n' "$_MOLE_CONTAINER_CACHE_PROBE_DEADLINE"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [ "$(wc -l < "$lsof_trace" | tr -d ' ')" -eq 1 ] || return 1
+    local deadline="${output##*DEADLINE=}"
+    [[ "$deadline" =~ ^[0-9]+$ ]] || return 1
+}
+
+@test "safe_remove preserves an interrupted container probe and stops later deletes (#1471)" {
+    local cache_root="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches"
+    local first="$cache_root/First"
+    local second="$cache_root/Second"
+    mkdir -p "$first" "$second"
+    printf 'first\n' > "$first/state.json"
+    printf 'second\n' > "$second/state.json"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" first="$first" second="$second" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof_trace=$(mktemp)
+lsof() { printf 'call\n' >> "$lsof_trace"; return 130; }
+run_with_timeout() { shift; "$@"; }
+rm() { printf 'UNEXPECTED_REMOVE:%s\n' "$*"; return 99; }
+MOLE_CURRENT_COMMAND=clean
+MOLE_CLEAN_CANCEL_STATUS=0
+first_rc=0
+safe_remove "$first" true 1 || first_rc=$?
+second_rc=0
+safe_remove "$second" true 1 || second_rc=$?
+lsof_calls=$(wc -l < "$lsof_trace" | tr -d ' ')
+command rm -f "$lsof_trace"
+printf 'FIRST_RC=%s SECOND_RC=%s CANCEL=%s LSOF=%s FIRST=%s SECOND=%s\n' \
+    "$first_rc" "$second_rc" "$MOLE_CLEAN_CANCEL_STATUS" "$lsof_calls" \
+    "$(test -d "$first" && echo yes || echo no)" \
+    "$(test -d "$second" && echo yes || echo no)"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"FIRST_RC=130 SECOND_RC=130 CANCEL=130 LSOF=1 FIRST=yes SECOND=yes"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+}
+
+@test "container cache probe refuses a path replaced during lsof (#1471)" {
+    local cache_dir="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/Race"
+    mkdir -p "$cache_dir"
+    printf 'old\n' > "$cache_dir/state.json"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() {
+    mv "$cache_dir" "$cache_dir-old"
+    mkdir -p "$cache_dir"
+    printf 'new-live\n' > "$cache_dir/events.jsonl"
+    return 1
+}
+run_with_timeout() { shift; "$@"; }
+remove_rc=0
+safe_remove "$cache_dir" true 1 || remove_rc=$?
+printf 'RC=%s NEW=%s OLD=%s\n' "$remove_rc" \
+    "$(test -f "$cache_dir/events.jsonl" && echo yes || echo no)" \
+    "$(test -f "$cache_dir-old/state.json" && echo yes || echo no)"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"RC=1 NEW=yes OLD=yes"* ]] || return 1
 }
 
 @test "validate_path_for_deletion allows a conclusively idle container cache (#1471)" {
@@ -588,15 +677,18 @@ _mole_user_cache_owner_process_state() { return 1; }
 lsof_calls=$(mktemp)
 rm_calls=$(mktemp)
 size_marker=$(mktemp)
+order_trace=$(mktemp)
 command rm -f "$size_marker"
 lsof() {
     printf 'call\n' >> "$lsof_calls"
+    printf 'LSOF\n' >> "$order_trace"
     [[ -f "$size_marker" ]] || return 2
     printf 'p901\nf5\nn%s/segments/events.jsonl\n' "$TARGET_DIR"
     return 0
 }
 run_with_timeout() { shift; "$@"; }
 get_path_size_kb() {
+    printf 'SIZE\n' >> "$order_trace"
     printf 'sized\n' > "$size_marker"
     printf '1\n'
 }
@@ -607,14 +699,15 @@ remove_rc=0
 safe_remove "$TARGET_DIR" true || remove_rc=$?
 lsof_call_count=$(wc -l < "$lsof_calls" | tr -d ' ')
 rm_call_count=$(wc -l < "$rm_calls" | tr -d ' ')
-command rm -f "$lsof_calls" "$rm_calls" "$size_marker"
-printf 'RC=%s LSOF_CALLS=%s EXISTS=%s RM_CALLS=%s\n' \
+order=$(tr '\n' ',' < "$order_trace")
+command rm -f "$lsof_calls" "$rm_calls" "$size_marker" "$order_trace"
+printf 'RC=%s LSOF_CALLS=%s EXISTS=%s RM_CALLS=%s ORDER=%s\n' \
     "$remove_rc" "$lsof_call_count" "$(test -d "$TARGET_DIR" && echo yes || echo no)" \
-    "$rm_call_count"
+    "$rm_call_count" "$order"
 EOF
 
     [ "$status" -eq 0 ] || return 1
-    [[ "$output" == *"RC=1 LSOF_CALLS=1 EXISTS=yes RM_CALLS=0"* ]] || return 1
+    [[ "$output" == *"RC=1 LSOF_CALLS=1 EXISTS=yes RM_CALLS=0 ORDER=SIZE,LSOF,"* ]] || return 1
 }
 
 @test "should_protect_path applies high-risk cleanup denylist" {
@@ -860,7 +953,42 @@ printf 'CALLS=%s EXISTS=%s\n' "$guard_calls" "$(test -d "$TARGET_DIR" && echo ye
 EOF
 
     [ "$status" -eq 0 ] || return 1
-	[[ "$output" == *"CALLS=2 EXISTS=yes"* ]] || return 1
+    [[ "$output" == *"CALLS=1 EXISTS=yes"* ]] || return 1
+}
+
+@test "safe_remove dry-run rechecks live cache state after sizing (#1471)" {
+    local target_dir="$TEST_DIR/cache-live-after-size"
+    mkdir -p "$target_dir"
+
+    run env PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$target_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/bin/clean.sh"
+state_file="$TARGET_DIR/.sized"
+trace_file="$TARGET_DIR/.trace"
+_mole_should_refuse_live_user_cache_path() {
+    [[ "${_MOLE_DEFER_CONTAINER_HANDLE_PROBE:-false}" == "true" ]] && return 1
+    printf 'GUARD:%s\n' "$(test -f "$state_file" && echo live || echo idle)" >> "$trace_file"
+    [[ -f "$state_file" ]]
+}
+get_path_size_kb() {
+    printf 'SIZE\n' >> "$trace_file"
+    touch "$state_file"
+    printf '7\n'
+}
+register_dry_run_cleanup_target() { printf 'UNEXPECTED_REGISTER:%s\n' "$1"; }
+append_dry_run_cleanup_target() { printf 'UNEXPECTED_APPEND:%s\n' "$1"; }
+MOLE_DRY_RUN=1 safe_remove "$TARGET_DIR" true && rc=0 || rc=$?
+printf 'RC=%s\n' "$rc"
+cat "$trace_file"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"RC=1"* ]] || return 1
+    [[ "$output" == *$'SIZE\nGUARD:live'* ]] || return 1
+    [[ "$(grep -c '^GUARD:' <<< "$output")" -eq 1 ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REGISTER"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_APPEND"* ]] || return 1
 }
 
 @test "safe_remove in silent mode suppresses error output" {
@@ -2468,32 +2596,26 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_FILE="$target_file" /bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
-ps_calls=$(mktemp)
+owner_calls=$(mktemp)
 rm_calls=$(mktemp)
-ps() {
-	printf 'call\n' >> "$ps_calls"
-	call_count=$(wc -l < "$ps_calls" | tr -d ' ')
-	if [[ $call_count -eq 1 ]]; then
-		cat <<'TABLE'
-  PID  PPID COMM             ARGS
-TABLE
-	else
-		cat <<'TABLE'
-  PID  PPID COMM             ARGS
-  901     1 /Applications/Example.app/Contents/MacOS/LateHelper /Applications/Example.app/Contents/MacOS/LateHelper com.example.LateHelper
-TABLE
-	fi
+owner_live="$TARGET_FILE.owner-live"
+_mole_user_cache_owner_process_state() {
+	printf 'call\n' >> "$owner_calls"
+	[[ -f "$owner_live" ]]
 }
 lsof() { return 1; }
-get_path_size_kb() { printf '1\n'; }
+get_path_size_kb() {
+	touch "$owner_live"
+	printf '1\n'
+}
 oplog_enabled() { return 0; }
 rm() { printf 'call\n' >> "$rm_calls"; return 99; }
 
 remove_rc=0
 safe_remove "$TARGET_FILE" true || remove_rc=$?
-call_count=$(wc -l < "$ps_calls" | tr -d ' ')
+call_count=$(wc -l < "$owner_calls" | tr -d ' ')
 rm_call_count=$(wc -l < "$rm_calls" | tr -d ' ')
-command rm -f "$ps_calls" "$rm_calls"
+command rm -f "$owner_calls" "$owner_live" "$rm_calls"
 printf 'RC=%s CALLS=%s EXISTS=%s RM_CALLS=%s\n' \
 	"$remove_rc" "$call_count" "$(test -f "$TARGET_FILE" && echo yes || echo no)" \
 	"$rm_call_count"

--- a/tests/core_safe_functions.bats
+++ b/tests/core_safe_functions.bats
@@ -411,6 +411,212 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "validate_path_for_deletion refuses open descendants in app and group container caches (#1471)" {
+    local app_cache="$HOME/Library/Containers/com.example.Editor/Data/Library/Caches/LiveState"
+    local group_cache="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/History"
+    mkdir -p "$app_cache/nested" "$group_cache/segments/current"
+    printf 'state\n' > "$app_cache/nested/session.json"
+    printf 'event\n' > "$group_cache/segments/current/events.jsonl"
+
+    local path
+    for path in "$app_cache" "$group_cache"; do
+        run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" path="$path" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() {
+    [[ "$*" == *"+D $path"* ]] || return 2
+    printf 'p901\nf5\nn%s/nested/open.jsonl\n' "$path"
+    return 0
+}
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$path"
+EOF
+        [ "$status" -eq 1 ] || return 1
+    done
+}
+
+@test "container cache handle probe is bounded and fails closed on uncertain results (#1471)" {
+    local cache_dir="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/History"
+    mkdir -p "$cache_dir/segments"
+    printf 'event\n' > "$cache_dir/segments/events.jsonl"
+
+    local probe_rc
+    for probe_rc in 2 124 130; do
+        run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" probe_rc="$probe_rc" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { return "$probe_rc"; }
+run_with_timeout() {
+    [[ "$1" == "$MOLE_TIMEOUT_QUICK_DETECT_SEC" ]] || return 99
+    shift
+    "$@"
+}
+validate_path_for_deletion "$cache_dir"
+EOF
+        [ "$status" -eq 1 ] || return 1
+    done
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+PATH=/bin
+validate_path_for_deletion "$cache_dir"
+EOF
+    [ "$status" -eq 1 ] || return 1
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+unset -f run_with_timeout
+validate_path_for_deletion "$cache_dir"
+EOF
+    [ "$status" -eq 1 ] || return 1
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() {
+    printf 'lsof: WARNING: cannot stat a descendant\n' >&2
+    return 1
+}
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$cache_dir"
+EOF
+    [ "$status" -eq 1 ] || return 1
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { printf 'UNEXPECTED_LSOF\n'; return 0; }
+run_with_timeout() { printf 'UNEXPECTED_TIMEOUT\n'; return 0; }
+_MOLE_CONTAINER_CACHE_PROBE_DEADLINE=$SECONDS
+validate_path_for_deletion "$cache_dir"
+EOF
+    [ "$status" -eq 1 ] || return 1
+    [[ "$output" != *"UNEXPECTED_"* ]] || return 1
+}
+
+@test "validate_path_for_deletion allows a conclusively idle container cache (#1471)" {
+    local cache_dir="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/Idle"
+    mkdir -p "$cache_dir"
+    printf 'idle\n' > "$cache_dir/state.json"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof() { return 1; }
+run_with_timeout() { shift; "$@"; }
+validate_path_for_deletion "$cache_dir"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+}
+
+@test "container cache probe budget stops later recursive lsof calls fail closed (#1471)" {
+    local cache_root="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches"
+    mkdir -p "$cache_root/First" "$cache_root/Second" "$cache_root/Third"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_root="$cache_root" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+timeout_calls=$(mktemp)
+lsof_calls=$(mktemp)
+_mole_timeout_with_deadline() {
+    printf 'call\n' >> "$timeout_calls"
+    call_count=$(wc -l < "$timeout_calls" | tr -d ' ')
+    [[ $call_count -eq 1 ]] || return 124
+    printf '2\n'
+}
+lsof() {
+    printf 'call\n' >> "$lsof_calls"
+    return 1
+}
+run_with_timeout() { shift; "$@"; }
+_MOLE_CONTAINER_CACHE_PROBE_DEADLINE=""
+
+states=""
+for item in "$cache_root/First" "$cache_root/Second" "$cache_root/Third"; do
+    state=0
+    validate_path_for_deletion "$item" || state=$?
+    states="${states}${state}"
+done
+lsof_count=$(wc -l < "$lsof_calls" | tr -d ' ')
+command rm -f "$timeout_calls" "$lsof_calls"
+printf 'STATES=%s LSOF_CALLS=%s\n' "$states" "$lsof_count"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"STATES=011 LSOF_CALLS=1"* ]] || return 1
+}
+
+@test "container cache guard detects a real open descendant through bounded lsof (#1471)" {
+    command -v lsof > /dev/null 2>&1 || skip "lsof is unavailable"
+    local cache_dir="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/RealHandle"
+    local live_file="$cache_dir/segments/events.jsonl"
+    mkdir -p "${live_file%/*}"
+    printf 'event\n' > "$live_file"
+
+    exec 9> "$live_file"
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" cache_dir="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+validate_path_for_deletion "$cache_dir"
+EOF
+    exec 9>&-
+
+    [ "$status" -eq 1 ] || return 1
+}
+
+@test "safe_remove rechecks container handles at the final deletion boundary (#1471)" {
+    local cache_dir="$HOME/Library/Group Containers/TEAM.com.example.shared/Library/Caches/History"
+    mkdir -p "$cache_dir/segments"
+    printf 'event\n' > "$cache_dir/segments/events.jsonl"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" TARGET_DIR="$cache_dir" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_user_cache_owner_process_state() { return 1; }
+lsof_calls=$(mktemp)
+rm_calls=$(mktemp)
+size_marker=$(mktemp)
+command rm -f "$size_marker"
+lsof() {
+    printf 'call\n' >> "$lsof_calls"
+    [[ -f "$size_marker" ]] || return 2
+    printf 'p901\nf5\nn%s/segments/events.jsonl\n' "$TARGET_DIR"
+    return 0
+}
+run_with_timeout() { shift; "$@"; }
+get_path_size_kb() {
+    printf 'sized\n' > "$size_marker"
+    printf '1\n'
+}
+oplog_enabled() { return 0; }
+rm() { printf 'call\n' >> "$rm_calls"; return 99; }
+
+remove_rc=0
+safe_remove "$TARGET_DIR" true || remove_rc=$?
+lsof_call_count=$(wc -l < "$lsof_calls" | tr -d ' ')
+rm_call_count=$(wc -l < "$rm_calls" | tr -d ' ')
+command rm -f "$lsof_calls" "$rm_calls" "$size_marker"
+printf 'RC=%s LSOF_CALLS=%s EXISTS=%s RM_CALLS=%s\n' \
+    "$remove_rc" "$lsof_call_count" "$(test -d "$TARGET_DIR" && echo yes || echo no)" \
+    "$rm_call_count"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"RC=1 LSOF_CALLS=1 EXISTS=yes RM_CALLS=0"* ]] || return 1
+}
+
 @test "should_protect_path applies high-risk cleanup denylist" {
     run /bin/bash -c "
         source '$PROJECT_ROOT/lib/core/common.sh'


### PR DESCRIPTION
## Summary

- preserve App Container and Group Container cache trees while their owner or a descendant still has an open handle
- apply the same validation to dry-run previews and the final `safe_remove` sink
- fail closed when `lsof` is unavailable, times out, is interrupted, or returns diagnostics that cannot prove the tree idle

Fixes #1471.

## Scope and behavior

The guard only recognizes these cache shapes:

- `~/Library/Caches/<reverse-DNS>/...`
- `~/Library/Containers/<bundle>/Data/Library/Caches/...`
- `~/Library/Group Containers/<id>/Caches/...`
- `~/Library/Group Containers/<id>/Library/Caches/...`

For a candidate path it checks both the owning container process and open handles below the cache tree. Exact files use an exact `lsof` probe; directories use a bounded descendant probe. A clean current snapshot may proceed, while live or unknown results are preserved.

App Container and Group Container probes each share a five-second cumulative budget. Once a budget is exhausted, remaining candidates fail closed without spawning more probes. The real removal path revalidates once at the final sink so callers cannot accidentally bypass the guard.

## Safety tradeoff

`lsof` provides a point-in-time snapshot rather than an ownership lease, so a process could reopen the path in the short interval after a successful probe. Renaming the tree into quarantine would not close that race safely: moving a live cache path can itself disrupt the owner, and the original name cannot be restored without risking overwrite if the application recreates it. This change therefore keeps the residual interval small, documents it, and fails closed for every indeterminate probe result.

## Validation

- `tests/core_safe_functions.bats`: 186/186 passed
- `tests/clean_user_core.bats`: 183/183 passed
- `./scripts/check.sh --format`
- ShellCheck and Bash syntax checks
- real macOS `lsof +D` verification for both an idle directory and an open descendant

## Contribution value

- Real-value KPI: prevents destructive cleanup of cache trees actively used by real applications, including dry-run parity for operator trust.
- Community-quality KPI: narrowly scoped roots, fail-closed uncertainty, bounded runtime, and regression coverage keep the maintenance and review cost proportional to the safety gain.
