### PR TITLE
fix(status): preserve multiword process owner names

### DIFF
--- a/cmd/status/metrics_process.go
+++ b/cmd/status/metrics_process.go
@@ -72,7 +72,7 @@ func parseProcessOutputStrict(raw string) ([]ProcessInfo, error) {
 			PID:         pid,
 			PPID:        ppid,
 			State:       fields[2],
-			Name:        processNameFromCommand(command),
+			Name:        processNameFromComm(command),
 			Command:     command,
 			CPU:         cpuVal,
 			Memory:      memVal,
@@ -197,6 +197,14 @@ func summarizeZombies(processes []ProcessInfo, limit int, parentsAvailable bool)
 		complete = false
 	}
 	return count, parents, complete
+}
+
+func processNameFromComm(command string) string {
+	name := command
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return strings.TrimSpace(name)
 }
 
 func processNameFromCommand(command string) string {

--- a/cmd/status/process_watch_test.go
+++ b/cmd/status/process_watch_test.go
@@ -135,6 +135,28 @@ func TestParseProcessOutputStrictCapturesStateAndResidentMemory(t *testing.T) {
 	}
 }
 
+func TestPrimaryProcessOutputPreservesMultiwordZombieParentName(t *testing.T) {
+	raw := strings.Join([]string{
+		"123 1 S 0.0 0.1 1024 /Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge Helper (Renderer)",
+		"456 123 Z 0.0 0.0 0 child <defunct>",
+	}, "\n")
+
+	procs, err := parseProcessOutputStrict(raw)
+	if err != nil {
+		t.Fatalf("parseProcessOutputStrict() error = %v", err)
+	}
+	count, parents, complete := summarizeZombies(procs, zombieParentLimit, true)
+	if count != 1 || len(parents) != 1 {
+		t.Fatalf("unexpected zombie summary: count=%d parents=%#v", count, parents)
+	}
+	if parents[0] != (ZombieParent{PID: 123, Name: "Microsoft Edge Helper (Renderer)", Count: 1}) {
+		t.Fatalf("zombie parent = %#v", parents[0])
+	}
+	if !complete {
+		t.Fatal("complete primary process table should preserve complete parent attribution")
+	}
+}
+
 func TestParsePsAuxOutputCapturesResidentMemory(t *testing.T) {
 	raw := strings.Join([]string{
 		"USER PID %CPU %MEM VSZ RSS TT STAT STARTED TIME COMMAND",


### PR DESCRIPTION
## Summary

- preserve the complete basename from Darwin's primary `ps ... comm=` field, including spaces and parenthesized suffixes
- keep the existing `ps aux` command-line heuristic unchanged
- add a regression proving zombie-parent attribution reports `Microsoft Edge Helper (Renderer)` rather than `Microsoft`

## Why

The parent-attribution path added in #1476 consumes `comm=`, whose trailing value is the executable name rather than an argument-bearing command line. Reusing the fallback command-line parser truncated multiword owners at the first space, making the new JSON/TUI diagnostic ambiguous for browser helper processes.

This separates the two input contracts without changing process collection, counts, ordering, health scoring, or fallback behavior.

## Validation

- `go test ./cmd/status`
- `go test ./cmd/...`
- `go test ./...`
- `./scripts/check.sh --format`
- `git diff --check`
