### PR TITLE
fix(status): mark stale process data in the TUI

### DIFF
--- a/cmd/status/diagnosis.go
+++ b/cmd/status/diagnosis.go
@@ -12,14 +12,18 @@ func statusDiagnosisLine(m MetricsSnapshot) string {
 		}
 	}
 	if m.CPU.Usage > cpuHighThreshold {
-		if proc, ok := leadingCPUProcess(m.TopProcesses, 50); ok {
-			return fmt.Sprintf("%s high CPU", shorten(proc.Name, 18))
+		if processSnapshotFresh(m.ProcessStale) {
+			if proc, ok := leadingCPUProcess(m.TopProcesses, 50); ok {
+				return fmt.Sprintf("%s high CPU", shorten(proc.Name, 18))
+			}
 		}
 		return "CPU load high"
 	}
 	if m.Memory.Pressure == "warn" || m.Memory.Pressure == "critical" || m.Memory.UsedPercent > memHighThreshold {
-		if proc, ok := leadingMemoryProcess(m.TopProcesses); ok && proc.Memory > 0 {
-			return fmt.Sprintf("%s memory pressure", shorten(proc.Name, 18))
+		if processSnapshotFresh(m.ProcessStale) {
+			if proc, ok := leadingMemoryProcess(m.TopProcesses); ok && proc.Memory > 0 {
+				return fmt.Sprintf("%s memory pressure", shorten(proc.Name, 18))
+			}
 		}
 		return "Memory pressure high"
 	}

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -190,7 +190,12 @@ func (m model) View() string {
 	}
 
 	header, mole := renderHeader(m.metrics, m.errMessage, m.animFrame, termWidth, m.catHidden)
-	alertBar := renderProcessAlertBar(m.metrics.ProcessAlerts, termWidth)
+	alertBar := renderProcessAlertBar(
+		m.metrics.ProcessAlerts,
+		m.metrics.ProcessStale,
+		m.metrics.ProcessCollectedAt,
+		termWidth,
+	)
 
 	renderFrame := func(cpuCores int) string {
 		var cardContent string

--- a/cmd/status/process_watch_test.go
+++ b/cmd/status/process_watch_test.go
@@ -403,12 +403,13 @@ func TestProcessWatcherResetsOnPIDReuse(t *testing.T) {
 }
 
 func TestRenderProcessAlertBar(t *testing.T) {
+	stale := false
 	alerts := []ProcessAlert{
 		{PID: 10, Name: "node", CPU: 150, Threshold: 100, Window: "5m0s", Status: "active"},
 		{PID: 11, Name: "java", CPU: 130, Threshold: 100, Window: "5m0s", Status: "active"},
 	}
 
-	bar := renderProcessAlertBar(alerts, 120)
+	bar := renderProcessAlertBar(alerts, &stale, nil, 120)
 	if !strings.Contains(bar, "ALERT") {
 		t.Fatalf("missing alert prefix: %q", bar)
 	}
@@ -420,6 +421,48 @@ func TestRenderProcessAlertBar(t *testing.T) {
 	}
 	if strings.Contains(bar, "terminate") || strings.Contains(bar, "ignore") {
 		t.Fatalf("unexpected action text in read-only alert bar: %q", bar)
+	}
+}
+
+func TestRenderProcessAlertBarMarksStaleSamplesBeforeTruncation(t *testing.T) {
+	stale := true
+	collectedAt := time.Date(2026, time.August, 30, 9, 7, 0, 0, time.FixedZone("UTC+8", 8*60*60))
+	alerts := []ProcessAlert{{
+		PID: 10, Name: "node", CPU: 150, Threshold: 100, Window: "5m0s", Status: "active",
+	}}
+
+	narrowBar := stripANSI(renderProcessAlertBar(alerts, &stale, &collectedAt, 10))
+	if !strings.HasPrefix(strings.TrimSpace(narrowBar), "OLD") {
+		t.Fatalf("historical alert marker should survive narrow rendering, got %q", narrowBar)
+	}
+	if strings.Contains(narrowBar, "2026") {
+		t.Fatalf("narrow rendering should not show a partial timestamp, got %q", narrowBar)
+	}
+	wideBar := stripANSI(renderProcessAlertBar(alerts, &stale, &collectedAt, 120))
+	if !strings.HasPrefix(strings.TrimSpace(wideBar), "LAST ALERT · STALE 2026-08-30T09:07:00+08:00") {
+		t.Fatalf("stale process alert should include unambiguous age and historical semantics, got %q", wideBar)
+	}
+	if strings.Contains(wideBar, "· ALERT ") {
+		t.Fatalf("stale process alert should not present itself as current, got %q", wideBar)
+	}
+	unboundedBar := stripANSI(renderProcessAlertBar(alerts, &stale, &collectedAt, 0))
+	if !strings.HasPrefix(strings.TrimSpace(unboundedBar), "LAST ALERT · STALE 2026-08-30T09:07:00+08:00") {
+		t.Fatalf("unbounded rendering should preserve the full historical marker, got %q", unboundedBar)
+	}
+	boundaryBar := stripANSI(renderProcessAlertBar(alerts, &stale, &collectedAt, 28))
+	if !strings.HasPrefix(strings.TrimSpace(boundaryBar), "LAST ALERT · STALE") || strings.Contains(boundaryBar, "2026") {
+		t.Fatalf("partial RFC3339 timestamp should collapse atomically, got %q", boundaryBar)
+	}
+}
+
+func TestRenderProcessAlertBarMarksUnknownFreshnessAsLastKnown(t *testing.T) {
+	alerts := []ProcessAlert{{
+		PID: 10, Name: "node", CPU: 150, Threshold: 100, Window: "5m0s", Status: "active",
+	}}
+
+	bar := stripANSI(renderProcessAlertBar(alerts, nil, nil, 80))
+	if !strings.HasPrefix(strings.TrimSpace(bar), "LAST ALERT · UNKNOWN") {
+		t.Fatalf("unknown-freshness process alert should be last-known, got %q", bar)
 	}
 }
 

--- a/cmd/status/view.go
+++ b/cmd/status/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -288,26 +289,74 @@ func getScoreStyle(score int) lipgloss.Style {
 	}
 }
 
-func renderProcessAlertBar(alerts []ProcessAlert, width int) string {
+func renderProcessAlertBar(alerts []ProcessAlert, processStale *bool, processCollectedAt *time.Time, width int) string {
 	active := activeAlerts(alerts)
 	if len(active) == 0 {
 		return ""
 	}
 
 	focus := active[0]
+	prefix := "ALERT"
+	historical := !processSnapshotFresh(processStale)
+	if historical {
+		prefix = "LAST ALERT"
+		available := max(width-2, 0)
+		if width > 0 && lipgloss.Width(prefix) > available {
+			prefix = "OLD"
+		}
+	}
 
-	text := fmt.Sprintf(
-		"ALERT %s at %.1f%% for %s (threshold %.1f%%)",
+	detail := fmt.Sprintf(
+		"%s at %.1f%% for %s (threshold %.1f%%)",
 		formatProcessLabel(ProcessInfo{PID: focus.PID, Name: focus.Name}),
 		focus.CPU,
 		focus.Window,
 		focus.Threshold,
 	)
+	text := prefix + " " + detail
 	if len(active) > 1 {
 		text += fmt.Sprintf(" · +%d more", len(active)-1)
 	}
+	if historical {
+		freshnessWidth := -1
+		if width > 0 {
+			freshnessWidth = max(width-2-lipgloss.Width(prefix+" · "), 0)
+		}
+		if freshness := processFreshnessLabel(processStale, processCollectedAt, freshnessWidth); freshness != "" {
+			text = prefix + " · " + freshness + " · " + strings.TrimPrefix(text, prefix+" ")
+		}
+	}
 
 	return renderBanner(alertBarStyle, text, width)
+}
+
+func processSnapshotStale(stale *bool) bool {
+	return stale != nil && *stale
+}
+
+func processSnapshotFresh(stale *bool) bool {
+	return stale != nil && !*stale
+}
+
+func processFreshnessLabel(stale *bool, collectedAt *time.Time, maxWidth int) string {
+	if processSnapshotFresh(stale) {
+		return ""
+	}
+	base := "STALE"
+	if stale == nil {
+		base = "UNKNOWN"
+	}
+	if maxWidth >= 0 && lipgloss.Width(base) > maxWidth {
+		return ""
+	}
+	if base == "UNKNOWN" || collectedAt == nil || collectedAt.IsZero() {
+		return base
+	}
+	label := base + " " + collectedAt.Format(time.RFC3339)
+	if maxWidth >= 0 && lipgloss.Width(label) > maxWidth {
+		return base
+	}
+	return label
 }
 
 func renderBanner(style lipgloss.Style, text string, width int) string {
@@ -640,12 +689,42 @@ func buildCards(m MetricsSnapshot, width int, cpuCores int, batteryProbed bool) 
 	if m.ZombieCount != nil {
 		zombieCount = *m.ZombieCount
 	}
+	processCard := renderProcessCardWithZombies(m.TopProcesses, zombieCount, m.ZombieParents, width)
+	hasRenderedProcessData := len(m.TopProcesses) > 0 || zombieCount > 0
+	hasActiveProcessAlert := len(activeAlerts(m.ProcessAlerts)) > 0
+	switch {
+	case processSnapshotFresh(m.ProcessStale):
+		if !hasRenderedProcessData {
+			message := "No process activity"
+			if hasActiveProcessAlert {
+				message = "No process rows · active alert above"
+			}
+			processCard.lines = []string{subtleStyle.Render(message)}
+		}
+	case processSnapshotStale(m.ProcessStale):
+		freshnessWidth := width
+		if freshnessWidth <= 0 {
+			freshnessWidth = colWidth
+		}
+		freshness := processFreshnessLabel(m.ProcessStale, m.ProcessCollectedAt, freshnessWidth)
+		if hasRenderedProcessData {
+			processCard.lines = append([]string{warnStyle.Render(freshness)}, processCard.lines...)
+		} else {
+			processCard.lines = []string{warnStyle.Render(freshness + " · no retained process activity")}
+		}
+	default:
+		if hasRenderedProcessData {
+			processCard.lines = append([]string{warnStyle.Render("UNKNOWN")}, processCard.lines...)
+		} else if hasActiveProcessAlert || m.ProcessCollectedAt != nil || m.ZombieCount != nil {
+			processCard.lines = []string{warnStyle.Render("UNKNOWN · process sample unavailable")}
+		}
+	}
 	cards := []cardData{
 		renderCPUCard(m.CPU, m.Thermal, cpuCores),
 		renderMemoryCard(m.Memory, width),
 		renderDiskCard(m.Disks, m.DiskIO, m.TrashSize, m.TrashApprox),
 		renderBatteryCard(m.Batteries, m.Thermal, batteryProbed),
-		renderProcessCardWithZombies(m.TopProcesses, zombieCount, m.ZombieParents, width),
+		processCard,
 		renderNetworkCard(m.Network, m.NetworkHistory, m.Proxy, width),
 	}
 	// Sensors card disabled - redundant with CPU temp

--- a/cmd/status/view_test.go
+++ b/cmd/status/view_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -1080,8 +1081,10 @@ func TestStatusDiagnosisLinePrioritizesFailingSMART(t *testing.T) {
 }
 
 func TestStatusDiagnosisLineUsesTopCPUProcess(t *testing.T) {
+	stale := false
 	m := MetricsSnapshot{
-		CPU: CPUStatus{Usage: 95},
+		CPU:          CPUStatus{Usage: 95},
+		ProcessStale: &stale,
 		TopProcesses: []ProcessInfo{
 			{Name: "Safari", CPU: 12},
 			{Name: "Xcode", CPU: 82},
@@ -1094,9 +1097,24 @@ func TestStatusDiagnosisLineUsesTopCPUProcess(t *testing.T) {
 	}
 }
 
-func TestStatusDiagnosisLineUsesMemoryContributorWhenCPUIsCalm(t *testing.T) {
+func TestStatusDiagnosisLineDoesNotNameStaleCPUProcess(t *testing.T) {
+	stale := true
 	m := MetricsSnapshot{
-		CPU: CPUStatus{Usage: 20},
+		CPU:          CPUStatus{Usage: 95},
+		ProcessStale: &stale,
+		TopProcesses: []ProcessInfo{{Name: "Xcode", CPU: 82}},
+	}
+
+	if got := statusDiagnosisLine(m); got != "CPU load high" {
+		t.Fatalf("statusDiagnosisLine() = %q, want generic live-system diagnosis", got)
+	}
+}
+
+func TestStatusDiagnosisLineUsesMemoryContributorWhenCPUIsCalm(t *testing.T) {
+	stale := false
+	m := MetricsSnapshot{
+		CPU:          CPUStatus{Usage: 20},
+		ProcessStale: &stale,
 		Memory: MemoryStatus{
 			UsedPercent: 86,
 			Pressure:    "warn",
@@ -1110,6 +1128,21 @@ func TestStatusDiagnosisLineUsesMemoryContributorWhenCPUIsCalm(t *testing.T) {
 	got := statusDiagnosisLine(m)
 	if got != "Chrome memory pressure" {
 		t.Fatalf("statusDiagnosisLine() = %q, want memory contributor", got)
+	}
+}
+
+func TestStatusDiagnosisLineDoesNotNameUnknownMemoryProcess(t *testing.T) {
+	m := MetricsSnapshot{
+		CPU: CPUStatus{Usage: 20},
+		Memory: MemoryStatus{
+			UsedPercent: 86,
+			Pressure:    "warn",
+		},
+		TopProcesses: []ProcessInfo{{Name: "Chrome", Memory: 31}},
+	}
+
+	if got := statusDiagnosisLine(m); got != "Memory pressure high" {
+		t.Fatalf("statusDiagnosisLine() = %q, want generic diagnosis for unknown freshness", got)
 	}
 }
 
@@ -1152,6 +1185,72 @@ func TestRenderProcessCardShowsCollectingWhenEmpty(t *testing.T) {
 	}
 	if got := stripANSI(card.lines[0]); got != "Collecting..." {
 		t.Fatalf("renderProcessCard() empty line = %q", got)
+	}
+}
+
+func TestBuildCardsMarksStaleProcessSampleAtNarrowAndWideWidths(t *testing.T) {
+	stale := true
+	collectedAt := time.Date(2026, time.August, 30, 9, 7, 0, 0, time.Local)
+	snapshot := MetricsSnapshot{
+		TopProcesses:       []ProcessInfo{{Name: "Xcode", CPU: 82}},
+		ProcessStale:       &stale,
+		ProcessCollectedAt: &collectedAt,
+	}
+
+	for _, width := range []int{5, 19, 20, 56} {
+		cards := buildCards(snapshot, width, 0, true)
+		processCard := cards[4]
+		rendered := stripANSI(renderCard(processCard, width))
+		if !strings.Contains(rendered, "STALE") {
+			t.Fatalf("process card width %d missing stale marker: %q", width, rendered)
+		}
+		if width >= 19 && !strings.Contains(rendered, "82.0%") {
+			t.Fatalf("process card width %d should retain cached process metrics: %q", width, rendered)
+		}
+		if width >= 56 && !strings.Contains(rendered, "Xcode") {
+			t.Fatalf("wide process card should retain the cached process name: %q", rendered)
+		}
+	}
+}
+
+func TestBuildCardsMarksUnknownProcessFreshness(t *testing.T) {
+	snapshot := MetricsSnapshot{
+		TopProcesses: []ProcessInfo{{Name: "Xcode", CPU: 82}},
+	}
+
+	cards := buildCards(snapshot, 56, 0, true)
+	rendered := stripANSI(renderCard(cards[4], 56))
+	if !strings.Contains(rendered, "UNKNOWN") || !strings.Contains(rendered, "Xcode") {
+		t.Fatalf("unknown-freshness process card should label retained evidence: %q", rendered)
+	}
+}
+
+func TestBuildCardsDistinguishesEmptyProcessSampleStates(t *testing.T) {
+	fresh := false
+	stale := true
+	zero := 0
+	tests := []struct {
+		name     string
+		snapshot MetricsSnapshot
+		want     string
+	}{
+		{name: "fresh empty", snapshot: MetricsSnapshot{ProcessStale: &fresh}, want: "No process activity"},
+		{name: "fresh alert only", snapshot: MetricsSnapshot{ProcessStale: &fresh, ProcessAlerts: []ProcessAlert{{Status: "active"}}}, want: "No process rows · active alert above"},
+		{name: "stale empty", snapshot: MetricsSnapshot{ProcessStale: &stale}, want: "STALE · no retained process activity"},
+		{name: "stale measured zero", snapshot: MetricsSnapshot{ProcessStale: &stale, ZombieCount: &zero}, want: "STALE · no retained process activity"},
+		{name: "unknown retained alert", snapshot: MetricsSnapshot{ProcessAlerts: []ProcessAlert{{Status: "active"}}}, want: "UNKNOWN · process sample unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cards := buildCards(tt.snapshot, 38, 0, true)
+			rendered := stripANSI(renderCard(cards[4], 38))
+			if !strings.Contains(rendered, tt.want) {
+				t.Fatalf("process state should render %q, got %q", tt.want, rendered)
+			}
+			if strings.Contains(rendered, "Collecting") {
+				t.Fatalf("known or retained process state should not look like initial collection, got %q", rendered)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- label cached process cards as stale, including the original sample time when it fits
- present retained process alerts as last-known rather than current alerts
- name a CPU or memory culprit only when process freshness is explicitly current
- distinguish fresh-empty, stale-empty, and unknown process snapshots

V1.53 retains the last process sample when process collection fails, but the interactive TUI currently drops `ProcessStale` and `ProcessCollectedAt`. That can make cached process rows, zombie attribution, and persistent alerts look current beside live host metrics.

The narrow-width path keeps the historical marker first and atomically drops the timestamp rather than showing a partial time.

## Testing

- `go test ./cmd/status`
- `go test ./cmd/...`
- `go test ./...`
