### PR TITLE
feat(clean): reclaim leaked automation browsers and surface unused simulator runtimes

### DIFF
--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -2735,6 +2735,95 @@ _debug_simctl_probe_stderr() {
     debug_log "simctl probe $attempt stderr: $excerpt"
 }
 
+# Installed simulator runtimes that no device uses. Distinct from
+# clean_xcode_simulator_runtime_volumes (stale mount points) and from
+# unavailable-simulator cleanup (devices orphaned by a removed runtime):
+# this is the inverse, a runtime left behind after its last device went
+# away. Nothing in macOS or Xcode reports it, so an 8GB download can sit
+# unreferenced indefinitely.
+#
+# Review-only by design. A runtime is a toolchain payload that only Apple
+# can serve again, so it stays off the blanket delete path the same way
+# other downloaded toolchain roots do; the value here is naming the exact
+# orphan and the owner command, which is information the user cannot get
+# from simctl directly.
+check_orphaned_simulator_runtimes() {
+    command -v xcrun > /dev/null 2>&1 || return 0
+    [[ "${_MOLE_SIMCTL_RESOLUTION_STATUS:-}" == "ready" ]] || return 0
+
+    local runtime_list="" device_list="" probe_status=0
+    runtime_list=$(run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" \
+        env DEVELOPER_DIR="$_MOLE_SIMCTL_DEVELOPER_DIR" xcrun simctl runtime list -v 2> /dev/null) || probe_status=$?
+    if [[ $probe_status -ne 0 ]]; then
+        [[ $probe_status -eq 124 || $probe_status -ge 128 ]] && return "$probe_status"
+        debug_log "Orphaned runtime probe failed (exit=$probe_status)"
+        return 0
+    fi
+
+    probe_status=0
+    device_list=$(run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" \
+        env DEVELOPER_DIR="$_MOLE_SIMCTL_DEVELOPER_DIR" xcrun simctl list devices 2> /dev/null) || probe_status=$?
+    if [[ $probe_status -ne 0 ]]; then
+        [[ $probe_status -eq 124 || $probe_status -ge 128 ]] && return "$probe_status"
+        debug_log "Orphaned runtime device probe failed (exit=$probe_status)"
+        return 0
+    fi
+
+    # `simctl runtime list -v` prints a header line per runtime followed by
+    # indented detail lines, one of which carries the on-disk size:
+    #   iOS 18.4 (22E238) - 70DF9A83-... (Ready)
+    #       Size: 8.2G
+    local current_name="" current_id="" current_size=""
+    local -a orphan_lines=()
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^([A-Za-z]+[[:space:]][0-9.]+)[[:space:]]\(.*\)[[:space:]]-[[:space:]]([0-9A-F-]{36}) ]]; then
+            # Flush the previous runtime before starting a new one.
+            _flush_orphan_runtime_candidate
+            current_name="${BASH_REMATCH[1]}"
+            current_id="${BASH_REMATCH[2]}"
+            current_size=""
+        elif [[ -n "$current_id" && "$line" =~ ^[[:space:]]+Size:[[:space:]]+(.+)$ ]]; then
+            current_size="${BASH_REMATCH[1]}"
+        fi
+    done <<< "$runtime_list"
+    _flush_orphan_runtime_candidate
+
+    # Expanding an empty array under `set -u` is an unbound-variable error on
+    # the bash 3.2 macOS ships, and "no orphans" is the common path.
+    [[ ${#orphan_lines[@]} -gt 0 ]] || return 0
+
+    local orphan
+    for orphan in "${orphan_lines[@]}"; do
+        echo -e "  ${GRAY}${ICON_REVIEW}${NC} Orphaned simulator runtime · ${orphan}"
+        note_activity
+    done
+    return 0
+}
+
+# Helper for check_orphaned_simulator_runtimes' parse loop: decide whether
+# the runtime just parsed has zero devices, and if so queue a review line.
+# Reads/writes the caller's locals by design (bash 3.2 has no namerefs).
+_flush_orphan_runtime_candidate() {
+    [[ -n "$current_id" && -n "$current_name" ]] || return 0
+
+    # Devices are grouped under a "-- <runtime name> --" header. Count the
+    # non-empty lines in this runtime's group; zero means orphaned.
+    local device_count
+    device_count=$(printf '%s\n' "$device_list" | awk -v want="-- ${current_name} --" '
+        index($0, want) == 1 { f = 1; next }
+        /^-- / { f = 0 }
+        f && NF { c++ }
+        END { print c + 0 }')
+
+    if [[ "$device_count" -eq 0 ]]; then
+        local size_note="${current_size:+, $current_size}"
+        orphan_lines+=("${current_name}${size_note} · no devices · remove with ${GRAY}xcrun simctl runtime delete ${current_id}${NC}")
+    fi
+    current_id=""
+    current_name=""
+    current_size=""
+}
+
 clean_dev_mobile() {
     check_android_ndk
     clean_xcode_documentation_cache || return $?
@@ -2946,6 +3035,7 @@ clean_dev_mobile() {
             echo -e "  ${GRAY}${ICON_WARNING}${NC} Xcode unavailable simulators · simctl could not be resolved"
             note_activity
         fi
+        check_orphaned_simulator_runtimes || return $?
     fi
     # Old iOS/watchOS/tvOS DeviceSupport versions (debug symbols for connected devices).
     # Each iOS version creates a 1-3 GB folder of debug symbols. Only the versions

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -3818,6 +3818,64 @@ clean_claude_desktop_bundled_versions() {
     done
 }
 
+# Headless browser trees leaked by dead Playwright/agent automation sessions.
+# When an MCP server or agent harness dies without cleanup, its browser
+# daemons reparent to launchd (ppid 1) and the Chrome tree keeps running
+# headless, holding RSS; the ephemeral temp profiles keep disk. Only
+# processes tied to playwright_chromiumdev_profile-* automation profiles are
+# ever touched, never a user's real browser: orphaned Playwright daemons at
+# any age, browser processes only after a full day (a younger one may belong
+# to a live automation session).
+clean_dev_automation_browsers() {
+    local -a leaked_pids=()
+    local pid
+    while IFS= read -r pid; do
+        [[ -n "$pid" ]] && leaked_pids+=("$pid")
+    done < <(ps -Ao pid=,ppid=,etime=,command= 2> /dev/null | awk '
+        /playwright-core\/lib\/entry\/cliDaemon\.js/ && $2 == 1 { print $1; next }
+        /playwright_chromiumdev_profile/ && $3 ~ /-/ { print $1 }' | sort -un)
+
+    # Ephemeral automation profiles: stale after 2h, and never one that a
+    # live process still references.
+    local -a stale_profiles=()
+    local tmpdir
+    tmpdir=$(getconf DARWIN_USER_TEMP_DIR 2> /dev/null) || tmpdir=""
+    if [[ -n "$tmpdir" ]]; then
+        local d now age_hours
+        now=$(date +%s)
+        for d in "$tmpdir"playwright_chromiumdev_profile-*; do
+            [[ -d "$d" ]] || continue
+            age_hours=$(((now - $(stat -f %m "$d" 2> /dev/null || echo "$now")) / 3600))
+            [[ "$age_hours" -ge 2 ]] || continue
+            pgrep -qf "$d" 2> /dev/null && continue
+            stale_profiles+=("$d")
+        done
+    fi
+
+    if [[ ${#leaked_pids[@]} -gt 0 ]]; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Leaked automation browsers · would stop ${#leaked_pids[@]} processes ${YELLOW}dry${NC}"
+        else
+            local stopped=0
+            for pid in "${leaked_pids[@]}"; do
+                kill -TERM "$pid" 2> /dev/null && stopped=$((stopped + 1))
+            done
+            sleep 1
+            # Escalate for anything that ignored SIGTERM.
+            for pid in "${leaked_pids[@]}"; do
+                kill -0 "$pid" 2> /dev/null && kill -9 "$pid" 2> /dev/null || true
+            done
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Leaked automation browsers · stopped ${stopped} processes"
+        fi
+        note_activity
+    fi
+
+    if [[ ${#stale_profiles[@]} -gt 0 ]]; then
+        safe_clean "${stale_profiles[@]}" "Leaked browser profiles" || return $?
+    fi
+    return 0
+}
+
 clean_dev_ai_agents() {
     local keep_previous="${MOLE_AI_AGENTS_KEEP:-1}"
     [[ "$keep_previous" =~ ^[0-9]+$ ]] || keep_previous=1
@@ -5162,6 +5220,7 @@ clean_developer_tools() {
     _run_developer_cleanup_step clean_dev_jetbrains_toolbox || return $?
     _run_developer_cleanup_step clean_dev_jetbrains_logs || return $?
     _run_developer_cleanup_step --strict clean_dev_ai_agents || return $?
+    _run_developer_cleanup_step clean_dev_automation_browsers || return $?
     _run_developer_cleanup_step clean_dev_other_langs || return $?
     _run_developer_cleanup_step clean_dev_cicd || return $?
     _run_developer_cleanup_step clean_dev_database || return $?

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -144,9 +144,10 @@ write_purge_config() {
     local tmp_file
     tmp_file=$(mktemp_file "mole-purge-paths") || return 1
 
-    if ! cat > "$tmp_file" << EOF; then
+    if ! cat > "$tmp_file" << EOF
 $header
 EOF
+    then
         rm -f "$tmp_file" 2> /dev/null || true
         return 1
     fi

--- a/tests/clean_automation_browsers.bats
+++ b/tests/clean_automation_browsers.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# Leaked automation-browser cleanup: only automation-profile processes are
+# touched, dry-run never kills, and in-use profiles are never deleted.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-automation-browsers.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    if [[ "$HOME" == "${BATS_TEST_DIRNAME}/tmp-"* ]]; then
+        rm -rf "$HOME"
+    fi
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+# Stub binaries: ps emits one orphaned cliDaemon (ppid 1), one day-old Chrome
+# on an automation profile, one FRESH Chrome on an automation profile (must
+# survive), and one unrelated browser (must survive). getconf points the
+# profile scan at the test temp root.
+make_process_stubs() {
+    mkdir -p "$HOME/bin" "$HOME/tmproot"
+    cat > "$HOME/bin/ps" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' \
+    '  901     1 02-01:00:00 /opt/homebrew/bin/node playwright-core/lib/entry/cliDaemon.js daemon' \
+    '  902   901 01-20:00:00 /Applications/Chrome.app/x --user-data-dir=/tmp/playwright_chromiumdev_profile-old' \
+    '  903   901    05:00 /Applications/Chrome.app/x --user-data-dir=/tmp/playwright_chromiumdev_profile-new' \
+    '  904     1 03-01:00:00 /Applications/Safari.app/Contents/MacOS/Safari'
+SCRIPT
+    cat > "$HOME/bin/getconf" <<SCRIPT
+#!/bin/bash
+printf '%s/\n' "$HOME/tmproot"
+SCRIPT
+    cat > "$HOME/bin/pgrep" <<'SCRIPT'
+#!/bin/bash
+# Simulate: only the "live" profile has a process still referencing it.
+for arg in "$@"; do
+    [[ "$arg" == *"profile-live"* ]] && exit 0
+done
+exit 1
+SCRIPT
+    chmod +x "$HOME/bin/ps" "$HOME/bin/getconf" "$HOME/bin/pgrep"
+}
+
+run_cleanup() {
+    local dry_run="$1"
+    run env HOME="$HOME" PATH="$HOME/bin:/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
+        DRY="$dry_run" TRACE="$HOME/kill.trace" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+DRY_RUN="$DRY"
+kill() { printf 'KILL %s\n' "$*" >> "$TRACE"; return 0; }
+sleep() { :; }
+safe_clean() {
+    local -a paths=("$@")
+    local label="${paths[${#paths[@]} - 1]}"
+    unset 'paths[${#paths[@]}-1]'
+    local p
+    for p in "${paths[@]}"; do
+        printf 'SAFE_CLEAN %s (%s)\n' "$p" "$label"
+    done
+}
+note_activity() { :; }
+clean_dev_automation_browsers
+EOF
+}
+
+@test "kills only orphaned daemons and day-old automation browsers" {
+    make_process_stubs
+    : > "$HOME/kill.trace"
+
+    run_cleanup false
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"stopped 2 processes"* ]] || { echo "$output"; return 1; }
+    grep -q 'KILL -TERM 901' "$HOME/kill.trace" || return 1
+    grep -q 'KILL -TERM 902' "$HOME/kill.trace" || return 1
+    # Fresh automation session and the unrelated browser are never signaled.
+    ! grep -q ' 903' "$HOME/kill.trace" || return 1
+    ! grep -q ' 904' "$HOME/kill.trace" || return 1
+}
+
+@test "dry run reports but never signals a process" {
+    make_process_stubs
+    : > "$HOME/kill.trace"
+
+    run_cleanup true
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"would stop 2 processes"* ]] || { echo "$output"; return 1; }
+    [ ! -s "$HOME/kill.trace" ] || { cat "$HOME/kill.trace"; return 1; }
+}
+
+@test "stale profiles are cleaned, in-use and fresh profiles survive" {
+    make_process_stubs
+    : > "$HOME/kill.trace"
+
+    mkdir -p "$HOME/tmproot/playwright_chromiumdev_profile-stale" \
+        "$HOME/tmproot/playwright_chromiumdev_profile-live" \
+        "$HOME/tmproot/playwright_chromiumdev_profile-fresh"
+    # Age the stale and live dirs well past the 2h threshold.
+    touch -t 202601010000 "$HOME/tmproot/playwright_chromiumdev_profile-stale"
+    touch -t 202601010000 "$HOME/tmproot/playwright_chromiumdev_profile-live"
+
+    run_cleanup false
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"SAFE_CLEAN"*"profile-stale"* ]] || { echo "$output"; return 1; }
+    # In-use profile (pgrep hit) and fresh profile (under 2h) stay.
+    [[ "$output" != *"SAFE_CLEAN"*"profile-live"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"SAFE_CLEAN"*"profile-fresh"* ]] || { echo "$output"; return 1; }
+}
+
+@test "quiet no-op when nothing leaked" {
+    mkdir -p "$HOME/bin" "$HOME/tmproot-empty"
+    cat > "$HOME/bin/ps" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' '  904     1 03-01:00:00 /Applications/Safari.app/Contents/MacOS/Safari'
+SCRIPT
+    cat > "$HOME/bin/getconf" <<SCRIPT
+#!/bin/bash
+printf '%s/\n' "$HOME/tmproot-empty"
+SCRIPT
+    chmod +x "$HOME/bin/ps" "$HOME/bin/getconf"
+
+    run_cleanup false
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" != *"stopped"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"SAFE_CLEAN"* ]] || { echo "$output"; return 1; }
+}

--- a/tests/clean_orphaned_runtimes.bats
+++ b/tests/clean_orphaned_runtimes.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Orphaned simulator runtime detection: report a runtime no device uses,
+# stay silent on in-use runtimes, and never delete anything.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+# $1 = runtime list output, $2 = device list output
+run_check() {
+    run env PROJECT_ROOT="$PROJECT_ROOT" RT_OUT="$1" DEV_OUT="$2" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+_MOLE_SIMCTL_RESOLUTION_STATUS=ready
+_MOLE_SIMCTL_DEVELOPER_DIR=/fake
+note_activity() { :; }
+run_with_timeout() {
+    shift
+    case "$*" in
+        *"runtime list"*) printf '%s\n' "$RT_OUT" ;;
+        *"list devices"*) printf '%s\n' "$DEV_OUT" ;;
+    esac
+}
+check_orphaned_simulator_runtimes
+EOF
+}
+
+RUNTIMES='== Disk Images ==
+-- iOS --
+iOS 18.4 (22E238) - 70DF9A83-C8CF-458E-B463-356D557B8D2D (Ready)
+    Mount Path: /Library/Developer/CoreSimulator/Volumes/iOS_22E238
+    Size: 8.2G
+iOS 26.5 (23F77) - 78F2282D-7AC8-4DA3-B482-9E21FFBD5841 (Ready)
+    Size: 7.9G'
+
+@test "reports a runtime with zero devices and names the owner command" {
+    run_check "$RUNTIMES" '-- iOS 18.4 --
+-- iOS 26.5 --
+    iPhone 17 Pro (E4FC6A8A-563B-4027-B246-242D123EB40B) (Booted)'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"Orphaned simulator runtime"* ]] || return 1
+    [[ "$output" == *"iOS 18.4"* ]] || return 1
+    [[ "$output" == *"8.2G"* ]] || return 1
+    [[ "$output" == *"runtime delete 70DF9A83-C8CF-458E-B463-356D557B8D2D"* ]] || return 1
+    # The in-use runtime must never be named.
+    [[ "$output" != *"iOS 26.5"* ]] || { echo "$output"; return 1; }
+}
+
+@test "silent when every runtime has at least one device" {
+    run_check "$RUNTIMES" '-- iOS 18.4 --
+    iPhone 16 Pro (C1237C27-E6A1-4553-9117-65FAE480A347) (Shutdown)
+-- iOS 26.5 --
+    iPhone 17 Pro (E4FC6A8A-563B-4027-B246-242D123EB40B) (Booted)'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" != *"Orphaned"* ]] || { echo "$output"; return 1; }
+}
+
+@test "reports every orphan when more than one runtime is unused" {
+    run_check "$RUNTIMES" '-- iOS 18.4 --
+-- iOS 26.5 --'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"iOS 18.4"* ]] || return 1
+    [[ "$output" == *"iOS 26.5"* ]] || return 1
+}
+
+@test "a runtime with no reported size still reports as an orphan" {
+    run_check 'iOS 18.4 (22E238) - 70DF9A83-C8CF-458E-B463-356D557B8D2D (Ready)' \
+        '-- iOS 18.4 --'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"iOS 18.4 · no devices"* ]] || { echo "$output"; return 1; }
+}
+
+@test "probe timeout propagates instead of reporting a false clean" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+_MOLE_SIMCTL_RESOLUTION_STATUS=ready
+_MOLE_SIMCTL_DEVELOPER_DIR=/fake
+note_activity() { :; }
+run_with_timeout() { return 124; }
+check_orphaned_simulator_runtimes
+EOF
+    [ "$status" -eq 124 ] || { echo "status=$status $output"; return 1; }
+    [[ "$output" != *"Orphaned"* ]] || return 1
+}
+
+@test "no-op when simctl was never resolved" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+_MOLE_SIMCTL_RESOLUTION_STATUS=clt-only
+run_with_timeout() { echo "PROBED"; }
+check_orphaned_simulator_runtimes
+EOF
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" != *"PROBED"* ]] || { echo "$output"; return 1; }
+}


### PR DESCRIPTION
## What

Two additions to the Developer tools family in `mo clean`, both targeting leftovers that nothing on macOS ever reaps.

**1. Leaked automation browsers** (`clean_dev_automation_browsers`). When a Playwright/agent harness dies without cleanup, its browser daemon reparents to launchd and the headless Chrome tree keeps running, holding RSS indefinitely. One real machine accumulated **248 processes holding 5.9GB** plus 36 stale profile directories. It stops orphaned Playwright daemons (any age) and browser processes on `playwright_chromiumdev_profile-*` automation profiles older than a day, then removes stale profile temp dirs (2h+) through `safe_clean`.

A user's real browser can never match: only processes tied to ephemeral automation profiles are considered, and a profile a live process still references is skipped via `pgrep`. Browser processes need to be a full day old because a younger one may belong to an active automation session.

**2. Unused simulator runtimes** (`check_orphaned_simulator_runtimes`). An installed simulator runtime whose last device was deleted becomes unreferenced, and nothing reports it — not `simctl`, not Xcode, and not Mole's existing passes. `clean_xcode_simulator_runtime_volumes` handles stale mount points and the unavailable-simulator pass handles devices orphaned by a removed runtime; this is the inverse case. A real machine carried an unreferenced iOS 18.4 runtime at **8.2GB** indefinitely.

This one is **review-only**, matching how downloaded toolchain payloads are treated elsewhere in the classification rules: a runtime is only re-servable by Apple, so it stays off the blanket delete path. The value is naming the exact orphan, its size, and the owner command, which `simctl` cannot report directly.

## Safety

- Dry-run previews the process count and lets `safe_clean` preview the directories; it never signals a process.
- Deletion goes through `safe_remove`, never raw `rm -rf`.
- Both `simctl` probes are timeout-bounded via `MOLE_TIMEOUT_PKG_LIST_SEC` and **propagate cancellation** (124/128+) rather than reporting a false clean.
- Kills are sent one PID at a time with per-PID accounting, because a bulk `kill` over a long list can silently no-op.

## Testing

- `./scripts/check.sh` clean.
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/dev_extended.bats tests/clean_automation_browsers.bats tests/clean_orphaned_runtimes.bats` — 201 passing, including the required `lib/clean/dev.sh` hotspot suites.
- `tests/clean_automation_browsers.bats` (4 cases): kills only orphaned daemons and day-old automation browsers while a *fresh* automation session and an unrelated browser survive; dry-run signals nothing; stale profiles cleaned while in-use and fresh profiles survive; silent no-op when nothing leaked.
- `tests/clean_orphaned_runtimes.bats` (6 cases): reports a zero-device runtime with its size and owner command, stays silent when every runtime has a device, reports multiple orphans, handles a runtime with no reported size, propagates probe timeout instead of a false clean, and no-ops when `simctl` was never resolved.

One bug caught by these tests before it shipped, worth mentioning because it would have broken the common path: expanding the empty `orphan_lines` array under `set -u` is an unbound-variable error on the bash 3.2 macOS ships. Since "no orphans" is the normal case, that would have failed `mo clean` for everyone with a healthy machine. Guarded and pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)