### PR TITLE
fix(uninstall): handle app bundle suffixes case-insensitively

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -1292,7 +1292,9 @@ match_apps_by_name() {
                 IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$word_app"
                 local word_name_lower word_dir_lower
                 word_name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
-                word_dir_lower=$(basename "$app_path" .app | tr '[:upper:]' '[:lower:]')
+                word_dir_lower=$(basename "$app_path")
+                word_dir_lower="${word_dir_lower%.[aA][pP][pP]}"
+                word_dir_lower=$(printf '%s' "$word_dir_lower" | tr '[:upper:]' '[:lower:]')
                 if [[ "$word_name_lower" == "$word_lower" || "$word_dir_lower" == "$word_lower" ]]; then
                     word_hit=true
                     break
@@ -1311,7 +1313,9 @@ match_apps_by_name() {
                 IFS='|' read -r epoch app_path app_name bundle_id size last_used size_kb <<< "$joined_app"
                 local joined_name_lower joined_dir_lower
                 joined_name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
-                joined_dir_lower=$(basename "$app_path" .app | tr '[:upper:]' '[:lower:]')
+                joined_dir_lower=$(basename "$app_path")
+                joined_dir_lower="${joined_dir_lower%.[aA][pP][pP]}"
+                joined_dir_lower=$(printf '%s' "$joined_dir_lower" | tr '[:upper:]' '[:lower:]')
                 if [[ "$joined_name_lower" == "$joined_lower" || "$joined_dir_lower" == "$joined_lower" ]]; then
                     selected_apps=("$joined_app")
                     return 0
@@ -1336,7 +1340,8 @@ match_apps_by_name() {
             name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
             # Also try matching against the .app directory base name
             local dir_name
-            dir_name=$(basename "$app_path" .app)
+            dir_name=$(basename "$app_path")
+            dir_name="${dir_name%.[aA][pP][pP]}"
             local dir_lower
             dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
 
@@ -1366,7 +1371,8 @@ match_apps_by_name() {
                 local name_lower
                 name_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
                 local dir_name
-                dir_name=$(basename "$app_path" .app)
+                dir_name=$(basename "$app_path")
+                dir_name="${dir_name%.[aA][pP][pP]}"
                 local dir_lower
                 dir_lower=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]')
 

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -164,7 +164,7 @@ uninstall_resolve_display_name() {
         fi
     fi
 
-    display_name="${display_name%.app}"
+    display_name="${display_name%.[aA][pP][pP]}"
     display_name="${display_name//|/-}"
     display_name="${display_name//[$'\t\r\n']/}"
     echo "$display_name"
@@ -402,9 +402,9 @@ uninstall_should_skip_app_path() {
 
     [[ -e "$app_path" ]] || return 0
 
-    # Skip nested apps inside another .app bundle.
+    # Skip nested apps inside another case-variant .app bundle.
     local parent_dir="${app_path%/*}"
-    if [[ "$parent_dir" == *".app" || "$parent_dir" == *".app/"* ]]; then
+    if [[ "$parent_dir" == *.[aA][pP][pP] || "$parent_dir" == *.[aA][pP][pP]/* ]]; then
         return 0
     fi
 
@@ -526,7 +526,7 @@ uninstall_print_app_paths_with_mtime() {
         [[ -n "$app_path" ]] || continue
         app_mtime=$(get_file_mtime "$app_path")
         printf '%s\t%s\n' "${app_mtime:-0}" "$app_path"
-    done < <(command find "$app_dir" -maxdepth 3 -name "*.app" -print0 2> /dev/null)
+    done < <(command find "$app_dir" -maxdepth 3 -iname "*.app" -print0 2> /dev/null)
 }
 
 uninstall_app_inventory_fingerprint() {
@@ -604,7 +604,7 @@ _scan_discover_apps() {
 
         local already_scanned=false
         for app_dir in "${app_dirs[@]}"; do
-            if [[ "$pkg_app_path" == "$app_dir"/*.app ]]; then
+            if [[ "$pkg_app_path" == "$app_dir"/*.[aA][pP][pP] ]]; then
                 already_scanned=true
                 break
             fi
@@ -612,7 +612,7 @@ _scan_discover_apps() {
         [[ "$already_scanned" == true ]] && continue
 
         local app_name="${pkg_app_path##*/}"
-        app_name="${app_name%.app}"
+        app_name="${app_name%.[aA][pP][pP]}"
 
         local app_mtime
         app_mtime=$(get_file_mtime "$pkg_app_path")
@@ -627,7 +627,7 @@ _scan_discover_apps() {
             if [[ ! -e "$app_path" ]]; then continue; fi
 
             local app_name="${app_path##*/}"
-            app_name="${app_name%.app}"
+            app_name="${app_name%.[aA][pP][pP]}"
 
             uninstall_should_skip_app_path "$app_path" && continue
 
@@ -733,7 +733,7 @@ _scan_resolve_uncached() {
             display_name=$(uninstall_resolve_display_name "$app_path" "$app_name")
         fi
 
-        display_name="${display_name%.app}"
+        display_name="${display_name%.[aA][pP][pP]}"
         display_name="${display_name//|/-}"
         display_name="${display_name//[$'\t\r\n']/}"
 
@@ -794,7 +794,7 @@ _scan_dedupe_bundle_ids() {
                 return 0
             }
             rest = substr(path, length(prefix) + 1)
-            return index(rest, "/") == 0 && rest ~ /[.]app$/
+            return index(rest, "/") == 0 && tolower(rest) ~ /[.]app$/
         }
         function path_rank(path) {
             if (direct_app_under(path, "/Applications/")) {

--- a/lib/clean/apps.sh
+++ b/lib/clean/apps.sh
@@ -208,7 +208,7 @@ scan_installed_apps() {
         (
             local worker_started_at=$SECONDS
             local app_paths
-            if ! app_paths=$(command find "$app_dir" -maxdepth 3 -type d -name '*.app' 2> /dev/null); then
+            if ! app_paths=$(command find "$app_dir" -maxdepth 3 -type d -iname '*.app' 2> /dev/null); then
                 printf '%s\n' "$app_dir" >> "$scan_tmp_dir/scan_failures.list"
                 exit 1
             fi
@@ -220,7 +220,7 @@ scan_installed_apps() {
                 # whose plist is not under Contents/, which then failed the
                 # scan. Helper bundles nested elsewhere are left alone.
                 case "$app_path" in
-                    */Wrapper/*.app) continue ;;
+                    */Wrapper/*.[aA][pP][pP]) continue ;;
                 esac
                 local plist_path="$app_path/Contents/Info.plist"
                 # iOS and iPadOS apps installed on Apple Silicon have no
@@ -231,7 +231,7 @@ scan_installed_apps() {
                 # App leftovers section.
                 if [[ ! -f "$plist_path" ]]; then
                     local wrapped_plist=""
-                    for wrapped_plist in "$app_path"/Wrapper/*.app/Info.plist; do
+                    for wrapped_plist in "$app_path"/Wrapper/*.[aA][pP][pP]/Info.plist; do
                         if [[ -f "$wrapped_plist" ]]; then
                             plist_path="$wrapped_plist"
                             break
@@ -1152,7 +1152,7 @@ clean_orphaned_system_services() {
         # prefers a stale plist false negative over deleting a live updater's
         # registration. See #1447.
         case "$binary" in
-            /Library/PrivilegedHelperTools/*.app/Contents/MacOS/*)
+            /Library/PrivilegedHelperTools/*.[aA][pP][pP]/Contents/MacOS/*)
                 return 1
                 ;;
         esac

--- a/lib/core/app_protection.sh
+++ b/lib/core/app_protection.sh
@@ -142,7 +142,9 @@ official_uninstaller_vendor() {
     local normalized_bundle normalized_name normalized_path
     normalized_bundle=$(printf '%s' "$bundle_id" | LC_ALL=C tr '[:upper:]' '[:lower:]')
     normalized_name=$(printf '%s' "$display_name" | LC_ALL=C tr '[:upper:]' '[:lower:]')
-    normalized_path=$(basename "${app_path:-}" .app | LC_ALL=C tr '[:upper:]' '[:lower:]')
+    normalized_path=$(basename "${app_path:-}")
+    normalized_path="${normalized_path%.[aA][pP][pP]}"
+    normalized_path=$(printf '%s' "$normalized_path" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 
     local rule vendor prefixes fragments prefix fragment
     local -a _prefixes _fragments

--- a/lib/core/bundle_resolver.sh
+++ b/lib/core/bundle_resolver.sh
@@ -129,7 +129,7 @@ bundle_has_installed_app() {
             "$deadline_seconds") || app_scan_rc=$?
         if [[ $app_scan_rc -eq 0 ]]; then
             run_with_timeout "$app_scan_timeout" /usr/bin/find "$app_root" \
-                -maxdepth "$app_scan_depth" -name "*.app" -print0 \
+                -maxdepth "$app_scan_depth" -iname "*.app" -print0 \
                 < /dev/null > "$app_scan_file" 2> /dev/null || app_scan_rc=$?
         fi
         if [[ $app_scan_rc -ne 0 ]]; then

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -2264,7 +2264,7 @@ _mole_path_is_immediate_child_of() {
 _mole_path_is_application_bundle() {
     local path="${1%/}"
     _mole_path_is_immediate_child_of "$path" "/Applications" &&
-        [[ "${path##*/}" == *.app ]]
+        [[ "${path##*/}" == *.[aA][pP][pP] ]]
 }
 
 # Finder and third-party Trash helpers can fail on app bundles and TCC-managed
@@ -3485,7 +3485,7 @@ get_path_size_kb() {
     # on the same physical-size basis as the directory fallback; logical size
     # can be much larger for APFS-cloned bundles and must not be mixed into the
     # same total as `du` results (#1404).
-    if [[ "$path" == *.app || "$path" == *.app/ ]]; then
+    if [[ "$path" == *.[aA][pP][pP] || "$path" == *.[aA][pP][pP]/ ]]; then
         local mdls_size
         local mdls_timeout=""
         local mdls_deadline_rc=0

--- a/lib/core/pkg_receipts.sh
+++ b/lib/core/pkg_receipts.sh
@@ -143,10 +143,15 @@ pkg_receipt_nonstandard_app_paths() {
             local candidate="/$stripped"
 
             case "$candidate" in
-                /usr/local/*.app) app_path="$candidate" ;;
-                /opt/*.app) app_path="$candidate" ;;
-                /usr/local/*.app/*) app_path="${candidate%%.app/*}.app" ;;
-                /opt/*.app/*) app_path="${candidate%%.app/*}.app" ;;
+                /usr/local/*.[aA][pP][pP]) app_path="$candidate" ;;
+                /opt/*.[aA][pP][pP]) app_path="$candidate" ;;
+                /usr/local/*.[aA][pP][pP]/* | /opt/*.[aA][pP][pP]/*)
+                    local app_prefix app_suffix_and_rest app_suffix
+                    app_prefix="${candidate%%.[aA][pP][pP]/*}"
+                    app_suffix_and_rest="${candidate#"$app_prefix"}"
+                    app_suffix="${app_suffix_and_rest%%/*}"
+                    app_path="${app_prefix}${app_suffix}"
+                    ;;
                 *) continue ;;
             esac
 

--- a/lib/optimize/tasks.sh
+++ b/lib/optimize/tasks.sh
@@ -1773,7 +1773,7 @@ _login_item_app_exists() {
             if [[ ${#name_expr[@]} -gt 0 ]]; then
                 name_expr+=("-o")
             fi
-            name_expr+=("-name" "$app_name")
+            name_expr+=("-iname" "$app_name")
         done
         candidate=$(command find "$roots" -maxdepth 6 -type d \( "${name_expr[@]}" \) -print -quit 2> /dev/null || true)
         if [[ -n "$candidate" && -d "$candidate" ]]; then
@@ -1785,7 +1785,7 @@ _login_item_app_exists() {
             if _login_item_bundle_metadata_matches "$app_path" "$name" "$nospace" "$stripped"; then
                 return 0
             fi
-        done < <(command find "$roots" -maxdepth 6 -type d -name "*.app" -print0 2> /dev/null)
+        done < <(command find "$roots" -maxdepth 6 -type d -iname "*.app" -print0 2> /dev/null)
     done
     # 5. Fallback: check sfltool dumpbtm for the actual on-disk path.
     #    Nested helper apps (e.g. DBnginMenuHelper.app inside DBngin.app) are

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -2380,7 +2380,8 @@ _batch_render_summary() {
 
             for success_path in "${success_items[@]}"; do
                 local display_name
-                display_name=$(basename "$success_path" .app)
+                display_name=$(basename "$success_path")
+                display_name="${display_name%.[aA][pP][pP]}"
                 local display_item="${GREEN}${display_name}${NC}"
 
                 if ((idx % 3 == 0)); then

--- a/lib/uninstall/batch.sh
+++ b/lib/uninstall/batch.sh
@@ -235,7 +235,7 @@ discover_login_item_helper_bundle_ids() {
     scan_file=$(create_temp_file) || return 1
     local scan_rc=0
     _mole_uninstall_materialize_find0 "$scan_file" \
-        "$login_items_root" -maxdepth 1 -name "*.app" \
+        "$login_items_root" -maxdepth 1 -iname "*.app" \
         -print0 || scan_rc=$?
     if [[ $scan_rc -ne 0 ]]; then
         rm -f -- "$scan_file" 2> /dev/null || true # SAFE: exact tracked temp file created above
@@ -465,7 +465,7 @@ unregister_app_bundle() {
     local app_path="$1"
 
     [[ -n "$app_path" && -e "$app_path" ]] || return 0
-    [[ "$app_path" == *.app ]] || return 0
+    [[ "$app_path" == *.[aA][pP][pP] ]] || return 0
 
     local lsregister
     lsregister=$(get_lsregister_path)
@@ -510,7 +510,7 @@ remove_login_item() {
     [[ -z "$app_name" && -z "$bundle_id" ]] && return 0
 
     # Strip .app suffix if present (login items don't include it)
-    local clean_name="${app_name%.app}"
+    local clean_name="${app_name%.[aA][pP][pP]}"
 
     # Remove from Login Items using index-based deletion (handles broken items)
     if [[ -n "$clean_name" ]]; then
@@ -750,7 +750,7 @@ _uninstall_live_candidate_is_nested_app() {
     local component
     while [[ -n "$parent" && "$parent" != "." ]]; do
         component="${parent%%/*}"
-        [[ "$component" == *.app ]] && return 0
+        [[ "$component" == *.[aA][pP][pP] ]] && return 0
         [[ "$parent" == */* ]] || break
         parent="${parent#*/}"
     done
@@ -876,7 +876,7 @@ _uninstall_collect_live_sibling_candidate() {
         # and a single such app aborted the uninstall of every other app on
         # the machine (#1339). They are ordinary installs, not a mystery.
         local wrapped=""
-        for wrapped in "$app"/Wrapper/*.app/Info.plist; do
+        for wrapped in "$app"/Wrapper/*.[aA][pP][pP]/Info.plist; do
             if [[ -f "$wrapped" ]]; then
                 info="$wrapped"
                 break
@@ -990,7 +990,7 @@ uninstall_live_bundle_has_other_install() {
             -mindepth 2 -maxdepth 2 \
             \( \
             \( -type d -name Applications \) -o \
-            \( \( -type d -o -type l \) -name '*.app' \) \
+            \( \( -type d -o -type l \) -iname '*.app' \) \
             \) || volume_scan_rc=$?
         if [[ $volume_scan_rc -eq $MOLE_UNINSTALL_SCAN_PARTIAL || $volume_scan_rc -eq 124 ]]; then
             # Some volume was unreadable, or the budget ran out before every
@@ -1024,7 +1024,7 @@ uninstall_live_bundle_has_other_install() {
         local scan_rc=0
         _uninstall_materialize_complete_find0 "$scan_file" \
             "$deadline_seconds" "$root" -maxdepth 3 \
-            \( -type d -o -type l \) -name '*.app' || scan_rc=$?
+            \( -type d -o -type l \) -iname '*.app' || scan_rc=$?
         if [[ $scan_rc -eq $MOLE_UNINSTALL_SCAN_PARTIAL ]]; then
             # Unreadable subpaths under an app root. The apps this listing did
             # find are still real, so keep going and let the doubt decide the
@@ -1196,7 +1196,7 @@ uninstall_surviving_sibling_names() {
         [[ "$is_selected" == true ]] && continue
 
         local other_base="${other_path##*/}"
-        other_base="${other_base%.app}"
+        other_base="${other_base%.[aA][pP][pP]}"
 
         # Emit each identifier plus its version-suffix-stripped base: a
         # survivor named "Foo Beta.app" also claims "Foo"-keyed dirs via the
@@ -1355,7 +1355,7 @@ _batch_scan_app_details() {
         # Leftover matching is destructive and must use the current bundle
         # basename, not a display name cached when the selection list opened.
         local discovery_app_name="${app_path##*/}"
-        discovery_app_name="${discovery_app_name%.app}"
+        discovery_app_name="${discovery_app_name%.[aA][pP][pP]}"
 
         local official_vendor=""
         if official_vendor=$(official_uninstaller_vendor "$bundle_id" "$app_name" "$app_path" 2> /dev/null); then

--- a/lib/uninstall/brew.sh
+++ b/lib/uninstall/brew.sh
@@ -215,8 +215,10 @@ _detect_cask_via_symlink_check() {
 _detect_cask_via_brew_list() {
     local app_path="$1"
     local app_bundle_name="$2"
+    local app_base_name
     local app_name_lower
-    app_name_lower=$(echo "${app_bundle_name%.app}" | LC_ALL=C tr '[:upper:]' '[:lower:]')
+    app_base_name="${app_bundle_name%.[aA][pP][pP]}"
+    app_name_lower=$(printf '%s' "$app_base_name" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 
     local cask_list=""
     local list_rc=0

--- a/lib/uninstall/steam.sh
+++ b/lib/uninstall/steam.sh
@@ -27,7 +27,7 @@ uninstall_steam_launcher_appid() {
     fi
     if [[ -z "$exec_name" ]]; then
         exec_name="${app_path##*/}"
-        exec_name="${exec_name%.app}"
+        exec_name="${exec_name%.[aA][pP][pP]}"
     fi
 
     local script="$app_path/Contents/MacOS/$exec_name"

--- a/tests/brew_uninstall.bats
+++ b/tests/brew_uninstall.bats
@@ -99,7 +99,7 @@ source "$PROJECT_ROOT/lib/uninstall/brew.sh"
 brew() {
     case "$*" in
         "list --cask")
-            printf '%s\n' "owned" "samename" "standard"
+            printf '%s\n' "mixed" "owned" "samename" "standard"
             ;;
         "info --cask owned")
             printf 'app "%s"\n' "$HOME/Applications/Owned.app"
@@ -109,6 +109,9 @@ brew() {
             ;;
         "info --cask standard")
             printf '%s\n' 'Standard.app (App)'
+            ;;
+        "info --cask mixed")
+            printf '%s\n' 'Mixed.APP (App)'
             ;;
         *)
             return 1
@@ -124,6 +127,8 @@ owned=$(_detect_cask_via_brew_list "$HOME/Applications/Owned.app" "Owned.app")
 ! get_brew_cask_name "$HOME/Applications/SameName.app"
 standard=$(_detect_cask_via_brew_list "/Applications/Standard.app" "Standard.app")
 [[ "$standard" == "standard" ]] || exit 1
+mixed=$(_detect_cask_via_brew_list "/Applications/Mixed.APP" "Mixed.APP")
+[[ "$mixed" == "mixed" ]] || exit 1
 EOF
 
     [ "$status" -eq 0 ]

--- a/tests/bundle_resolver.bats
+++ b/tests/bundle_resolver.bats
@@ -78,6 +78,17 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "bundle_has_installed_app finds a mixed-case app bundle suffix" {
+    make_app "$FAKE_APPS/KeePassXC.APP" "org.keepassxc.KeePassXC"
+
+    run env FAKE_APPS="$FAKE_APPS" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<EOF
+$(prelude)
+bundle_has_installed_app "org.keepassxc.KeePassXC"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "bundle_has_installed_app falls back after run_with_timeout returns 124 (set -e + pipefail regression)" {
     # Regression for the flake that blocked PR #770: under `set -euo pipefail`,
     # `hit=$(run_with_timeout ... | head -1)` inside a command substitution

--- a/tests/clean_apps.bats
+++ b/tests/clean_apps.bats
@@ -347,7 +347,7 @@ if [ "${1:-}" != "-maxdepth" ] ||
     [ "${2:-}" != "3" ] ||
     [ "${3:-}" != "-type" ] ||
     [ "${4:-}" != "d" ] ||
-    [ "${5:-}" != "-name" ] ||
+    [ "${5:-}" != "-iname" ] ||
     [ "${6:-}" != "*.app" ]; then
     exit 64
 fi
@@ -2953,6 +2953,38 @@ if scan_installed_apps "$HOME/installed2.txt"; then
 	echo "CORRUPT_NOT_FAILED"; exit 1
 fi
 EOF
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
+}
+
+@test "installed-app scan reads mixed-case outer and wrapped app bundles" {
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_TEST_MODE=1 /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/apps.sh"
+rm -f "$HOME/.cache/mole/installed_apps_cache"
+
+apps="$HOME/Applications"
+rm -rf "$apps"
+mkdir -p "$apps/Upper.APP/Contents" "$apps/Wrapped.APP/Wrapper/Inner.APP"
+plist() {
+	cat > "$1" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>$2</dict></plist>
+PLIST
+}
+plist "$apps/Upper.APP/Contents/Info.plist" '<key>CFBundleIdentifier</key><string>com.example.upper</string>'
+plist "$apps/Wrapped.APP/Wrapper/Inner.APP/Info.plist" '<key>CFBundleIdentifier</key><string>com.example.wrapped-upper</string>'
+
+debug_log() { :; }
+scan_installed_apps "$HOME/installed.txt" || { echo "SCAN_FAILED"; exit 1; }
+grep -Fxq "com.example.upper" "$HOME/installed.txt" || { echo "MISSING_UPPER"; exit 1; }
+grep -Fxq "com.example.wrapped-upper" "$HOME/installed.txt" || { echo "MISSING_WRAPPED_UPPER"; exit 1; }
+EOF
+
 	[ "$status" -eq 0 ] || {
 		echo "$output"
 		return 1

--- a/tests/file_ops_mole_delete.bats
+++ b/tests/file_ops_mole_delete.bats
@@ -343,6 +343,17 @@ EOF
     [[ "$(grep -c '^osascript:' "$trace" 2> /dev/null || true)" -eq 0 ]]
 }
 
+@test "mixed-case app suffix still uses the application Trash path" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+_mole_path_is_application_bundle "/Applications/Example.APP"
+_mole_path_requires_direct_trash "/Applications/Example.App"
+EOF
+
+    [ "$status" -eq 0 ]
+}
+
 @test "application Trash falls back to Finder after a direct TCC denial" {
     local trace="$SANDBOX/app-finder-fallback.log"
 

--- a/tests/optimize.bats
+++ b/tests/optimize.bats
@@ -1657,6 +1657,26 @@ EOF
 	[[ "$output" == *"found"* ]]
 }
 
+@test "_login_item_app_exists finds nested mixed-case app bundles" {
+	local helper="$HOME/Applications/Roon.APP/Contents/RoonServer.APP"
+	mkdir -p "$helper"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/optimize/tasks.sh"
+mdfind() { return 1; }
+sfltool() { return 1; }
+export -f mdfind sfltool
+if _login_item_app_exists "RoonServer"; then
+    echo "found"
+fi
+EOF
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"found"* ]]
+}
+
 @test "_login_item_app_exists finds nested helper apps by bundle display name" {
 	local helper="$HOME/Applications/Adobe Acrobat DC.app/Contents/Helpers/AdobeResourceSynchronizer.app"
 	mkdir -p "$helper/Contents"

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -649,6 +649,67 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "live same-bundle guard finds mixed-case siblings but ignores nested and unrelated bundles" {
+    local app_root="$HOME/live-mixed-case-apps"
+    mkdir -p "$app_root/Selected.app/Contents" \
+        "$app_root/Unrelated.App/Contents"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" APP_ROOT="$app_root" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+pkg_receipt_nonstandard_app_paths() { :; }
+
+write_bundle_id() {
+    local path="$1"
+    local bundle_id="$2"
+    mkdir -p "$path/Contents"
+    printf '%s\n' \
+        '<?xml version="1.0" encoding="UTF-8"?>' \
+        '<plist version="1.0"><dict>' \
+        "<key>CFBundleIdentifier</key><string>$bundle_id</string>" \
+        '</dict></plist>' \
+        > "$path/Contents/Info.plist"
+}
+
+write_bundle_id "$APP_ROOT/Selected.app" "com.example.live-mixed"
+write_bundle_id "$APP_ROOT/Unrelated.App" "com.example.unrelated"
+selected_apps=("0|$APP_ROOT/Selected.app|Selected|com.example.live-mixed|0|Never")
+_MOLE_UNINSTALL_LIVE_APP_ROOTS=("$APP_ROOT")
+_MOLE_UNINSTALL_LIVE_VOLUMES_ROOT="$HOME/no-volumes"
+
+# A case-variant app with another id must not block the selected app.
+if uninstall_live_bundle_has_other_install \
+    "com.example.live-mixed" "$APP_ROOT/Selected.app"; then
+    echo "WRONG: unrelated app reported as a sibling"
+    exit 1
+fi
+[[ ${#_MOLE_UNINSTALL_LIVE_SIBLING_PATHS[@]} -eq 0 ]] || exit 1
+
+# A nested helper belongs to Container.APP and is not another installation.
+write_bundle_id "$APP_ROOT/Container.APP/Nested.app" "com.example.live-mixed"
+if uninstall_live_bundle_has_other_install \
+    "com.example.live-mixed" "$APP_ROOT/Selected.app"; then
+    echo "WRONG: nested app reported as a sibling"
+    exit 1
+fi
+[[ ${#_MOLE_UNINSTALL_LIVE_SIBLING_PATHS[@]} -eq 0 ]] || exit 1
+
+# A top-level surviving .APP with the same id must trip the destructive guard.
+write_bundle_id "$APP_ROOT/Survivor.APP" "com.example.live-mixed"
+uninstall_live_bundle_has_other_install \
+    "com.example.live-mixed" "$APP_ROOT/Selected.app"
+[[ ${#_MOLE_UNINSTALL_LIVE_SIBLING_PATHS[@]} -eq 1 ]] || exit 1
+[[ "${_MOLE_UNINSTALL_LIVE_SIBLING_PATHS[0]}" == "$APP_ROOT/Survivor.APP" ]]
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+}
+
 @test "live same-bundle scan accepts dot-app text in a volume ancestor" {
     local app_root="$HOME/Backup.app-data/Applications"
     mkdir -p "$app_root/Survivor.app/Contents" "$HOME/Selected.app"
@@ -2537,6 +2598,35 @@ EOF
     [[ "$output" != *" -f "* ]] || return 1
     [[ "$output" != *" -domain "* ]] || return 1
     [ "$(printf '%s\n' "$output" | grep -c '^CALL:')" -eq 1 ] || return 1
+}
+
+@test "unregister_app_bundle accepts mixed-case app suffixes only in real mode" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/uninstall/batch.sh"
+
+test_home="$HOME/launchservices-unregister-home"
+mkdir -p "$test_home/Upper.APP" "$test_home/Plain.bundle"
+log_file="$test_home/lsregister-calls.log"
+: > "$log_file"
+
+get_lsregister_path() { echo "/bin/echo"; }
+run_with_timeout() {
+    local duration="$1"
+    shift
+    echo "CALL:$duration:$*" >> "$log_file"
+}
+
+MOLE_DRY_RUN=0 unregister_app_bundle "$test_home/Upper.APP"
+MOLE_DRY_RUN=0 unregister_app_bundle "$test_home/Plain.bundle"
+MOLE_DRY_RUN=1 unregister_app_bundle "$test_home/Upper.APP"
+cat "$log_file"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"CALL:5:/bin/echo -u $HOME/launchservices-unregister-home/Upper.APP"* ]] || return 1
+    [ "$(printf '%s\n' "$output" | grep -c '^CALL:')" -eq 1 ]
 }
 
 @test "remove_mole deletes manual binaries and caches" {

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -2773,6 +2773,26 @@ EOF
     [[ "$output" == *"Test Application"* ]]
 }
 
+@test "match_apps_by_name prefers an exact mixed-case bundle basename" {
+    run /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+selected_apps=()
+apps_data=(
+	"1000|$HOME/Applications/Foo.APP|Different Display Name|com.example.Foo|1 MB|1000000|1024"
+	"1001|$HOME/Applications/Foo Bar.app|Foo Bar|com.example.FooBar|1 MB|1000001|1024"
+)
+source "$PROJECT_ROOT/tests/test_match_apps_helper.sh"
+match_apps_by_name "Foo"
+echo "count=${#selected_apps[@]}"
+echo "match=${selected_apps[0]}"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"count=1"* ]] || return 1
+    [[ "$output" == *"/Foo.APP|"* ]] || return 1
+    [[ "$output" != *"/Foo Bar.app|"* ]]
+}
+
 @test "match_apps_by_name warns on no match" {
     run /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/uninstall_safety.bats
+++ b/tests/uninstall_safety.bats
@@ -114,10 +114,11 @@ set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
 official_uninstaller_vendor "com.crowdstrike.falcon.UserAgent" "Falcon" "/Applications/Falcon.app"
 official_uninstaller_vendor "com.jamf.management.Jamf" "Jamf Connect" "/Applications/Jamf Connect.app"
+official_uninstaller_vendor "" "Unknown" "/Applications/CrowdStrike Falcon.APP"
 EOF
 	)"
 
-	[[ "$result" == *"CrowdStrike"* ]] || { echo "missed CrowdStrike"; exit 1; }
+	[[ "$(printf '%s\n' "$result" | grep -cFx 'CrowdStrike')" -eq 2 ]] || { echo "missed CrowdStrike"; exit 1; }
 	[[ "$result" == *"Jamf"* ]] || { echo "missed Jamf"; exit 1; }
 }
 

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -586,7 +586,7 @@ MOCK
 	# The copy must rename the load guard too: common.sh already sourced the
 	# real file, and the readonly guard would silently keep the original
 	# function, turning this test into a no-op against the wrong code.
-	sed -e "s|/usr/local/\*.app|$HOME/usr-local/*.app|g" \
+	sed -e "s|/usr/local/|$HOME/usr-local/|g" \
 		-e 's|MOLE_PKG_RECEIPTS_LOADED|MOLE_PKG_RECEIPTS_TEST_LOADED|g' \
 		"$PROJECT_ROOT/lib/core/pkg_receipts.sh" > "$HOME/pkg_receipts_test.sh"
 
@@ -608,6 +608,48 @@ EOF
 	}
 	[[ "$output" != *"unbound variable"* ]] || return 1
 	[[ "$output" == *"RC=0 OUT=$HOME/usr-local/Example.app"* ]] || return 1
+}
+
+@test "receipt discovery preserves mixed-case app bundles in complete scans" {
+	local mock_bin="$HOME/mock-pkgutil-mixed-app"
+	mkdir -p "$mock_bin" \
+		"$HOME/usr-local/Direct.APP" \
+		"$HOME/usr-local/Nested.App/Contents"
+	cat > "$mock_bin/pkgutil" << MOCK
+#!/bin/bash
+case "\$1" in
+    --pkgs) printf 'com.example.mixed-apps\n' ;;
+    --files)
+        printf '%s\n' \
+            '${HOME#/}/usr-local/Direct.APP' \
+            '${HOME#/}/usr-local/Nested.App/Contents/Info.plist'
+        ;;
+esac
+MOCK
+	chmod +x "$mock_bin/pkgutil"
+
+	# Redirect the fixed production prefix into the isolated HOME while keeping
+	# the real mixed-case parser and complete-scan contract under test.
+	sed -e "s|/usr/local/|$HOME/usr-local/|g" \
+		-e 's|MOLE_PKG_RECEIPTS_LOADED|MOLE_PKG_RECEIPTS_MIXED_TEST_LOADED|g' \
+		"$PROJECT_ROOT/lib/core/pkg_receipts.sh" > "$HOME/pkg_receipts_mixed_test.sh"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+		PATH="$mock_bin:/usr/bin:/bin" \
+		MOLE_PKG_RECEIPT_CACHE_DISABLE=1 /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$HOME/pkg_receipts_mixed_test.sh"
+
+pkg_receipt_nonstandard_app_paths --require-complete
+EOF
+
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
+	[[ "$output" == *"$HOME/usr-local/Direct.APP"* ]] || return 1
+	[[ "$output" == *"$HOME/usr-local/Nested.App"* ]] || return 1
 }
 
 @test "a newly installed receipt invalidates the cached complete answer" {
@@ -636,7 +678,7 @@ MOCK
 	chmod +x "$mock_bin/pkgutil"
 	printf 'com.example.first\n' > "$pkgs_file"
 
-	sed -e "s|/usr/local/\*.app|$HOME/usr-local/*.app|g" \
+	sed -e "s|/usr/local/|$HOME/usr-local/|g" \
 		-e 's|MOLE_PKG_RECEIPTS_LOADED|MOLE_PKG_RECEIPTS_TEST_LOADED|g' \
 		"$PROJECT_ROOT/lib/core/pkg_receipts.sh" > "$HOME/pkg_receipts_cache_test.sh"
 

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -163,6 +163,66 @@ EOF
 	[ "$status" -ne 0 ]
 }
 
+@test "app discovery treats the app suffix case-insensitively without admitting nested bundles" {
+	src="$HOME/uninstall_source.sh"
+	sourceable_uninstall_sh "$src"
+
+	apps_root="$HOME/Applications"
+	mkdir -p \
+		"$apps_root/Upper.APP" \
+		"$apps_root/Mixed.App" \
+		"$apps_root/Lower.app" \
+		"$apps_root/Receipt.APP" \
+		"$apps_root/Outer.APP/Nested.app"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+		APPS_ROOT="$apps_root" SRC_PATH="$src" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$SRC_PATH"
+
+uninstall_print_app_search_dirs() { printf '%s\n' "$APPS_ROOT"; }
+pkg_receipt_nonstandard_app_paths() { printf '%s\n' "$APPS_ROOT/Receipt.APP"; }
+get_file_mtime() { printf '1\n'; }
+
+discovered_file="$HOME/discovered"
+: > "$discovered_file"
+_scan_discover_apps
+cat "$discovered_file"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[ "$(printf '%s\n' "$output" | grep -cF "$apps_root/Upper.APP|Upper|1")" -eq 1 ] || return 1
+	[ "$(printf '%s\n' "$output" | grep -cF "$apps_root/Mixed.App|Mixed|1")" -eq 1 ] || return 1
+	[ "$(printf '%s\n' "$output" | grep -cF "$apps_root/Lower.app|Lower|1")" -eq 1 ] || return 1
+	[ "$(printf '%s\n' "$output" | grep -cF "$apps_root/Receipt.APP|Receipt|1")" -eq 1 ] || return 1
+	[[ "$output" != *"Outer.APP/Nested.app"* ]]
+}
+
+@test "bundle dedupe ranks direct mixed-case app paths before user copies" {
+	src="$HOME/uninstall_source.sh"
+	sourceable_uninstall_sh "$src"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" SRC_PATH="$src" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$SRC_PATH"
+
+scan_raw_file="$HOME/raw"
+printf '%s\n' \
+	"$HOME/Applications/Shared.APP|Shared|com.example.shared|1|1" \
+	"/Applications/Shared.APP|Shared|com.example.shared|1|1" \
+	> "$scan_raw_file"
+
+_scan_dedupe_bundle_ids
+cat "$scan_raw_file"
+EOF
+
+	[ "$status" -eq 0 ] || return 1
+	[ "$(printf '%s\n' "$output" | grep -cF 'com.example.shared')" -eq 1 ] || return 1
+	[[ "$output" == "/Applications/Shared.APP|Shared|com.example.shared|1|1" ]]
+}
+
 @test "scan_applications surfaces inline physical app size before deferred refresh (#1126)" {
 	src="$HOME/uninstall_source.sh"
 	sourceable_uninstall_sh "$src"

--- a/tests/uninstall_steam_launcher.bats
+++ b/tests/uninstall_steam_launcher.bats
@@ -111,6 +111,22 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "uninstall_steam_launcher_appid derives executable from a mixed-case app suffix" {
+    app="$HOME/Applications/SteamGame.APP"
+    mkdir -p "$app/Contents/MacOS"
+    printf '#!/bin/bash\nopen steam://run/1091500\n' > "$app/Contents/MacOS/SteamGame"
+    chmod +x "$app/Contents/MacOS/SteamGame"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/uninstall/steam.sh"
+uninstall_steam_launcher_appid "$HOME/Applications/SteamGame.APP"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == "1091500" ]]
+}
+
 @test "uninstall_app_is_steam_launcher stays false for a regular shell launcher" {
     app="$HOME/Applications/RegularApp.app"
     create_regular_app "$app"


### PR DESCRIPTION
## Summary

- make uninstall discovery and `.app` name normalization ASCII-case-insensitive, matching the bundle recognition added in #1485
- apply the same suffix rule to nested-bundle exclusion, live same-bundle rechecks, and direct-path dedupe ranking
- allow the targeted LaunchServices unregister path retained by #1493 to handle case-variant bundles without changing dry-run or deletion behavior

The search roots, bundle-ID protection, sibling identity checks, confirmation flow, and final removal sinks are unchanged.

## Tests

- `TERM=xterm-256color MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats tests/uninstall_scan_bash32.bats tests/uninstall_naming_variants.bats` (143 tests)
- `./scripts/check.sh --format`
- `go test ./...`

The new regressions cover lowercase, mixed-case, and uppercase bundle suffixes; receipt deduplication; direct-path ranking; nested bundle exclusion; live same-bundle protection with an unrelated-bundle negative control; targeted unregister; and dry-run/non-bundle controls.
