### PR TITLE
fix(cli): give mo analyze and mo status real help output

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -53,11 +53,11 @@ func parseArgs(args []string, stdout, stderr io.Writer) (int, bool) {
 	err := flag.CommandLine.Parse(args)
 	switch {
 	case errors.Is(err, flag.ErrHelp):
-		fmt.Fprint(stdout, usageText)
+		_, _ = fmt.Fprint(stdout, usageText)
 		return 0, false
 	case err != nil:
-		fmt.Fprintln(stderr, err)
-		fmt.Fprintln(stderr, "Use 'mo analyze --help' for usage information")
+		_, _ = fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprintln(stderr, "Use 'mo analyze --help' for usage information")
 		return 1, false
 	}
 	return 0, true

--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -4,8 +4,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,8 +22,51 @@ var (
 	jsonMode = flag.Bool("json", false, "output analysis as JSON instead of TUI")
 )
 
+// usageText is the help every other Mole subcommand prints by hand. The Go flag
+// package would otherwise render "Usage of /usr/local/bin/analyze-go:", naming a
+// bundled binary the user never typed, so the text is written out here instead.
+const usageText = `Usage: mo analyze [OPTIONS] [PATH]
+
+Explore disk usage. Without PATH, scans a machine-wide overview.
+
+Options:
+  --json          Output the analysis as JSON instead of the interactive TUI
+  -h, --help      Show this help message
+
+Examples:
+  mo analyze                 Machine-wide overview
+  mo analyze ~/Library       Scan one directory
+  mo analyze --json /Volumes Machine-readable output
+`
+
+// parseArgs applies Mole's CLI conventions to the flag package: help goes to
+// stdout and exits 0, and an unknown flag goes to stderr and exits 1 the way
+// every bash subcommand does, rather than the flag package's stderr-and-2.
+// It returns the exit code and whether main should keep running.
+func parseArgs(args []string, stdout, stderr io.Writer) (int, bool) {
+	flag.CommandLine.Init("mo analyze", flag.ContinueOnError)
+	// Parse must not print: this function decides which stream each message
+	// belongs on, and the default handler writes usage to stderr for both.
+	flag.CommandLine.SetOutput(io.Discard)
+	flag.CommandLine.Usage = func() {}
+
+	err := flag.CommandLine.Parse(args)
+	switch {
+	case errors.Is(err, flag.ErrHelp):
+		fmt.Fprint(stdout, usageText)
+		return 0, false
+	case err != nil:
+		fmt.Fprintln(stderr, err)
+		fmt.Fprintln(stderr, "Use 'mo analyze --help' for usage information")
+		return 1, false
+	}
+	return 0, true
+}
+
 func main() {
-	flag.Parse()
+	if code, keepGoing := parseArgs(os.Args[1:], os.Stdout, os.Stderr); !keepGoing {
+		os.Exit(code)
+	}
 
 	abs, isOverview, err := resolveScanTarget(os.Getenv("MO_ANALYZE_PATH"), flag.Args())
 	if err != nil {

--- a/cmd/analyze/usage_test.go
+++ b/cmd/analyze/usage_test.go
@@ -1,0 +1,107 @@
+//go:build darwin
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+)
+
+// resetFlags restores the package-level flag set between cases. parseArgs calls
+// Init on flag.CommandLine, so a case that runs after a failed parse would
+// otherwise inherit the previous run's error handling.
+func resetFlags(t *testing.T) {
+	t.Helper()
+	saved := *jsonMode
+	t.Cleanup(func() {
+		flag.CommandLine.Init("mo analyze", flag.ExitOnError)
+		*jsonMode = saved
+	})
+}
+
+func TestParseArgsHelpGoesToStdout(t *testing.T) {
+	for _, arg := range []string{"-h", "--help", "-help"} {
+		t.Run(arg, func(t *testing.T) {
+			resetFlags(t)
+			var stdout, stderr bytes.Buffer
+
+			code, keepGoing := parseArgs([]string{arg}, &stdout, &stderr)
+
+			if keepGoing {
+				t.Fatalf("parseArgs(%q) kept going, want early exit", arg)
+			}
+			if code != 0 {
+				t.Errorf("exit code = %d, want 0", code)
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr = %q, want empty: help is data, not an error", stderr.String())
+			}
+			if !strings.HasPrefix(stdout.String(), "Usage: mo analyze") {
+				t.Errorf("stdout = %q, want it to start with the mo analyze usage line", stdout.String())
+			}
+		})
+	}
+}
+
+// The flag package names os.Args[0], which for a bundled binary is a path the
+// user never typed. Guard against a regression that reintroduces it.
+func TestParseArgsHelpNeverNamesTheBundledBinary(t *testing.T) {
+	resetFlags(t)
+	var stdout, stderr bytes.Buffer
+
+	parseArgs([]string{"--help"}, &stdout, &stderr)
+
+	if strings.Contains(stdout.String(), "Usage of ") {
+		t.Errorf("stdout = %q, want no flag-package 'Usage of <path>' line", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "analyze-go") {
+		t.Errorf("stdout = %q, want no bundled binary name", stdout.String())
+	}
+}
+
+func TestParseArgsUnknownFlagExitsOne(t *testing.T) {
+	resetFlags(t)
+	var stdout, stderr bytes.Buffer
+
+	code, keepGoing := parseArgs([]string{"--bogus"}, &stdout, &stderr)
+
+	if keepGoing {
+		t.Fatal("parseArgs kept going on an unknown flag, want early exit")
+	}
+	// Every bash subcommand exits 1 on a bad option; the flag package's default
+	// is 2, which made mo analyze the odd one out.
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want empty: errors go to stderr", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "not defined") {
+		t.Errorf("stderr = %q, want it to name the offending flag", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "mo analyze --help") {
+		t.Errorf("stderr = %q, want it to point at mo analyze --help", stderr.String())
+	}
+}
+
+func TestParseArgsAcceptsKnownFlagsAndPath(t *testing.T) {
+	resetFlags(t)
+	var stdout, stderr bytes.Buffer
+
+	code, keepGoing := parseArgs([]string{"--json", "/Volumes"}, &stdout, &stderr)
+
+	if !keepGoing || code != 0 {
+		t.Fatalf("parseArgs = (%d, %v), want (0, true)", code, keepGoing)
+	}
+	if !*jsonMode {
+		t.Error("--json did not set jsonMode")
+	}
+	if got := flag.Args(); len(got) != 1 || got[0] != "/Volumes" {
+		t.Errorf("positional args = %v, want [/Volumes]", got)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Errorf("a valid invocation printed stdout=%q stderr=%q, want both empty", stdout.String(), stderr.String())
+	}
+}

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -3,8 +3,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -345,18 +347,70 @@ func parseWatchInterval(raw string) (time.Duration, error) {
 	return d, nil
 }
 
-func main() {
-	flag.Parse()
+// usageText is the help every other Mole subcommand prints by hand. The Go flag
+// package would otherwise render "Usage of /usr/local/bin/status-go:", naming a
+// bundled binary the user never typed, so the text is written out here instead.
+const usageText = `Usage: mo status [OPTIONS]
+
+Monitor system health. Without options it opens the interactive dashboard, and
+switches to a single JSON snapshot when stdout is not a terminal.
+
+Options:
+  --json                          Output one metrics snapshot as JSON
+  --watch                         Stream snapshots as newline-delimited JSON
+  --interval DURATION             With --watch, collection interval (default 1s)
+  --proc-cpu-alerts               Enable high-CPU process alerts (default true)
+  --proc-cpu-threshold PERCENT    Alert above this CPU percent (default 100)
+  --proc-cpu-window DURATION      Time above the threshold before alerting (default 5m)
+  -h, --help                      Show this help message
+
+Examples:
+  mo status                       Interactive dashboard
+  mo status --json                One machine-readable snapshot
+  mo status --watch --interval 2s Continuous NDJSON stream
+`
+
+// parseArgs applies Mole's CLI conventions to the flag package: help goes to
+// stdout and exits 0, and a bad invocation goes to stderr and exits 1 the way
+// every bash subcommand does, rather than the flag package's stderr-and-2.
+// It returns the exit code and whether main should keep running.
+func parseArgs(args []string, stdout, stderr io.Writer) (int, bool) {
+	flag.CommandLine.Init("mo status", flag.ContinueOnError)
+	// Parse must not print: this function decides which stream each message
+	// belongs on, and the default handler writes usage to stderr for both.
+	flag.CommandLine.SetOutput(io.Discard)
+	flag.CommandLine.Usage = func() {}
+
+	err := flag.CommandLine.Parse(args)
+	switch {
+	case errors.Is(err, flag.ErrHelp):
+		fmt.Fprint(stdout, usageText)
+		return 0, false
+	case err != nil:
+		fmt.Fprintln(stderr, err)
+		fmt.Fprintln(stderr, "Use 'mo status --help' for usage information")
+		return 1, false
+	}
+
 	if err := validateFlags(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(2)
+		fmt.Fprintln(stderr, err)
+		fmt.Fprintln(stderr, "Use 'mo status --help' for usage information")
+		return 1, false
+	}
+	return 0, true
+}
+
+func main() {
+	if code, keepGoing := parseArgs(os.Args[1:], os.Stdout, os.Stderr); !keepGoing {
+		os.Exit(code)
 	}
 
 	if *watchMode {
 		interval, err := parseWatchInterval(*watchInterval)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(2)
+			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, "Use 'mo status --help' for usage information")
+			os.Exit(1)
 		}
 		runWatchMode(interval)
 		return

--- a/cmd/status/main.go
+++ b/cmd/status/main.go
@@ -384,17 +384,17 @@ func parseArgs(args []string, stdout, stderr io.Writer) (int, bool) {
 	err := flag.CommandLine.Parse(args)
 	switch {
 	case errors.Is(err, flag.ErrHelp):
-		fmt.Fprint(stdout, usageText)
+		_, _ = fmt.Fprint(stdout, usageText)
 		return 0, false
 	case err != nil:
-		fmt.Fprintln(stderr, err)
-		fmt.Fprintln(stderr, "Use 'mo status --help' for usage information")
+		_, _ = fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprintln(stderr, "Use 'mo status --help' for usage information")
 		return 1, false
 	}
 
 	if err := validateFlags(); err != nil {
-		fmt.Fprintln(stderr, err)
-		fmt.Fprintln(stderr, "Use 'mo status --help' for usage information")
+		_, _ = fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprintln(stderr, "Use 'mo status --help' for usage information")
 		return 1, false
 	}
 	return 0, true

--- a/cmd/status/usage_test.go
+++ b/cmd/status/usage_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"strings"
+	"testing"
+	"time"
+)
+
+// resetFlags restores the package-level flag set and flag values between cases.
+// parseArgs calls Init on flag.CommandLine, so a case that runs after a failed
+// parse would otherwise inherit the previous run's error handling.
+func resetFlags(t *testing.T) {
+	t.Helper()
+	savedJSON, savedWatch := *jsonOutput, *watchMode
+	savedThreshold, savedWindow := *procCPUThreshold, *procCPUWindow
+	savedInterval := *watchInterval
+	t.Cleanup(func() {
+		flag.CommandLine.Init("mo status", flag.ExitOnError)
+		*jsonOutput, *watchMode = savedJSON, savedWatch
+		*procCPUThreshold, *procCPUWindow = savedThreshold, savedWindow
+		*watchInterval = savedInterval
+	})
+}
+
+func TestParseArgsHelpGoesToStdout(t *testing.T) {
+	for _, arg := range []string{"-h", "--help", "-help"} {
+		t.Run(arg, func(t *testing.T) {
+			resetFlags(t)
+			var stdout, stderr bytes.Buffer
+
+			code, keepGoing := parseArgs([]string{arg}, &stdout, &stderr)
+
+			if keepGoing {
+				t.Fatalf("parseArgs(%q) kept going, want early exit", arg)
+			}
+			if code != 0 {
+				t.Errorf("exit code = %d, want 0", code)
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr = %q, want empty: help is data, not an error", stderr.String())
+			}
+			if !strings.HasPrefix(stdout.String(), "Usage: mo status") {
+				t.Errorf("stdout = %q, want it to start with the mo status usage line", stdout.String())
+			}
+		})
+	}
+}
+
+// Help that omits a flag is help that goes stale. Every declared flag must show up.
+func TestParseArgsHelpListsEveryFlag(t *testing.T) {
+	resetFlags(t)
+	var stdout, stderr bytes.Buffer
+	parseArgs([]string{"--help"}, &stdout, &stderr)
+
+	flag.CommandLine.VisitAll(func(f *flag.Flag) {
+		// The test binary registers its own -test.* flags on the same set.
+		if strings.HasPrefix(f.Name, "test.") {
+			return
+		}
+		if !strings.Contains(stdout.String(), "--"+f.Name) {
+			t.Errorf("usage text does not document --%s", f.Name)
+		}
+	})
+}
+
+// The flag package names os.Args[0], which for a bundled binary is a path the
+// user never typed. Guard against a regression that reintroduces it.
+func TestParseArgsHelpNeverNamesTheBundledBinary(t *testing.T) {
+	resetFlags(t)
+	var stdout, stderr bytes.Buffer
+
+	parseArgs([]string{"--help"}, &stdout, &stderr)
+
+	if strings.Contains(stdout.String(), "Usage of ") {
+		t.Errorf("stdout = %q, want no flag-package 'Usage of <path>' line", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "status-go") {
+		t.Errorf("stdout = %q, want no bundled binary name", stdout.String())
+	}
+}
+
+func TestParseArgsRejectsBadInvocations(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"unknown flag", []string{"--bogus"}, "not defined"},
+		{"negative threshold", []string{"--proc-cpu-threshold=-1"}, "--proc-cpu-threshold"},
+		{"zero window", []string{"--proc-cpu-window=0s"}, "--proc-cpu-window"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetFlags(t)
+			var stdout, stderr bytes.Buffer
+
+			code, keepGoing := parseArgs(tc.args, &stdout, &stderr)
+
+			if keepGoing {
+				t.Fatalf("parseArgs(%v) kept going, want early exit", tc.args)
+			}
+			// Every bash subcommand exits 1 on a bad option; the flag package's
+			// default is 2, which made mo status the odd one out.
+			if code != 1 {
+				t.Errorf("exit code = %d, want 1", code)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q, want empty: errors go to stderr", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Errorf("stderr = %q, want it to mention %q", stderr.String(), tc.want)
+			}
+			if !strings.Contains(stderr.String(), "mo status --help") {
+				t.Errorf("stderr = %q, want it to point at mo status --help", stderr.String())
+			}
+		})
+	}
+}
+
+func TestParseArgsAcceptsKnownFlags(t *testing.T) {
+	resetFlags(t)
+	var stdout, stderr bytes.Buffer
+
+	code, keepGoing := parseArgs([]string{"--watch", "--interval", "2s", "--proc-cpu-window", "1m"}, &stdout, &stderr)
+
+	if !keepGoing || code != 0 {
+		t.Fatalf("parseArgs = (%d, %v), want (0, true)", code, keepGoing)
+	}
+	if !*watchMode || *watchInterval != "2s" || *procCPUWindow != time.Minute {
+		t.Errorf("flags = watch:%v interval:%q window:%v, want true, \"2s\", 1m", *watchMode, *watchInterval, *procCPUWindow)
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Errorf("a valid invocation printed stdout=%q stderr=%q, want both empty", stdout.String(), stderr.String())
+	}
+}


### PR DESCRIPTION
## Problem

`mo analyze` and `mo status` are the only two subcommands whose help comes from the Go `flag` package default. Every bash subcommand prints hand-written help; these two print the parser's fallback.

Before this change, on `main`:

```
$ mo analyze --help
Usage of /usr/local/bin/analyze-go:      <- stderr, names a binary the user never typed
  -json
    	output analysis as JSON instead of TUI
exit 0

$ mo analyze --bogus
flag provided but not defined: -bogus    <- stderr
Usage of /usr/local/bin/analyze-go:
  -json
    	output analysis as JSON instead of TUI
exit 2
```

Three problems in that output:

1. `Usage of /usr/local/bin/analyze-go:` names the bundled binary. The user typed `mo analyze`; `analyze-go` is an implementation detail of `bin/analyze.sh`.
2. Help goes to **stderr**. `mo purge --help`, `mo history --help` and the rest write to stdout, so `mo analyze --help | less` shows nothing.
3. A bad flag exits **2**. Every bash subcommand exits **1** and points at `--help`.

`mo status` is worse on point 1, because it has six flags and no other place documents them together.

## Change

Both `main.go` files now own their usage text next to the flag declarations, and route output by stream:

```
$ mo analyze --help
Usage: mo analyze [OPTIONS] [PATH]

Explore disk usage. Without PATH, scans a machine-wide overview.

Options:
  --json          Output the analysis as JSON instead of the interactive TUI
  -h, --help      Show this help message

Examples:
  mo analyze                 Machine-wide overview
  mo analyze ~/Library       Scan one directory
  mo analyze --json /Volumes Machine-readable output
exit 0, stdout

$ mo analyze --bogus
flag provided but not defined: -bogus
Use 'mo analyze --help' for usage information
exit 1, stderr
```

Keeping the text in `main.go` rather than in `bin/analyze.sh` is deliberate: `mo status` has six flags, and a copy in the wrapper goes stale the first time one is added. A test walks `flag.CommandLine` and fails when a declared flag is missing from the usage text.

## Behaviour change worth calling out

`mo status` argument errors move from exit 2 to exit 1. That covers unknown flags, `--proc-cpu-threshold` below zero, `--proc-cpu-window` at or below zero, and an unparseable `--watch --interval`. The reason is consistency with the ten bash subcommands, which all exit 1 on a bad option. Nothing in `tests/` asserted the old code.

`mo analyze --json` and `mo status --json` / `--watch` output are untouched.

## Scope

`cmd/analyze/main.go` is described in AGENTS.md as bootstrap only, flag parsing, `main()`, helpers, which is exactly what this touches. No TUI, scanner, cache or metrics code is involved.

## Tests

New `cmd/analyze/usage_test.go` and `cmd/status/usage_test.go` cover, for both binaries: help on stdout with exit 0 for `-h`, `--help` and `-help`; no `Usage of ` or bundled binary name in the output; an unknown flag on stderr with exit 1 naming `--help`; and a valid invocation printing nothing. `cmd/status` additionally pins that every declared flag is documented, and that the three validation failures exit 1.

```
$ go test ./cmd/...
ok  	github.com/tw93/mole/cmd/analyze	5.093s
ok  	github.com/tw93/mole/cmd/status	2.340s

$ bats tests/cli.bats
41 tests, 0 failures

$ ./scripts/check.sh
=== Checks Completed ===
```
