### PR TITLE
feat(analyze): show mo uninstall hint when deleting an app bundle

### DIFF
--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -446,17 +446,26 @@ func TestIsAppBundleEntry(t *testing.T) {
 
 func TestUninstallCommandForApp(t *testing.T) {
 	tests := []struct {
-		name string
-		want string
+		name  string
+		input string
+		want  string
 	}{
-		{name: "Safari.app", want: "mo uninstall Safari"},
-		{name: "Google Chrome.app", want: `mo uninstall "Google Chrome"`},
+		{name: "simple", input: "Safari.app", want: "mo uninstall Safari"},
+		{name: "space", input: "Google Chrome.app", want: "mo uninstall 'Google Chrome'"},
+		{name: "dollar", input: "My$App.app", want: "mo uninstall 'My$App'"},
+		{name: "command substitution", input: "Unsafe$(printf HACKED).app", want: "mo uninstall 'Unsafe$(printf HACKED)'"},
+		{name: "semicolon", input: "Foo;Bar.app", want: "mo uninstall 'Foo;Bar'"},
+		{name: "backtick", input: "My`App.app", want: "mo uninstall 'My`App'"},
+		{name: "single quote", input: "Bob's App.app", want: `mo uninstall 'Bob'\''s App'`},
+		{name: "leading dash", input: "-Example.app", want: "mo uninstall <App>"},
+		{name: "tab", input: "Tabbed\tApp.app", want: "mo uninstall <App>"},
+		{name: "newline", input: "Split\nApp.app", want: "mo uninstall <App>"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := uninstallCommandForApp(tt.name); got != tt.want {
-				t.Errorf("uninstallCommandForApp(%q) = %q, want %q", tt.name, got, tt.want)
+			if got := uninstallCommandForApp(tt.input); got != tt.want {
+				t.Errorf("uninstallCommandForApp(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/cmd/analyze/analyze_test.go
+++ b/cmd/analyze/analyze_test.go
@@ -422,6 +422,96 @@ func TestUpdateKeyCtrlCQuits(t *testing.T) {
 	}
 }
 
+func TestIsAppBundleEntry(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry dirEntry
+		want  bool
+	}{
+		{name: "lowercase bundle", entry: dirEntry{Name: "Safari.app", IsDir: true}, want: true},
+		{name: "uppercase extension", entry: dirEntry{Name: "Safari.APP", IsDir: true}, want: true},
+		{name: "file", entry: dirEntry{Name: "report.app", IsDir: false}, want: false},
+		{name: "longer extension", entry: dirEntry{Name: "Notes.application", IsDir: true}, want: false},
+		{name: "no extension", entry: dirEntry{Name: "Safari", IsDir: true}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAppBundleEntry(tt.entry); got != tt.want {
+				t.Errorf("isAppBundleEntry(%+v) = %v, want %v", tt.entry, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUninstallCommandForApp(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "Safari.app", want: "mo uninstall Safari"},
+		{name: "Google Chrome.app", want: `mo uninstall "Google Chrome"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := uninstallCommandForApp(tt.name); got != tt.want {
+				t.Errorf("uninstallCommandForApp(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestViewDeleteConfirmShowsUninstallHintForAppBundle(t *testing.T) {
+	entry := dirEntry{Name: "Safari.app", Path: "/Applications/Safari.app", Size: 1, IsDir: true}
+	m := model{
+		path:          "/Applications",
+		entries:       []dirEntry{entry},
+		deleteConfirm: true,
+		deleteTarget:  &entry,
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "mo uninstall Safari") {
+		t.Fatalf("expected app-specific uninstall command, got:\n%s", view)
+	}
+	if !strings.Contains(view, "bundle only") {
+		t.Fatalf("expected bundle-only warning, got:\n%s", view)
+	}
+}
+
+func TestViewDeleteConfirmNoHintForRegularDirectory(t *testing.T) {
+	entry := dirEntry{Name: "cache", Path: "/tmp/cache", Size: 1, IsDir: true}
+	m := model{
+		path:          "/tmp",
+		entries:       []dirEntry{entry},
+		deleteConfirm: true,
+		deleteTarget:  &entry,
+	}
+
+	view := m.View()
+	if strings.Contains(view, "mo uninstall") {
+		t.Fatalf("did not expect uninstall hint for a regular directory, got:\n%s", view)
+	}
+}
+
+func TestViewDeleteConfirmMultiSelectShowsGenericHint(t *testing.T) {
+	app := dirEntry{Name: "Safari.app", Path: "/Applications/Safari.app", Size: 1, IsDir: true}
+	cache := dirEntry{Name: "cache", Path: "/Applications/cache", Size: 1, IsDir: true}
+	m := model{
+		path:          "/Applications",
+		entries:       []dirEntry{app, cache},
+		multiSelected: map[string]bool{app.Path: true, cache.Path: true},
+		deleteConfirm: true,
+		deleteTarget:  &cache,
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "mo uninstall <App>") {
+		t.Fatalf("expected generic uninstall hint for multi-select containing an app bundle, got:\n%s", view)
+	}
+}
+
 func TestViewShowsEscBackAndCtrlCQuitHints(t *testing.T) {
 	m := model{
 		path:       "/tmp/project",

--- a/cmd/analyze/view.go
+++ b/cmd/analyze/view.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 )
@@ -414,6 +415,7 @@ func (m model) View() string {
 		fmt.Fprintln(&b)
 		var deleteCount int
 		var totalDeleteSize int64
+		hasAppBundle := false
 		if m.showLargeFiles && len(m.largeMultiSelected) > 0 {
 			deleteCount = len(m.largeMultiSelected)
 			for path := range m.largeMultiSelected {
@@ -430,6 +432,9 @@ func (m model) View() string {
 				for _, entry := range m.entries {
 					if entry.Path == path {
 						totalDeleteSize += entry.Size
+						if isAppBundleEntry(entry) {
+							hasAppBundle = true
+						}
 						break
 					}
 				}
@@ -447,8 +452,37 @@ func (m model) View() string {
 				m.deleteTarget.Name, humanizeBytes(m.deleteTarget.Size),
 				colorGray, colorReset)
 		}
+		if deleteCount > 1 && hasAppBundle {
+			fmt.Fprintf(&b, "%sApp bundles delete the bundle only. Use mo uninstall <App> to also remove support files.%s\n",
+				colorYellow, colorReset)
+		} else if deleteCount <= 1 && isAppBundleEntry(*m.deleteTarget) {
+			fmt.Fprintf(&b, "%sApp bundle: this deletes the bundle only. Use %s to also remove its support files.%s\n",
+				colorYellow, uninstallCommandForApp(m.deleteTarget.Name), colorReset)
+		}
 	}
 	return b.String()
+}
+
+// isAppBundleEntry reports whether a scanned entry is a macOS application
+// bundle: a directory whose name ends in ".app". Contents are not inspected;
+// the hint this powers is informational, so a false positive on a plain
+// folder named like a bundle is harmless.
+func isAppBundleEntry(entry dirEntry) bool {
+	return entry.IsDir && strings.EqualFold(filepath.Ext(entry.Name), ".app")
+}
+
+// uninstallCommandForApp renders the mo uninstall invocation for an app
+// bundle name, quoting names that contain whitespace so the printed command
+// stays copy-pasteable (mo uninstall treats each argument as one app name).
+func uninstallCommandForApp(name string) string {
+	appName := strings.TrimSuffix(name, filepath.Ext(name))
+	if appName == "" {
+		appName = name
+	}
+	if strings.ContainsAny(appName, " \t") {
+		return fmt.Sprintf("mo uninstall %q", appName)
+	}
+	return "mo uninstall " + appName
 }
 
 func allOverviewEntriesPending(entries []dirEntry) bool {

--- a/cmd/analyze/view.go
+++ b/cmd/analyze/view.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"unicode"
 )
 
 // View renders the TUI.
@@ -471,18 +472,39 @@ func isAppBundleEntry(entry dirEntry) bool {
 	return entry.IsDir && strings.EqualFold(filepath.Ext(entry.Name), ".app")
 }
 
-// uninstallCommandForApp renders the mo uninstall invocation for an app
-// bundle name, quoting names that contain whitespace so the printed command
-// stays copy-pasteable (mo uninstall treats each argument as one app name).
+// uninstallCommandForApp renders a shell-safe mo uninstall invocation for an
+// app bundle name. Simple names stay unquoted; other printable names use POSIX
+// single-quote escaping. Names that look like flags or contain control
+// characters fall back to the generic placeholder.
 func uninstallCommandForApp(name string) string {
 	appName := strings.TrimSuffix(name, filepath.Ext(name))
 	if appName == "" {
 		appName = name
 	}
-	if strings.ContainsAny(appName, " \t") {
-		return fmt.Sprintf("mo uninstall %q", appName)
+	if appName == "" || strings.HasPrefix(appName, "-") || strings.IndexFunc(appName, unicode.IsControl) >= 0 {
+		return "mo uninstall <App>"
 	}
-	return "mo uninstall " + appName
+	if isShellSafeUnquotedAppName(appName) {
+		return "mo uninstall " + appName
+	}
+	return "mo uninstall '" + strings.ReplaceAll(appName, "'", `'\''`) + "'"
+}
+
+func isShellSafeUnquotedAppName(name string) bool {
+	for _, r := range name {
+		if r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' {
+			continue
+		}
+		switch r {
+		case '_', '-', '.', '+':
+			continue
+		default:
+			return false
+		}
+	}
+	return name != ""
 }
 
 func allOverviewEntriesPending(entries []dirEntry) bool {


### PR DESCRIPTION
## Summary

- Implements the smaller version tw93 approved in discussion #1405: when delete confirmation targets a recognized `.app` bundle, the prompt says deletion removes the bundle only and names `mo uninstall <App>` for support files.
- Multi-select shows a generic one-line variant. What gets deleted is unchanged.

## Safety Review

- This affects the analyze delete confirmation display only.
- Deletion targets, Trash routing, path validation, and confirmation keys are unchanged.
- No new flags or filesystem access were added to the render path.

## Tests

- `MOLE_TEST_NO_AUTH=1 go test ./cmd/analyze` (including five new tests)
- `./scripts/check.sh --format`
- `make build`
- `MOLE_TEST_NO_AUTH=1 go test ./...`
- Manual TUI check in `~/Applications`: verified the app-specific hint for a `.app` bundle, canceled with Esc, and verified that a regular directory shows no hint.

## Safety-related changes

- None.
