### PR TITLE
fix(status): surface zombie processes and parent owners

### DIFF
--- a/cmd/status/main_test.go
+++ b/cmd/status/main_test.go
@@ -421,6 +421,8 @@ func TestMetricsSnapshotFieldsHaveCollectionClassifications(t *testing.T) {
 		"Sensors":        "enrichment",
 		"Bluetooth":      "enrichment",
 		"TopProcesses":   "live-or-enrichment",
+		"ZombieCount":    "live-or-enrichment",
+		"ZombieParents":  "live-or-enrichment",
 		"ProcessWatch":   "config",
 		"ProcessAlerts":  "live-or-enrichment",
 	}

--- a/cmd/status/main_test.go
+++ b/cmd/status/main_test.go
@@ -228,6 +228,8 @@ func TestProcessCollectionUpdatesProcessFreshness(t *testing.T) {
 }
 
 func TestCollectorAppliesCachedEnrichmentToFastSnapshot(t *testing.T) {
+	zeroZombies := 0
+	parentsComplete := true
 	previous := MetricsSnapshot{
 		CPU:         CPUStatus{PCoreCount: 8, ECoreCount: 4},
 		Memory:      MemoryStatus{Cached: 512, Pressure: "warn"},
@@ -243,6 +245,8 @@ func TestCollectorAppliesCachedEnrichmentToFastSnapshot(t *testing.T) {
 		TopProcesses: []ProcessInfo{
 			{PID: 42, Name: "Xcode", CPU: 82},
 		},
+		ZombieCount:           &zeroZombies,
+		ZombieParentsComplete: &parentsComplete,
 		ProcessAlerts: []ProcessAlert{
 			{PID: 42, Name: "Xcode", CPU: 140, Status: "active"},
 		},
@@ -250,6 +254,7 @@ func TestCollectorAppliesCachedEnrichmentToFastSnapshot(t *testing.T) {
 
 	collector := NewCollector(ProcessWatchOptions{})
 	collector.cacheEnrichment(previous)
+	collector.cacheProcessEnrichment(previous)
 	previous.GPU[0].Name = "mutated"
 
 	next := MetricsSnapshot{
@@ -371,8 +376,12 @@ func TestCollectorKeepsFastDisksWhenCacheHasNone(t *testing.T) {
 
 func TestCollectorKeepsLiveProcessDataWhenApplyingEnrichment(t *testing.T) {
 	collector := NewCollector(ProcessWatchOptions{})
-	collector.cacheEnrichment(MetricsSnapshot{
-		TopProcesses: []ProcessInfo{{PID: 1, Name: "old", CPU: 10}},
+	zeroZombies := 0
+	parentsComplete := true
+	collector.cacheProcessEnrichment(MetricsSnapshot{
+		TopProcesses:          []ProcessInfo{{PID: 1, Name: "old", CPU: 10}},
+		ZombieCount:           &zeroZombies,
+		ZombieParentsComplete: &parentsComplete,
 		ProcessAlerts: []ProcessAlert{
 			{PID: 1, Name: "old", Status: "active"},
 		},
@@ -397,34 +406,35 @@ func TestCollectorKeepsLiveProcessDataWhenApplyingEnrichment(t *testing.T) {
 
 func TestMetricsSnapshotFieldsHaveCollectionClassifications(t *testing.T) {
 	classified := map[string]string{
-		"CollectedAt":    "fast",
-		"Host":           "fast",
-		"Platform":       "fast",
-		"Uptime":         "fast",
-		"UptimeSeconds":  "fast",
-		"Procs":          "fast",
-		"Hardware":       "enrichment",
-		"HealthScore":    "recomputed",
-		"HealthScoreMsg": "recomputed",
-		"CPU":            "mixed",
-		"GPU":            "enrichment",
-		"Memory":         "mixed",
-		"Disks":          "enrichment",
-		"TrashSize":      "enrichment",
-		"TrashApprox":    "enrichment",
-		"DiskIO":         "fast",
-		"Network":        "fast",
-		"NetworkHistory": "fast",
-		"Proxy":          "enrichment",
-		"Batteries":      "enrichment",
-		"Thermal":        "enrichment",
-		"Sensors":        "enrichment",
-		"Bluetooth":      "enrichment",
-		"TopProcesses":   "live-or-enrichment",
-		"ZombieCount":    "live-or-enrichment",
-		"ZombieParents":  "live-or-enrichment",
-		"ProcessWatch":   "config",
-		"ProcessAlerts":  "live-or-enrichment",
+		"CollectedAt":           "fast",
+		"Host":                  "fast",
+		"Platform":              "fast",
+		"Uptime":                "fast",
+		"UptimeSeconds":         "fast",
+		"Procs":                 "fast",
+		"Hardware":              "enrichment",
+		"HealthScore":           "recomputed",
+		"HealthScoreMsg":        "recomputed",
+		"CPU":                   "mixed",
+		"GPU":                   "enrichment",
+		"Memory":                "mixed",
+		"Disks":                 "enrichment",
+		"TrashSize":             "enrichment",
+		"TrashApprox":           "enrichment",
+		"DiskIO":                "fast",
+		"Network":               "fast",
+		"NetworkHistory":        "fast",
+		"Proxy":                 "enrichment",
+		"Batteries":             "enrichment",
+		"Thermal":               "enrichment",
+		"Sensors":               "enrichment",
+		"Bluetooth":             "enrichment",
+		"TopProcesses":          "live-or-enrichment",
+		"ZombieCount":           "live-or-enrichment",
+		"ZombieParents":         "live-or-enrichment",
+		"ZombieParentsComplete": "live-or-enrichment",
+		"ProcessWatch":          "config",
+		"ProcessAlerts":         "live-or-enrichment",
 	}
 
 	typ := reflect.TypeFor[MetricsSnapshot]()

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -70,25 +70,26 @@ type MetricsSnapshot struct {
 	HealthScore    int          `json:"health_score"`     // 0-100 system health score
 	HealthScoreMsg string       `json:"health_score_msg"` // Brief explanation
 
-	CPU            CPUStatus          `json:"cpu"`
-	GPU            []GPUStatus        `json:"gpu"`
-	Memory         MemoryStatus       `json:"memory"`
-	Disks          []DiskStatus       `json:"disks"`
-	TrashSize      uint64             `json:"trash_size"`
-	TrashApprox    bool               `json:"trash_approx"`
-	DiskIO         DiskIOStatus       `json:"disk_io"`
-	Network        []NetworkStatus    `json:"network"`
-	NetworkHistory NetworkHistory     `json:"network_history"`
-	Proxy          ProxyStatus        `json:"proxy"`
-	Batteries      []BatteryStatus    `json:"batteries"`
-	Thermal        ThermalStatus      `json:"thermal"`
-	Sensors        []SensorReading    `json:"sensors"`
-	Bluetooth      []BluetoothDevice  `json:"bluetooth"`
-	TopProcesses   []ProcessInfo      `json:"top_processes"`
-	ZombieCount    *int               `json:"zombie_count,omitempty"`
-	ZombieParents  []ZombieParent     `json:"zombie_parents"`
-	ProcessWatch   ProcessWatchConfig `json:"process_watch"`
-	ProcessAlerts  []ProcessAlert     `json:"process_alerts"`
+	CPU                   CPUStatus          `json:"cpu"`
+	GPU                   []GPUStatus        `json:"gpu"`
+	Memory                MemoryStatus       `json:"memory"`
+	Disks                 []DiskStatus       `json:"disks"`
+	TrashSize             uint64             `json:"trash_size"`
+	TrashApprox           bool               `json:"trash_approx"`
+	DiskIO                DiskIOStatus       `json:"disk_io"`
+	Network               []NetworkStatus    `json:"network"`
+	NetworkHistory        NetworkHistory     `json:"network_history"`
+	Proxy                 ProxyStatus        `json:"proxy"`
+	Batteries             []BatteryStatus    `json:"batteries"`
+	Thermal               ThermalStatus      `json:"thermal"`
+	Sensors               []SensorReading    `json:"sensors"`
+	Bluetooth             []BluetoothDevice  `json:"bluetooth"`
+	TopProcesses          []ProcessInfo      `json:"top_processes"`
+	ZombieCount           *int               `json:"zombie_count,omitempty"`
+	ZombieParents         []ZombieParent     `json:"zombie_parents"`
+	ZombieParentsComplete *bool              `json:"zombie_parents_complete,omitempty"`
+	ProcessWatch          ProcessWatchConfig `json:"process_watch"`
+	ProcessAlerts         []ProcessAlert     `json:"process_alerts"`
 }
 
 type HardwareInfo struct {
@@ -252,29 +253,32 @@ type Collector struct {
 	prevDiskIO     disk.IOCountersStat
 	lastDiskAt     time.Time
 
-	watchMu        sync.Mutex
-	processWatch   ProcessWatchConfig
-	processWatcher *ProcessWatcher
-	enrichment     snapshotEnrichment
-	hasEnrichment  bool
+	watchMu           sync.Mutex
+	processWatch      ProcessWatchConfig
+	processWatcher    *ProcessWatcher
+	enrichment        snapshotEnrichment
+	hasEnrichment     bool
+	processEnrichment processEnrichment
+	hasProcessData    bool
 }
 
 type collectedMetrics struct {
-	cpuStats     CPUStatus
-	memStats     MemoryStatus
-	diskStats    []DiskStatus
-	trashSize    uint64
-	trashApprox  bool
-	diskIO       DiskIOStatus
-	netStats     []NetworkStatus
-	proxyStats   ProxyStatus
-	batteryStats []BatteryStatus
-	thermalStats ThermalStatus
-	sensorStats  []SensorReading
-	gpuStats     []GPUStatus
-	btStats      []BluetoothDevice
-	allProcs     []ProcessInfo
-	hasProcesses bool
+	cpuStats                CPUStatus
+	memStats                MemoryStatus
+	diskStats               []DiskStatus
+	trashSize               uint64
+	trashApprox             bool
+	diskIO                  DiskIOStatus
+	netStats                []NetworkStatus
+	proxyStats              ProxyStatus
+	batteryStats            []BatteryStatus
+	thermalStats            ThermalStatus
+	sensorStats             []SensorReading
+	gpuStats                []GPUStatus
+	btStats                 []BluetoothDevice
+	allProcs                []ProcessInfo
+	hasProcesses            bool
+	processParentsAvailable bool
 }
 
 type snapshotEnrichment struct {
@@ -295,11 +299,14 @@ type snapshotEnrichment struct {
 	thermal        ThermalStatus
 	sensors        []SensorReading
 	bluetooth      []BluetoothDevice
-	topProcesses   []ProcessInfo
-	zombieCount    int
-	hasZombieCount bool
-	zombieParents  []ZombieParent
-	processAlerts  []ProcessAlert
+}
+
+type processEnrichment struct {
+	topProcesses          []ProcessInfo
+	zombieCount           int
+	zombieParents         []ZombieParent
+	zombieParentsComplete bool
+	processAlerts         []ProcessAlert
 }
 
 func NewCollector(options ProcessWatchOptions) *Collector {
@@ -388,6 +395,9 @@ func (c *Collector) collectFast(includeProcesses bool) (MetricsSnapshot, error) 
 
 	snapshot := c.snapshotFromMetrics(now, hostInfo, collected, false)
 	c.applyEnrichment(&snapshot, collected.hasProcesses)
+	if collected.hasProcesses {
+		c.cacheProcessEnrichment(snapshot)
+	}
 	return snapshot, mergeErr
 }
 
@@ -437,6 +447,9 @@ func (c *Collector) collectFull() (MetricsSnapshot, error) {
 	mergeErr := collectConcurrently(tasks...)
 
 	snapshot := c.snapshotFromMetrics(now, hostInfo, collected, true)
+	if collected.hasProcesses {
+		c.cacheProcessEnrichment(snapshot)
+	}
 	if mergeErr == nil {
 		c.cacheEnrichment(snapshot)
 	}
@@ -444,12 +457,13 @@ func (c *Collector) collectFull() (MetricsSnapshot, error) {
 }
 
 func collectProcessesInto(collected *collectedMetrics) error {
-	procs, err := collectProcessesFunc()
+	sample, err := collectProcessesFunc()
 	if err != nil {
 		return err
 	}
-	collected.allProcs = procs
+	collected.allProcs = sample.processes
 	collected.hasProcesses = true
+	collected.processParentsAvailable = sample.parentsAvailable
 	return nil
 }
 
@@ -475,11 +489,17 @@ func (c *Collector) snapshotFromMetrics(now time.Time, hostInfo *host.InfoStat, 
 	var topProcs []ProcessInfo
 	var zombieCount *int
 	var zombieParents []ZombieParent
+	var zombieParentsComplete *bool
 	if collected.hasProcesses {
 		topProcs = topProcesses(collected.allProcs, 5)
-		count, parents := summarizeZombies(collected.allProcs, zombieParentLimit)
+		count, parents, complete := summarizeZombies(
+			collected.allProcs,
+			zombieParentLimit,
+			collected.processParentsAvailable,
+		)
 		zombieCount = &count
 		zombieParents = parents
+		zombieParentsComplete = &complete
 	}
 
 	var processAlerts []ProcessAlert
@@ -515,16 +535,17 @@ func (c *Collector) snapshotFromMetrics(now time.Time, hostInfo *host.InfoStat, 
 			RxHistory: c.rxHistoryBuf.Slice(),
 			TxHistory: c.txHistoryBuf.Slice(),
 		},
-		Proxy:         collected.proxyStats,
-		Batteries:     collected.batteryStats,
-		Thermal:       collected.thermalStats,
-		Sensors:       collected.sensorStats,
-		Bluetooth:     collected.btStats,
-		TopProcesses:  topProcs,
-		ZombieCount:   zombieCount,
-		ZombieParents: zombieParents,
-		ProcessWatch:  c.processWatch,
-		ProcessAlerts: processAlerts,
+		Proxy:                 collected.proxyStats,
+		Batteries:             collected.batteryStats,
+		Thermal:               collected.thermalStats,
+		Sensors:               collected.sensorStats,
+		Bluetooth:             collected.btStats,
+		TopProcesses:          topProcs,
+		ZombieCount:           zombieCount,
+		ZombieParents:         zombieParents,
+		ZombieParentsComplete: zombieParentsComplete,
+		ProcessWatch:          c.processWatch,
+		ProcessAlerts:         processAlerts,
 	}
 }
 
@@ -552,39 +573,51 @@ func (c *Collector) cacheEnrichment(snapshot MetricsSnapshot) {
 		thermal:        snapshot.Thermal,
 		sensors:        slices.Clone(snapshot.Sensors),
 		bluetooth:      slices.Clone(snapshot.Bluetooth),
-		topProcesses:   slices.Clone(snapshot.TopProcesses),
-		processAlerts:  slices.Clone(snapshot.ProcessAlerts),
-	}
-	if snapshot.ZombieCount != nil {
-		next.zombieCount = *snapshot.ZombieCount
-		next.hasZombieCount = true
-		next.zombieParents = slices.Clone(snapshot.ZombieParents)
-	} else if c.hasEnrichment && c.enrichment.hasZombieCount {
-		next.zombieCount = c.enrichment.zombieCount
-		next.hasZombieCount = true
-		next.zombieParents = slices.Clone(c.enrichment.zombieParents)
 	}
 	c.enrichment = next
 	c.hasEnrichment = true
 }
 
-func (c *Collector) applyEnrichment(snapshot *MetricsSnapshot, preserveLiveProcesses bool) {
-	if snapshot == nil || !c.hasEnrichment {
+func (c *Collector) cacheProcessEnrichment(snapshot MetricsSnapshot) {
+	if snapshot.ZombieCount == nil {
 		return
 	}
-	c.enrichment.apply(snapshot, preserveLiveProcesses)
-	snapshot.HealthScore, snapshot.HealthScoreMsg = calculateHealthScore(
-		snapshot.CPU,
-		snapshot.Memory,
-		snapshot.Disks,
-		snapshot.DiskIO,
-		snapshot.Thermal,
-		snapshot.Batteries,
-		snapshot.UptimeSeconds,
-	)
+	complete := false
+	if snapshot.ZombieParentsComplete != nil {
+		complete = *snapshot.ZombieParentsComplete
+	}
+	c.processEnrichment = processEnrichment{
+		topProcesses:          slices.Clone(snapshot.TopProcesses),
+		zombieCount:           *snapshot.ZombieCount,
+		zombieParents:         slices.Clone(snapshot.ZombieParents),
+		zombieParentsComplete: complete,
+		processAlerts:         slices.Clone(snapshot.ProcessAlerts),
+	}
+	c.hasProcessData = true
 }
 
-func (e snapshotEnrichment) apply(snapshot *MetricsSnapshot, preserveLiveProcesses bool) {
+func (c *Collector) applyEnrichment(snapshot *MetricsSnapshot, preserveLiveProcesses bool) {
+	if snapshot == nil {
+		return
+	}
+	if c.hasEnrichment {
+		c.enrichment.apply(snapshot)
+		snapshot.HealthScore, snapshot.HealthScoreMsg = calculateHealthScore(
+			snapshot.CPU,
+			snapshot.Memory,
+			snapshot.Disks,
+			snapshot.DiskIO,
+			snapshot.Thermal,
+			snapshot.Batteries,
+			snapshot.UptimeSeconds,
+		)
+	}
+	if !preserveLiveProcesses && c.hasProcessData {
+		c.processEnrichment.apply(snapshot)
+	}
+}
+
+func (e snapshotEnrichment) apply(snapshot *MetricsSnapshot) {
 	snapshot.Hardware = e.hardware
 	snapshot.CPU.PCoreCount = e.cpuPCores
 	snapshot.CPU.ECoreCount = e.cpuECores
@@ -606,19 +639,16 @@ func (e snapshotEnrichment) apply(snapshot *MetricsSnapshot, preserveLiveProcess
 	snapshot.Thermal = e.thermal
 	snapshot.Sensors = slices.Clone(e.sensors)
 	snapshot.Bluetooth = slices.Clone(e.bluetooth)
-	if !preserveLiveProcesses {
-		snapshot.TopProcesses = slices.Clone(e.topProcesses)
-		// Reuse the most recent process sample on fast paints, on the same cadence
-		// as TopProcesses. Before the first successful process sample the pointer
-		// remains nil, so JSON consumers can distinguish unknown from measured zero.
-		snapshot.ZombieCount = nil
-		if e.hasZombieCount {
-			count := e.zombieCount
-			snapshot.ZombieCount = &count
-		}
-		snapshot.ZombieParents = slices.Clone(e.zombieParents)
-		snapshot.ProcessAlerts = slices.Clone(e.processAlerts)
-	}
+}
+
+func (e processEnrichment) apply(snapshot *MetricsSnapshot) {
+	snapshot.TopProcesses = slices.Clone(e.topProcesses)
+	count := e.zombieCount
+	complete := e.zombieParentsComplete
+	snapshot.ZombieCount = &count
+	snapshot.ZombieParents = slices.Clone(e.zombieParents)
+	snapshot.ZombieParentsComplete = &complete
+	snapshot.ProcessAlerts = slices.Clone(e.processAlerts)
 }
 
 var runCmd = func(ctx context.Context, name string, args ...string) (string, error) {

--- a/cmd/status/metrics.go
+++ b/cmd/status/metrics.go
@@ -85,6 +85,8 @@ type MetricsSnapshot struct {
 	Sensors        []SensorReading    `json:"sensors"`
 	Bluetooth      []BluetoothDevice  `json:"bluetooth"`
 	TopProcesses   []ProcessInfo      `json:"top_processes"`
+	ZombieCount    *int               `json:"zombie_count,omitempty"`
+	ZombieParents  []ZombieParent     `json:"zombie_parents"`
 	ProcessWatch   ProcessWatchConfig `json:"process_watch"`
 	ProcessAlerts  []ProcessAlert     `json:"process_alerts"`
 }
@@ -106,11 +108,18 @@ type DiskIOStatus struct {
 type ProcessInfo struct {
 	PID         int     `json:"pid"`
 	PPID        int     `json:"ppid"`
+	State       string  `json:"-"`
 	Name        string  `json:"name"`
 	Command     string  `json:"command"`
 	CPU         float64 `json:"cpu"`
 	Memory      float64 `json:"memory"` // Percent of physical memory, kept for compatibility.
 	MemoryBytes uint64  `json:"memory_bytes,omitempty"`
+}
+
+type ZombieParent struct {
+	PID   int    `json:"pid"`
+	Name  string `json:"name"`
+	Count int    `json:"count"`
 }
 
 type CPUStatus struct {
@@ -287,6 +296,9 @@ type snapshotEnrichment struct {
 	sensors        []SensorReading
 	bluetooth      []BluetoothDevice
 	topProcesses   []ProcessInfo
+	zombieCount    int
+	hasZombieCount bool
+	zombieParents  []ZombieParent
 	processAlerts  []ProcessAlert
 }
 
@@ -461,8 +473,13 @@ func (c *Collector) snapshotFromMetrics(now time.Time, hostInfo *host.InfoStat, 
 		hostInfo.Uptime,
 	)
 	var topProcs []ProcessInfo
+	var zombieCount *int
+	var zombieParents []ZombieParent
 	if collected.hasProcesses {
 		topProcs = topProcesses(collected.allProcs, 5)
+		count, parents := summarizeZombies(collected.allProcs, zombieParentLimit)
+		zombieCount = &count
+		zombieParents = parents
 	}
 
 	var processAlerts []ProcessAlert
@@ -504,6 +521,8 @@ func (c *Collector) snapshotFromMetrics(now time.Time, hostInfo *host.InfoStat, 
 		Sensors:       collected.sensorStats,
 		Bluetooth:     collected.btStats,
 		TopProcesses:  topProcs,
+		ZombieCount:   zombieCount,
+		ZombieParents: zombieParents,
 		ProcessWatch:  c.processWatch,
 		ProcessAlerts: processAlerts,
 	}
@@ -517,7 +536,7 @@ func (c *Collector) hardwareForSnapshot() HardwareInfo {
 }
 
 func (c *Collector) cacheEnrichment(snapshot MetricsSnapshot) {
-	c.enrichment = snapshotEnrichment{
+	next := snapshotEnrichment{
 		hardware:       snapshot.Hardware,
 		cpuPCores:      snapshot.CPU.PCoreCount,
 		cpuECores:      snapshot.CPU.ECoreCount,
@@ -536,6 +555,16 @@ func (c *Collector) cacheEnrichment(snapshot MetricsSnapshot) {
 		topProcesses:   slices.Clone(snapshot.TopProcesses),
 		processAlerts:  slices.Clone(snapshot.ProcessAlerts),
 	}
+	if snapshot.ZombieCount != nil {
+		next.zombieCount = *snapshot.ZombieCount
+		next.hasZombieCount = true
+		next.zombieParents = slices.Clone(snapshot.ZombieParents)
+	} else if c.hasEnrichment && c.enrichment.hasZombieCount {
+		next.zombieCount = c.enrichment.zombieCount
+		next.hasZombieCount = true
+		next.zombieParents = slices.Clone(c.enrichment.zombieParents)
+	}
+	c.enrichment = next
 	c.hasEnrichment = true
 }
 
@@ -579,6 +608,15 @@ func (e snapshotEnrichment) apply(snapshot *MetricsSnapshot, preserveLiveProcess
 	snapshot.Bluetooth = slices.Clone(e.bluetooth)
 	if !preserveLiveProcesses {
 		snapshot.TopProcesses = slices.Clone(e.topProcesses)
+		// Reuse the most recent process sample on fast paints, on the same cadence
+		// as TopProcesses. Before the first successful process sample the pointer
+		// remains nil, so JSON consumers can distinguish unknown from measured zero.
+		snapshot.ZombieCount = nil
+		if e.hasZombieCount {
+			count := e.zombieCount
+			snapshot.ZombieCount = &count
+		}
+		snapshot.ZombieParents = slices.Clone(e.zombieParents)
 		snapshot.ProcessAlerts = slices.Clone(e.processAlerts)
 	}
 }

--- a/cmd/status/metrics_fast_test.go
+++ b/cmd/status/metrics_fast_test.go
@@ -94,15 +94,21 @@ func TestCollectProcessesKeepsLiveProcessesWithCachedEnrichment(t *testing.T) {
 	collectProcessesFunc = func() ([]ProcessInfo, error) {
 		return []ProcessInfo{
 			{PID: 200, PPID: 1, Name: "new-hot-process", Command: "/usr/bin/new-hot-process", CPU: 240, Memory: 1.5},
+			{PID: 201, PPID: 200, State: "Z+", Name: "defunct-child", Command: "defunct-child"},
 		}, nil
 	}
 
 	collector := NewCollector(ProcessWatchOptions{Enabled: true, CPUThreshold: 50})
+	cachedZombieCount := 7
 	collector.cacheEnrichment(MetricsSnapshot{
 		Hardware:  HardwareInfo{Model: "MacBook Pro"},
 		TrashSize: 99,
 		TopProcesses: []ProcessInfo{
 			{PID: 100, Name: "old-process", CPU: 10},
+		},
+		ZombieCount: &cachedZombieCount,
+		ZombieParents: []ZombieParent{
+			{PID: 100, Name: "old-process", Count: 7},
 		},
 		ProcessAlerts: []ProcessAlert{
 			{PID: 100, Name: "old-process", Status: "active"},
@@ -117,10 +123,35 @@ func TestCollectProcessesKeepsLiveProcessesWithCachedEnrichment(t *testing.T) {
 	if snapshot.Hardware.Model != "MacBook Pro" || snapshot.TrashSize != 99 {
 		t.Fatalf("expected cached enrichment to be preserved, got hardware=%#v trash=%d", snapshot.Hardware, snapshot.TrashSize)
 	}
-	if len(snapshot.TopProcesses) != 1 || snapshot.TopProcesses[0].Name != "new-hot-process" {
+	if len(snapshot.TopProcesses) < 1 || snapshot.TopProcesses[0].Name != "new-hot-process" {
 		t.Fatalf("expected live top process data, got %#v", snapshot.TopProcesses)
 	}
 	if len(snapshot.ProcessAlerts) != 1 || snapshot.ProcessAlerts[0].Name != "new-hot-process" {
 		t.Fatalf("expected live process alert data, got %#v", snapshot.ProcessAlerts)
+	}
+	if snapshot.ZombieCount == nil || *snapshot.ZombieCount != 1 || len(snapshot.ZombieParents) != 1 || snapshot.ZombieParents[0].PID != 200 {
+		t.Fatalf("expected live zombie summary, got count=%v parents=%#v", snapshot.ZombieCount, snapshot.ZombieParents)
+	}
+}
+
+func TestCacheEnrichmentPreservesLatestMeasuredZombieSummary(t *testing.T) {
+	collector := NewCollector(ProcessWatchOptions{})
+	measured := 3
+	collector.cacheEnrichment(MetricsSnapshot{
+		ZombieCount: &measured,
+		ZombieParents: []ZombieParent{
+			{PID: 42, Name: "Chrome", Count: 3},
+		},
+	})
+
+	collector.cacheEnrichment(MetricsSnapshot{Hardware: HardwareInfo{Model: "newer enrichment"}})
+	var snapshot MetricsSnapshot
+	collector.applyEnrichment(&snapshot, false)
+
+	if snapshot.ZombieCount == nil || *snapshot.ZombieCount != 3 {
+		t.Fatalf("latest measured zombie count was not preserved: %v", snapshot.ZombieCount)
+	}
+	if len(snapshot.ZombieParents) != 1 || snapshot.ZombieParents[0].PID != 42 {
+		t.Fatalf("latest measured zombie parents were not preserved: %#v", snapshot.ZombieParents)
 	}
 }

--- a/cmd/status/metrics_fast_test.go
+++ b/cmd/status/metrics_fast_test.go
@@ -91,16 +91,17 @@ func TestCollectProcessesKeepsLiveProcessesWithCachedEnrichment(t *testing.T) {
 	ioCountersFunc = func(bool) ([]gopsutilnet.IOCountersStat, error) {
 		return []gopsutilnet.IOCountersStat{{Name: "en0", BytesRecv: 1024, BytesSent: 2048}}, nil
 	}
-	collectProcessesFunc = func() ([]ProcessInfo, error) {
-		return []ProcessInfo{
+	collectProcessesFunc = func() (processSample, error) {
+		return processSample{processes: []ProcessInfo{
 			{PID: 200, PPID: 1, Name: "new-hot-process", Command: "/usr/bin/new-hot-process", CPU: 240, Memory: 1.5},
 			{PID: 201, PPID: 200, State: "Z+", Name: "defunct-child", Command: "defunct-child"},
-		}, nil
+		}, parentsAvailable: true}, nil
 	}
 
 	collector := NewCollector(ProcessWatchOptions{Enabled: true, CPUThreshold: 50})
 	cachedZombieCount := 7
-	collector.cacheEnrichment(MetricsSnapshot{
+	cachedParentsComplete := true
+	cached := MetricsSnapshot{
 		Hardware:  HardwareInfo{Model: "MacBook Pro"},
 		TrashSize: 99,
 		TopProcesses: []ProcessInfo{
@@ -110,10 +111,13 @@ func TestCollectProcessesKeepsLiveProcessesWithCachedEnrichment(t *testing.T) {
 		ZombieParents: []ZombieParent{
 			{PID: 100, Name: "old-process", Count: 7},
 		},
+		ZombieParentsComplete: &cachedParentsComplete,
 		ProcessAlerts: []ProcessAlert{
 			{PID: 100, Name: "old-process", Status: "active"},
 		},
-	})
+	}
+	collector.cacheEnrichment(cached)
+	collector.cacheProcessEnrichment(cached)
 
 	snapshot, err := collector.CollectProcesses()
 	if err != nil {
@@ -132,16 +136,30 @@ func TestCollectProcessesKeepsLiveProcessesWithCachedEnrichment(t *testing.T) {
 	if snapshot.ZombieCount == nil || *snapshot.ZombieCount != 1 || len(snapshot.ZombieParents) != 1 || snapshot.ZombieParents[0].PID != 200 {
 		t.Fatalf("expected live zombie summary, got count=%v parents=%#v", snapshot.ZombieCount, snapshot.ZombieParents)
 	}
+	if snapshot.ZombieParentsComplete == nil || !*snapshot.ZombieParentsComplete {
+		t.Fatalf("expected complete live parent attribution, got %v", snapshot.ZombieParentsComplete)
+	}
+
+	fastSnapshot, err := collector.CollectFast()
+	if err != nil {
+		t.Fatalf("CollectFast() error = %v", err)
+	}
+	if fastSnapshot.ZombieCount == nil || *fastSnapshot.ZombieCount != 1 ||
+		len(fastSnapshot.ZombieParents) != 1 || fastSnapshot.ZombieParents[0].PID != 200 {
+		t.Fatalf("fast refresh restored stale zombies: count=%v parents=%#v", fastSnapshot.ZombieCount, fastSnapshot.ZombieParents)
+	}
 }
 
-func TestCacheEnrichmentPreservesLatestMeasuredZombieSummary(t *testing.T) {
+func TestSlowEnrichmentDoesNotReplaceLatestProcessSummary(t *testing.T) {
 	collector := NewCollector(ProcessWatchOptions{})
 	measured := 3
-	collector.cacheEnrichment(MetricsSnapshot{
+	complete := true
+	collector.cacheProcessEnrichment(MetricsSnapshot{
 		ZombieCount: &measured,
 		ZombieParents: []ZombieParent{
 			{PID: 42, Name: "Chrome", Count: 3},
 		},
+		ZombieParentsComplete: &complete,
 	})
 
 	collector.cacheEnrichment(MetricsSnapshot{Hardware: HardwareInfo{Model: "newer enrichment"}})
@@ -153,5 +171,8 @@ func TestCacheEnrichmentPreservesLatestMeasuredZombieSummary(t *testing.T) {
 	}
 	if len(snapshot.ZombieParents) != 1 || snapshot.ZombieParents[0].PID != 42 {
 		t.Fatalf("latest measured zombie parents were not preserved: %#v", snapshot.ZombieParents)
+	}
+	if snapshot.ZombieParentsComplete == nil || !*snapshot.ZombieParentsComplete {
+		t.Fatalf("latest parent completeness was not preserved: %v", snapshot.ZombieParentsComplete)
 	}
 }

--- a/cmd/status/metrics_process.go
+++ b/cmd/status/metrics_process.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"runtime"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 )
 
 var collectProcessesFunc = collectProcesses
+
+const zombieParentLimit = 3
 
 func collectProcesses() ([]ProcessInfo, error) {
 	if runtime.GOOS != "darwin" {
@@ -20,15 +23,54 @@ func collectProcesses() ([]ProcessInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,pcpu=,pmem=,rss=,comm=", "-r")
-	if err != nil {
-		out, err = runCmd(ctx, "ps", "aux")
-		if err != nil {
-			return nil, err
+	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,state=,pcpu=,pmem=,rss=,comm=", "-r")
+	if err == nil {
+		if procs, parseErr := parseProcessOutputStrict(out); parseErr == nil {
+			return procs, nil
 		}
-		return parsePsAuxOutput(out), nil
 	}
-	return parseProcessOutput(out), nil
+
+	out, err = runCmd(ctx, "ps", "aux")
+	if err != nil {
+		return nil, err
+	}
+	return parsePsAuxOutputStrict(out)
+}
+
+func parseProcessOutputStrict(raw string) ([]ProcessInfo, error) {
+	rows := strings.Split(strings.TrimSpace(raw), "\n")
+	if len(rows) == 0 || (len(rows) == 1 && rows[0] == "") {
+		return nil, fmt.Errorf("empty ps process table")
+	}
+
+	procs := make([]ProcessInfo, 0, len(rows))
+	for _, row := range rows {
+		fields := strings.Fields(row)
+		if len(fields) < 7 || !isProcessStateToken(fields[2]) {
+			return nil, fmt.Errorf("unexpected ps process row")
+		}
+		pid, pidErr := strconv.Atoi(fields[0])
+		ppid, ppidErr := strconv.Atoi(fields[1])
+		cpuVal, cpuErr := strconv.ParseFloat(fields[3], 64)
+		memVal, memErr := strconv.ParseFloat(fields[4], 64)
+		rssKB, rssErr := strconv.ParseUint(fields[5], 10, 64)
+		command := strings.Join(fields[6:], " ")
+		if pidErr != nil || ppidErr != nil || cpuErr != nil || memErr != nil || rssErr != nil ||
+			pid <= 0 || ppid < 0 || command == "" {
+			return nil, fmt.Errorf("unexpected ps process row")
+		}
+		procs = append(procs, ProcessInfo{
+			PID:         pid,
+			PPID:        ppid,
+			State:       fields[2],
+			Name:        processNameFromCommand(command),
+			Command:     command,
+			CPU:         cpuVal,
+			Memory:      memVal,
+			MemoryBytes: rssKB * 1024,
+		})
+	}
+	return procs, nil
 }
 
 func parseProcessOutput(raw string) []ProcessInfo {
@@ -44,21 +86,31 @@ func parseProcessOutput(raw string) []ProcessInfo {
 			continue
 		}
 		ppid, _ := strconv.Atoi(fields[1])
-		cpuVal, err := strconv.ParseFloat(fields[2], 64)
+		metricStart := 2
+		state := ""
+		cpuVal, err := strconv.ParseFloat(fields[metricStart], 64)
 		if err != nil {
-			continue
+			if len(fields) < 6 || !isProcessStateToken(fields[2]) {
+				continue
+			}
+			state = fields[2]
+			metricStart++
+			cpuVal, err = strconv.ParseFloat(fields[metricStart], 64)
+			if err != nil {
+				continue
+			}
 		}
-		memVal, err := strconv.ParseFloat(fields[3], 64)
+		memVal, err := strconv.ParseFloat(fields[metricStart+1], 64)
 		if err != nil {
 			continue
 		}
 
 		rssBytes := uint64(0)
-		commandStart := 4
-		if len(fields) >= 6 {
-			if rssKB, err := strconv.ParseUint(fields[4], 10, 64); err == nil {
+		commandStart := metricStart + 2
+		if len(fields) >= metricStart+4 {
+			if rssKB, err := strconv.ParseUint(fields[metricStart+2], 10, 64); err == nil {
 				rssBytes = rssKB * 1024
-				commandStart = 5
+				commandStart = metricStart + 3
 			}
 		}
 
@@ -69,6 +121,7 @@ func parseProcessOutput(raw string) []ProcessInfo {
 		procs = append(procs, ProcessInfo{
 			PID:         pid,
 			PPID:        ppid,
+			State:       state,
 			Name:        processNameFromCommand(command),
 			Command:     command,
 			CPU:         cpuVal,
@@ -116,6 +169,7 @@ func parsePsAuxOutput(raw string) []ProcessInfo {
 		procs = append(procs, ProcessInfo{
 			PID:         pid,
 			PPID:        0,
+			State:       fields[7],
 			Name:        processNameFromCommand(command),
 			Command:     command,
 			CPU:         cpuVal,
@@ -124,6 +178,110 @@ func parsePsAuxOutput(raw string) []ProcessInfo {
 		})
 	}
 	return procs
+}
+
+func parsePsAuxOutputStrict(raw string) ([]ProcessInfo, error) {
+	rows := strings.Split(strings.TrimSpace(raw), "\n")
+	expectedHeader := []string{"USER", "PID", "%CPU", "%MEM", "VSZ", "RSS", "TT", "STAT", "STARTED", "TIME", "COMMAND"}
+	if len(rows) < 2 || !slices.Equal(strings.Fields(rows[0]), expectedHeader) {
+		return nil, fmt.Errorf("unexpected ps aux header")
+	}
+
+	procs := make([]ProcessInfo, 0, len(rows)-1)
+	for _, row := range rows[1:] {
+		fields := strings.Fields(row)
+		if len(fields) < 11 || !isProcessStateToken(fields[7]) {
+			return nil, fmt.Errorf("unexpected ps aux process row")
+		}
+		pid, pidErr := strconv.Atoi(fields[1])
+		cpuVal, cpuErr := strconv.ParseFloat(fields[2], 64)
+		memVal, memErr := strconv.ParseFloat(fields[3], 64)
+		_, vszErr := strconv.ParseUint(fields[4], 10, 64)
+		rssKB, rssErr := strconv.ParseUint(fields[5], 10, 64)
+		command := strings.Join(fields[10:], " ")
+		if pidErr != nil || cpuErr != nil || memErr != nil || vszErr != nil || rssErr != nil || pid <= 0 || command == "" {
+			return nil, fmt.Errorf("unexpected ps aux process row")
+		}
+		procs = append(procs, ProcessInfo{
+			PID:         pid,
+			PPID:        0,
+			State:       fields[7],
+			Name:        processNameFromCommand(command),
+			Command:     command,
+			CPU:         cpuVal,
+			Memory:      memVal,
+			MemoryBytes: rssKB * 1024,
+		})
+	}
+	return procs, nil
+}
+
+func isProcessStateToken(state string) bool {
+	if state == "" {
+		return false
+	}
+	if !strings.ContainsRune("DIRSTUWZ", rune(state[0])) {
+		return false
+	}
+	for _, modifier := range state[1:] {
+		if !strings.ContainsRune("+<>AELNSsVWX", modifier) {
+			return false
+		}
+	}
+	return true
+}
+
+func isZombieState(state string) bool {
+	return strings.HasPrefix(strings.TrimSpace(state), "Z")
+}
+
+func summarizeZombies(processes []ProcessInfo, limit int) (int, []ZombieParent) {
+	byPID := make(map[int]ProcessInfo, len(processes))
+	for _, proc := range processes {
+		byPID[proc.PID] = proc
+	}
+
+	count := 0
+	byParent := make(map[int]int)
+	for _, proc := range processes {
+		if !isZombieState(proc.State) {
+			continue
+		}
+		count++
+		if proc.PPID <= 0 {
+			continue
+		}
+		parent, ok := byPID[proc.PPID]
+		if !ok || parent.Name == "" {
+			continue
+		}
+		byParent[proc.PPID]++
+	}
+
+	parents := make([]ZombieParent, 0, len(byParent))
+	for ppid, zombieCount := range byParent {
+		parents = append(parents, ZombieParent{
+			PID:   ppid,
+			Name:  byPID[ppid].Name,
+			Count: zombieCount,
+		})
+	}
+	sort.Slice(parents, func(i, j int) bool {
+		if parents[i].Count != parents[j].Count {
+			return parents[i].Count > parents[j].Count
+		}
+		if parents[i].Name != parents[j].Name {
+			return parents[i].Name < parents[j].Name
+		}
+		return parents[i].PID < parents[j].PID
+	})
+	if limit <= 0 {
+		return count, nil
+	}
+	if len(parents) > limit {
+		parents = parents[:limit]
+	}
+	return count, parents
 }
 
 func processNameFromCommand(command string) string {

--- a/cmd/status/metrics_process.go
+++ b/cmd/status/metrics_process.go
@@ -12,13 +12,18 @@ import (
 	"time"
 )
 
+type processSample struct {
+	processes        []ProcessInfo
+	parentsAvailable bool
+}
+
 var collectProcessesFunc = collectProcesses
 
 const zombieParentLimit = 3
 
-func collectProcesses() ([]ProcessInfo, error) {
+func collectProcesses() (processSample, error) {
 	if runtime.GOOS != "darwin" {
-		return nil, nil
+		return processSample{}, nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -26,15 +31,19 @@ func collectProcesses() ([]ProcessInfo, error) {
 	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,state=,pcpu=,pmem=,rss=,comm=", "-r")
 	if err == nil {
 		if procs, parseErr := parseProcessOutputStrict(out); parseErr == nil {
-			return procs, nil
+			return processSample{processes: procs, parentsAvailable: true}, nil
 		}
 	}
 
 	out, err = runCmd(ctx, "ps", "aux")
 	if err != nil {
-		return nil, err
+		return processSample{}, err
 	}
-	return parsePsAuxOutputStrict(out)
+	procs, err := parsePsAuxOutputStrict(out)
+	if err != nil {
+		return processSample{}, err
+	}
+	return processSample{processes: procs}, nil
 }
 
 func parseProcessOutputStrict(raw string) ([]ProcessInfo, error) {
@@ -71,113 +80,6 @@ func parseProcessOutputStrict(raw string) ([]ProcessInfo, error) {
 		})
 	}
 	return procs, nil
-}
-
-func parseProcessOutput(raw string) []ProcessInfo {
-	procs := make([]ProcessInfo, 0, strings.Count(raw, "\n"))
-	for line := range strings.Lines(strings.TrimSpace(raw)) {
-		fields := strings.Fields(line)
-		if len(fields) < 5 {
-			continue
-		}
-
-		pid, err := strconv.Atoi(fields[0])
-		if err != nil || pid <= 0 {
-			continue
-		}
-		ppid, _ := strconv.Atoi(fields[1])
-		metricStart := 2
-		state := ""
-		cpuVal, err := strconv.ParseFloat(fields[metricStart], 64)
-		if err != nil {
-			if len(fields) < 6 || !isProcessStateToken(fields[2]) {
-				continue
-			}
-			state = fields[2]
-			metricStart++
-			cpuVal, err = strconv.ParseFloat(fields[metricStart], 64)
-			if err != nil {
-				continue
-			}
-		}
-		memVal, err := strconv.ParseFloat(fields[metricStart+1], 64)
-		if err != nil {
-			continue
-		}
-
-		rssBytes := uint64(0)
-		commandStart := metricStart + 2
-		if len(fields) >= metricStart+4 {
-			if rssKB, err := strconv.ParseUint(fields[metricStart+2], 10, 64); err == nil {
-				rssBytes = rssKB * 1024
-				commandStart = metricStart + 3
-			}
-		}
-
-		command := strings.Join(fields[commandStart:], " ")
-		if command == "" {
-			continue
-		}
-		procs = append(procs, ProcessInfo{
-			PID:         pid,
-			PPID:        ppid,
-			State:       state,
-			Name:        processNameFromCommand(command),
-			Command:     command,
-			CPU:         cpuVal,
-			Memory:      memVal,
-			MemoryBytes: rssBytes,
-		})
-	}
-	return procs
-}
-
-// parsePsAuxOutput parses the fallback "ps aux" format.
-// Columns: USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND
-func parsePsAuxOutput(raw string) []ProcessInfo {
-	procs := make([]ProcessInfo, 0, strings.Count(raw, "\n"))
-	first := true
-	for line := range strings.Lines(strings.TrimSpace(raw)) {
-		if first {
-			first = false
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 11 {
-			continue
-		}
-		pid, err := strconv.Atoi(fields[1])
-		if err != nil || pid <= 0 {
-			continue
-		}
-		cpuVal, err := strconv.ParseFloat(fields[2], 64)
-		if err != nil {
-			continue
-		}
-		memVal, err := strconv.ParseFloat(fields[3], 64)
-		if err != nil {
-			continue
-		}
-		rssKB, err := strconv.ParseUint(fields[5], 10, 64)
-		if err != nil {
-			rssKB = 0
-		}
-		command := strings.Join(fields[10:], " ")
-		if command == "" {
-			continue
-		}
-		procs = append(procs, ProcessInfo{
-			PID:         pid,
-			PPID:        0,
-			State:       fields[7],
-			Name:        processNameFromCommand(command),
-			Command:     command,
-			CPU:         cpuVal,
-			Memory:      memVal,
-			MemoryBytes: rssKB * 1024,
-		})
-	}
-	return procs
 }
 
 func parsePsAuxOutputStrict(raw string) ([]ProcessInfo, error) {
@@ -220,7 +122,10 @@ func isProcessStateToken(state string) bool {
 	if state == "" {
 		return false
 	}
-	if !strings.ContainsRune("DIRSTUWZ", rune(state[0])) {
+	// Darwin can report "?" while a process state is temporarily unknown.
+	// Keep the row so one transient state does not invalidate the whole sample;
+	// isZombieState still treats only Z-prefixed states as zombies.
+	if !strings.ContainsRune("?DIRSTUWZ", rune(state[0])) {
 		return false
 	}
 	for _, modifier := range state[1:] {
@@ -235,24 +140,30 @@ func isZombieState(state string) bool {
 	return strings.HasPrefix(strings.TrimSpace(state), "Z")
 }
 
-func summarizeZombies(processes []ProcessInfo, limit int) (int, []ZombieParent) {
+func summarizeZombies(processes []ProcessInfo, limit int, parentsAvailable bool) (int, []ZombieParent, bool) {
 	byPID := make(map[int]ProcessInfo, len(processes))
 	for _, proc := range processes {
 		byPID[proc.PID] = proc
 	}
 
 	count := 0
+	complete := parentsAvailable
 	byParent := make(map[int]int)
 	for _, proc := range processes {
 		if !isZombieState(proc.State) {
 			continue
 		}
 		count++
+		if !parentsAvailable {
+			continue
+		}
 		if proc.PPID <= 0 {
+			complete = false
 			continue
 		}
 		parent, ok := byPID[proc.PPID]
 		if !ok || parent.Name == "" {
+			complete = false
 			continue
 		}
 		byParent[proc.PPID]++
@@ -276,12 +187,16 @@ func summarizeZombies(processes []ProcessInfo, limit int) (int, []ZombieParent) 
 		return parents[i].PID < parents[j].PID
 	})
 	if limit <= 0 {
-		return count, nil
+		if len(parents) > 0 {
+			complete = false
+		}
+		return count, nil, complete
 	}
 	if len(parents) > limit {
 		parents = parents[:limit]
+		complete = false
 	}
-	return count, parents
+	return count, parents, complete
 }
 
 func processNameFromCommand(command string) string {

--- a/cmd/status/process_watch_test.go
+++ b/cmd/status/process_watch_test.go
@@ -44,6 +44,44 @@ func TestCollectProcessesUnderCommaLocale(t *testing.T) {
 	}
 }
 
+func TestParsePsAuxOutputStrictAcceptsCurrentDarwinOutput(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("ps output format is darwin-specific")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := runCmd(ctx, "ps", "aux")
+	if err != nil {
+		t.Fatalf("ps aux error = %v", err)
+	}
+	procs, err := parsePsAuxOutputStrict(out)
+	if err != nil {
+		t.Fatalf("parsePsAuxOutputStrict(current output) error = %v", err)
+	}
+	if len(procs) == 0 {
+		t.Fatal("parsePsAuxOutputStrict(current output) returned no processes")
+	}
+}
+
+func TestParsePrimaryProcessOutputStrictAcceptsCurrentDarwinOutput(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("ps output format is darwin-specific")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := runCmd(ctx, "ps", "-Aceo", "pid=,ppid=,state=,pcpu=,pmem=,rss=,comm=", "-r")
+	if err != nil {
+		t.Fatalf("primary ps command error = %v", err)
+	}
+	procs, err := parseProcessOutputStrict(out)
+	if err != nil {
+		t.Fatalf("parseProcessOutputStrict(current output) error = %v", err)
+	}
+	if len(procs) == 0 {
+		t.Fatal("parseProcessOutputStrict(current output) returned no processes")
+	}
+}
+
 func TestParseProcessOutput(t *testing.T) {
 	raw := strings.Join([]string{
 		"123 1 145.2 10.1 7340032 /Applications/Visual Studio Code.app/Contents/MacOS/Electron",
@@ -88,6 +126,24 @@ func TestParseProcessOutputKeepsOldFiveColumnShape(t *testing.T) {
 	}
 }
 
+func TestParseProcessOutputCapturesZombieState(t *testing.T) {
+	raw := strings.Join([]string{
+		"123 10 Z+ 0.0 0.0 0 worker <defunct>",
+		"456 10 S 1.5 0.2 1024 /usr/bin/worker",
+	}, "\n")
+
+	procs := parseProcessOutput(raw)
+	if len(procs) != 2 {
+		t.Fatalf("parseProcessOutput() len = %d, want 2", len(procs))
+	}
+	if procs[0].State != "Z+" {
+		t.Fatalf("zombie state = %q, want Z+", procs[0].State)
+	}
+	if procs[1].State != "S" {
+		t.Fatalf("ordinary state = %q, want S", procs[1].State)
+	}
+}
+
 func TestParsePsAuxOutputCapturesResidentMemory(t *testing.T) {
 	raw := strings.Join([]string{
 		"USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND",
@@ -101,8 +157,104 @@ func TestParsePsAuxOutputCapturesResidentMemory(t *testing.T) {
 	if procs[0].MemoryBytes != 2097152*1024 {
 		t.Fatalf("unexpected memory bytes %d", procs[0].MemoryBytes)
 	}
+	if procs[0].State != "S" {
+		t.Fatalf("unexpected process state %q", procs[0].State)
+	}
 	if !strings.Contains(procs[0].Command, "--type=renderer") {
 		t.Fatalf("command path missing args: %q", procs[0].Command)
+	}
+}
+
+func TestFallbackCountsZombiesWithoutGuessingParents(t *testing.T) {
+	raw := strings.Join([]string{
+		"USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND",
+		"raj 10 1.0 1.0 100 10 ?? S 10:00AM 0:01 /Applications/Chrome.app/Contents/MacOS/Chrome",
+		"raj 11 0.0 0.0 0 0 ?? Z+ 10:00AM 0:00 child <defunct>",
+	}, "\n")
+	procs, err := parsePsAuxOutputStrict(raw)
+	if err != nil {
+		t.Fatalf("parsePsAuxOutputStrict() error = %v", err)
+	}
+
+	count, parents := summarizeZombies(procs, 3)
+	if count != 1 {
+		t.Fatalf("fallback zombie count = %d, want 1", count)
+	}
+	if len(parents) != 0 {
+		t.Fatalf("fallback should omit unknown parent detail, got %#v", parents)
+	}
+}
+
+func TestStrictProcessParsersRejectPartialTables(t *testing.T) {
+	if _, err := parseProcessOutputStrict("123 1 Z 0.0 0.0 0 child\nbad line"); err == nil {
+		t.Fatal("parseProcessOutputStrict() accepted a partial process table")
+	}
+	for name, raw := range map[string]string{
+		"missing state": "123 1 0.0 0.0 0 child",
+		"bad ppid":      "123 parent Z 0.0 0.0 0 child",
+		"bad rss":       "123 1 Z 0.0 0.0 unknown child",
+		"reordered":     "123 1 0.0 Z 0.0 0 child",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseProcessOutputStrict(raw); err == nil {
+				t.Fatalf("parseProcessOutputStrict(%q) accepted malformed output", raw)
+			}
+		})
+	}
+	if _, err := parsePsAuxOutputStrict("USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND\nbad line"); err == nil {
+		t.Fatal("parsePsAuxOutputStrict() accepted a partial process table")
+	}
+	malformedState := "USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND\nraj 11 0.0 0.0 0 0 ?? ZOMBIE 10:00AM 0:00 child"
+	if _, err := parsePsAuxOutputStrict(malformedState); err == nil {
+		t.Fatal("parsePsAuxOutputStrict() accepted malformed STAT")
+	}
+	reordered := "USER PID %MEM %CPU VSZ RSS TT STAT STARTED TIME COMMAND\nraj 11 0.0 0.0 0 0 ?? Z 10:00AM 0:00 child"
+	if _, err := parsePsAuxOutputStrict(reordered); err == nil {
+		t.Fatal("parsePsAuxOutputStrict() accepted reordered columns")
+	}
+}
+
+func TestProcessStateTokenGrammar(t *testing.T) {
+	for _, state := range []string{"D", "I", "R", "S", "T", "U", "W", "Z", "Z+", "Ss", "R<", "SN+", "S>", "RE", "SV", "RX", "SAW"} {
+		if !isProcessStateToken(state) {
+			t.Fatalf("isProcessStateToken(%q) = false, want true", state)
+		}
+	}
+	for _, state := range []string{"", "ZOMBIE", "sleeping", "0", "Z?"} {
+		if isProcessStateToken(state) {
+			t.Fatalf("isProcessStateToken(%q) = true, want false", state)
+		}
+	}
+}
+
+func TestSummarizeZombiesCountsAndRanksKnownParents(t *testing.T) {
+	processes := []ProcessInfo{
+		{PID: 10, Name: "Chrome"},
+		{PID: 20, Name: "zsh"},
+		{PID: 101, PPID: 10, State: "Z", Name: "child-a"},
+		{PID: 102, PPID: 10, State: "Z+", Name: "child-b"},
+		{PID: 103, PPID: 20, State: "Z", Name: "child-c"},
+		{PID: 104, PPID: 999, State: "Z", Name: "unknown-parent"},
+		{PID: 105, PPID: 10, State: "S", Name: "live-child"},
+	}
+
+	count, parents := summarizeZombies(processes, 3)
+	if count != 4 {
+		t.Fatalf("zombie count = %d, want 4", count)
+	}
+	if len(parents) != 2 {
+		t.Fatalf("zombie parents = %#v, want 2 known parents", parents)
+	}
+	if parents[0] != (ZombieParent{PID: 10, Name: "Chrome", Count: 2}) {
+		t.Fatalf("first zombie parent = %#v", parents[0])
+	}
+	if parents[1] != (ZombieParent{PID: 20, Name: "zsh", Count: 1}) {
+		t.Fatalf("second zombie parent = %#v", parents[1])
+	}
+
+	_, limited := summarizeZombies(processes, 1)
+	if len(limited) != 1 || limited[0].PID != 10 {
+		t.Fatalf("limited zombie parents = %#v", limited)
 	}
 }
 
@@ -247,7 +399,14 @@ func TestRenderProcessAlertBar(t *testing.T) {
 }
 
 func TestMetricsSnapshotJSONIncludesProcessWatch(t *testing.T) {
+	zombieCount := 2
 	snapshot := MetricsSnapshot{
+		ZombieCount: &zombieCount,
+		ZombieParents: []ZombieParent{{
+			PID:   42,
+			Name:  "Chrome",
+			Count: 2,
+		}},
 		ProcessWatch: ProcessWatchConfig{
 			Enabled:      true,
 			CPUThreshold: 100,
@@ -273,5 +432,27 @@ func TestMetricsSnapshotJSONIncludesProcessWatch(t *testing.T) {
 	}
 	if !strings.Contains(out, "\"process_alerts\"") {
 		t.Fatalf("missing process_alerts in json: %s", out)
+	}
+	if !strings.Contains(out, "\"zombie_count\":2") || !strings.Contains(out, "\"zombie_parents\"") {
+		t.Fatalf("missing zombie summary in json: %s", out)
+	}
+}
+
+func TestMetricsSnapshotJSONDistinguishesUnmeasuredFromZeroZombies(t *testing.T) {
+	unmeasured, err := json.Marshal(MetricsSnapshot{})
+	if err != nil {
+		t.Fatalf("json.Marshal(unmeasured) error = %v", err)
+	}
+	if strings.Contains(string(unmeasured), "\"zombie_count\"") {
+		t.Fatalf("unmeasured snapshot should omit zombie_count: %s", unmeasured)
+	}
+
+	zero := 0
+	measured, err := json.Marshal(MetricsSnapshot{ZombieCount: &zero})
+	if err != nil {
+		t.Fatalf("json.Marshal(measured) error = %v", err)
+	}
+	if !strings.Contains(string(measured), "\"zombie_count\":0") {
+		t.Fatalf("measured zero snapshot should include zombie_count: %s", measured)
 	}
 }

--- a/cmd/status/process_watch_test.go
+++ b/cmd/status/process_watch_test.go
@@ -35,12 +35,15 @@ func TestCollectProcessesUnderCommaLocale(t *testing.T) {
 	t.Setenv("LC_ALL", "ru_RU.UTF-8")
 	t.Setenv("LC_NUMERIC", "ru_RU.UTF-8")
 
-	procs, err := collectProcesses()
+	sample, err := collectProcesses()
 	if err != nil {
 		t.Fatalf("collectProcesses() error = %v", err)
 	}
-	if len(procs) == 0 {
+	if len(sample.processes) == 0 {
 		t.Fatal("collectProcesses() returned no processes under a comma-decimal locale")
+	}
+	if !sample.parentsAvailable {
+		t.Fatal("primary process sample should include parent metadata")
 	}
 }
 
@@ -82,65 +85,53 @@ func TestParsePrimaryProcessOutputStrictAcceptsCurrentDarwinOutput(t *testing.T)
 	}
 }
 
-func TestParseProcessOutput(t *testing.T) {
-	raw := strings.Join([]string{
-		"123 1 145.2 10.1 7340032 /Applications/Visual Studio Code.app/Contents/MacOS/Electron",
-		"456 1 99.5 2.2 262144 /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder",
-		"bad line",
-	}, "\n")
+func TestCollectProcessesMarksFallbackParentAttributionIncomplete(t *testing.T) {
+	originalRunCmd := runCmd
+	t.Cleanup(func() { runCmd = originalRunCmd })
 
-	procs := parseProcessOutput(raw)
-	if len(procs) != 2 {
-		t.Fatalf("parseProcessOutput() len = %d, want 2", len(procs))
+	runCmd = func(_ context.Context, _ string, args ...string) (string, error) {
+		if len(args) > 0 && args[0] == "-Aceo" {
+			return "malformed primary output", nil
+		}
+		return strings.Join([]string{
+			"USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND",
+			"raj 11 0.0 0.0 0 0 ?? Z+ 10:00AM 0:00 child <defunct>",
+		}, "\n"), nil
 	}
 
-	if procs[0].PID != 123 || procs[0].PPID != 1 {
-		t.Fatalf("unexpected pid/ppid: %+v", procs[0])
+	sample, err := collectProcesses()
+	if err != nil {
+		t.Fatalf("collectProcesses() error = %v", err)
 	}
-	if procs[0].Name != "Electron" {
-		t.Fatalf("unexpected process name %q", procs[0].Name)
+	if sample.parentsAvailable {
+		t.Fatal("ps aux fallback should not claim parent metadata")
 	}
-	if !strings.Contains(procs[0].Command, "Visual Studio Code.app") {
-		t.Fatalf("command path missing spaces: %q", procs[0].Command)
-	}
-	if procs[0].MemoryBytes != 7340032*1024 {
-		t.Fatalf("unexpected memory bytes %d", procs[0].MemoryBytes)
+	if len(sample.processes) != 1 || !isZombieState(sample.processes[0].State) {
+		t.Fatalf("unexpected fallback sample: %#v", sample.processes)
 	}
 }
 
-func TestParseProcessOutputKeepsOldFiveColumnShape(t *testing.T) {
-	raw := "123 1 145.2 10.1 /Applications/Visual Studio Code.app/Contents/MacOS/Electron"
-
-	procs := parseProcessOutput(raw)
-	if len(procs) != 1 {
-		t.Fatalf("parseProcessOutput() len = %d, want 1", len(procs))
-	}
-	if procs[0].Memory != 10.1 {
-		t.Fatalf("unexpected memory percent %.1f", procs[0].Memory)
-	}
-	if procs[0].MemoryBytes != 0 {
-		t.Fatalf("old ps shape should not invent memory bytes, got %d", procs[0].MemoryBytes)
-	}
-	if procs[0].Command != "/Applications/Visual Studio Code.app/Contents/MacOS/Electron" {
-		t.Fatalf("unexpected command %q", procs[0].Command)
-	}
-}
-
-func TestParseProcessOutputCapturesZombieState(t *testing.T) {
+func TestParseProcessOutputStrictCapturesStateAndResidentMemory(t *testing.T) {
 	raw := strings.Join([]string{
 		"123 10 Z+ 0.0 0.0 0 worker <defunct>",
 		"456 10 S 1.5 0.2 1024 /usr/bin/worker",
 	}, "\n")
 
-	procs := parseProcessOutput(raw)
+	procs, err := parseProcessOutputStrict(raw)
+	if err != nil {
+		t.Fatalf("parseProcessOutputStrict() error = %v", err)
+	}
 	if len(procs) != 2 {
-		t.Fatalf("parseProcessOutput() len = %d, want 2", len(procs))
+		t.Fatalf("parseProcessOutputStrict() len = %d, want 2", len(procs))
 	}
 	if procs[0].State != "Z+" {
 		t.Fatalf("zombie state = %q, want Z+", procs[0].State)
 	}
 	if procs[1].State != "S" {
 		t.Fatalf("ordinary state = %q, want S", procs[1].State)
+	}
+	if procs[1].MemoryBytes != 1024*1024 {
+		t.Fatalf("resident memory = %d, want %d", procs[1].MemoryBytes, 1024*1024)
 	}
 }
 
@@ -150,9 +141,12 @@ func TestParsePsAuxOutputCapturesResidentMemory(t *testing.T) {
 		"raj 123 4.5 6.0 123456 2097152 ?? S 10:00AM 1:23 /Applications/Chrome.app/Contents/MacOS/Chrome --type=renderer",
 	}, "\n")
 
-	procs := parsePsAuxOutput(raw)
+	procs, err := parsePsAuxOutputStrict(raw)
+	if err != nil {
+		t.Fatalf("parsePsAuxOutputStrict() error = %v", err)
+	}
 	if len(procs) != 1 {
-		t.Fatalf("parsePsAuxOutput() len = %d, want 1", len(procs))
+		t.Fatalf("parsePsAuxOutputStrict() len = %d, want 1", len(procs))
 	}
 	if procs[0].MemoryBytes != 2097152*1024 {
 		t.Fatalf("unexpected memory bytes %d", procs[0].MemoryBytes)
@@ -176,12 +170,15 @@ func TestFallbackCountsZombiesWithoutGuessingParents(t *testing.T) {
 		t.Fatalf("parsePsAuxOutputStrict() error = %v", err)
 	}
 
-	count, parents := summarizeZombies(procs, 3)
+	count, parents, complete := summarizeZombies(procs, 3, false)
 	if count != 1 {
 		t.Fatalf("fallback zombie count = %d, want 1", count)
 	}
 	if len(parents) != 0 {
 		t.Fatalf("fallback should omit unknown parent detail, got %#v", parents)
+	}
+	if complete {
+		t.Fatal("fallback parent attribution should be marked incomplete")
 	}
 }
 
@@ -215,7 +212,7 @@ func TestStrictProcessParsersRejectPartialTables(t *testing.T) {
 }
 
 func TestProcessStateTokenGrammar(t *testing.T) {
-	for _, state := range []string{"D", "I", "R", "S", "T", "U", "W", "Z", "Z+", "Ss", "R<", "SN+", "S>", "RE", "SV", "RX", "SAW"} {
+	for _, state := range []string{"?", "?+", "?E", "D", "I", "R", "S", "T", "U", "W", "Z", "Z+", "Ss", "R<", "SN+", "S>", "RE", "SV", "RX", "SAW"} {
 		if !isProcessStateToken(state) {
 			t.Fatalf("isProcessStateToken(%q) = false, want true", state)
 		}
@@ -238,7 +235,7 @@ func TestSummarizeZombiesCountsAndRanksKnownParents(t *testing.T) {
 		{PID: 105, PPID: 10, State: "S", Name: "live-child"},
 	}
 
-	count, parents := summarizeZombies(processes, 3)
+	count, parents, complete := summarizeZombies(processes, 3, true)
 	if count != 4 {
 		t.Fatalf("zombie count = %d, want 4", count)
 	}
@@ -251,10 +248,16 @@ func TestSummarizeZombiesCountsAndRanksKnownParents(t *testing.T) {
 	if parents[1] != (ZombieParent{PID: 20, Name: "zsh", Count: 1}) {
 		t.Fatalf("second zombie parent = %#v", parents[1])
 	}
+	if complete {
+		t.Fatal("missing parent row should mark attribution incomplete")
+	}
 
-	_, limited := summarizeZombies(processes, 1)
+	_, limited, limitedComplete := summarizeZombies(processes, 1, true)
 	if len(limited) != 1 || limited[0].PID != 10 {
 		t.Fatalf("limited zombie parents = %#v", limited)
+	}
+	if limitedComplete {
+		t.Fatal("truncated parent list should be marked incomplete")
 	}
 }
 
@@ -400,6 +403,7 @@ func TestRenderProcessAlertBar(t *testing.T) {
 
 func TestMetricsSnapshotJSONIncludesProcessWatch(t *testing.T) {
 	zombieCount := 2
+	zombieParentsComplete := true
 	snapshot := MetricsSnapshot{
 		ZombieCount: &zombieCount,
 		ZombieParents: []ZombieParent{{
@@ -407,6 +411,7 @@ func TestMetricsSnapshotJSONIncludesProcessWatch(t *testing.T) {
 			Name:  "Chrome",
 			Count: 2,
 		}},
+		ZombieParentsComplete: &zombieParentsComplete,
 		ProcessWatch: ProcessWatchConfig{
 			Enabled:      true,
 			CPUThreshold: 100,
@@ -433,7 +438,8 @@ func TestMetricsSnapshotJSONIncludesProcessWatch(t *testing.T) {
 	if !strings.Contains(out, "\"process_alerts\"") {
 		t.Fatalf("missing process_alerts in json: %s", out)
 	}
-	if !strings.Contains(out, "\"zombie_count\":2") || !strings.Contains(out, "\"zombie_parents\"") {
+	if !strings.Contains(out, "\"zombie_count\":2") || !strings.Contains(out, "\"zombie_parents\"") ||
+		!strings.Contains(out, "\"zombie_parents_complete\":true") {
 		t.Fatalf("missing zombie summary in json: %s", out)
 	}
 }
@@ -443,16 +449,19 @@ func TestMetricsSnapshotJSONDistinguishesUnmeasuredFromZeroZombies(t *testing.T)
 	if err != nil {
 		t.Fatalf("json.Marshal(unmeasured) error = %v", err)
 	}
-	if strings.Contains(string(unmeasured), "\"zombie_count\"") {
-		t.Fatalf("unmeasured snapshot should omit zombie_count: %s", unmeasured)
+	if strings.Contains(string(unmeasured), "\"zombie_count\"") ||
+		strings.Contains(string(unmeasured), "\"zombie_parents_complete\"") {
+		t.Fatalf("unmeasured snapshot should omit zombie measurements: %s", unmeasured)
 	}
 
 	zero := 0
-	measured, err := json.Marshal(MetricsSnapshot{ZombieCount: &zero})
+	complete := true
+	measured, err := json.Marshal(MetricsSnapshot{ZombieCount: &zero, ZombieParentsComplete: &complete})
 	if err != nil {
 		t.Fatalf("json.Marshal(measured) error = %v", err)
 	}
-	if !strings.Contains(string(measured), "\"zombie_count\":0") {
+	if !strings.Contains(string(measured), "\"zombie_count\":0") ||
+		!strings.Contains(string(measured), "\"zombie_parents_complete\":true") {
 		t.Fatalf("measured zero snapshot should include zombie_count: %s", measured)
 	}
 }

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -567,8 +567,16 @@ func ioBar(rate float64) string {
 }
 
 func renderProcessCard(procs []ProcessInfo, cardWidth int) cardData {
+	return renderProcessCardWithZombies(procs, 0, nil, cardWidth)
+}
+
+func renderProcessCardWithZombies(procs []ProcessInfo, zombieCount int, zombieParents []ZombieParent, cardWidth int) cardData {
 	var lines []string
 	maxProcs := 3
+	if zombieCount > 0 {
+		lines = append(lines, renderZombieProcessLine(zombieCount, zombieParents, cardWidth))
+		maxProcs = 2
+	}
 	for i, p := range procs {
 		if i >= maxProcs {
 			break
@@ -595,6 +603,18 @@ func renderProcessCard(procs []ProcessInfo, cardWidth int) cardData {
 	return cardData{icon: iconProcs, title: "Processes", lines: lines}
 }
 
+func renderZombieProcessLine(count int, parents []ZombieParent, cardWidth int) string {
+	if cardWidth <= 0 {
+		cardWidth = colWidth
+	}
+	line := fmt.Sprintf("Zombies %d", count)
+	if len(parents) > 0 {
+		owner := formatProcessLabel(ProcessInfo{PID: parents[0].PID, Name: parents[0].Name})
+		line += fmt.Sprintf(" · %s ×%d", owner, parents[0].Count)
+	}
+	return warnStyle.Render(shorten(line, cardWidth))
+}
+
 func processBar(percent float64, cardWidth int) string {
 	if cardWidth >= processWideMinWidth {
 		return progressBar(percent)
@@ -616,12 +636,16 @@ func processMemoryText(p ProcessInfo) string {
 // has completed at least once; until it has, an empty battery list means "not
 // measured yet", not "this Mac has no battery".
 func buildCards(m MetricsSnapshot, width int, cpuCores int, batteryProbed bool) []cardData {
+	zombieCount := 0
+	if m.ZombieCount != nil {
+		zombieCount = *m.ZombieCount
+	}
 	cards := []cardData{
 		renderCPUCard(m.CPU, m.Thermal, cpuCores),
 		renderMemoryCard(m.Memory, width),
 		renderDiskCard(m.Disks, m.DiskIO, m.TrashSize, m.TrashApprox),
 		renderBatteryCard(m.Batteries, m.Thermal, batteryProbed),
-		renderProcessCard(m.TopProcesses, width),
+		renderProcessCardWithZombies(m.TopProcesses, zombieCount, m.ZombieParents, width),
 		renderNetworkCard(m.Network, m.NetworkHistory, m.Proxy, width),
 	}
 	// Sensors card disabled - redundant with CPU temp

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -1155,6 +1155,37 @@ func TestRenderProcessCardShowsCollectingWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestRenderProcessCardShowsBoundedZombieGuidance(t *testing.T) {
+	card := renderProcessCardWithZombies(
+		[]ProcessInfo{
+			{Name: "Chrome", CPU: 12, MemoryBytes: 512 << 20},
+			{Name: "WindowServer", CPU: 8, MemoryBytes: 256 << 20},
+			{Name: "Xcode", CPU: 4, MemoryBytes: 128 << 20},
+		},
+		94,
+		[]ZombieParent{{PID: 42, Name: "Chrome", Count: 6}},
+		colWidth,
+	)
+
+	if len(card.lines) != 3 {
+		t.Fatalf("renderProcessCardWithZombies() lines = %d, want 3", len(card.lines))
+	}
+	plain := stripANSI(card.lines[0])
+	if !strings.Contains(plain, "Zombies 94") || !strings.Contains(plain, "Chrome (42)") {
+		t.Fatalf("zombie summary missing count or parent: %q", plain)
+	}
+	if strings.Contains(strings.ToLower(plain), "restart") || strings.Contains(strings.ToLower(plain), "quit") {
+		t.Fatalf("zombie summary should attribute without indiscriminate process advice: %q", plain)
+	}
+	if lipgloss.Width(plain) > colWidth {
+		t.Fatalf("zombie summary exceeds card width: %q", plain)
+	}
+	joined := stripANSI(strings.Join(card.lines, "\n"))
+	if strings.Contains(joined, "Xcode") {
+		t.Fatalf("zombie guidance should keep card at three rows, got %q", joined)
+	}
+}
+
 func TestRenderProcessCardAlignsMetricColumns(t *testing.T) {
 	const wideCardWidth = 56
 	card := renderProcessCard([]ProcessInfo{


### PR DESCRIPTION
Fixes #1474.

## Summary

- collect Darwin process state alongside PID/PPID and expose a measured `zombie_count` plus up to three deterministically ranked parent owners in JSON/NDJSON
- show one compact zombie-attribution line in the Processes card without changing the health score or adding any cleanup/termination behavior
- fail closed on incomplete process tables, distinguish unmeasured data from a measured zero, and keep the `ps aux` fallback count-only rather than guessing parent identity across snapshots
- preserve the latest successful zombie sample on fast refreshes, matching the existing top-process cadence

## Testing

- `go test ./cmd/status`
- `go test ./cmd/...`
- `go test ./...`
- `./scripts/check.sh --format`

The status tests also exercise the exact current-Darwin primary and fallback `ps` commands, malformed and reordered columns, valid state modifiers, unknown parents, cache preservation, JSON zero/unknown behavior, and narrow-card rendering.
