### PR TITLE
fix(windows): pass install directory by name during update

### DIFF
--- a/bin/update.ps1
+++ b/bin/update.ps1
@@ -218,13 +218,13 @@ else {
     Write-Host "Updated source: $before -> $after" -ForegroundColor Green
 }
 
-$installArgs = @(
-    "-InstallDir", $windowsDir
-)
+$installParams = @{
+    InstallDir = $windowsDir
+}
 
 if (Test-InstallDirOnUserPath -Path $windowsDir) {
-    $installArgs += "-AddToPath"
+    $installParams.AddToPath = $true
 }
 
 Write-Host "Refreshing local installation..." -ForegroundColor Cyan
-& $installScript @installArgs
+& $installScript @installParams

--- a/install.ps1
+++ b/install.ps1
@@ -32,7 +32,7 @@ function Resolve-InstallInvocation {
     # the path made AddToPath truthy and the optional marker became
     # CreateShortcut. Decode only that exact legacy shape for the first update
     # that pulls this installer while the old updater is still running.
-    if ($RequestedInstallDir -ceq "-InstallDir" -and $RequestedAddToPath.IsPresent) {
+    if ($RequestedInstallDir -ceq "-InstallDir") {
         return [PSCustomObject]@{
             InstallDir     = $SourceDir
             AddToPath      = $RequestedCreateShortcut.IsPresent

--- a/install.ps1
+++ b/install.ps1
@@ -19,11 +19,47 @@ Set-StrictMode -Version Latest
 # Configuration
 # ============================================================================
 
+function Resolve-InstallInvocation {
+    param(
+        [string]$SourceDir,
+        [string]$RequestedInstallDir,
+        [switch]$RequestedAddToPath,
+        [switch]$RequestedCreateShortcut
+    )
+
+    # v1.30.0 passed @("-InstallDir", $sourceDir, optional "-AddToPath")
+    # through array splatting. PowerShell bound those values positionally, so
+    # the path made AddToPath truthy and the optional marker became
+    # CreateShortcut. Decode only that exact legacy shape for the first update
+    # that pulls this installer while the old updater is still running.
+    if ($RequestedInstallDir -ceq "-InstallDir" -and $RequestedAddToPath.IsPresent) {
+        return [PSCustomObject]@{
+            InstallDir     = $SourceDir
+            AddToPath      = $RequestedCreateShortcut.IsPresent
+            CreateShortcut = $false
+        }
+    }
+
+    return [PSCustomObject]@{
+        InstallDir     = $RequestedInstallDir
+        AddToPath      = $RequestedAddToPath.IsPresent
+        CreateShortcut = $RequestedCreateShortcut.IsPresent
+    }
+}
+
 $script:SourceDir = if ($MyInvocation.MyCommand.Path) {
     Split-Path -Parent $MyInvocation.MyCommand.Path
 } else {
     $PSScriptRoot
 }
+$resolvedInvocation = Resolve-InstallInvocation `
+    -SourceDir $script:SourceDir `
+    -RequestedInstallDir $InstallDir `
+    -RequestedAddToPath:$AddToPath `
+    -RequestedCreateShortcut:$CreateShortcut
+$InstallDir = $resolvedInvocation.InstallDir
+$AddToPath = [switch]$resolvedInvocation.AddToPath
+$CreateShortcut = [switch]$resolvedInvocation.CreateShortcut
 $script:CoreDir = Join-Path $script:SourceDir "lib\core"
 $script:ShortcutName = "Mole"
 

--- a/tests/Commands.Tests.ps1
+++ b/tests/Commands.Tests.ps1
@@ -152,6 +152,72 @@ Describe "Update Command" {
             $result -join "`n" | Should -Match "source|origin/windows|git"
         }
     }
+
+    Context "Installation Refresh" {
+        It "Should pass the source directory to the installer by name" {
+            $fixtureRoot = Join-Path $TestDrive "update-fixture"
+            $fixtureBin = Join-Path $fixtureRoot "bin"
+            $fakeTools = Join-Path $fixtureRoot "fake-tools"
+            $capturePath = Join-Path $fixtureRoot "install-dir.txt"
+            $fixtureUpdater = Join-Path $fixtureBin "update.ps1"
+
+            New-Item -ItemType Directory -Path $fixtureBin, $fakeTools, (Join-Path $fixtureRoot ".git") -Force | Out-Null
+            Copy-Item (Join-Path $script:BinDir "update.ps1") $fixtureUpdater
+
+            @'
+param(
+    [string]$InstallDir,
+    [switch]$AddToPath,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [object[]]$RemainingArguments
+)
+
+Set-Content -LiteralPath $env:MOLE_INSTALL_CAPTURE -Value $InstallDir -NoNewline
+'@ | Set-Content (Join-Path $fixtureRoot "install.ps1")
+
+            @'
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$GitArgs
+)
+
+$commandArgs = @($GitArgs)
+if ($commandArgs.Count -ge 3 -and $commandArgs[0] -eq "-C") {
+    $commandArgs = @($commandArgs[2..($commandArgs.Count - 1)])
+}
+
+$commandLine = $commandArgs -join " "
+$global:LASTEXITCODE = 0
+switch -Regex ($commandLine) {
+    '^status --porcelain --untracked-files=no$' { break }
+    '^remote get-url origin$' { "https://github.com/tw93/Mole.git"; break }
+    '^branch --show-current$' { "windows"; break }
+    '^rev-parse --short HEAD$' { "abc123"; break }
+    '^pull --ff-only origin windows$' { break }
+    default {
+        Write-Error "Unexpected git command: $commandLine"
+        $global:LASTEXITCODE = 1
+    }
+}
+'@ | Set-Content (Join-Path $fakeTools "git.ps1")
+
+            $originalPath = $env:PATH
+            $originalCapture = $env:MOLE_INSTALL_CAPTURE
+            try {
+                $env:PATH = "$fakeTools;$originalPath"
+                $env:MOLE_INSTALL_CAPTURE = $capturePath
+
+                & $fixtureUpdater
+
+                $capturePath | Should -Exist
+                Get-Content $capturePath -Raw | Should -Be $fixtureRoot
+            }
+            finally {
+                $env:PATH = $originalPath
+                $env:MOLE_INSTALL_CAPTURE = $originalCapture
+            }
+        }
+    }
 }
 
 Describe "Remove Command" {

--- a/tests/Commands.Tests.ps1
+++ b/tests/Commands.Tests.ps1
@@ -217,6 +217,107 @@ switch -Regex ($commandLine) {
                 $env:MOLE_INSTALL_CAPTURE = $originalCapture
             }
         }
+
+        It "Should refresh the source directory on the first update from v1.30.0" {
+            $fixtureRoot = Join-Path $TestDrive "legacy-update-fixture"
+            $fixtureBin = Join-Path $fixtureRoot "bin"
+            $fixtureCore = Join-Path $fixtureRoot "lib\core"
+            $fixtureUpdater = Join-Path $fixtureBin "update.ps1"
+            $fixtureInstaller = Join-Path $fixtureRoot "install.ps1"
+            $strayInstallDir = Join-Path $TestDrive "-InstallDir"
+
+            New-Item -ItemType Directory -Path $fixtureBin, $fixtureCore -Force | Out-Null
+            Copy-Item $script:InstallScript $fixtureInstaller
+            Set-Content (Join-Path $fixtureRoot "VERSION") "1.30.0"
+            New-Item -ItemType File -Path (Join-Path $fixtureBin "analyze.exe"), (Join-Path $fixtureBin "status.exe") -Force | Out-Null
+
+            @'
+function Get-MoleVersionString {
+    param([string]$RootDir)
+    return "1.30.0"
+}
+'@ | Set-Content (Join-Path $fixtureCore "version.ps1")
+
+            @'
+function Get-MoleVersionFromScriptFile {
+    param([string]$WindowsDir)
+    return "1.30.0"
+}
+
+function Ensure-TuiBinary {
+    param(
+        [string]$Name,
+        [string]$WindowsDir,
+        [string]$DestinationPath,
+        [string]$SourcePath,
+        [string]$Version
+    )
+    return $DestinationPath
+}
+'@ | Set-Content (Join-Path $fixtureCore "tui_binaries.ps1")
+
+            # Exact v1.30.0 updater call shape. The installer file beside this
+            # script represents the new file that git pull just wrote.
+            @'
+$windowsDir = Split-Path -Parent $PSScriptRoot
+$installScript = Join-Path $windowsDir "install.ps1"
+$installArgs = @("-InstallDir", $windowsDir)
+& $installScript @installArgs
+if (-not $?) { exit 1 }
+'@ | Set-Content $fixtureUpdater
+
+            Push-Location $TestDrive
+            try {
+                & powershell -NoProfile -ExecutionPolicy Bypass -File $fixtureUpdater
+                $LASTEXITCODE | Should -Be 0
+            }
+            finally {
+                Pop-Location
+            }
+
+            (Join-Path $fixtureRoot "mole.cmd") | Should -Exist
+            $strayInstallDir | Should -Not -Exist
+        }
+
+        It "Should recover the legacy updater PATH intent without creating a shortcut" {
+            $probe = Join-Path $TestDrive "legacy-argument-probe.ps1"
+            @'
+. $env:MOLE_INSTALL_SCRIPT -ShowHelp | Out-Null
+
+$withoutPath = Resolve-InstallInvocation `
+    -SourceDir "C:\Mole" `
+    -RequestedInstallDir "-InstallDir" `
+    -RequestedAddToPath
+$withPath = Resolve-InstallInvocation `
+    -SourceDir "C:\Mole" `
+    -RequestedInstallDir "-InstallDir" `
+    -RequestedAddToPath `
+    -RequestedCreateShortcut
+
+[PSCustomObject]@{
+    WithoutPathInstallDir = $withoutPath.InstallDir
+    WithoutPathAddToPath = $withoutPath.AddToPath
+    WithPathInstallDir = $withPath.InstallDir
+    WithPathAddToPath = $withPath.AddToPath
+    WithPathCreateShortcut = $withPath.CreateShortcut
+} | ConvertTo-Json -Compress
+'@ | Set-Content $probe
+
+            $originalInstallScript = $env:MOLE_INSTALL_SCRIPT
+            try {
+                $env:MOLE_INSTALL_SCRIPT = $script:InstallScript
+                $result = & powershell -NoProfile -ExecutionPolicy Bypass -File $probe | ConvertFrom-Json
+            }
+            finally {
+                $env:MOLE_INSTALL_SCRIPT = $originalInstallScript
+            }
+
+            $result.WithoutPathInstallDir | Should -Be "C:\Mole"
+            $result.WithoutPathAddToPath | Should -BeFalse
+            $result.WithPathInstallDir | Should -Be "C:\Mole"
+            $result.WithPathAddToPath | Should -BeTrue
+            $result.WithPathCreateShortcut | Should -BeFalse
+        }
     }
 }
 

--- a/tests/Commands.Tests.ps1
+++ b/tests/Commands.Tests.ps1
@@ -282,7 +282,7 @@ if (-not $?) { exit 1 }
         It "Should recover the legacy updater PATH intent without creating a shortcut" {
             $probe = Join-Path $TestDrive "legacy-argument-probe.ps1"
             @'
-. $env:MOLE_INSTALL_SCRIPT -ShowHelp | Out-Null
+. $env:MOLE_INSTALL_SCRIPT -ShowHelp 6>$null
 
 $withoutPath = Resolve-InstallInvocation `
     -SourceDir "C:\Mole" `


### PR DESCRIPTION
I ran into this while using `mo update` on Windows. Instead of refreshing the existing installation, the installer created a directory literally named `-InstallDir`.

The updater was passing the installer arguments through an array, so PowerShell treated them as positional values. This changes it to hashtable splatting so `InstallDir` and `AddToPath` are passed by name.

I also added a regression test for this case!

Thanks

I tested with PowerShell 7 and Pester 5.9.1: 101 tests passed.