### PR TITLE
integrate: merge #1515 #1505 #1504 onto latest main

### DIFF
--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1442,6 +1442,8 @@ start_cleanup() {
     export MOLE_CLEAN_SIZING_TIMEOUTS
     MOLE_CLEAN_REMOVAL_TIMEOUTS=0
     export MOLE_CLEAN_REMOVAL_TIMEOUTS
+    MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS=""
+    export MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS
     log_operation_session_start "clean"
     DRY_RUN_SEEN_IDENTITIES=()
     DRY_RUN_TOTAL_PARTIAL=false
@@ -1964,7 +1966,29 @@ perform_cleanup() {
     fi
 
     if [[ ${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} -gt 0 ]]; then
-        summary_details+=("${GRAY}${ICON_WARNING}${NC} ${MOLE_CLEAN_REMOVAL_TIMEOUTS} item(s) exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s removal budget and may be only partly removed. Run clean again, or raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} for slower disks.")
+        # Name the timed-out paths so the note is actionable without opening
+        # the operation log. Cap the list: a pathological disk can time out on
+        # many items and the note must stay one line.
+        local removal_timeout_note="item(s) exceeded the ${MOLE_TIMEOUT_DISK_VERIFY_SEC}s removal budget and may be only partly removed"
+        local -a removal_timeout_paths=()
+        local removal_timeout_path
+        while IFS= read -r removal_timeout_path; do
+            [[ -n "$removal_timeout_path" ]] && removal_timeout_paths+=("$removal_timeout_path")
+        done <<< "${MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS:-}"
+        if [[ ${#removal_timeout_paths[@]} -gt 0 ]]; then
+            local removal_timeout_show=3
+            [[ ${#removal_timeout_paths[@]} -lt $removal_timeout_show ]] && removal_timeout_show=${#removal_timeout_paths[@]}
+            local removal_timeout_list=""
+            local removal_timeout_idx
+            for ((removal_timeout_idx = 0; removal_timeout_idx < removal_timeout_show; removal_timeout_idx++)); do
+                removal_timeout_list+="${removal_timeout_list:+, }${removal_timeout_paths[$removal_timeout_idx]}"
+            done
+            if [[ ${#removal_timeout_paths[@]} -gt $removal_timeout_show ]]; then
+                removal_timeout_list+=", +$((${#removal_timeout_paths[@]} - removal_timeout_show)) more"
+            fi
+            removal_timeout_note+=": ${removal_timeout_list}"
+        fi
+        summary_details+=("${GRAY}${ICON_WARNING}${NC} ${MOLE_CLEAN_REMOVAL_TIMEOUTS} ${removal_timeout_note}. Run clean again, or raise ${GRAY}MOLE_TIMEOUT_DISK_VERIFY_SEC${NC} for slower disks.")
     fi
 
     if [[ $had_errexit -eq 1 ]]; then

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -1808,10 +1808,22 @@ clean_xcode_xctest_devices() {
         return 0
     fi
 
+    # Test clones accumulate one UUID directory per test run, so the root
+    # grows without bound and a single-tree removal can exceed the per-item
+    # removal budget after deleting only part of it. Delete each entry
+    # separately so the budget, sink guard, and sizing apply per clone. The
+    # root itself stays: Xcode recreates clones inside it.
+    local -a device_entries=()
+    local device_entry
+    while IFS= read -r -d '' device_entry; do
+        device_entries+=("$device_entry")
+    done < <(command find "$xctest_devices_dir" -mindepth 1 -maxdepth 1 -print0 2> /dev/null)
+    [[ ${#device_entries[@]} -gt 0 ]] || return 0
+
     _xcode_safe_clean_guarded \
         _xctest_devices_delete_guard_allows \
         "Xcode XCTestDevices" \
-        "$xctest_devices_dir" \
+        "${device_entries[@]}" \
         "Xcode XCTestDevices test data" || true
 }
 

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -2735,6 +2735,95 @@ _debug_simctl_probe_stderr() {
     debug_log "simctl probe $attempt stderr: $excerpt"
 }
 
+# Installed simulator runtimes that no device uses. Distinct from
+# clean_xcode_simulator_runtime_volumes (stale mount points) and from
+# unavailable-simulator cleanup (devices orphaned by a removed runtime):
+# this is the inverse, a runtime left behind after its last device went
+# away. Nothing in macOS or Xcode reports it, so an 8GB download can sit
+# unreferenced indefinitely.
+#
+# Review-only by design. A runtime is a toolchain payload that only Apple
+# can serve again, so it stays off the blanket delete path the same way
+# other downloaded toolchain roots do; the value here is naming the exact
+# orphan and the owner command, which is information the user cannot get
+# from simctl directly.
+check_orphaned_simulator_runtimes() {
+    command -v xcrun > /dev/null 2>&1 || return 0
+    [[ "${_MOLE_SIMCTL_RESOLUTION_STATUS:-}" == "ready" ]] || return 0
+
+    local runtime_list="" device_list="" probe_status=0
+    runtime_list=$(run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" \
+        env DEVELOPER_DIR="$_MOLE_SIMCTL_DEVELOPER_DIR" xcrun simctl runtime list -v 2> /dev/null) || probe_status=$?
+    if [[ $probe_status -ne 0 ]]; then
+        [[ $probe_status -eq 124 || $probe_status -ge 128 ]] && return "$probe_status"
+        debug_log "Orphaned runtime probe failed (exit=$probe_status)"
+        return 0
+    fi
+
+    probe_status=0
+    device_list=$(run_with_timeout "$MOLE_TIMEOUT_PKG_LIST_SEC" \
+        env DEVELOPER_DIR="$_MOLE_SIMCTL_DEVELOPER_DIR" xcrun simctl list devices 2> /dev/null) || probe_status=$?
+    if [[ $probe_status -ne 0 ]]; then
+        [[ $probe_status -eq 124 || $probe_status -ge 128 ]] && return "$probe_status"
+        debug_log "Orphaned runtime device probe failed (exit=$probe_status)"
+        return 0
+    fi
+
+    # `simctl runtime list -v` prints a header line per runtime followed by
+    # indented detail lines, one of which carries the on-disk size:
+    #   iOS 18.4 (22E238) - 70DF9A83-... (Ready)
+    #       Size: 8.2G
+    local current_name="" current_id="" current_size=""
+    local -a orphan_lines=()
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^([A-Za-z]+[[:space:]][0-9.]+)[[:space:]]\(.*\)[[:space:]]-[[:space:]]([0-9A-F-]{36}) ]]; then
+            # Flush the previous runtime before starting a new one.
+            _flush_orphan_runtime_candidate
+            current_name="${BASH_REMATCH[1]}"
+            current_id="${BASH_REMATCH[2]}"
+            current_size=""
+        elif [[ -n "$current_id" && "$line" =~ ^[[:space:]]+Size:[[:space:]]+(.+)$ ]]; then
+            current_size="${BASH_REMATCH[1]}"
+        fi
+    done <<< "$runtime_list"
+    _flush_orphan_runtime_candidate
+
+    # Expanding an empty array under `set -u` is an unbound-variable error on
+    # the bash 3.2 macOS ships, and "no orphans" is the common path.
+    [[ ${#orphan_lines[@]} -gt 0 ]] || return 0
+
+    local orphan
+    for orphan in "${orphan_lines[@]}"; do
+        echo -e "  ${GRAY}${ICON_REVIEW}${NC} Orphaned simulator runtime · ${orphan}"
+        note_activity
+    done
+    return 0
+}
+
+# Helper for check_orphaned_simulator_runtimes' parse loop: decide whether
+# the runtime just parsed has zero devices, and if so queue a review line.
+# Reads/writes the caller's locals by design (bash 3.2 has no namerefs).
+_flush_orphan_runtime_candidate() {
+    [[ -n "$current_id" && -n "$current_name" ]] || return 0
+
+    # Devices are grouped under a "-- <runtime name> --" header. Count the
+    # non-empty lines in this runtime's group; zero means orphaned.
+    local device_count
+    device_count=$(printf '%s\n' "$device_list" | awk -v want="-- ${current_name} --" '
+        index($0, want) == 1 { f = 1; next }
+        /^-- / { f = 0 }
+        f && NF { c++ }
+        END { print c + 0 }')
+
+    if [[ "$device_count" -eq 0 ]]; then
+        local size_note="${current_size:+, $current_size}"
+        orphan_lines+=("${current_name}${size_note} · no devices · remove with ${GRAY}xcrun simctl runtime delete ${current_id}${NC}")
+    fi
+    current_id=""
+    current_name=""
+    current_size=""
+}
+
 clean_dev_mobile() {
     check_android_ndk
     clean_xcode_documentation_cache || return $?
@@ -2946,6 +3035,7 @@ clean_dev_mobile() {
             echo -e "  ${GRAY}${ICON_WARNING}${NC} Xcode unavailable simulators · simctl could not be resolved"
             note_activity
         fi
+        check_orphaned_simulator_runtimes || return $?
     fi
     # Old iOS/watchOS/tvOS DeviceSupport versions (debug symbols for connected devices).
     # Each iOS version creates a 1-3 GB folder of debug symbols. Only the versions

--- a/lib/clean/dev.sh
+++ b/lib/clean/dev.sh
@@ -3818,6 +3818,64 @@ clean_claude_desktop_bundled_versions() {
     done
 }
 
+# Headless browser trees leaked by dead Playwright/agent automation sessions.
+# When an MCP server or agent harness dies without cleanup, its browser
+# daemons reparent to launchd (ppid 1) and the Chrome tree keeps running
+# headless, holding RSS; the ephemeral temp profiles keep disk. Only
+# processes tied to playwright_chromiumdev_profile-* automation profiles are
+# ever touched, never a user's real browser: orphaned Playwright daemons at
+# any age, browser processes only after a full day (a younger one may belong
+# to a live automation session).
+clean_dev_automation_browsers() {
+    local -a leaked_pids=()
+    local pid
+    while IFS= read -r pid; do
+        [[ -n "$pid" ]] && leaked_pids+=("$pid")
+    done < <(ps -Ao pid=,ppid=,etime=,command= 2> /dev/null | awk '
+        /playwright-core\/lib\/entry\/cliDaemon\.js/ && $2 == 1 { print $1; next }
+        /playwright_chromiumdev_profile/ && $3 ~ /-/ { print $1 }' | sort -un)
+
+    # Ephemeral automation profiles: stale after 2h, and never one that a
+    # live process still references.
+    local -a stale_profiles=()
+    local tmpdir
+    tmpdir=$(getconf DARWIN_USER_TEMP_DIR 2> /dev/null) || tmpdir=""
+    if [[ -n "$tmpdir" ]]; then
+        local d now age_hours
+        now=$(date +%s)
+        for d in "$tmpdir"playwright_chromiumdev_profile-*; do
+            [[ -d "$d" ]] || continue
+            age_hours=$(((now - $(stat -f %m "$d" 2> /dev/null || echo "$now")) / 3600))
+            [[ "$age_hours" -ge 2 ]] || continue
+            pgrep -qf "$d" 2> /dev/null && continue
+            stale_profiles+=("$d")
+        done
+    fi
+
+    if [[ ${#leaked_pids[@]} -gt 0 ]]; then
+        if [[ "$DRY_RUN" == "true" ]]; then
+            echo -e "  ${YELLOW}${ICON_DRY_RUN}${NC} Leaked automation browsers · would stop ${#leaked_pids[@]} processes ${YELLOW}dry${NC}"
+        else
+            local stopped=0
+            for pid in "${leaked_pids[@]}"; do
+                kill -TERM "$pid" 2> /dev/null && stopped=$((stopped + 1))
+            done
+            sleep 1
+            # Escalate for anything that ignored SIGTERM.
+            for pid in "${leaked_pids[@]}"; do
+                kill -0 "$pid" 2> /dev/null && kill -9 "$pid" 2> /dev/null || true
+            done
+            echo -e "  ${GREEN}${ICON_SUCCESS}${NC} Leaked automation browsers · stopped ${stopped} processes"
+        fi
+        note_activity
+    fi
+
+    if [[ ${#stale_profiles[@]} -gt 0 ]]; then
+        safe_clean "${stale_profiles[@]}" "Leaked browser profiles" || return $?
+    fi
+    return 0
+}
+
 clean_dev_ai_agents() {
     local keep_previous="${MOLE_AI_AGENTS_KEEP:-1}"
     [[ "$keep_previous" =~ ^[0-9]+$ ]] || keep_previous=1
@@ -5162,6 +5220,7 @@ clean_developer_tools() {
     _run_developer_cleanup_step clean_dev_jetbrains_toolbox || return $?
     _run_developer_cleanup_step clean_dev_jetbrains_logs || return $?
     _run_developer_cleanup_step --strict clean_dev_ai_agents || return $?
+    _run_developer_cleanup_step clean_dev_automation_browsers || return $?
     _run_developer_cleanup_step clean_dev_other_langs || return $?
     _run_developer_cleanup_step clean_dev_cicd || return $?
     _run_developer_cleanup_step clean_dev_database || return $?

--- a/lib/clean/project.sh
+++ b/lib/clean/project.sh
@@ -144,9 +144,10 @@ write_purge_config() {
     local tmp_file
     tmp_file=$(mktemp_file "mole-purge-paths") || return 1
 
-    if ! cat > "$tmp_file" << EOF; then
+    if ! cat > "$tmp_file" << EOF
 $header
 EOF
+    then
         rm -f "$tmp_file" 2> /dev/null || true
         return 1
     fi

--- a/lib/core/file_ops.sh
+++ b/lib/core/file_ops.sh
@@ -37,6 +37,14 @@ if [[ -z "${MOLE_TIMEOUTS_LOADED:-}" ]]; then
     source "$_MOLE_CORE_DIR/timeouts.sh"
 fi
 
+# Keep the removal-timeout summary actionable: record which path ran out of
+# budget so the closing note can name it instead of a bare count.
+_mole_record_removal_timeout_path() {
+    local path="$1"
+    MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS="${MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS:+$MOLE_CLEAN_REMOVAL_TIMEOUT_PATHS
+}$path"
+}
+
 # Bound production sudo commands while keeping shell-function mocks observable
 # in tests. Timeout behavior itself must use a PATH stub so it exercises the
 # same external-command branch that users run.
@@ -1548,6 +1556,7 @@ safe_remove() {
             # failed removal, not a user interrupt: count it and keep going so
             # one slow cache never cancels the remaining cleanup.
             MOLE_CLEAN_REMOVAL_TIMEOUTS=$((${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} + 1))
+            _mole_record_removal_timeout_path "$path"
         fi
         return 124
     fi
@@ -1962,6 +1971,7 @@ safe_sudo_remove() {
         else
             log_operation "${MOLE_CURRENT_COMMAND:-clean}" "FAILED" "$path" "removal timed out"
             MOLE_CLEAN_REMOVAL_TIMEOUTS=$((${MOLE_CLEAN_REMOVAL_TIMEOUTS:-0} + 1))
+            _mole_record_removal_timeout_path "$path"
         fi
         return 124
     fi

--- a/lib/optimize/diagnostics.sh
+++ b/lib/optimize/diagnostics.sh
@@ -392,8 +392,20 @@ run_optimize_diagnostics() {
         fi
     done
 
-    if [[ -z "$primary_family" ]]; then
+    # Memory and stuck-process checks run alongside the family CPU scan. They
+    # cover the two shapes the family list cannot see, and each stays silent
+    # when healthy, so a clean machine still prints one reassuring line below.
+    local extra_findings=0
+    local mem_out runaway_out vm_out
+    mem_out=$(opt_diag_memory_pressure) || true
+    vm_out=$(opt_diag_idle_vm) || true
+    runaway_out=$(opt_diag_runaway_process) || true
+    [[ -n "$mem_out" || -n "$vm_out" || -n "$runaway_out" ]] && extra_findings=1
+
+    if [[ -z "$primary_family" && "$extra_findings" -eq 0 ]]; then
         echo -e "  ${GREEN}${ICON_SUCCESS}${NC} No sustained high-CPU bottleneck detected"
+    elif [[ -z "$primary_family" ]]; then
+        : # extra findings print below; no CPU-family bottleneck to headline
     else
         label=$(opt_diag_family_label "$primary_family")
         echo -e "  ${YELLOW}${ICON_WARNING}${NC} Likely bottleneck: ${label} (~${primary_avg}% CPU sustained)"
@@ -407,6 +419,10 @@ run_optimize_diagnostics() {
             done <<< "$sustained_details"
         fi
     fi
+
+    [[ -n "$runaway_out" ]] && printf '%s\n' "$runaway_out"
+    [[ -n "$mem_out" ]] && printf '%s\n' "$mem_out"
+    [[ -n "$vm_out" ]] && printf '%s\n' "$vm_out"
 
     # Mounted-image checks are scoped to sustained syspolicyd pressure: a
     # mounted DMG on an otherwise healthy system is not a diagnosis finding,
@@ -431,4 +447,209 @@ run_optimize_diagnostics() {
 
         opt_diag_offer_detach_candidates "$detach_candidates"
     fi
+}
+
+# ============================================================================
+# Memory and runaway-process diagnosis
+#
+# The family-based CPU checks above only look at five known process families,
+# so they miss the two failure shapes that actually make a Mac feel slow:
+#   1. memory exhaustion (swap thrash), where load is high but nothing is busy
+#   2. a single process stuck in a run loop that is not in the family list
+# Both are read-only diagnosis. Nothing here kills or changes anything.
+# ============================================================================
+
+readonly MOLE_OPTIMIZE_SWAP_PCT_DEFAULT=50
+readonly MOLE_OPTIMIZE_FREE_PCT_DEFAULT=15
+readonly MOLE_OPTIMIZE_IDLE_VM_GB_DEFAULT=2
+readonly MOLE_OPTIMIZE_RUNAWAY_PCT_DEFAULT=25
+readonly MOLE_OPTIMIZE_RUNAWAY_MIN_HOURS_DEFAULT=12
+
+# Injection seams so diagnosis is deterministic under test, matching the
+# existing MOLE_OPTIMIZE_PS_SAMPLE_* convention above. Without these, the
+# memory and runaway checks read live system state and any assertion about a
+# "quiet" run depends on whatever the test host happens to be doing.
+opt_diag_get_swapusage() {
+    if [[ -n "${MOLE_OPTIMIZE_SWAPUSAGE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_SWAPUSAGE"
+        return 0
+    fi
+    sysctl -n vm.swapusage 2> /dev/null || true
+}
+
+opt_diag_get_mem_free_pct() {
+    if [[ -n "${MOLE_OPTIMIZE_MEM_FREE_PCT:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_MEM_FREE_PCT"
+        return 0
+    fi
+    memory_pressure 2> /dev/null | awk -F': ' '/free percentage/ {gsub(/%/,"",$2); print int($2)}' | tail -1
+}
+
+# shellcheck disable=SC2009  # pgrep cannot report RSS; the column is the point.
+opt_diag_get_rss_sample() {
+    if [[ -n "${MOLE_OPTIMIZE_RSS_SAMPLE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_RSS_SAMPLE"
+        return 0
+    fi
+    ps -Ao rss,comm 2> /dev/null | tail -n +2 | grep -v CoreSimulator || true
+}
+
+# shellcheck disable=SC2009  # pgrep cannot report TIME/ELAPSED; both are required.
+opt_diag_get_proctime_sample() {
+    if [[ -n "${MOLE_OPTIMIZE_PROCTIME_SAMPLE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_PROCTIME_SAMPLE"
+        return 0
+    fi
+    ps -Ao pid,time,etime,comm 2> /dev/null | tail -n +2 | grep -v CoreSimulator || true
+}
+
+# shellcheck disable=SC2009  # needs full COMMAND path to match the VM binary.
+opt_diag_get_vm_sample() {
+    if [[ -n "${MOLE_OPTIMIZE_VM_SAMPLE:-}" ]]; then
+        printf '%s\n' "$MOLE_OPTIMIZE_VM_SAMPLE"
+        return 0
+    fi
+    ps -Ao rss,command 2> /dev/null | tail -n +2 | grep -v CoreSimulator || true
+}
+
+opt_diag_int_env() {
+    local value="${1:-}" fallback="${2:-0}"
+    [[ "$value" =~ ^[0-9]+$ ]] || value="$fallback"
+    printf '%s\n' "$value"
+}
+
+# Convert ps time/etime ([[dd-]hh:]mm:ss) to seconds. Returns 0 on garbage so a
+# malformed row can never inflate a ratio into a false runaway report.
+opt_diag_time_to_seconds() {
+    printf '%s\n' "${1:-}" | awk -F: '
+        BEGIN { d = 0 }
+        {
+            n = NF
+            if (n < 2 || n > 3) { print 0; exit }
+            first = $1
+            if (first ~ /-/) { split(first, p, "-"); d = p[1]; first = p[2] }
+            if (n == 3) { h = first; m = $2; s = $3 }
+            else        { h = 0;     m = first; s = $2 }
+            if (h !~ /^[0-9]+$/ || m !~ /^[0-9]+$/ || s !~ /^[0-9.]+$/) { print 0; exit }
+            printf "%d\n", d * 86400 + h * 3600 + m * 60 + s
+        }'
+}
+
+# Swap pressure, and the processes actually responsible for it. Silent when
+# memory is healthy.
+opt_diag_memory_pressure() {
+    local swap_line swap_total swap_used swap_pct free_pct warn_swap warn_free
+    warn_swap=$(opt_diag_int_env "${MOLE_OPTIMIZE_SWAP_PCT:-}" "$MOLE_OPTIMIZE_SWAP_PCT_DEFAULT")
+    warn_free=$(opt_diag_int_env "${MOLE_OPTIMIZE_FREE_PCT:-}" "$MOLE_OPTIMIZE_FREE_PCT_DEFAULT")
+
+    swap_line=$(opt_diag_get_swapusage)
+    [[ -n "$swap_line" ]] || return 0
+    swap_total=$(printf '%s\n' "$swap_line" | awk '{gsub(/M/,"",$3); print int($3)}')
+    swap_used=$(printf '%s\n' "$swap_line" | awk '{gsub(/M/,"",$6); print int($6)}')
+    [[ "$swap_total" =~ ^[0-9]+$ && "$swap_used" =~ ^[0-9]+$ ]] || return 0
+
+    swap_pct=0
+    [[ "$swap_total" -gt 0 ]] && swap_pct=$((swap_used * 100 / swap_total))
+    free_pct=$(opt_diag_get_mem_free_pct)
+    [[ "$free_pct" =~ ^[0-9]+$ ]] || free_pct=100
+
+    if [[ "$swap_pct" -lt "$warn_swap" && "$free_pct" -ge "$warn_free" ]]; then
+        return 0
+    fi
+
+    echo -e "  ${YELLOW}${ICON_WARNING}${NC} Memory pressure: swap $((swap_used / 1024))GB of $((swap_total / 1024))GB used (${swap_pct}%), ${free_pct}% free"
+    echo -e "  ${GRAY}${ICON_REVIEW}${NC} High load with little CPU activity is usually this, not compute"
+
+    # Name the actual holders. Simulator runtimes ship duplicate daemons whose
+    # rows would otherwise crowd out the real offenders.
+    local shown=0
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        echo -e "    ${GRAY}${line}${NC}"
+        shown=$((shown + 1))
+        # Strip the ps header BEFORE sorting. Sorting first pushes the
+        # non-numeric header row to the end, so an NR>1 filter would silently
+        # discard the LARGEST process instead — the exact row that matters most.
+    done < <(opt_diag_get_rss_sample |
+        sort -rn |
+        awk '$1 > 1048576 {
+                gsub(/^.*\//, "", $2)
+                printf "  %-34s %.1f GB\n", $2, $1/1048576
+             }' |
+        head -4)
+    [[ "$shown" -gt 0 ]] || echo -e "    ${GRAY}(no single process over 1GB; pressure is spread across many)${NC}"
+    return 0
+}
+
+# A virtual machine holding gigabytes while doing no work. Docker Desktop is
+# the common case: its Linux VM claims its full memory reservation even with
+# zero containers running, which is invisible to disk-oriented checks.
+opt_diag_idle_vm() {
+    local min_gb vm_kb vm_gb
+    min_gb=$(opt_diag_int_env "${MOLE_OPTIMIZE_IDLE_VM_GB:-}" "$MOLE_OPTIMIZE_IDLE_VM_GB_DEFAULT")
+
+    vm_kb=$(opt_diag_get_vm_sample |
+        awk '/Virtualization.framework.*VirtualMachine/ {s += $1} END {print s + 0}')
+    [[ "$vm_kb" =~ ^[0-9]+$ ]] || return 0
+    [[ "$vm_kb" -gt $((min_gb * 1048576)) ]] || return 0
+    vm_gb=$(awk -v k="$vm_kb" 'BEGIN {printf "%.1f", k/1048576}')
+
+    # Only claim it is idle if the owner agrees. A probe that cannot answer
+    # must not produce a "safe to quit" recommendation.
+    local running=""
+    if command -v docker > /dev/null 2>&1; then
+        running=$(run_with_timeout "$MOLE_TIMEOUT_SHORT_QUERY_SEC" docker ps -q 2> /dev/null | grep -c . || true)
+    fi
+
+    if [[ "$running" == "0" ]]; then
+        echo -e "  ${YELLOW}${ICON_WARNING}${NC} Docker Desktop VM holding ${vm_gb}GB with no running containers"
+        echo -e "  ${GRAY}${ICON_REVIEW}${NC} Quitting Docker Desktop reclaims all of it; it reserves memory even when idle"
+    else
+        echo -e "  ${GRAY}${ICON_LIST}${NC} Virtual machine using ${vm_gb}GB${running:+ (${running} containers running)}"
+    fi
+    return 0
+}
+
+# A process stuck in a run loop: high CPU averaged over its entire lifetime,
+# which is what `ps` TIME/ELAPSED actually measures. A momentary spike cannot
+# trip this, and neither can a short-lived process.
+opt_diag_runaway_process() {
+    local pct_floor min_hours
+    pct_floor=$(opt_diag_int_env "${MOLE_OPTIMIZE_RUNAWAY_PCT:-}" "$MOLE_OPTIMIZE_RUNAWAY_PCT_DEFAULT")
+    min_hours=$(opt_diag_int_env "${MOLE_OPTIMIZE_RUNAWAY_MIN_HOURS:-}" "$MOLE_OPTIMIZE_RUNAWAY_MIN_HOURS_DEFAULT")
+
+    local found=1 pid comm cputime etime cpu_s el_s pct hours
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        pid=$(printf '%s\n' "$line" | awk '{print $1}')
+        cputime=$(printf '%s\n' "$line" | awk '{print $2}')
+        etime=$(printf '%s\n' "$line" | awk '{print $3}')
+        comm=$(printf '%s\n' "$line" | awk '{for (i=4; i<=NF; i++) printf "%s%s", $i, (i<NF?" ":"")}')
+        comm="${comm##*/}"
+
+        # kernel_task is expected to accumulate CPU; it is thermal management,
+        # not a stuck process, and reporting it would be noise every run.
+        [[ "$comm" == "kernel_task" ]] && continue
+        # WindowServer and the other scanned families are already headlined by
+        # the family CPU check above; repeating them here would double-report
+        # a single problem under two different names.
+        case "$comm" in
+            WindowServer | mds | mds_stores | mdworker* | syspolicyd) continue ;;
+        esac
+
+        cpu_s=$(opt_diag_time_to_seconds "$cputime")
+        el_s=$(opt_diag_time_to_seconds "$etime")
+        [[ "$el_s" -gt $((min_hours * 3600)) ]] || continue
+        [[ "$cpu_s" -gt 0 ]] || continue
+
+        pct=$((cpu_s * 100 / el_s))
+        [[ "$pct" -ge "$pct_floor" ]] || continue
+
+        hours=$((cpu_s / 3600))
+        echo -e "  ${YELLOW}${ICON_WARNING}${NC} ${comm} has burned ${hours}h CPU over $((el_s / 3600))h of runtime (~${pct}% sustained)"
+        echo -e "  ${GRAY}${ICON_REVIEW}${NC} A stuck run loop. Restarting it usually clears it: ${NC}kill -TERM ${pid}${GRAY} (launchd respawns system daemons)${NC}"
+        found=0
+    done < <(opt_diag_get_proctime_sample | head -400)
+
+    return "$found"
 }

--- a/lib/optimize/diagnostics.sh
+++ b/lib/optimize/diagnostics.sh
@@ -567,17 +567,29 @@ opt_diag_memory_pressure() {
         [[ -n "$line" ]] || continue
         echo -e "    ${GRAY}${line}${NC}"
         shown=$((shown + 1))
-        # Strip the ps header BEFORE sorting. Sorting first pushes the
-        # non-numeric header row to the end, so an NR>1 filter would silently
-        # discard the LARGEST process instead — the exact row that matters most.
+        # The ps header is stripped inside opt_diag_get_rss_sample, BEFORE the
+        # sort here. Filtering it afterwards with NR>1 would discard the
+        # LARGEST process instead, since the non-numeric header sorts last.
+        #
+        # 256MB floor rather than 1GB: when pressure is spread across several
+        # mid-size processes there is no single 1GB offender, and a 1GB cutoff
+        # then prints nothing actionable at exactly the moment the user most
+        # needs a name. Observed live at 97% swap with no 1GB process.
     done < <(opt_diag_get_rss_sample |
         sort -rn |
-        awk '$1 > 1048576 {
-                gsub(/^.*\//, "", $2)
-                printf "  %-34s %.1f GB\n", $2, $1/1048576
+        awk '$1 > 262144 {
+                kb = $1
+                # comm can contain spaces ("Claude Helper (Renderer)"), so take
+                # every remaining field. Reading $2 alone printed fragments like
+                # "(2.1.223)" - a version string, not a process name.
+                name = ""
+                for (i = 2; i <= NF; i++) name = name (i > 2 ? " " : "") $i
+                sub(/^.*\//, "", name)
+                if (length(name) > 26) name = substr(name, 1, 25) "\xe2\x80\xa6"
+                printf "%-28s %5.1f GB\n", name, kb/1048576
              }' |
         head -4)
-    [[ "$shown" -gt 0 ]] || echo -e "    ${GRAY}(no single process over 1GB; pressure is spread across many)${NC}"
+    [[ "$shown" -gt 0 ]] || echo -e "    ${GRAY}pressure is spread across many small processes${NC}"
     return 0
 }
 

--- a/lib/optimize/diagnostics.sh
+++ b/lib/optimize/diagnostics.sh
@@ -585,7 +585,12 @@ opt_diag_memory_pressure() {
                 name = ""
                 for (i = 2; i <= NF; i++) name = name (i > 2 ? " " : "") $i
                 sub(/^.*\//, "", name)
-                if (length(name) > 26) name = substr(name, 1, 25) "\xe2\x80\xa6"
+                # Truncate from the LEFT. These are often reverse-DNS names
+                # where the tail identifies the process
+                # ("com.apple.Virtualization.VirtualMachine"); keeping the head
+                # would print "com.apple.Virtualization.…" and hide which
+                # service it actually is.
+                if (length(name) > 26) name = "\xe2\x80\xa6" substr(name, length(name) - 24)
                 printf "%-28s %5.1f GB\n", name, kb/1048576
              }' |
         head -4)

--- a/lib/optimize/diagnostics.sh
+++ b/lib/optimize/diagnostics.sh
@@ -619,8 +619,13 @@ opt_diag_idle_vm() {
     fi
 
     if [[ "$running" == "0" ]]; then
-        echo -e "  ${YELLOW}${ICON_WARNING}${NC} Docker Desktop VM holding ${vm_gb}GB with no running containers"
-        echo -e "  ${GRAY}${ICON_REVIEW}${NC} Quitting Docker Desktop reclaims all of it; it reserves memory even when idle"
+        if command -v docker > /dev/null 2>&1; then
+            echo -e "  ${YELLOW}${ICON_WARNING}${NC} Virtual machine holding ${vm_gb}GB with no running containers (likely Docker Desktop)"
+            echo -e "  ${GRAY}${ICON_REVIEW}${NC} If this is Docker Desktop, quitting it reclaims all of it; it reserves memory even when idle"
+        else
+            echo -e "  ${YELLOW}${ICON_WARNING}${NC} Virtual machine holding ${vm_gb}GB"
+            echo -e "  ${GRAY}${ICON_REVIEW}${NC} Check Docker Desktop, UTM, or other virtualization tools for reclaimable memory"
+        fi
     else
         echo -e "  ${GRAY}${ICON_LIST}${NC} Virtual machine using ${vm_gb}GB${running:+ (${running} containers running)}"
     fi

--- a/tests/clean_automation_browsers.bats
+++ b/tests/clean_automation_browsers.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# Leaked automation-browser cleanup: only automation-profile processes are
+# touched, dry-run never kills, and in-use profiles are never deleted.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+
+    ORIGINAL_HOME="${HOME:-}"
+    export ORIGINAL_HOME
+
+    HOME="$(mktemp -d "${BATS_TEST_DIRNAME}/tmp-automation-browsers.XXXXXX")"
+    export HOME
+    mkdir -p "$HOME"
+}
+
+teardown_file() {
+    if [[ "$HOME" == "${BATS_TEST_DIRNAME}/tmp-"* ]]; then
+        rm -rf "$HOME"
+    fi
+    if [[ -n "${ORIGINAL_HOME:-}" ]]; then
+        export HOME="$ORIGINAL_HOME"
+    fi
+}
+
+# Stub binaries: ps emits one orphaned cliDaemon (ppid 1), one day-old Chrome
+# on an automation profile, one FRESH Chrome on an automation profile (must
+# survive), and one unrelated browser (must survive). getconf points the
+# profile scan at the test temp root.
+make_process_stubs() {
+    mkdir -p "$HOME/bin" "$HOME/tmproot"
+    cat > "$HOME/bin/ps" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' \
+    '  901     1 02-01:00:00 /opt/homebrew/bin/node playwright-core/lib/entry/cliDaemon.js daemon' \
+    '  902   901 01-20:00:00 /Applications/Chrome.app/x --user-data-dir=/tmp/playwright_chromiumdev_profile-old' \
+    '  903   901    05:00 /Applications/Chrome.app/x --user-data-dir=/tmp/playwright_chromiumdev_profile-new' \
+    '  904     1 03-01:00:00 /Applications/Safari.app/Contents/MacOS/Safari'
+SCRIPT
+    cat > "$HOME/bin/getconf" <<SCRIPT
+#!/bin/bash
+printf '%s/\n' "$HOME/tmproot"
+SCRIPT
+    cat > "$HOME/bin/pgrep" <<'SCRIPT'
+#!/bin/bash
+# Simulate: only the "live" profile has a process still referencing it.
+for arg in "$@"; do
+    [[ "$arg" == *"profile-live"* ]] && exit 0
+done
+exit 1
+SCRIPT
+    chmod +x "$HOME/bin/ps" "$HOME/bin/getconf" "$HOME/bin/pgrep"
+}
+
+run_cleanup() {
+    local dry_run="$1"
+    run env HOME="$HOME" PATH="$HOME/bin:/usr/bin:/bin" PROJECT_ROOT="$PROJECT_ROOT" \
+        DRY="$dry_run" TRACE="$HOME/kill.trace" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+DRY_RUN="$DRY"
+kill() { printf 'KILL %s\n' "$*" >> "$TRACE"; return 0; }
+sleep() { :; }
+safe_clean() {
+    local -a paths=("$@")
+    local label="${paths[${#paths[@]} - 1]}"
+    unset 'paths[${#paths[@]}-1]'
+    local p
+    for p in "${paths[@]}"; do
+        printf 'SAFE_CLEAN %s (%s)\n' "$p" "$label"
+    done
+}
+note_activity() { :; }
+clean_dev_automation_browsers
+EOF
+}
+
+@test "kills only orphaned daemons and day-old automation browsers" {
+    make_process_stubs
+    : > "$HOME/kill.trace"
+
+    run_cleanup false
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"stopped 2 processes"* ]] || { echo "$output"; return 1; }
+    grep -q 'KILL -TERM 901' "$HOME/kill.trace" || return 1
+    grep -q 'KILL -TERM 902' "$HOME/kill.trace" || return 1
+    # Fresh automation session and the unrelated browser are never signaled.
+    ! grep -q ' 903' "$HOME/kill.trace" || return 1
+    ! grep -q ' 904' "$HOME/kill.trace" || return 1
+}
+
+@test "dry run reports but never signals a process" {
+    make_process_stubs
+    : > "$HOME/kill.trace"
+
+    run_cleanup true
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"would stop 2 processes"* ]] || { echo "$output"; return 1; }
+    [ ! -s "$HOME/kill.trace" ] || { cat "$HOME/kill.trace"; return 1; }
+}
+
+@test "stale profiles are cleaned, in-use and fresh profiles survive" {
+    make_process_stubs
+    : > "$HOME/kill.trace"
+
+    mkdir -p "$HOME/tmproot/playwright_chromiumdev_profile-stale" \
+        "$HOME/tmproot/playwright_chromiumdev_profile-live" \
+        "$HOME/tmproot/playwright_chromiumdev_profile-fresh"
+    # Age the stale and live dirs well past the 2h threshold.
+    touch -t 202601010000 "$HOME/tmproot/playwright_chromiumdev_profile-stale"
+    touch -t 202601010000 "$HOME/tmproot/playwright_chromiumdev_profile-live"
+
+    run_cleanup false
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"SAFE_CLEAN"*"profile-stale"* ]] || { echo "$output"; return 1; }
+    # In-use profile (pgrep hit) and fresh profile (under 2h) stay.
+    [[ "$output" != *"SAFE_CLEAN"*"profile-live"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"SAFE_CLEAN"*"profile-fresh"* ]] || { echo "$output"; return 1; }
+}
+
+@test "quiet no-op when nothing leaked" {
+    mkdir -p "$HOME/bin" "$HOME/tmproot-empty"
+    cat > "$HOME/bin/ps" <<'SCRIPT'
+#!/bin/bash
+printf '%s\n' '  904     1 03-01:00:00 /Applications/Safari.app/Contents/MacOS/Safari'
+SCRIPT
+    cat > "$HOME/bin/getconf" <<SCRIPT
+#!/bin/bash
+printf '%s/\n' "$HOME/tmproot-empty"
+SCRIPT
+    chmod +x "$HOME/bin/ps" "$HOME/bin/getconf"
+
+    run_cleanup false
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" != *"stopped"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"SAFE_CLEAN"* ]] || { echo "$output"; return 1; }
+}

--- a/tests/clean_orphaned_runtimes.bats
+++ b/tests/clean_orphaned_runtimes.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Orphaned simulator runtime detection: report a runtime no device uses,
+# stay silent on in-use runtimes, and never delete anything.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+# $1 = runtime list output, $2 = device list output
+run_check() {
+    run env PROJECT_ROOT="$PROJECT_ROOT" RT_OUT="$1" DEV_OUT="$2" \
+        /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+_MOLE_SIMCTL_RESOLUTION_STATUS=ready
+_MOLE_SIMCTL_DEVELOPER_DIR=/fake
+note_activity() { :; }
+run_with_timeout() {
+    shift
+    case "$*" in
+        *"runtime list"*) printf '%s\n' "$RT_OUT" ;;
+        *"list devices"*) printf '%s\n' "$DEV_OUT" ;;
+    esac
+}
+check_orphaned_simulator_runtimes
+EOF
+}
+
+RUNTIMES='== Disk Images ==
+-- iOS --
+iOS 18.4 (22E238) - 70DF9A83-C8CF-458E-B463-356D557B8D2D (Ready)
+    Mount Path: /Library/Developer/CoreSimulator/Volumes/iOS_22E238
+    Size: 8.2G
+iOS 26.5 (23F77) - 78F2282D-7AC8-4DA3-B482-9E21FFBD5841 (Ready)
+    Size: 7.9G'
+
+@test "reports a runtime with zero devices and names the owner command" {
+    run_check "$RUNTIMES" '-- iOS 18.4 --
+-- iOS 26.5 --
+    iPhone 17 Pro (E4FC6A8A-563B-4027-B246-242D123EB40B) (Booted)'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"Orphaned simulator runtime"* ]] || return 1
+    [[ "$output" == *"iOS 18.4"* ]] || return 1
+    [[ "$output" == *"8.2G"* ]] || return 1
+    [[ "$output" == *"runtime delete 70DF9A83-C8CF-458E-B463-356D557B8D2D"* ]] || return 1
+    # The in-use runtime must never be named.
+    [[ "$output" != *"iOS 26.5"* ]] || { echo "$output"; return 1; }
+}
+
+@test "silent when every runtime has at least one device" {
+    run_check "$RUNTIMES" '-- iOS 18.4 --
+    iPhone 16 Pro (C1237C27-E6A1-4553-9117-65FAE480A347) (Shutdown)
+-- iOS 26.5 --
+    iPhone 17 Pro (E4FC6A8A-563B-4027-B246-242D123EB40B) (Booted)'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" != *"Orphaned"* ]] || { echo "$output"; return 1; }
+}
+
+@test "reports every orphan when more than one runtime is unused" {
+    run_check "$RUNTIMES" '-- iOS 18.4 --
+-- iOS 26.5 --'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"iOS 18.4"* ]] || return 1
+    [[ "$output" == *"iOS 26.5"* ]] || return 1
+}
+
+@test "a runtime with no reported size still reports as an orphan" {
+    run_check 'iOS 18.4 (22E238) - 70DF9A83-C8CF-458E-B463-356D557B8D2D (Ready)' \
+        '-- iOS 18.4 --'
+
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" == *"iOS 18.4 · no devices"* ]] || { echo "$output"; return 1; }
+}
+
+@test "probe timeout propagates instead of reporting a false clean" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+_MOLE_SIMCTL_RESOLUTION_STATUS=ready
+_MOLE_SIMCTL_DEVELOPER_DIR=/fake
+note_activity() { :; }
+run_with_timeout() { return 124; }
+check_orphaned_simulator_runtimes
+EOF
+    [ "$status" -eq 124 ] || { echo "status=$status $output"; return 1; }
+    [[ "$output" != *"Orphaned"* ]] || return 1
+}
+
+@test "no-op when simctl was never resolved" {
+    run env PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/lib/core/common.sh"
+source "$PROJECT_ROOT/lib/clean/dev.sh"
+_MOLE_SIMCTL_RESOLUTION_STATUS=clt-only
+run_with_timeout() { echo "PROBED"; }
+check_orphaned_simulator_runtimes
+EOF
+    [ "$status" -eq 0 ] || { echo "$output"; return 1; }
+    [[ "$output" != *"PROBED"* ]] || { echo "$output"; return 1; }
+}

--- a/tests/clean_summary_cancel.bats
+++ b/tests/clean_summary_cancel.bats
@@ -159,6 +159,41 @@ EOF
     [[ "$output" == *"3 item(s) exceeded the 30s removal budget"* ]]
 }
 
+@test "run with removal timeouts names the timed-out paths (#1384)" {
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+for fn in clean_user_essentials clean_finder_metadata clean_app_caches \
+    clean_browsers run_cloud_and_office_cleanup clean_developer_tools \
+    clean_user_gui_applications clean_virtualization_tools \
+    clean_application_support_logs clean_orphaned_app_data \
+    clean_orphaned_system_services clean_orphaned_container_stubs \
+    show_user_launch_agent_hint_notice \
+    clean_apple_silicon_caches clean_cached_device_firmware \
+    clean_time_machine_failed_backups check_large_file_candidates \
+    show_project_artifact_hint_notice; do
+    eval "$fn() { return 0; }"
+done
+run_with_shell_timeout() { return 0; }
+clean_user_essentials() {
+    MOLE_CLEAN_REMOVAL_TIMEOUTS=2
+    _mole_record_removal_timeout_path "$HOME/Library/Developer/XCTestDevices/clone-one"
+    _mole_record_removal_timeout_path "$HOME/Library/Developer/XCTestDevices/clone-two"
+    return 0
+}
+perform_cleanup
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"2 item(s) exceeded the 30s removal budget"* ]] || return 1
+    [[ "$output" == *"XCTestDevices/clone-one"* ]] || return 1
+    [[ "$output" == *"XCTestDevices/clone-two"* ]] || return 1
+}
+
 @test "sizing timeouts still clean and the summary reports the under-count (#1374)" {
     mkdir -p "$HOME/Library/Caches/cache1374"
     printf x > "$HOME/Library/Caches/cache1374/file.bin"

--- a/tests/dev_extended.bats
+++ b/tests/dev_extended.bats
@@ -1377,9 +1377,12 @@ EOF
     [[ "$output" != *"already clean"* ]]
 }
 
-@test "clean_xcode_xctest_devices targets only exact XCTestDevices directory" {
+@test "clean_xcode_xctest_devices targets each clone entry, not the root" {
     local developer_root="$HOME/Library/Developer"
-    mkdir -p "$developer_root/XCTestDevices" "$developer_root/XCTestDevices-old"
+    local xctest_root="$developer_root/XCTestDevices"
+    mkdir -p "$xctest_root/11111111-2222-3333-4444-555555555555" \
+        "$xctest_root/66666666-7777-8888-9999-000000000000" \
+        "$developer_root/XCTestDevices-old"
 
     run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" /bin/bash --noprofile --norc << 'EOF'
 set -euo pipefail
@@ -1388,12 +1391,23 @@ source "$PROJECT_ROOT/lib/clean/dev.sh"
 note_activity() { :; }
 pgrep() { return 1; }
 _coresimulator_booted_device_state() { return 1; }
-safe_clean() { printf 'SAFE:%s|%s\n' "$1" "$2"; }
+safe_clean() { for target in "$@"; do printf 'SAFE:%s\n' "$target"; done; }
 clean_xcode_xctest_devices
 EOF
 
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"SAFE:$developer_root/XCTestDevices|Xcode XCTestDevices test data"* ]] || return 1
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"SAFE:$HOME/Library/Developer/XCTestDevices/11111111-2222-3333-4444-555555555555"* ]] || return 1
+    [[ "$output" == *"SAFE:$HOME/Library/Developer/XCTestDevices/66666666-7777-8888-9999-000000000000"* ]] || return 1
+    # The root itself is never a deletion target: it stays for Xcode to
+    # recreate clones in, and a root-sized item would outgrow the per-item
+    # removal budget.
+    if printf '%s\n' "$output" | command grep -qx "SAFE:$HOME/Library/Developer/XCTestDevices"; then
+        echo "WRONG: root passed as target"
+        return 1
+    fi
     [[ "$output" != *"XCTestDevices-old"* ]]
 }
 
@@ -1469,6 +1483,38 @@ EOF
     }
     [[ "$output" != *"Xcode XCTestDevices · stopped"* ]] || return 1
     [[ "$output" != *"UNEXPECTED_REMOVE"* ]]
+}
+
+@test "clean_xcode_xctest_devices removal budget applies per clone entry" {
+    local xctest_root="$HOME/PerEntryXCTestDevices"
+    mkdir -p "$xctest_root/11111111-2222-3333-4444-555555555555" \
+        "$xctest_root/66666666-7777-8888-9999-000000000000"
+
+    run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
+        MOLE_XCODE_XCTEST_DEVICES_DIR="$xctest_root" MOLE_TEST_NO_AUTH=1 \
+        /bin/bash --noprofile --norc << 'EOF'
+set -euo pipefail
+source "$PROJECT_ROOT/bin/clean.sh"
+DRY_RUN=false
+note_activity() { :; }
+pgrep() { return 1; }
+_coresimulator_booted_device_state() { return 1; }
+# One sink call per clone: a root-sized single item outgrows the per-item
+# removal budget after deleting only part of it.
+safe_remove() { printf 'REMOVE:%s\n' "$1"; return 0; }
+clean_xcode_xctest_devices
+EOF
+
+    [ "$status" -eq 0 ] || {
+        echo "$output"
+        return 1
+    }
+    [[ "$output" == *"REMOVE:$HOME/PerEntryXCTestDevices/11111111-2222-3333-4444-555555555555"* ]] || return 1
+    [[ "$output" == *"REMOVE:$HOME/PerEntryXCTestDevices/66666666-7777-8888-9999-000000000000"* ]] || return 1
+    if printf '%s\n' "$output" | command grep -qx "REMOVE:$HOME/PerEntryXCTestDevices"; then
+        echo "WRONG: root passed as one removal item"
+        return 1
+    fi
 }
 
 @test "clean_xcode_xctest_devices dry-run keeps XCTestDevices directory" {

--- a/tests/optimize.bats
+++ b/tests/optimize.bats
@@ -1301,6 +1301,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'120 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-capture\n35 /usr/libexec/syspolicyd\n20 /System/Library/PrivateFrameworks/SkyLight.framework/Resources/WindowServer' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'140 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-processor\n30 /usr/libexec/syspolicyd\n18 /System/Library/PrivateFrameworks/SkyLight.framework/Resources/WindowServer' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -1318,6 +1323,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd\n12 /usr/libexec/diskimagesiod' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd\n10 /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Resources/bin/simdiskimaged' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /System/Library/AssetsV2/com_apple_MobileAsset_iOSSimulatorRuntime/example.asset/AssetData/Restore/000.dmg\n/dev/disk8s1\t/Library/Developer/CoreSimulator/Volumes/iOS_23E244\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1339,6 +1349,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'180 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-capture' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'5 /Applications/AliEntSafe.app/Contents/Services/CloudShell.app/Contents/MacOS/CloudShell --type=event-capture' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"
@@ -1355,6 +1370,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Users/test/Downloads/TestInstaller.dmg\n/dev/disk14s1\t/Volumes/Test Installer\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1377,6 +1397,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'1 /usr/sbin/distnoted' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'1 /usr/sbin/distnoted' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Users/test/Downloads/TestInstaller.dmg\n/dev/disk14s1\t/Volumes/Test Installer\n' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
@@ -1397,6 +1422,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Users/test/Downloads/KeepMe.dmg\n/dev/disk15s1\t/Volumes/KeepMe\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1426,6 +1456,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" MOLE_DRY_RUN=1 \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'55 /usr/libexec/syspolicyd' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'60 /usr/libexec/syspolicyd' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		MOLE_OPTIMIZE_SPCTL_STATUS="assessments enabled" \
 		MOLE_OPTIMIZE_HDIUTIL_INFO=$'================================================\nimage-path      : /Volumes/EXT3/Mail/TB.dmg\n/dev/disk6s2               Apple_HFS                       /Volumes/mail\n' \
 		/bin/bash --noprofile --norc <<'EOF'
@@ -1446,6 +1481,11 @@ EOF
 	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 		MOLE_OPTIMIZE_PS_SAMPLE_1=$'4 /usr/sbin/distnoted\n3 /usr/libexec/coreaudiod' \
 		MOLE_OPTIMIZE_PS_SAMPLE_2=$'5 /usr/sbin/distnoted\n2 /usr/libexec/coreaudiod' \
+		MOLE_OPTIMIZE_SWAPUSAGE='total = 8192.00M  used = 100.00M  free = 8092.00M' \
+		MOLE_OPTIMIZE_MEM_FREE_PCT=70 \
+		MOLE_OPTIMIZE_RSS_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_VM_SAMPLE=$'1000 Finder' \
+		MOLE_OPTIMIZE_PROCTIME_SAMPLE=$'1 00:01 05:00 quietd' \
 		/bin/bash --noprofile --norc <<'EOF'
 set -euo pipefail
 source "$PROJECT_ROOT/lib/core/common.sh"

--- a/tests/optimize_perf_diagnosis.bats
+++ b/tests/optimize_perf_diagnosis.bats
@@ -88,6 +88,7 @@ setup_file() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"8.2GB"* ]] || { echo "$output"; return 1; }
     [[ "$output" == *"no running containers"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"likely Docker Desktop"* ]] || { echo "$output"; return 1; }
 }
 
 @test "idle VM does NOT claim reclaimable when containers are running" {

--- a/tests/optimize_perf_diagnosis.bats
+++ b/tests/optimize_perf_diagnosis.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+# Memory pressure, idle-VM, and runaway-process diagnosis.
+# All three are read-only and must stay silent on a healthy machine.
+
+setup_file() {
+    PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    export PROJECT_ROOT
+}
+
+# ---------- time parsing ----------
+
+@test "time_to_seconds handles mm:ss, hh:mm:ss and dd-hh:mm:ss" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        opt_diag_time_to_seconds '01:30'
+        opt_diag_time_to_seconds '02:00:00'
+        opt_diag_time_to_seconds '16-08:00:00'
+    "
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 90 ]
+    [ "${lines[1]}" -eq 7200 ]
+    [ "${lines[2]}" -eq 1411200 ]
+}
+
+@test "time_to_seconds returns 0 on garbage so it cannot fake a runaway" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        opt_diag_time_to_seconds 'not-a-time'
+        opt_diag_time_to_seconds ''
+        opt_diag_time_to_seconds '1:2:3:4'
+    "
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 0 ]
+    [ "${lines[1]}" -eq 0 ]
+    [ "${lines[2]}" -eq 0 ]
+}
+
+# ---------- memory pressure ----------
+
+@test "memory pressure stays silent when swap is healthy" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        sysctl() { echo 'total = 8192.00M  used = 100.00M  free = 8092.00M'; }
+        memory_pressure() { echo 'System-wide memory free percentage: 80%'; }
+        out=\$(opt_diag_memory_pressure)
+        [ -z \"\$out\" ] && echo SILENT || echo \"LEAKED: \$out\"
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SILENT"* ]] || { echo "$output"; return 1; }
+}
+
+@test "memory pressure fires on exhausted swap and names the holders" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        sysctl() { echo 'total = 16384.00M  used = 15500.00M  free = 884.00M'; }
+        memory_pressure() { echo 'System-wide memory free percentage: 8%'; }
+        ps() { printf '%s\n' '   RSS COMM' '8600000 com.apple.Virtualization.VirtualMachine' '2000000 /usr/local/bin/codex' '500 tiny'; }
+        opt_diag_memory_pressure
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Memory pressure"* ]] || return 1
+    [[ "$output" == *"94%"* ]] || { echo "$output"; return 1; }
+    # The largest process must appear — a header-vs-sort bug once dropped it.
+    [[ "$output" == *"VirtualMachine"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"8.2 GB"* ]] || { echo "$output"; return 1; }
+    # Basename only, and sub-1GB noise excluded.
+    [[ "$output" != *"/usr/local/bin/codex"* ]] || return 1
+    [[ "$output" != *"tiny"* ]] || return 1
+    # The ps header must never render as a process.
+    [[ "$output" != *"COMM"* ]] || { echo "$output"; return 1; }
+}
+
+# ---------- idle VM ----------
+
+@test "idle VM reports reclaimable memory when no containers run" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' '   RSS COMMAND' '8600000 /System/Library/Frameworks/Virtualization.framework/XPCServices/com.apple.Virtualization.VirtualMachine.xpc/Contents/MacOS/com.apple.Virtualization.VirtualMachine'; }
+        docker() { :; }
+        run_with_timeout() { shift; printf ''; }
+        opt_diag_idle_vm
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"8.2GB"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"no running containers"* ]] || { echo "$output"; return 1; }
+}
+
+@test "idle VM does NOT claim reclaimable when containers are running" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' '   RSS COMMAND' '8600000 Virtualization.framework/x/com.apple.Virtualization.VirtualMachine'; }
+        docker() { :; }
+        run_with_timeout() { shift; printf '%s\n' abc123 def456; }
+        opt_diag_idle_vm
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"no running containers"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"2 containers running"* ]] || { echo "$output"; return 1; }
+}
+
+@test "idle VM silent when no VM is present" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' '   RSS COMMAND' '100 Finder'; }
+        out=\$(opt_diag_idle_vm)
+        [ -z \"\$out\" ] && echo SILENT || echo \"LEAKED: \$out\"
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SILENT"* ]] || { echo "$output"; return 1; }
+}
+
+# ---------- runaway process ----------
+
+@test "runaway fires on a long-lived process pinning a core" {
+    # ControlCenter's real shape: 138h CPU across 16 days of uptime.
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '785 138:00:00 16-08:00:00 /System/Library/CoreServices/ControlCenter.app/Contents/MacOS/ControlCenter'; }
+        opt_diag_runaway_process
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ControlCenter"* ]] || { echo "$output"; return 1; }
+    [[ "$output" == *"138h"* ]] || return 1
+    [[ "$output" == *"kill -TERM 785"* ]] || return 1
+}
+
+@test "runaway ignores a brief spike and short-lived processes" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        # 100% of a core but only 5 minutes old -> below the 12h floor.
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '999 05:00 05:00 somebuild'; }
+        opt_diag_runaway_process || echo NO_FINDING
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NO_FINDING"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"somebuild"* ]] || return 1
+}
+
+@test "runaway ignores kernel_task, which legitimately accumulates CPU" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '0 200:00:00 16-08:00:00 kernel_task'; }
+        opt_diag_runaway_process || echo NO_FINDING
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NO_FINDING"* ]] || { echo "$output"; return 1; }
+    [[ "$output" != *"kernel_task"* ]] || return 1
+}
+
+@test "runaway ignores a long-lived but mostly idle process" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        # 1h CPU over 16 days = ~0%, the shape of a healthy daemon.
+        ps() { printf '%s\n' 'PID TIME ELAPSED COMM' '500 01:00:00 16-08:00:00 quietd'; }
+        opt_diag_runaway_process || echo NO_FINDING
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NO_FINDING"* ]] || { echo "$output"; return 1; }
+}
+
+@test "thresholds reject non-numeric env overrides" {
+    run /bin/bash -c "
+        source '$PROJECT_ROOT/lib/core/common.sh'
+        source '$PROJECT_ROOT/lib/optimize/diagnostics.sh'
+        opt_diag_int_env 'bogus' 50
+        opt_diag_int_env '12.5' 50
+        opt_diag_int_env '70' 50
+    "
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 50 ]
+    [ "${lines[1]}" -eq 50 ]
+    [ "${lines[2]}" -eq 70 ]
+}


### PR DESCRIPTION
## Summary

Integrates three contributor PRs onto current `main` after #1506 landed:

- **#1515** XCTestDevices per-clone deletion + named removal timeouts
- **#1505** Playwright leaked automation browser cleanup + orphaned simulator runtime review
- **#1504** optimize performance diagnosis: memory pressure, idle VM, runaway process

Also includes a small follow-up on #1504 idle-VM copy so we do not label every Virtualization.framework VM as Docker Desktop.

## Test plan

- [x] `./scripts/check.sh --format`
- [x] `MOLE_TEST_NO_AUTH=1 bats tests/dev_extended.bats -f xctest_devices`
- [x] `MOLE_TEST_NO_AUTH=1 bats tests/clean_summary_cancel.bats -f "removal timeouts"`
- [x] `MOLE_TEST_NO_AUTH=1 bats tests/clean_automation_browsers.bats tests/clean_orphaned_runtimes.bats`
- [x] `MOLE_TEST_NO_AUTH=1 bats tests/optimize_perf_diagnosis.bats`
- [x] `MOLE_TEST_NO_AUTH=1 bats tests/optimize.bats -f run_optimize_diagnostics`