### PR TITLE
feat(clean): clean Feishu/Lark embedded webview Service Worker cache (~28GB reclaimed)

### DIFF
--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -434,14 +434,72 @@ clean_code_editors() {
 # the sibling ScriptCache (MV3 worker bytecode). Documents live on Lark's
 # servers and auth lives in Cookies / Local Storage, neither of which this path
 # touches; a cleared editor bundle is re-precached on next open.
+feishu_or_lark_running() {
+    mole_pgrep_any \
+        -x "Feishu" \
+        -x "Lark" \
+        -f '/(Feishu|Lark)[.]app/'
+}
+
+_feishu_service_worker_delete_guard_allows() {
+    mole_clean_process_guard feishu_or_lark_running "Feishu or Lark started"
+}
+
 clean_feishu_service_worker_caches() {
-    declare -f clean_service_worker_cache > /dev/null 2>&1 || return 0
-    local sw_root="$HOME/Library/Application Support/LarkShell/aha/users"
-    [[ -d "$sw_root" ]] || return 0
-    local _profile
-    for _profile in "$sw_root"/*/profile_explorer; do
-        [[ -d "$_profile" ]] || continue
-        clean_service_worker_cache "Feishu" "${_profile%/}/Service Worker/CacheStorage"
+    local -a sw_roots=(
+        "$HOME/Library/Application Support/LarkShell/aha/users"
+        "$HOME/Library/Application Support/LarkInternational/aha/users"
+    )
+    local -a root_labels=("Feishu" "Lark")
+    local -a cache_paths=()
+    local -a cache_labels=()
+    local root_index sw_root app_label physical_root _profile cache_path physical_cache
+    for ((root_index = 0; root_index < ${#sw_roots[@]}; root_index++)); do
+        sw_root="${sw_roots[$root_index]}"
+        app_label="${root_labels[$root_index]}"
+        [[ -d "$sw_root" ]] || continue
+        physical_root=$(cd -P "$sw_root" 2> /dev/null && pwd -P) || continue
+        if [[ "$physical_root" != "$sw_root" ]]; then
+            debug_log "Refusing symlinked ${app_label} profile root: $sw_root -> $physical_root"
+            continue
+        fi
+        for _profile in "$sw_root"/*/profile_explorer; do
+            [[ -d "$_profile" ]] || continue
+            cache_path="${_profile%/}/Service Worker/CacheStorage"
+            [[ -d "$cache_path" ]] || continue
+            physical_cache=$(cd -P "$cache_path" 2> /dev/null && pwd -P) || continue
+            if [[ "$physical_cache" != "$cache_path" ]]; then
+                debug_log "Refusing symlinked ${app_label} Service Worker cache: $cache_path -> $physical_cache"
+                continue
+            fi
+            cache_paths+=("$cache_path")
+            cache_labels+=("$app_label")
+        done
+    done
+    [[ ${#cache_paths[@]} -gt 0 ]] || return 0
+
+    local _MOLE_CLEAN_GUARD_REASON=""
+    if ! _feishu_service_worker_delete_guard_allows; then
+        mole_report_guard_stop "Feishu/Lark Service Worker" \
+            mole_defer_cleanup_family "Feishu/Lark"
+        return 0
+    fi
+
+    local cleanup_deadline=$((SECONDS + MOLE_TIMEOUT_DISK_VERIFY_SEC))
+    local cache_index guarded_rc=0
+    for ((cache_index = 0; cache_index < ${#cache_paths[@]}; cache_index++)); do
+        app_label="${cache_labels[$cache_index]}"
+        cache_path="${cache_paths[$cache_index]}"
+        guarded_rc=0
+        clean_service_worker_cache "$app_label" "$cache_path" \
+            _feishu_service_worker_delete_guard_allows \
+            "$cleanup_deadline" || guarded_rc=$?
+        if [[ $guarded_rc -eq 75 ]]; then
+            mole_report_guard_stop "Feishu/Lark Service Worker" \
+                mole_defer_cleanup_family "Feishu/Lark"
+            return 0
+        fi
+        [[ $guarded_rc -eq 0 ]] || return "$guarded_rc"
     done
 }
 # Communication apps.

--- a/lib/clean/app_caches.sh
+++ b/lib/clean/app_caches.sh
@@ -420,6 +420,30 @@ clean_code_editors() {
         safe_clean ~/Library/Application\ Support/CodeBuddy\ CN/logs/* "CodeBuddy CN logs"
     fi
 }
+# Lark / Feishu desktop embeds a Chromium webview (the "aha" explorer profile)
+# to render its in-app docs, sheets, slides, and AI surfaces. Every workspace
+# origin the user opens precaches the full editor bundle into that profile's
+# Service Worker CacheStorage, and stale workspaces plus superseded precache
+# versions are never evicted, so it grows without bound (measured at 27GB across
+# nine origin buckets on a heavy user's machine, oldest files ~11 months old).
+# This lives at a non-standard path the browser cleaners never reach.
+#
+# Reuse the shared Service Worker cleaner so the same per-origin-hash iteration,
+# PROTECTED_SW_DOMAINS skip, user-whitelist honoring, and safe_remove funnel that
+# Chrome and Arc get apply here unchanged. Only CacheStorage is targeted, never
+# the sibling ScriptCache (MV3 worker bytecode). Documents live on Lark's
+# servers and auth lives in Cookies / Local Storage, neither of which this path
+# touches; a cleared editor bundle is re-precached on next open.
+clean_feishu_service_worker_caches() {
+    declare -f clean_service_worker_cache > /dev/null 2>&1 || return 0
+    local sw_root="$HOME/Library/Application Support/LarkShell/aha/users"
+    [[ -d "$sw_root" ]] || return 0
+    local _profile
+    for _profile in "$sw_root"/*/profile_explorer; do
+        [[ -d "$_profile" ]] || continue
+        clean_service_worker_cache "Feishu" "${_profile%/}/Service Worker/CacheStorage"
+    done
+}
 # Communication apps.
 clean_communication_apps() {
     safe_clean ~/Library/Application\ Support/discord/Cache/* "Discord cache"
@@ -436,6 +460,7 @@ clean_communication_apps() {
     safe_clean ~/Library/Caches/com.tencent.WeWorkMac/* "WeCom cache"
     safe_clean ~/Library/Caches/com.tencent.qq/* "QQ cache"
     safe_clean ~/Library/Caches/com.feishu.*/* "Feishu cache"
+    clean_feishu_service_worker_caches
     if [[ -d ~/Library/Application\ Support/Microsoft/Teams ]]; then
         safe_clean ~/Library/Application\ Support/Microsoft/Teams/Cache/* "Microsoft Teams legacy cache"
         safe_clean ~/Library/Application\ Support/Microsoft/Teams/Application\ Cache/* "Microsoft Teams legacy application cache"

--- a/lib/clean/caches.sh
+++ b/lib/clean/caches.sh
@@ -43,27 +43,61 @@ check_tcc_permissions() {
     ensure_user_file "$permission_flag"
     return 0
 }
-# Args: $1=browser_name, $2=cache_path, $3=optional post-size guard callback
+# Args: $1=browser_name, $2=cache_path, $3=optional post-size guard callback,
+#       $4=optional absolute SECONDS deadline shared by a larger cleanup family
 # Clean Service Worker cache while protecting critical web editors.
 clean_service_worker_cache() {
     local browser_name="$1"
-    local cache_path="$2"
+    local cache_path="${2%/}"
     local delete_guard="${3:-}"
+    local deadline_seconds="${4:-}"
     [[ ! -d "$cache_path" ]] && return 0
+
+    # A lexical CacheStorage path below Application Support is not enough
+    # authority for recursive deletion. Refuse a root reached through any
+    # symlink so find and the later sink stay inside the profile we inspected.
+    local physical_cache_path=""
+    physical_cache_path=$(cd -P "$cache_path" 2> /dev/null && pwd -P) || return 1
+    if [[ "$physical_cache_path" != "$cache_path" ]]; then
+        debug_log "Refusing symlinked Service Worker cache root: $cache_path -> $physical_cache_path"
+        return 1
+    fi
+
+    # Materialize the complete producer result before the first sink. A timed
+    # out find may have printed a valid prefix, but that prefix is not a safe
+    # deletion plan and must be discarded as a unit.
+    local candidates_file=""
+    candidates_file=$(create_temp_file 2> /dev/null) || return 1
+    local find_timeout=""
+    local find_rc=0
+    find_timeout=$(_mole_timeout_with_deadline \
+        "$MOLE_TIMEOUT_PKG_LIST_SEC" "$deadline_seconds") || find_rc=$?
+    if [[ $find_rc -eq 0 ]]; then
+        # shellcheck disable=SC2016
+        run_with_timeout "$find_timeout" sh -c \
+            'find "$1" -type d -depth 2 2>/dev/null' _ "$cache_path" \
+            > "$candidates_file" || find_rc=$?
+    fi
+    if [[ $find_rc -ne 0 ]]; then
+        debug_log "Service Worker cache discovery failed for $cache_path (status $find_rc)"
+        _mole_record_clean_cancellation "$find_rc"
+        return "$find_rc"
+    fi
+
     local cleaned_size=0
     local protected_count=0
     local guard_stopped=false
-    # shellcheck disable=SC2016
     while IFS= read -r cache_dir; do
         [[ ! -d "$cache_dir" ]] && continue
-        # Extract a best-effort domain name from cache folder.
-        local domain=$(basename "$cache_dir" | grep -oE '[a-zA-Z0-9][-a-zA-Z0-9]*\.[a-zA-Z]{2,}' | head -1 || echo "")
-        local size=0
-        local _du_out
-        if _du_out=$(run_with_timeout "$MOLE_TIMEOUT_MEDIUM_PROBE_SEC" du -skP "$cache_dir" 2> /dev/null); then
-            local _sz="${_du_out%%[^0-9]*}"
-            [[ "$_sz" =~ ^[0-9]+$ ]] && size="$_sz"
+        [[ "$cache_dir" == "$cache_path/"* ]] || return 1
+        if [[ -n "$deadline_seconds" && $SECONDS -ge $deadline_seconds ]]; then
+            _mole_record_clean_cancellation 124
+            return 124
         fi
+
+        # Extract a best-effort domain name from cache folder.
+        local domain=""
+        domain=$(basename "$cache_dir" | grep -oE '[a-zA-Z0-9][-a-zA-Z0-9]*\.[a-zA-Z]{2,}' | head -1 || echo "")
         local is_protected=false
         for protected_domain in "${PROTECTED_SW_DOMAINS[@]}"; do
             if [[ "$domain" == *"$protected_domain"* ]]; then
@@ -81,20 +115,63 @@ clean_service_worker_cache() {
             protected_count=$((protected_count + 1))
         fi
         if [[ "$is_protected" == "false" ]]; then
+            _mole_snapshot_path_identity "$cache_dir" || continue
+            local expected_parent="$_MOLE_PATH_SNAPSHOT_PARENT"
+            local expected_parent_id="$_MOLE_PATH_SNAPSHOT_PARENT_ID"
+            local expected_target_id="$_MOLE_PATH_SNAPSHOT_TARGET_ID"
+            case "$expected_parent" in
+                "$physical_cache_path" | "$physical_cache_path"/*) ;;
+                *)
+                    debug_log "Refusing Service Worker candidate outside cache root: $cache_dir -> $expected_parent"
+                    return 1
+                    ;;
+            esac
+
+            local size=0
+            local _du_out=""
+            local du_timeout=""
+            local du_rc=0
+            du_timeout=$(_mole_timeout_with_deadline \
+                "$MOLE_TIMEOUT_MEDIUM_PROBE_SEC" "$deadline_seconds") || du_rc=$?
+            if [[ $du_rc -eq 0 ]]; then
+                _du_out=$(run_with_timeout "$du_timeout" du -skP "$cache_dir" 2> /dev/null) || du_rc=$?
+            fi
+            if [[ $du_rc -eq 124 || $du_rc -ge 128 ]]; then
+                _mole_record_clean_cancellation "$du_rc"
+                return "$du_rc"
+            fi
+            if [[ $du_rc -eq 0 ]]; then
+                local _sz="${_du_out%%[^0-9]*}"
+                [[ "$_sz" =~ ^[0-9]+$ ]] && size="$_sz"
+            fi
+
             if [[ -n "$delete_guard" ]] && ! "$delete_guard"; then
                 guard_stopped=true
                 break
+            fi
+            if ! _mole_path_matches_identity \
+                "$cache_dir" "$expected_parent" "$expected_parent_id" \
+                "$expected_target_id"; then
+                debug_log "Skipping Service Worker cache after identity changed: $cache_dir"
+                continue
             fi
             if [[ "$DRY_RUN" == "true" ]]; then
                 if declare -f record_dry_run_cleanup_target > /dev/null 2>&1; then
                     record_dry_run_cleanup_target "$cache_dir" "$size" 1 true || continue
                 fi
-            elif ! safe_remove "$cache_dir" true "$size"; then
-                continue
+            else
+                local remove_rc=0
+                safe_remove "$cache_dir" true "$size" "$deadline_seconds" \
+                    "$expected_parent" "$expected_parent_id" \
+                    "$expected_target_id" || remove_rc=$?
+                if [[ $remove_rc -eq 124 || $remove_rc -ge 128 ]]; then
+                    return "$remove_rc"
+                fi
+                [[ $remove_rc -eq 0 ]] || continue
             fi
             cleaned_size=$((cleaned_size + size))
         fi
-    done < <(run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" sh -c 'find "$1" -type d -depth 2 2>/dev/null || true' _ "$cache_path")
+    done < "$candidates_file"
     if [[ $cleaned_size -gt 0 ]]; then
         local spinner_was_running=false
         if [[ -t 1 && -n "${INLINE_SPINNER_PID:-}" ]]; then

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -878,21 +878,121 @@ EOF
 @test "clean_communication_apps cleans Feishu embedded webview Service Worker per profile" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
-base="$HOME/Library/Application Support/LarkShell/aha/users"
-mkdir -p "$base/57bea93a/profile_explorer/Service Worker/CacheStorage"
-mkdir -p "$base/6ef03470/profile_explorer/Service Worker/CacheStorage"
+feishu_base="$HOME/Library/Application Support/LarkShell/aha/users"
+lark_base="$HOME/Library/Application Support/LarkInternational/aha/users"
+mkdir -p "$feishu_base/57bea93a/profile_explorer/Service Worker/CacheStorage"
+mkdir -p "$feishu_base/6ef03470/profile_explorer/Service Worker/CacheStorage"
+mkdir -p "$lark_base/70ac6ef0/profile_explorer/Service Worker/CacheStorage"
 # A non-profile sibling under users/ must be ignored.
-mkdir -p "$base/global"
+mkdir -p "$feishu_base/global"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
 source "$PROJECT_ROOT/lib/clean/app_caches.sh"
 safe_clean() { echo "SC|$2"; }
-clean_service_worker_cache() { echo "SW|$1|$2"; }
+feishu_or_lark_running() { return 1; }
+clean_service_worker_cache() { echo "SW|$1|$2|$3|$4"; }
 clean_communication_apps
 EOF
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"SW|Feishu|$HOME/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage"* ]] || return 1
-    [[ "$output" == *"SW|Feishu|$HOME/Library/Application Support/LarkShell/aha/users/6ef03470/profile_explorer/Service Worker/CacheStorage"* ]] || return 1
+    [[ "$output" == *"SW|Feishu|$HOME/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage|_feishu_service_worker_delete_guard_allows|"* ]] || return 1
+    [[ "$output" == *"SW|Feishu|$HOME/Library/Application Support/LarkShell/aha/users/6ef03470/profile_explorer/Service Worker/CacheStorage|_feishu_service_worker_delete_guard_allows|"* ]] || return 1
+    [[ "$output" == *"SW|Lark|$HOME/Library/Application Support/LarkInternational/aha/users/70ac6ef0/profile_explorer/Service Worker/CacheStorage|_feishu_service_worker_delete_guard_allows|"* ]] || return 1
     [[ "$output" != *"users/global/"* ]] || return 1
+}
+
+@test "clean_feishu_service_worker_caches preserves pipe characters in profile paths" {
+    local pipe_home="$HOME/home|pipe"
+    run env HOME="$pipe_home" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+cache="$HOME/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage"
+mkdir -p "$cache"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+feishu_or_lark_running() { return 1; }
+clean_service_worker_cache() { printf 'SW:%s:%s\n' "$1" "$2"; }
+clean_feishu_service_worker_caches
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"SW:Feishu:$pipe_home/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage"* ]]
+}
+
+@test "clean_feishu_service_worker_caches skips all profiles while owner is running" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+cache="$HOME/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage"
+mkdir -p "$cache/origin/cache"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+feishu_or_lark_running() { return 0; }
+mole_defer_cleanup_family() { echo "DEFER:$1"; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
+clean_feishu_service_worker_caches
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"DEFER:Feishu/Lark"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
+}
+
+@test "clean_feishu_service_worker_caches fails closed on unknown owner state" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+cache="$HOME/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage"
+mkdir -p "$cache/origin/cache"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+feishu_or_lark_running() { return 2; }
+mole_defer_cleanup_family() { echo "UNEXPECTED_DEFER:$1"; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
+note_activity() { :; }
+clean_feishu_service_worker_caches
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"Feishu/Lark Service Worker · stopped (process state unknown)"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_DEFER"* ]]
+}
+
+@test "clean_feishu_service_worker_caches rechecks owner after sizing" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+marker="$HOME/feishu-started"
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+declare -a PROTECTED_SW_DOMAINS=("never.invalid")
+cache="$HOME/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage"
+candidate="$cache/origin/cache"
+mkdir -p "$candidate"
+feishu_or_lark_running() { [[ -e "$marker" ]] && return 0 || return 1; }
+mole_defer_cleanup_family() { echo "DEFER:$1"; }
+safe_remove() { echo "UNEXPECTED_REMOVE:$1"; return 0; }
+note_activity() { :; }
+run_with_timeout() {
+    shift
+    if [[ "$1" == "sh" ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+    if [[ "$1" == "du" ]]; then
+        touch "$marker"
+        printf '512\t%s\n' "$candidate"
+        return 0
+    fi
+    "$@"
+}
+clean_feishu_service_worker_caches
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"DEFER:Feishu/Lark"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
 }
 
 @test "clean_feishu_service_worker_caches is a no-op when the aha profile root is absent" {

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -875,6 +875,43 @@ EOF
     [[ "$output" == *"Microsoft Teams legacy logs"* ]]
 }
 
+@test "clean_communication_apps cleans Feishu embedded webview Service Worker per profile" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+base="$HOME/Library/Application Support/LarkShell/aha/users"
+mkdir -p "$base/57bea93a/profile_explorer/Service Worker/CacheStorage"
+mkdir -p "$base/6ef03470/profile_explorer/Service Worker/CacheStorage"
+# A non-profile sibling under users/ must be ignored.
+mkdir -p "$base/global"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+safe_clean() { echo "SC|$2"; }
+clean_service_worker_cache() { echo "SW|$1|$2"; }
+clean_communication_apps
+EOF
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SW|Feishu|$HOME/Library/Application Support/LarkShell/aha/users/57bea93a/profile_explorer/Service Worker/CacheStorage"* ]] || return 1
+    [[ "$output" == *"SW|Feishu|$HOME/Library/Application Support/LarkShell/aha/users/6ef03470/profile_explorer/Service Worker/CacheStorage"* ]] || return 1
+    [[ "$output" != *"users/global/"* ]] || return 1
+}
+
+@test "clean_feishu_service_worker_caches is a no-op when the aha profile root is absent" {
+    local empty_home
+    empty_home="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-app-caches.XXXXXX")"
+    run env HOME="$empty_home" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+clean_service_worker_cache() { echo "unexpected SW call"; }
+clean_feishu_service_worker_caches
+echo "done-no-op"
+EOF
+    rm -rf "$empty_home"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"unexpected SW call"* ]] || return 1
+    [[ "$output" == *"done-no-op"* ]] || return 1
+}
+
 @test "clean_gaming_platforms includes steam and minecraft related caches" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/clean_system_caches.bats
+++ b/tests/clean_system_caches.bats
@@ -309,6 +309,77 @@ EOF
     [[ "$output" != *"TestBrowser Service Worker"* ]]
 }
 
+@test "clean_service_worker_cache discards partial discovery after timeout" {
+    local test_cache="$HOME/test_sw_cache_partial_timeout"
+    mkdir -p "$test_cache/abc123_https_example.com_0"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<EOF
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+DRY_RUN=false
+declare -a PROTECTED_SW_DOMAINS=("never.invalid")
+safe_remove() { echo "UNEXPECTED_REMOVE:\$1"; return 0; }
+note_activity() { :; }
+run_with_timeout() {
+    shift
+    if [[ "\$1" == "sh" ]]; then
+        printf '%s\n' "$test_cache/abc123_https_example.com_0"
+        return 124
+    fi
+    if [[ "\$1" == "du" ]]; then
+        printf '512\t%s\n' "$test_cache/abc123_https_example.com_0"
+        return 0
+    fi
+    "\$@"
+}
+rc=0
+clean_service_worker_cache TestBrowser "$test_cache" || rc=\$?
+printf 'RC:%s\n' "\$rc"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"RC:124"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ "$output" != *"TestBrowser Service Worker"* ]]
+}
+
+@test "clean_service_worker_cache refuses a symlinked cache root" {
+    local outside="$HOME/outside-sw-profile"
+    local linked_profile="$HOME/linked-sw-profile"
+    mkdir -p "$outside/Service Worker/CacheStorage/abc123_https_example.com_0"
+    ln -s "$outside" "$linked_profile"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<EOF
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/caches.sh"
+DRY_RUN=false
+declare -a PROTECTED_SW_DOMAINS=("never.invalid")
+safe_remove() { echo "UNEXPECTED_REMOVE:\$1"; return 0; }
+note_activity() { :; }
+run_with_timeout() {
+    shift
+    if [[ "\$1" == "sh" ]]; then
+        printf '%s\n' "$linked_profile/Service Worker/CacheStorage/abc123_https_example.com_0"
+        return 0
+    fi
+    if [[ "\$1" == "du" ]]; then
+        printf '512\t%s\n' "$linked_profile/Service Worker/CacheStorage/abc123_https_example.com_0"
+        return 0
+    fi
+    "\$@"
+}
+rc=0
+clean_service_worker_cache TestBrowser "$linked_profile/Service Worker/CacheStorage" || rc=\$?
+printf 'RC:%s\n' "\$rc"
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" != *"UNEXPECTED_REMOVE"* ]] || return 1
+    [[ "$output" == *"RC:1"* ]]
+}
+
 @test "clean_project_caches completes without errors" {
     mkdir -p "$HOME/Projects/test-app/.next/cache"
     mkdir -p "$HOME/Projects/python-app/__pycache__"


### PR DESCRIPTION
### What

`mo clean` now clears the Service Worker `CacheStorage` of Lark / Feishu desktop's embedded Chromium webview, at:

```
~/Library/Application Support/LarkShell/aha/users/*/profile_explorer/Service Worker/CacheStorage
```

This routes through the existing `clean_service_worker_cache` helper — the same one already used for Chrome and Arc — so no new deletion logic is introduced.

### Why

Lark / Feishu desktop embeds a Chromium webview (the `aha` "explorer" profile) to render its in-app docs, sheets, slides, and AI surfaces. Every workspace origin the user opens precaches the full editor bundle into that profile's Service Worker `CacheStorage`, and stale workspaces plus superseded precache versions are never evicted — so it grows without bound at a non-standard path the browser cleaners never reach. This is the same class of problem as #843 (Final Cut Pro) and #1277 (JianyingPro): heavy generated cache outside the standard cache dirs.

### Measured value (real machine, macOS 15.7)

| Fact | Value |
|---|---|
| Total `profile_explorer/Service Worker/CacheStorage` | **27 GB** (main account) + 1.2 GB (second account) |
| Origin buckets | 9 (one per workspace/origin ever opened) |
| Oldest cached files | ~11 months (2025-10), never evicted |
| Growth | accumulating monthly, 10,916 files added in the last month alone |
| Cached origins (extracted from index) | `ask.feishu.cn`, `bytedance.larkoffice.com`, several `*.feishu.cn` tenants |
| Precache buckets | `docx`, `bitable`, `slides`, `base_app`, `knowledge_ai` — the doc-editor bundles |

Removing it reclaimed ~28 GB; afterwards Feishu docs, sheets, chat, and login all worked normally (the editor bundle is simply re-precached on next open).

### Safety / non-targets

- Only `CacheStorage` is targeted — never the sibling `ScriptCache` (MV3 worker bytecode), same as the Chrome/Arc treatment.
- Documents live on Lark's servers; auth lives in `Cookies` / `Local Storage`, neither of which this path touches.
- The shared helper already honors `PROTECTED_SW_DOMAINS` and the user whitelist, and deletes via `safe_remove` (Trash-routed, logged, path-protected). `feishu.cn` / `larkoffice.com` are not in `PROTECTED_SW_DOMAINS`, consistent with how the existing cleaner treats hash-keyed origin buckets.
- No-op when the `aha/users` root is absent; a `declare -f` guard skips cleanly if the shared helper is not loaded.

### Tests

`tests/clean_app_caches.bats`:
- `clean_communication_apps` calls the shared cleaner once per `profile_explorer` profile with the correct `CacheStorage` path, and ignores non-profile siblings under `users/`.
- `clean_feishu_service_worker_caches` is a no-op when the profile root is absent.

`./scripts/check.sh` passes (shellcheck, syntax, function-duplication audit). The two tests were mutation-checked (a wrong path turns the assertion red).

Happy to adjust naming or gate on a running check if you'd prefer — I mirrored the Chrome treatment, which cleans `CacheStorage` unconditionally.
