### PR TITLE
fix(uninstall): suppress dead-terminal countdown read errors

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -1835,7 +1835,7 @@ main() {
         local _pressed=false
         while [[ $_countdown -gt 0 ]]; do
             printf "\r${GRAY}Press Enter to return to the app list, press q to exit (%d)${NC} " "$_countdown"
-            if IFS= read -r -s -n1 -t 1 _key; then
+            if IFS= read -r -s -n1 -t 1 _key 2> /dev/null; then
                 _pressed=true
                 break
             fi

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -3273,6 +3273,62 @@ INNER
     [ "$status" -eq 0 ]
 }
 
+@test "completed uninstall suppresses dead-terminal countdown read errors (#1503)" {
+    local apps_cache
+    apps_cache="$(mktemp "${BATS_TEST_TMPDIR:-$BATS_RUN_TMPDIR:-$HOME}/tmp-1503-countdown.XXXXXX")"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" APPS_CACHE_FILE="$apps_cache" \
+        /bin/bash --noprofile --norc << 'INNER'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+
+log_operation_session_start() { :; }
+hide_cursor() { :; }
+show_cursor() { :; }
+clear_screen() { :; }
+start_uninstall_interactive_screen() { :; }
+stop_uninstall_interactive_screen() { :; }
+scan_applications() { printf '%s\n' "$APPS_CACHE_FILE"; }
+load_applications() { :; }
+select_apps_for_uninstall() {
+    selected_apps=("0|$HOME/Applications/TestApp.app|TestApp|com.example.TestApp|1KB|Today|1")
+}
+batch_uninstall_applications() { :; }
+uninstall_app_inventory_fingerprint() { printf 'stable\n'; }
+uninstall_normalize_size_display() { printf '%s\n' "$1"; }
+uninstall_normalize_last_used_display() { printf '%s\n' "$1"; }
+get_display_width() { printf '%s\n' "${#1}"; }
+truncate_by_display_width() { printf '%s\n' "$1"; }
+mole_tty_is_foreground() { return 0; }
+drain_pending_input() { :; }
+read() {
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == -t || "$arg" == -t* ]]; then
+            printf 'read error: 0: Input/output error\n' >&2
+            return 1
+        fi
+    done
+    builtin read "$@"
+}
+
+eval "$(sed -n '/^main()/,/main \"\$@\"/p' "$PROJECT_ROOT/bin/uninstall.sh" | sed '$d')"
+main > "$HOME/countdown.out" 2> "$HOME/countdown.err"
+
+[[ "$(cat "$HOME/countdown.err")" != *'Input/output error'* ]] || {
+    cat "$HOME/countdown.err" >&2
+    exit 1
+}
+[[ "$(grep -o 'Press Enter to return to the app list' "$HOME/countdown.out" | wc -l | tr -d ' ')" -eq 5 ]]
+INNER
+
+    rm -f "$apps_cache"
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+}
+
 @test "inventory cache reuse accepts removals only and rejects stale changes (#1315)" {
     run env HOME="$HOME/inventory-reuse" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'INNER'
 set -euo pipefail


### PR DESCRIPTION
## Summary

Closes #1503.

When the hosting terminal disappears after an uninstall, macOS Bash 3.2
returns EIO from each timed countdown read and prints a misleading error for
every remaining tick. Suppress only that builtin diagnostic; timeout, keypress,
countdown, return-code, and uninstall behavior remain unchanged.

## Tests

- `bats tests/uninstall.bats tests/uninstall_tty_foreground.bats tests/uninstall_scan_bash32.bats` (123 passing)
- `./scripts/check.sh --no-format`
- `bash -n bin/uninstall.sh lib/uninstall/batch.sh tests/uninstall.bats`
- `git diff --check`

The new regression drives the real interactive `main` path with a failing
timed `read`, verifies the synthetic EIO diagnostic is suppressed, and checks
that all five countdown ticks still render.
