### PR TITLE
feat(clean): add Final Cut Pro proxy media whitelist option

### DIFF
--- a/lib/manage/whitelist.sh
+++ b/lib/manage/whitelist.sh
@@ -154,6 +154,7 @@ Surge configuration and data|$HOME/Library/Application Support/com.nssurge.surge
 Docker BuildX cache|$HOME/.docker/buildx/cache/*|container_cache
 Podman container cache|$HOME/.local/share/containers/cache/*|container_cache
 Tart OCI/IPSW cache|$HOME/.tart/cache|container_cache
+Final Cut Pro proxy media (render files still cleaned)|$HOME/Movies/*.fcpbundle/*/Transcoded Media/Proxy Media|app_cache
 Font cache|$HOME/Library/Caches/com.apple.FontRegistry/*|system_cache
 Spotlight metadata cache|$HOME/Library/Caches/com.apple.spotlight/*|system_cache
 CloudKit cache|$HOME/Library/Caches/CloudKit/*|system_cache

--- a/tests/clean_app_caches.bats
+++ b/tests/clean_app_caches.bats
@@ -544,6 +544,54 @@ EOF
     [[ "$output" != *"UNEXPECTED_SAFE_CLEAN"* ]]
 }
 
+@test "whitelist row keeps FCP proxy media while render files are cleaned (#1499)" {
+    run env HOME="$HOME/fcp-1499" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/manage/whitelist.sh"
+source "$PROJECT_ROOT/lib/clean/app_caches.sh"
+
+# Flat and nested libraries: the nested one pins the segment-spanning glob.
+flat_proxy="$HOME/Movies/Project.fcpbundle/Event/Transcoded Media/Proxy Media"
+flat_render="$HOME/Movies/Project.fcpbundle/Event/Render Files/High Quality Media"
+nested_proxy="$HOME/Movies/Sub/Nested.fcpbundle/Event/Transcoded Media/Proxy Media"
+nested_render="$HOME/Movies/Sub/Nested.fcpbundle/Event/Render Files/High Quality Media"
+mkdir -p "$flat_proxy" "$flat_render" "$nested_proxy" "$nested_render"
+touch "$flat_proxy/proxy.mov" "$flat_render/render.mov"
+touch "$nested_proxy/proxy.mov" "$nested_render/render.mov"
+
+# Use the shipped catalog pattern, not a hand-written copy, so this test goes
+# red when the row is absent (pre-fix) or its pattern drifts.
+fcp_pattern=""
+while IFS='|' read -r name pattern _; do
+    if [[ "$name" == "Final Cut Pro proxy media"* ]]; then
+        fcp_pattern="${pattern/\$HOME/$HOME}"
+    fi
+done < <(get_all_cache_items)
+[[ -n "$fcp_pattern" ]] || exit 1
+
+WHITELIST_PATTERNS=("$fcp_pattern")
+pgrep() { return 1; }
+defer_cleanup_family() { echo "UNEXPECTED_DEFER:$1"; }
+safe_clean() {
+    local arg
+    for arg in "$@"; do
+        printf 'CLEAN:%s\n' "$arg"
+    done
+}
+
+clean_final_cut_pro_generated_caches
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"CLEAN:$HOME/fcp-1499/Movies/Project.fcpbundle/Event/Render Files/High Quality Media"* ]] || return 1
+    [[ "$output" == *"CLEAN:$HOME/fcp-1499/Movies/Sub/Nested.fcpbundle/Event/Render Files/High Quality Media"* ]] || return 1
+    [[ "$output" != *"Transcoded Media/Proxy Media"* ]] || return 1
+    [[ "$output" != *"UNEXPECTED_DEFER"* ]]
+}
+
 @test "clean_jianying_pro_generated_caches targets only whitelisted regenerable subdirs" {
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail

--- a/tests/manage_whitelist.bats
+++ b/tests/manage_whitelist.bats
@@ -389,6 +389,17 @@ EOF
     [[ "$output" == *"Chrome browser cache|\$HOME/Library/Caches/Google/Chrome/*|browser_cache"* ]] || return 1
 }
 
+@test "whitelist inventory exposes Final Cut Pro proxy media (#1499)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/manage/whitelist.sh"
+get_all_cache_items
+EOF
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"Final Cut Pro proxy media (render files still cleaned)|\$HOME/Movies/*.fcpbundle/*/Transcoded Media/Proxy Media|app_cache"* ]] || return 1
+}
+
 @test "mo clean --whitelist persists selections" {
     whitelist_file="$HOME/.config/mole/whitelist"
     mkdir -p "$(dirname "$whitelist_file")"


### PR DESCRIPTION
## Summary

- Add an opt-in `mo clean --whitelist` row — `Final Cut Pro proxy media (render files still cleaned)` — so proxy media for projects being actively edited can be kept while other generated FCP caches are still cleaned.
- One catalog glob covers every library and event with no per-project manual entries: `$HOME/Movies/*.fcpbundle/*/Transcoded Media/Proxy Media`. Bash pattern matching spans `/`, so nested libraries under `~/Movies` are covered too.
- Not default-on: the row is not in `DEFAULT_WHITELIST_PATTERNS`; nothing changes until the user selects it. `Render Files/High Quality Media` still cleans, and `Original Media`, `Analysis Files`, optimized media (`Transcoded Media/High Quality Media`), backups, and external `.fcpcache` were never targeted and remain unchanged (same scope as #843).

Fixes #1499

## Safety Review

- This touches the `mo clean` whitelist inventory, so it changes what is skipped when (and only when) the user selects the new row.
- No new deletion target, no new flag or env var, no sudo, no symlink handling change, and no change to `should_protect_path`, `safe_remove`, or the Final Cut Pro running-process guard.
- Enforcement reuses the existing paths end to end: `mole_cleanup_targets_exist` drops whitelisted targets before eligibility (so a fully whitelisted set does not produce a spurious "Final Cut Pro running" defer), and `safe_remove` rechecks the whitelist at the final sink.

## Tests

- New `whitelist inventory exposes Final Cut Pro proxy media (#1499)` in `tests/manage_whitelist.bats` pins the exact catalog row (label, pattern, category).
- New `whitelist row keeps FCP proxy media while render files are cleaned (#1499)` in `tests/clean_app_caches.bats`: fake flat and nested `.fcpbundle` fixtures (no real Final Cut Pro needed), isolated per-test `HOME`, and the whitelist pattern extracted from the shipped catalog rather than hardcoded — so the test goes red if the row is removed or its pattern drifts. Asserts both render dirs are offered to `safe_clean`, proxy dirs never appear, and no defer fires.
- Both new tests were observed red with the catalog row stashed (pre-fix) and green with it restored.
- The existing `clean_final_cut_pro_generated_caches targets only safe generated media` test continues to pin that `Original Media`, `Analysis Files`, and optimized media are never offered; it is unchanged and green.
- Ran: `MOLE_TEST_NO_AUTH=1 bats tests/manage_whitelist.bats tests/clean_app_caches.bats` and `./scripts/check.sh` (shfmt, shellcheck, golangci-lint, syntax, function-duplication).
- Manual check: fixture library under a throwaway `HOME` with the row saved through the real `save_whitelist_patterns` path — a real (non-dry-run) pass deletes only the render dirs while both proxy dirs survive on disk; without the row selected, proxy media is still cleaned, confirming opt-in.

## Safety-related changes

- New opt-in whitelist catalog row only. Default clean behavior is unchanged until the user selects the row in `mo clean --whitelist`.
