### PR TITLE
fix(clean): apply per-entry removal budget to XCTestDevices

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1442,6 +1442,8 @@ start_cleanup() {
     export MOLE_CLEAN_SIZING_TIMEOUTS
     MOLE_CLEAN_REMOVAL_TIMEOUTS=0
     export MOLE_CLEAN_REMOVAL_TIMEOUTS
+    MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS=""
+    export MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS
     log_operation_session_start "clean"
     DRY_RUN_SEEN_IDENTITIES=()
     DRY_RUN_TOTAL_PARTIAL=false
@@ -1964,7 +1966,29 @@ perform_cleanup() {
     fi
 
     if [[ ${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} -gt 0 ]]; then
-        summary_details+=("${GRAY}${ICON_WARNING}${NC} ${MOLE_CLEAN_REMOVAL_TIMEOUTS} item(s) exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s removal budget and may be only partly removed. Run clean again, or raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} for slower disks.")
+        # Name the timed-out paths so the note is actionable without opening
+        # the operation log. Cap the list: a pathological disk can time out on
+        # many items and the note must stay one line.
+        local removal_timeout_note="item(s) exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s removal budget and may be only partly removed"
+        local -a removal_timeout_paths=()
+        local removal_timeout_path
+        while IFS= read -r removal_timeout_path; do
+            [[ -n "$removal_timeout_path" ]] && removal_timeout_paths+=("$removal_timeout_path")
+        done <<< "${MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS:-}"
+        if [[ ${#removal_timeout_paths[@]} -gt 0 ]]; then
+            local removal_timeout_show=3
+            [[ ${#removal_timeout_paths[@]} -lt $removal_timeout_show ]] && removal_timeout_show=${#removal_timeout_paths[@]}
+            local removal_timeout_list=""
+            local removal_timeout_idx
+            for ((removal_timeout_idx = 0; removal_timeout_idx < removal_timeout_show; removal_timeout_idx++)); do
+                removal_timeout_list+="${removal_timeout_list:+, }${removal_timeout_paths[$removal_timeout_idx]}"
+            done
+            if [[ ${#removal_timeout_paths[@]} -gt $removal_timeout_show ]]; then
+                removal_timeout_list+=", +$((${#removal_timeout_paths[@]} - removal_timeout_show)) more"
+            fi
+            removal_timeout_note+=": ${removal_timeout_list}"
+        fi
+        summary_details+=("${GRAY}${ICON_WARNING}${NC} ${MOLE_CLEAN_REMOVAL_TIMEOUTS} ${removal_timeout_note}. Run clean again, or raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} for slower disks.")
     fi
 
     if [[ $had_errexit -eq 1 ]]; then

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1808,10 +1808,22 @@ clean_xcode_xctest_devices() {
         return 0
     fi
 
+    # Test clones accumulate one UUID directory per test run, so the root
+    # grows without bound and a single-tree removal can exceed the per-item
+    # removal budget after deleting only part of it. Delete each entry
+    # separately so the budget, sink guard, and sizing apply per clone. The
+    # root itself stays: Xcode recreates clones inside it.
+    local -a device_entries=()
+    local device_entry
+    while IFS= read -r -d '' device_entry; do
+        device_entries+=("$device_entry")
+    done < <(command find "$xctest_devices_dir" -mindepth 1 -maxdepth 1 -print0 2> /dev/null)
+    [[ ${#device_entries[@]} -gt 0 ]] || return 0
+
     _xcode_safe_clean_guarded \
         _xctest_devices_delete_guard_allows \
         "Xcode XCTestDevices" \
-        "$xctest_devices_dir" \
+        "${device_entries[@]}" \
         "Xcode XCTestDevices test data" || true
 }
 

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -37,6 +37,14 @@ if [[ -z "${MOLE_TIMEOUTS_LOADED:-}" ]]; then
     source "$_MOLE_CORE_DIR/timeouts.sh"
 fi
 
+# Keep the removal-timeout summary actionable: record which path ran out of
+# budget so the closing note can name it instead of a bare count.
+_mole_record_removal_timeout_path() {
+    local path="$1"
+    MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS="${MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS:+$MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS
+}$path"
+}
+
 # Bound production sudo commands while keeping shell-function mocks observable
 # in tests. Timeout behavior itself must use a PATH stub so it exercises the
 # same external-command branch that users run.
@@ -1548,6 +1556,7 @@ safe_remove() {
             # failed removal, not a user interrupt: count it and keep going so
             # one slow cache never cancels the remaining cleanup.
             MOLE_CLEAN_REMOVAL_TIMEOUTS=$((${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} + 1))
+            _mole_record_removal_timeout_path "$path"
         fi
         return 124
     fi
@@ -1962,6 +1971,7 @@ safe_sudo_remove() {
         else
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "removal timed out"
             MOLE_CLEAN_REMOVAL_TIMEOUTS=$((${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} + 1))
+            _mole_record_removal_timeout_path "$path"
         fi
         return 124
     fi

--- a/tests/clean_summary_cancel.bats
+++ b/tests/clean_summary_cancel.bats
@@ -159,6 +159,41 @@ EOF
     [[ "$output" == *"3 item(s) exceeded the 30s removal budget"* ]]
 }
 
+@test "run with removal timeouts names the timed-out paths (#1384)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+for fn in clean_user_essentials clean_finder_metadata clean_app_caches \
+    clean_browsers run_cloud_and_office_cleanup clean_developer_tools \
+    clean_user_gui_applications clean_virtualization_tools \
+    clean_application_support_logs clean_orphaned_app_data \
+    clean_orphaned_system_services clean_orphaned_container_stubs \
+    show_user_launch_agent_hint_notice \
+    clean_apple_silicon_caches clean_cached_device_firmware \
+    clean_time_machine_failed_backups check_large_file_candidates \
+    show_project_artifact_hint_notice; do
+    eval "$fn() { return 0; }"
+done
+run_with_shell_timeout() { return 0; }
+clean_user_essentials() {
+    MOLE_CLEAN_REMOVAL_TIMEOUTS=2
+    _mole_record_removal_timeout_path "$HOME/Library/Developer/XCTestDevices/clone-one"
+    _mole_record_removal_timeout_path "$HOME/Library/Developer/XCTestDevices/clone-two"
+    return 0
+}
+perform_cleanup
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"2 item(s) exceeded the 30s removal budget"* ]] || return 1
+    [[ "$output" == *"XCTestDevices/clone-one"* ]] || return 1
+    [[ "$output" == *"XCTestDevices/clone-two"* ]] || return 1
+}
+
 @test "sizing timeouts still clean and the summary reports the under-count (#1374)" {
     mkdir -p "$HOME/Library/Caches/cache1374"
     printf x > "$HOME/Library/Caches/cache1374/file.bin"

--- a/tests/dev_extended.bats
+++ b/tests/dev_extended.bats
@@ -1377,9 +1377,12 @@ EOF
     [[ "$output" != *"already clean"* ]]
 }
 
-@test "clean_xcode_xctest_devices targets only exact XCTestDevices directory" {
+@test "clean_xcode_xctest_devices targets each clone entry, not the root" {
     local developer_root="$HOME/Library/Developer"
-    mkdir -p "$developer_root/XCTestDevices" "$developer_root/XCTestDevices-old"
+    local xctest_root="$developer_root/XCTestDevices"
+    mkdir -p "$xctest_root/11111111-2222-3333-4444-555555555555" \
+        "$xctest_root/66666666-7777-8888-9999-000000000000" \
+        "$developer_root/XCTestDevices-old"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
@@ -1388,12 +1391,23 @@ source "$PROJECT_ROOT/lib/clean/dev.sh"
 note_activity() { :; }
 pgrep() { return 1; }
 _coresimulator_booted_device_state() { return 1; }
-safe_clean() { printf 'SAFE:%s|%s\n' "$1" "$2"; }
+safe_clean() { for target in "$@"; do printf 'SAFE:%s\n' "$target"; done; }
 clean_xcode_xctest_devices
 EOF
 
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"SAFE:$developer_root/XCTestDevices|Xcode XCTestDevices test data"* ]] || return 1
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"SAFE:$HOME/Library/Developer/XCTestDevices/11111111-2222-3333-4444-555555555555"* ]] || return 1
+    [[ "$output" == *"SAFE:$HOME/Library/Developer/XCTestDevices/66666666-7777-8888-9999-000000000000"* ]] || return 1
+    # The root itself is never a deletion target: it stays for Xcode to
+    # recreate clones in, and a root-sized item would outgrow the per-item
+    # removal budget.
+    if printf '%s\n' "$output" | command grep -qx "SAFE:$HOME/Library/Developer/XCTestDevices"; then
+        echo "WRONG: root passed as target"
+        return 1
+    fi
     [[ "$output" != *"XCTestDevices-old"* ]]
 }
 
@@ -1469,6 +1483,38 @@ EOF
     }
     [[ "$output" != *"Xcode XCTestDevices · stopped"* ]] || return 1
     [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
+}
+
+@test "clean_xcode_xctest_devices removal budget applies per clone entry" {
+    local xctest_root="$HOME/PerEntryXCTestDevices"
+    mkdir -p "$xctest_root/11111111-2222-3333-4444-555555555555" \
+        "$xctest_root/66666666-7777-8888-9999-000000000000"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        MOLE_XCODE_XCTEST_DEVICES_DIR="$xctest_root" MOLE_TEST_NO_AUTH=1 \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+note_activity() { :; }
+pgrep() { return 1; }
+_coresimulator_booted_device_state() { return 1; }
+# One sink call per clone: a root-sized single item outgrows the per-item
+# removal budget after deleting only part of it.
+safe_remove() { printf 'REMOVE:%s\n' "$1"; return 0; }
+clean_xcode_xctest_devices
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"REMOVE:$HOME/PerEntryXCTestDevices/11111111-2222-3333-4444-555555555555"* ]] || return 1
+    [[ "$output" == *"REMOVE:$HOME/PerEntryXCTestDevices/66666666-7777-8888-9999-000000000000"* ]] || return 1
+    if printf '%s\n' "$output" | command grep -qx "REMOVE:$HOME/PerEntryXCTestDevices"; then
+        echo "WRONG: root passed as one removal item"
+        return 1
+    fi
 }
 
 @test "clean_xcode_xctest_devices dry-run keeps XCTestDevices directory" {


### PR DESCRIPTION
## Problem

`clean_xcode_xctest_devices` removed the whole `~/Library/Developer/XCTestDevices` tree as **one** deletion item. Xcode creates one UUID-clone directory there per test run and never reaps them, so the root grows without bound. When the tree got large enough, the single removal exceeded the 30s per-item removal budget (`MOLE_TIMEOUT_DISK_VERIFY_SEC`), the `rm` was killed mid-tree, and the run reported one opaque failed item — leaving dozens of clones behind on disk.

Observed on a real machine (macOS 26, Apple Silicon):

```
$ du -sh ~/Library/Developer/*
 17M    XCPGDevices
2.1G    DVTDownloads
3.1G    Xcode
 31G    CoreSimulator
 84G    XCTestDevices
```

And the operation log after each `mo clean`:

```
[clean] FAILED /Users/haogre/Library/Developer/XCTestDevices (removal timed out)
```

84 GB of test clones with one 30-second budget meant roughly 6 clones per run got removed (the tail note said `1 item(s) exceeded the 30s removal budget`, without naming the item). Raising the budget globally is not a fix: the budget is shared with size checks and privileged probes, and the tree only grows, so any fixed value eventually loses.

## Change

1. **Per-entry deletion** (`lib/clean/dev.sh`): `clean_xcode_xctest_devices` now enumerates the first-level UUID entries and passes them to the existing guarded batch, matching the pattern `clean_xcode_system_coresimulator_caches` already uses. Sizing, the sink re-probe, and the removal budget now apply per clone (2–3 GB each, comfortably inside the budget). The root itself is never a deletion target — Xcode recreates clones inside it.

2. **Name the timed-out paths** (`lib/core/file_ops.sh`, `bin/clean.sh`): the closing `removal budget` note now lists the paths that timed out (capped at 3 + a remainder count), so the user learns which target was partly removed without opening the operation log:

```
◎ 1 item(s) exceeded the 30s removal budget and may be only partly removed: ~/Library/Developer/XCTestDevices/0635B5E2-…. Run clean again, or raise MOLE_TIMEOUT_DISK_VERIFY_SEC for slower disks.
```

No new flag or config key — the fix is structural, not a knob.

## Verification

- New Bats regressions, observed red against pre-fix code and green after:
  - `clean_xcode_xctest_devices targets each clone entry, not the root`
  - `clean_xcode_xctest_devices removal budget applies per clone entry`
  - `run with removal timeouts names the timed-out paths (#1384)`
- Existing XCTestDevices tests updated in place (guard/skip/defer/whitelist/dry-run behavior unchanged)
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_dev_caches.bats tests/dev_extended.bats` — all green
- `MOLE_TEST_NO_AUTH=1 bats tests/file_ops_mole_delete.bats tests/file_ops_size.bats tests/file_ops_safe_remove_symlink.bats tests/user_file_ops.bats tests/core_safe_functions.bats` — all green
- `MOLE_TEST_NO_AUTH=1 bats tests/clean_core.bats tests/clean_apps.bats tests/cli.bats tests/clean_summary_cancel.bats` — all green
- `./scripts/check.sh --format` and `./scripts/check.sh` (incl. function-duplication audit) — pass
- Real-machine verification on macOS 26 (installed locally): after the fix, one `mo clean` run removed the remaining backlog in one pass:

```
✓ Xcode XCTestDevices test data · 9 items, 23.85GB
```

(down from 84 GB observed initially; earlier runs against the old code had only managed ~6 clones per 30s window)