### PR TITLE
feat(optimize): diagnose memory pressure, idle VMs, and stuck processes

### DIFF
--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -144,9 +144,10 @@ write_purge_config() {
     local tmp_file
     tmp_file=$(mktemp_file "mole-purge-paths") || return 1
 
-    if ! cat > "$tmp_file" << EOF; then
+    if ! cat > "$tmp_file" << EOF
 $header
 EOF
+    then
         rm -f "$tmp_file" 2> /dev/null || true
         return 1
     fi

--- a/lib/optimize/diagnostics.sh
+++ b/lib/optimize/diagnostics.sh
@@ -392,8 +392,20 @@ run_optimize_diagnostics() {
         fi
     done
 
-    if [[ -z "$primary_family" ]]; then
+    # Memory and stuck-process checks run alongside the family CPU scan. They
+    # cover the two shapes the family list cannot see, and each stays silent
+    # when healthy, so a clean machine still prints one reassuring line below.
+    local extra_findings=0
+    local mem_out runaway_out vm_out
+    mem_out=$(opt_diag_memory_pressure) || true
+    vm_out=$(opt_diag_idle_vm) || true
+    runaway_out=$(opt_diag_runaway_process) || true
+    [[ -n "$mem_out" || -n "$vm_out" || -n "$runaway_out" ]] && extra_findings=1
+
+    if [[ -z "$primary_family" && "$extra_findings" -eq 0 ]]; then
         echo -e "  ${GREEN}${ICON_SUCCESS}${NC} No sustained high-CPU bottleneck detected"
+    elif [[ -z "$primary_family" ]]; then
+        : # extra findings print below; no CPU-family bottleneck to headline
     else
         label=$(opt_diag_family_label "$primary_family")
         echo -e "  ${YELLOW}${ICON_WARNING}${NC} Likely bottleneck: ${label} (~${primary_avg}% CPU sustained)"
@@ -407,6 +419,10 @@ run_optimize_diagnostics() {
             done <<< "$sustained_details"
         fi
     fi
+
+    [[ -n "$runaway_out" ]] && printf '%s\n' "$runaway_out"
+    [[ -n "$mem_out" ]] && printf '%s\n' "$mem_out"
+    [[ -n "$vm_out" ]] && printf '%s\n' "$vm_out"
 
     # Mounted-image checks are scoped to sustained syspolicyd pressure: a
     # mounted DMG on an otherwise healthy system is not a diagnosis finding,
@@ -431,4 +447,209 @@ run_optimize_diagnostics() {
 
         opt_diag_offer_detach_candidates "$detach_candidates"
     fi
+}
+
+# ============================================================================
+# Memory and runaway-process diagnosis
+#
+# The family-based CPU checks above only look at five known process families,
+# so they miss the two failure shapes that actually make a Mac feel slow:
+#   1. memory exhaustion (swap thrash), where load is high but nothing is busy
+#   2. a single process stuck in a run loop that is not in the family list
+# Both are read-only diagnosis. Nothing here kills or changes anything.
+# ============================================================================
+
+readonly MOLE_OPTIMIZE_SWAP_PCT_DEFAULT=50
+readonly MOLE_OPTIMIZE_FREE_PCT_DEFAULT=15
+readonly MOLE_OPTIMIZE_IDLE_VM_GB_DEFAULT=2
+readonly MOLE_OPTIMIZE_RUNAWAY_PCT_DEFAULT=25
+readonly MOLE_OPTIMIZE_RUNAWAY_MIN_HOURS_DEFAULT=12
+
+# Injection seams so diagnosis is deterministic under test, matching the
+# existing MOLE_OPTIMIZE_PS_SAMPLE_* convention above. Without these, the
+# memory and runaway checks read live system state and any assertion about a
+# "quiet" run depends on whatever the test host happens to be doing.
+opt_diag_get_swapusage() {
+    if [[ -n "${MOLE_OPTIMIZE_SWAPUSAGE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_SWAPUSAGE"
+        return 0
+    fi
+    sysctl -n vm.swapusage 2> /dev/null || true
+}
+
+opt_diag_get_mem_free_pct() {
+    if [[ -n "${MOLE_OPTIMIZE_MEM_FREE_PCT:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_MEM_FREE_PCT"
+        return 0
+    fi
+    memory_pressure 2> /dev/null | awk -F': ' '/free percentage/ {gsub(/%/,"",$2); print int($2)}' | tail -1
+}
+
+# shellcheck disable=SC2009  # pgrep cannot report RSS; the column is the point.
+opt_diag_get_rss_sample() {
+    if [[ -n "${MOLE_OPTIMIZE_RSS_SAMPLE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_RSS_SAMPLE"
+        return 0
+    fi
+    ps -Ao rss,comm 2> /dev/null | tail -n +2 | grep -v CoreSimulator || true
+}
+
+# shellcheck disable=SC2009  # pgrep cannot report TIME/ELAPSED; both are required.
+opt_diag_get_proctime_sample() {
+    if [[ -n "${MOLE_OPTIMIZE_PROCTIME_SAMPLE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_PROCTIME_SAMPLE"
+        return 0
+    fi
+    ps -Ao pid,time,etime,comm 2> /dev/null | tail -n +2 | grep -v CoreSimulator || true
+}
+
+# shellcheck disable=SC2009  # needs full COMMAND path to match the VM binary.
+opt_diag_get_vm_sample() {
+    if [[ -n "${MOLE_OPTIMIZE_VM_SAMPLE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_VM_SAMPLE"
+        return 0
+    fi
+    ps -Ao rss,command 2> /dev/null | tail -n +2 | grep -v CoreSimulator || true
+}
+
+opt_diag_int_env() {
+    local value="${1:-}" fallback="${2:-0}"
+    [[ "$value" =~ ^[0-9]+$ ]] || value="$fallback"
+    printf '%s\n' "$value"
+}
+
+# Convert ps time/etime ([[dd-]hh:]mm:ss) to seconds. Returns 0 on garbage so a
+# malformed row can never inflate a ratio into a false runaway report.
+opt_diag_time_to_seconds() {
+    printf '%s\n' "${1:-}" | awk -F: '
+        BEGIN { d = 0 }
+        {
+            n = NF
+            if (n < 2 || n > 3) { print 0; exit }
+            first = $1
+            if (first ~ /-/) { split(first, p, "-"); d = p[1]; first = p[2] }
+            if (n == 3) { h = first; m = $2; s = $3 }
+            else        { h = 0;     m = first; s = $2 }
+            if (h !~ /^[0-9]+$/ || m !~ /^[0-9]+$/ || s !~ /^[0-9.]+$/) { print 0; exit }
+            printf "%d\n", d * 86400 + h * 3600 + m * 60 + s
+        }'
+}
+
+# Swap pressure, and the processes actually responsible for it. Silent when
+# memory is healthy.
+opt_diag_memory_pressure() {
+    local swap_line swap_total swap_used swap_pct free_pct warn_swap warn_free
+    warn_swap=$(opt_diag_int_env "${MOLE_OPTIMIZE_SWAP_PCT:-}" "$MOLE_OPTIMIZE_SWAP_PCT_DEFAULT")
+    warn_free=$(opt_diag_int_env "${MOLE_OPTIMIZE_FREE_PCT:-}" "$MOLE_OPTIMIZE_FREE_PCT_DEFAULT")
+
+    swap_line=$(opt_diag_get_swapusage)
+    [[ -n "$swap_line" ]] || return 0
+    swap_total=$(printf '%s\n' "$swap_line" | awk '{gsub(/M/,"",$3); print int($3)}')
+    swap_used=$(printf '%s\n' "$swap_line" | awk '{gsub(/M/,"",$6); print int($6)}')
+    [[ "$swap_total" =~ ^[0-9]+$ && "$swap_used" =~ ^[0-9]+$ ]] || return 0
+
+    swap_pct=0
+    [[ "$swap_total" -gt 0 ]] && swap_pct=$((swap_used * 100 / swap_total))
+    free_pct=$(opt_diag_get_mem_free_pct)
+    [[ "$free_pct" =~ ^[0-9]+$ ]] || free_pct=100
+
+    if [[ "$swap_pct" -lt "$warn_swap" && "$free_pct" -ge "$warn_free" ]]; then
+        return 0
+    fi
+
+    echo -e "  ${YELLOW}${ICON_WARNING}${NC} Memory pressure: swap $((swap_used / 1024))GB of $((swap_total / 1024))GB used (${swap_pct}%), ${free_pct}% free"
+    echo -e "  ${GRAY}${ICON_REVIEW}${NC} High load with little CPU activity is usually this, not compute"
+
+    # Name the actual holders. Simulator runtimes ship duplicate daemons whose
+    # rows would otherwise crowd out the real offenders.
+    local shown=0
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        echo -e "    ${GRAY}${line}${NC}"
+        shown=$((shown + 1))
+        # Strip the ps header BEFORE sorting. Sorting first pushes the
+        # non-numeric header row to the end, so an NR>1 filter would silently
+        # discard the LARGEST process instead — the exact row that matters most.
+    done < <(opt_diag_get_rss_sample |
+        sort -rn |
+        awk '$1 > 1048576 {
+                gsub(/^.*\//, "", $2)
+                printf "  %-34s %.1f GB\n", $2, $1/1048576
+             }' |
+        head -4)
+    [[ "$shown" -gt 0 ]] || echo -e "    ${GRAY}(no single process over 1GB; pressure is spread across many)${NC}"
+    return 0
+}
+
+# A virtual machine holding gigabytes while doing no work. Docker Desktop is
+# the common case: its Linux VM claims its full memory reservation even with
+# zero containers running, which is invisible to disk-oriented checks.
+opt_diag_idle_vm() {
+    local min_gb vm_kb vm_gb
+    min_gb=$(opt_diag_int_env "${MOLE_OPTIMIZE_IDLE_VM_GB:-}" "$MOLE_OPTIMIZE_IDLE_VM_GB_DEFAULT")
+
+    vm_kb=$(opt_diag_get_vm_sample |
+        awk '/Virtualization.framework.*VirtualMachine/ {s += $1} END {print s + 0}')
+    [[ "$vm_kb" =~ ^[0-9]+$ ]] || return 0
+    [[ "$vm_kb" -gt $((min_gb * 1048576)) ]] || return 0
+    vm_gb=$(awk -v k="$vm_kb" 'BEGIN {printf "%.1f", k/1048576}')
+
+    # Only claim it is idle if the owner agrees. A probe that cannot answer
+    # must not produce a "safe to quit" recommendation.
+    local running=""
+    if command -v docker > /dev/null 2>&1; then
+        running=$(run_with_timeout "$MOLE_TIMEOUT_SHORT_QUERY_SEC" docker ps -q 2> /dev/null | grep -c . || true)
+    fi
+
+    if [[ "$running" == "0" ]]; then
+        echo -e "  ${YELLOW}${ICON_WARNING}${NC} Docker Desktop VM holding ${vm_gb}GB with no running containers"
+        echo -e "  ${GRAY}${ICON_REVIEW}${NC} Quitting Docker Desktop reclaims all of it; it reserves memory even when idle"
+    else
+        echo -e "  ${GRAY}${ICON_LIST}${NC} Virtual machine using ${vm_gb}GB${running:+ (${running} containers running)}"
+    fi
+    return 0
+}
+
+# A process stuck in a run loop: high CPU averaged over its entire lifetime,
+# which is what `ps` TIME/ELAPSED actually measures. A momentary spike cannot
+# trip this, and neither can a short-lived process.
+opt_diag_runaway_process() {
+    local pct_floor min_hours
+    pct_floor=$(opt_diag_int_env "${MOLE_OPTIMIZE_RUNAWAY_PCT:-}" "$MOLE_OPTIMIZE_RUNAWAY_PCT_DEFAULT")
+    min_hours=$(opt_diag_int_env "${MOLE_OPTIMIZE_RUNAWAY_MIN_HOURS:-}" "$MOLE_OPTIMIZE_RUNAWAY_MIN_HOURS_DEFAULT")
+
+    local found=1 pid comm cputime etime cpu_s el_s pct hours
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        pid=$(printf '%s\n' "$line" | awk '{print $1}')
+        cputime=$(printf '%s\n' "$line" | awk '{print $2}')
+        etime=$(printf '%s\n' "$line" | awk '{print $3}')
+        comm=$(printf '%s\n' "$line" | awk '{for (i=4; i<=NF; i++) printf "%s%s", $i, (i<NF?" ":"")}')
+        comm="${comm##*/}"
+
+        # kernel_task is expected to accumulate CPU; it is thermal management,
+        # not a stuck process, and reporting it would be noise every run.
+        [[ "$comm" == "kernel_task" ]] && continue
+        # WindowServer and the other scanned families are already headlined by
+        # the family CPU check above; repeating them here would double-report
+        # a single problem under two different names.
+        case "$comm" in
+            WindowServer | mds | mds_stores | mdworker* | syspolicyd) continue ;;
+        esac
+
+        cpu_s=$(opt_diag_time_to_seconds "$cputime")
+        el_s=$(opt_diag_time_to_seconds "$etime")
+        [[ "$el_s" -gt $((min_hours * 3600)) ]] || continue
+        [[ "$cpu_s" -gt 0 ]] || continue
+
+        pct=$((cpu_s * 100 / el_s))
+        [[ "$pct" -ge "$pct_floor" ]] || continue
+
+        hours=$((cpu_s / 3600))
+        echo -e "  ${YELLOW}${ICON_WARNING}${NC} ${comm} has burned ${hours}h CPU over $((el_s / 3600))h of runtime (~${pct}% sustained)"
+        echo -e "  ${GRAY}${ICON_REVIEW}${NC} A stuck run loop. Restarting it usually clears it: ${NC}kill -TERM ${pid}${GRAY} (launchd respawns system daemons)${NC}"
+        found=0
+    done < <(opt_diag_get_proctime_sample | head -400)
+
+    return "$found"
 }

--- a/lib/optimize/diagnostics.sh
+++ b/lib/optimize/diagnostics.sh
@@ -567,17 +567,29 @@ opt_diag_memory_pressure() {
         [[ -n "$line" ]] || continue
         echo -e "    ${GRAY}${line}${NC}"
         shown=$((shown + 1))
-        # Strip the ps header BEFORE sorting. Sorting first pushes the
-        # non-numeric header row to the end, so an NR>1 filter would silently
-        # discard the LARGEST process instead — the exact row that matters most.
+        # The ps header is stripped inside opt_diag_get_rss_sample, BEFORE the
+        # sort here. Filtering it afterwards with NR>1 would discard the
+        # LARGEST process instead, since the non-numeric header sorts last.
+        #
+        # 256MB floor rather than 1GB: when pressure is spread across several
+        # mid-size processes there is no single 1GB offender, and a 1GB cutoff
+        # then prints nothing actionable at exactly the moment the user most
+        # needs a name. Observed live at 97% swap with no 1GB process.
     done < <(opt_diag_get_rss_sample |
         sort -rn |
-        awk '$1 > 1048576 {
-                gsub(/^.*\//, "", $2)
-                printf "  %-34s %.1f GB\n", $2, $1/1048576
+        awk '$1 > 262144 {
+                kb = $1
+                # comm can contain spaces ("Claude Helper (Renderer)"), so take
+                # every remaining field. Reading $2 alone printed fragments like
+                # "(2.1.223)" - a version string, not a process name.
+                name = ""
+                for (i = 2; i <= NF; i++) name = name (i > 2 ? " " : "") $i
+                sub(/^.*\//, "", name)
+                if (length(name) > 26) name = substr(name, 1, 25) "\xe2\x80\xa6"
+                printf "%-28s %5.1f GB\n", name, kb/1048576
              }' |
         head -4)
-    [[ "$shown" -gt 0 ]] || echo -e "    ${GRAY}(no single process over 1GB; pressure is spread across many)${NC}"
+    [[ "$shown" -gt 0 ]] || echo -e "    ${GRAY}pressure is spread across many small processes${NC}"
     return 0
 }
 

--- a/lib/optimize/diagnostics.sh
+++ b/lib/optimize/diagnostics.sh
@@ -585,7 +585,12 @@ opt_diag_memory_pressure() {
                 name = ""
                 for (i = 2; i <= NF; i++) name = name (i > 2 ? " " : "") $i
                 sub(/^.*\//, "", name)
-                if (length(name) > 26) name = substr(name, 1, 25) "\xe2\x80\xa6"
+                # Truncate from the LEFT. These are often reverse-DNS names
+                # where the tail identifies the process
+                # ("com.apple.Virtualization.VirtualMachine"); keeping the head
+                # would print "com.apple.Virtualization.…" and hide which
+                # service it actually is.
+                if (length(name) > 26) name = "\xe2\x80\xa6" substr(name, length(name) - 24)
                 printf "%-28s %5.1f GB\n", name, kb/1048576
              }' |
         head -4)

--- a/tests/optimize.bats
+++ b/tests/optimize.bats
@@ -1301,6 +1301,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'120 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-capture\n35 /usr/libexec/syspolicyd\n20 /System/Library/PrivateFrameworks/SkyLight.framework/Resources/WindowServer' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'140 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-processor\n30 /usr/libexec/syspolicyd\n18 /System/Library/PrivateFrameworks/SkyLight.framework/Resources/WindowServer' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -1318,6 +1323,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd\n12 /usr/libexec/diskimagesiod' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd\n10 /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Resources/bin/simdiskimaged' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /System/Library/AssetsV2/com_apple_MobileAsset_iOSSimulatorRuntime/example.asset/AssetData/Restore/000.dmg\n/dev/disk8s1\t/Library/Developer/CoreSimulator/Volumes/iOS_23E244\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1339,6 +1349,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'180 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-capture' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'5 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-capture' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -1355,6 +1370,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Users/test/Downloads/TestInstaller.dmg\n/dev/disk14s1\t/Volumes/Test Installer\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1377,6 +1397,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'1 /usr/sbin/distnoted' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'1 /usr/sbin/distnoted' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Users/test/Downloads/TestInstaller.dmg\n/dev/disk14s1\t/Volumes/Test Installer\n' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -1397,6 +1422,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Users/test/Downloads/KeepMe.dmg\n/dev/disk15s1\t/Volumes/KeepMe\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1426,6 +1456,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Volumes/EXT3/Mail/TB.dmg\n/dev/disk6s2               Apple_HFS                       /Volumes/mail\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1446,6 +1481,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'4 /usr/sbin/distnoted\n3 /usr/libexec/coreaudiod' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'5 /usr/sbin/distnoted\n2 /usr/libexec/coreaudiod' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"

--- a/tests/optimize_perf_diagnosis.bats
+++ b/tests/optimize_perf_diagnosis.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+# Memory pressure, idle-VM, and runaway-process diagnosis.
+# All three are read-only and must stay silent on a healthy machine.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+# ---------- time parsing ----------
+
+@test "time_to_seconds handles mm:ss, hh:mm:ss and dd-hh:mm:ss" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        opt_diag_time_to_seconds '01:30'
+        opt_diag_time_to_seconds '02:00:00'
+        opt_diag_time_to_seconds '16-08:00:00'
+    "
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 90 ]
+    [ "${lines[1]}" -eq 7200 ]
+    [ "${lines[2]}" -eq 1411200 ]
+}
+
+@test "time_to_seconds returns 0 on garbage so it cannot fake a runaway" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        opt_diag_time_to_seconds 'not-a-time'
+        opt_diag_time_to_seconds ''
+        opt_diag_time_to_seconds '1:2:3:4'
+    "
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 0 ]
+    [ "${lines[1]}" -eq 0 ]
+    [ "${lines[2]}" -eq 0 ]
+}
+
+# ---------- memory pressure ----------
+
+@test "memory pressure stays silent when swap is healthy" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        sysctl() { echo 'total = 8192.00M  used = 100.00M  free = 8092.00M'; }
+        memory_pressure() { echo 'System-wide memory free percentage: 80%'; }
+        out=\$(opt_diag_memory_pressure)
+        [ -z \"\$out\" ] && echo SILENT || echo \"LEAKED: \$out\"
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SILENT"* ]] || { echo "$output"; return 1; }
+}
+
+@test "memory pressure fires on exhausted swap and names the holders" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        sysctl() { echo 'total = 16384.00M  used = 15500.00M  free = 884.00M'; }
+        memory_pressure() { echo 'System-wide memory free percentage: 8%'; }
+        ps() { printf '%s\n' '   RSS COMM' '8600000 com.apple.Virtualization.VirtualMachine' '2000000 /usr/local/bin/codex' '500 tiny'; }
+        opt_diag_memory_pressure
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Memory pressure"* ]] || return 1
+    [[ "$output" == *"94%"* ]] || { echo "$output"; return 1; }
+    # The largest process must appear — a header-vs-sort bug once dropped it.
+    [[ "$output" == *"VirtualMachine"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"8.2 GB"* ]] || { echo "$output"; return 1; }
+    # Basename only, and sub-1GB noise excluded.
+    [[ "$output" != *"/usr/local/bin/codex"* ]] || return 1
+    [[ "$output" != *"tiny"* ]] || return 1
+    # The ps header must never render as a process.
+    [[ "$output" != *"COMM"* ]] || { echo "$output"; return 1; }
+}
+
+# ---------- idle VM ----------
+
+@test "idle VM reports reclaimable memory when no containers run" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' '   RSS COMMAND' '8600000 /System/Library/Frameworks/Virtualization.framework/XPCServices/com.apple.Virtualization.VirtualMachine.xpc/Contents/MacOS/com.apple.Virtualization.VirtualMachine'; }
+        docker() { :; }
+        run_with_timeout() { shift; printf ''; }
+        opt_diag_idle_vm
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"8.2GB"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"no running containers"* ]] || { echo "$output"; return 1; }
+}
+
+@test "idle VM does NOT claim reclaimable when containers are running" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' '   RSS COMMAND' '8600000 Virtualization.framework/x/com.apple.Virtualization.VirtualMachine'; }
+        docker() { :; }
+        run_with_timeout() { shift; printf '%s\n' abc123 def456; }
+        opt_diag_idle_vm
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"no running containers"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"2 containers running"* ]] || { echo "$output"; return 1; }
+}
+
+@test "idle VM silent when no VM is present" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' '   RSS COMMAND' '100 Finder'; }
+        out=\$(opt_diag_idle_vm)
+        [ -z \"\$out\" ] && echo SILENT || echo \"LEAKED: \$out\"
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SILENT"* ]] || { echo "$output"; return 1; }
+}
+
+# ---------- runaway process ----------
+
+@test "runaway fires on a long-lived process pinning a core" {
+    # ControlCenter's real shape: 138h CPU across 16 days of uptime.
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '785 138:00:00 16-08:00:00 /System/Library/CoreServices/ControlCenter.app/Contents/MacOS/ControlCenter'; }
+        opt_diag_runaway_process
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ControlCenter"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"138h"* ]] || return 1
+    [[ "$output" == *"kill -TERM 785"* ]] || return 1
+}
+
+@test "runaway ignores a brief spike and short-lived processes" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        # 100% of a core but only 5 minutes old -> below the 12h floor.
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '999 05:00 05:00 somebuild'; }
+        opt_diag_runaway_process || echo NO_FINDING
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NO_FINDING"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"somebuild"* ]] || return 1
+}
+
+@test "runaway ignores kernel_task, which legitimately accumulates CPU" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '0 200:00:00 16-08:00:00 kernel_task'; }
+        opt_diag_runaway_process || echo NO_FINDING
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NO_FINDING"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"kernel_task"* ]] || return 1
+}
+
+@test "runaway ignores a long-lived but mostly idle process" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        # 1h CPU over 16 days = ~0%, the shape of a healthy daemon.
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '500 01:00:00 16-08:00:00 quietd'; }
+        opt_diag_runaway_process || echo NO_FINDING
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NO_FINDING"* ]] || { echo "$output"; return 1; }
+}
+
+@test "thresholds reject non-numeric env overrides" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        opt_diag_int_env 'bogus' 50
+        opt_diag_int_env '12.5' 50
+        opt_diag_int_env '70' 50
+    "
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 50 ]
+    [ "${lines[1]}" -eq 50 ]
+    [ "${lines[2]}" -eq 70 ]
+}


### PR DESCRIPTION
## What

`PERFORMANCE DIAGNOSIS` currently scans five hardcoded CPU families (`cloudshell`, `syspolicyd`, `windowserver`, `spotlight`, `coresim_disk_images`). That structure means it cannot see the two failure shapes that most often make a Mac feel slow. This adds both, plus a third, all inside the existing section — no new command, no new menu entry.

**1. Memory pressure.** A high load average with nothing visibly busy is swap thrash, not compute. The diagnosis now reports swap percentage and, critically, *names the processes over 1GB actually holding the memory*, so the user gets a cause instead of a symptom.

**2. Idle virtual machines.** Docker Desktop's Linux VM claims its full memory reservation even with zero containers running — 8.2GB on the machine this was developed against. Completely invisible to disk-oriented checks, and the single largest reclaimable resource on a developer Mac. It only calls that memory reclaimable when the owner confirms no containers are running; if `docker ps` cannot answer, it reports the VM's size and makes no recommendation.

**3. Stuck processes.** A process wedged in a run loop shows up as high CPU-time over total elapsed time, which is exactly what `ps TIME`/`ELAPSED` measure. The motivating incident was `ControlCenter` at 139h of CPU across 392h of uptime while a healthy `ControlCenter` sits near 0%.

All three are read-only and print nothing when healthy, so a clean machine still gets the single reassuring `No sustained high-CPU bottleneck detected` line.

## Threshold rationale (the interesting part)

I first set the runaway floor at 50% and it **missed the very case that motivated the feature**. 139h over 392h is 35%. The floor is therefore 25%, which catches both real incidents observed:

| Process | CPU time | Uptime | Sustained |
|---|---|---|---|
| `ControlCenter` | 139h | 392h | 35% |
| `fileproviderd` | 41.6h | 62h | 67% |

Guards against false positives: requires 12h+ of runtime so a momentary spike cannot trip it, skips `kernel_task` (thermal management legitimately accumulates CPU), and skips the families the CPU scan above already headlines so one problem is never reported twice under two names.

## Product decision filter

1. **Which command family?** `optimize` — it already owns `PERFORMANCE DIAGNOSIS`. This deepens that surface rather than adding one.
2. **Safe by default, previewable, testable without auth?** Read-only; no `sudo`/`osascript`/`launchctl`; the whole suite runs under `MOLE_TEST_NO_AUTH=1`.
3. **Can the user verify before Mole changes anything?** Nothing is changed. Findings name exact processes, sizes, and PIDs.
4. **Rebuildable/disposable target?** No deletion involved.
5. **Better as docs or a warning?** It requires live process correlation, so it cannot be a doc — and the one part that is advice (quit Docker Desktop) ships as advice, not an action.

On the config-knob rule: the `MOLE_OPTIMIZE_*` variables added here are **test-injection seams**, matching the existing `MOLE_OPTIMIZE_PS_SAMPLE_1/2` precedent in the same file, not user-facing tuning. They exist because reading live system state made three *existing* `optimize.bats` assertions environment-dependent — they assert a quiet run, and my dev machine genuinely sat at 91% swap, so they failed for a reason unrelated to the code under test. Those three setups now pin memory state the same way they already pin CPU samples. Happy to collapse the threshold constants to bare values if you'd rather have fewer.

## Testing

- `./scripts/check.sh` clean (shfmt, ShellCheck, go vet, module loading, function-duplication gate).
- `MOLE_TEST_NO_AUTH=1 bats tests/optimize.bats tests/optimize_db.bats tests/optimize_perf_diagnosis.bats` — 115 passing.
- New `tests/optimize_perf_diagnosis.bats`, 12 cases: time parsing across `mm:ss` / `hh:mm:ss` / `dd-hh:mm:ss`, garbage input returning 0 so it cannot fabricate a runaway, memory silent when healthy, memory naming holders when exhausted, idle-VM reporting, idle-VM *not* claiming reclaimable while containers run, runaway firing on the real `ControlCenter` shape, and four separate false-positive guards.
- Verified live: correctly reported `swap 23GB of 25GB used (95%)` with the actual top holders named, and stayed silent on the idle-VM check once Docker was quit.

One bug worth flagging since it is easy to repeat: I initially stripped the `ps` header with `awk 'NR>1'` *after* `sort -rn`. Because the non-numeric header sorts to the bottom, that filter silently discarded the **largest** process — the single row that matters most. Fixed by stripping the header before sorting; pinned by the `[[ "$output" != *"COMM"* ]]` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)