### PR TITLE
fix(uninstall): avoid restarting active app extensions

### DIFF
--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -480,7 +480,9 @@ unregister_app_bundle() {
     return 0
 }
 
-# Compact and rebuild LaunchServices after uninstall batch to clear stale app metadata.
+# Compact LaunchServices after uninstall without forcing every app and extension
+# to re-register. A domain-wide rebuild can terminate active app extensions,
+# including Network Extension packet tunnels such as Shadowrocket's.
 refresh_launch_services_after_uninstall() {
     local lsregister
     lsregister=$(get_lsregister_path)
@@ -488,26 +490,10 @@ refresh_launch_services_after_uninstall() {
 
     [[ "${MOLE_DRY_RUN:-0}" == "1" ]] && return 0
 
-    local success=0
-    set +e
-    # Add 10s timeout to prevent hanging (gc is usually fast)
-    # run_with_timeout falls back to shell implementation if timeout command unavailable
+    # Best-effort and bounded: stale records are collected, while the targeted
+    # -u call above handles the app bundle that was actually removed.
     run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" "$lsregister" -gc > /dev/null 2>&1 || true
-    # 15s: lsregister rebuild can be slow on some systems, see lib/core/timeouts.sh
-    run_with_timeout 15 "$lsregister" -r -f -domain local -domain user -domain system > /dev/null 2>&1
-    success=$?
-    # 124 = timeout exit code (from run_with_timeout or timeout command)
-    if [[ $success -eq 124 ]]; then
-        debug_log "LaunchServices rebuild timed out, trying lighter version"
-        run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" "$lsregister" -r -f -domain local -domain user > /dev/null 2>&1
-        success=$?
-    elif [[ $success -ne 0 ]]; then
-        run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" "$lsregister" -r -f -domain local -domain user > /dev/null 2>&1
-        success=$?
-    fi
-    set -e
-
-    [[ $success -eq 0 || $success -eq 124 ]]
+    return 0
 }
 
 # Remove macOS Login Items for an app

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -2502,31 +2502,23 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "refresh_launch_services_after_uninstall falls back after timeout" {
+@test "refresh_launch_services_after_uninstall compacts without forcing a domain re-registration" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 source "$PROJECT_ROOT/lib/uninstall/batch.sh"
 
-log_file="$HOME/lsregister-timeout.log"
+test_home="$HOME/launchservices-refresh-home"
+mkdir -p "$test_home"
+log_file="$test_home/lsregister-calls.log"
 : > "$log_file"
-call_index=0
 
 get_lsregister_path() { echo "/bin/echo"; }
-debug_log() { echo "DEBUG:$*" >> "$log_file"; }
 run_with_timeout() {
     local duration="$1"
     shift
-    call_index=$((call_index + 1))
-    echo "CALL${call_index}:$duration:$*" >> "$log_file"
-
-    if [[ "$call_index" -eq 2 ]]; then
-        return 124
-    fi
-    if [[ "$call_index" -eq 3 ]]; then
-        return 124
-    fi
-    return 0
+    echo "CALL:$duration:$*" >> "$log_file"
+    return 124
 }
 
 if refresh_launch_services_after_uninstall; then
@@ -2540,9 +2532,11 @@ EOF
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"RESULT:ok"* ]] || return 1
-    [[ "$output" == *"CALL2:15:/bin/echo -r -f -domain local -domain user -domain system"* ]] || return 1
-    [[ "$output" == *"CALL3:10:/bin/echo -r -f -domain local -domain user"* ]] || return 1
-    [[ "$output" == *"DEBUG:LaunchServices rebuild timed out, trying lighter version"* ]]
+    [[ "$output" == *"CALL:10:/bin/echo -gc"* ]] || return 1
+    [[ "$output" != *" -r "* ]] || return 1
+    [[ "$output" != *" -f "* ]] || return 1
+    [[ "$output" != *" -domain "* ]] || return 1
+    [ "$(printf '%s\n' "$output" | grep -c '^CALL:')" -eq 1 ] || return 1
 }
 
 @test "remove_mole deletes manual binaries and caches" {


### PR DESCRIPTION
## Summary

- 卸载完成后只执行有超时保护的 `lsregister -gc`，移除全局 `lsregister -r -f -domain ...` 重建。
- 保留卸载前针对目标应用执行的 `lsregister -u "$app_path"`，因此仍会注销实际被删除的应用。
- 增加回归测试，确保刷新逻辑只做一次 compact，即使超时也保持 best-effort，并且不会传入 `-r`、`-f` 或 `-domain`。

Fixes #1492

Related: #862, #930

## 原因

全量强制重建 LaunchServices 会重新注册系统中的所有应用和扩展。在真实复现中，从交互式卸载流程返回应用列表后，Shadowrocket 的 Network Extension 被系统终止：

```text
neagent: Extension com.liguangming.Shadowrocket.PacketTunnel died unexpectedly
nesessionmanager: plugin disconnected with reason Plugin failed
```

直接按目标应用执行的 `lsregister -u` 已足以处理被卸载 bundle；随后对所有 domain 执行 `-r -f` 没有必要，并且会影响与本次卸载无关的活跃扩展。

## Safety Review

- 此修改影响 uninstall 完成后的 LaunchServices 刷新，但不改变应用、关联文件或系统文件的删除范围。
- 保留目标 bundle 的注销逻辑及 `lsregister -gc` 失效记录清理。
- `-gc` 仍通过现有超时封装执行，失败或超时时按原有意图视为 best-effort，不阻止已经完成的卸载。
- 不涉及路径验证、受保护目录、符号链接、sudo 边界或安装/发布完整性。

## Tests

- `TERM=xterm-256color MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats tests/uninstall_remove_file_list.bats` — 108/108 passed
- `./scripts/check.sh --no-format` — passed（Go vet、ShellCheck、Bash syntax、function duplication、diagnostic guidance）
- `go test ./...` — passed
- 回归测试已在修复前观察到失败，并在修复后通过。

## 真实环境验证

使用一个无后台进程、无扩展、无用户数据的临时 `/Applications/MoleVPNRepro.app`，执行完全相同的交互式卸载流程：

- 修复前：返回应用列表后 `MacPacketTunnel` 消失，约 5 秒内 VPN 变为 `Disconnected`，90 秒后仍未恢复。
- 修复后：基线、返回列表后立即、5 秒、30 秒、90 秒均为 `Connected`；`MacPacketTunnel` PID 全程保持 `68027`，系统日志中没有 `died unexpectedly`、`Plugin failed` 或断开事件。
