### PR TITLE
fix(ci): isolate the #1517 Trash regression fixture

### DIFF
--- a/tests/clean_user_core.bats
+++ b/tests/clean_user_core.bats
@@ -582,6 +582,7 @@ EOF
 }
 
 @test "clean_trash removes input-method leftovers already in Trash (#1517)" {
+    rm -rf "$HOME/.Trash" # SAFE: reset this test's temporary HOME fixture before populating it
     mkdir -p "$HOME/.Trash/Input Methods"
     touch "$HOME/.Trash/com.sogou.inputmethod.sogou.plist"
     touch "$HOME/.Trash/com.tencent.inputmethod.QQInput.plist"


### PR DESCRIPTION
## Summary

- reset the test-owned Trash fixture before the input-method regression populates it
- preserve the preceding partial-empty regression, including its intentionally retained `two.tmp`
- make the three-item assertion independent of file-level test order and restore a trustworthy CI signal

## Why

`setup_file` shares one temporary `HOME` across this Bats file. The preceding partial-empty test deliberately leaves `~/.Trash/two.tmp`, so the next test currently creates three fixtures but production correctly removes four entries. Running the second test alone passes; running the adjacent pair on current `main` fails its three-item summary assertion.

This change gives the input-method regression ownership of its Trash fixture without weakening production cleanup behavior or accepting the incorrect four-item result.

## Validation

- current-main adjacent pair before the fix: 1 passed, 1 failed at the three-item assertion
- adjacent pair after the fix: 2 passed
- `bats tests/clean_user_core.bats`: the target regression passes; an initial full-file run had one unrelated browser fixture failure that passed when rerun alone
- `./scripts/check.sh --format`
- `git diff --check`
- full repository runner reached its exact summary `1821 tests, 2 failures, 6 skipped`; the target passed, while two unrelated machine/timing-sensitive tests outside this file failed (`codex resolution treats a failed mdfind...` and `safe_remove bounds a stalled external rm`), with the latter passing on isolated rerun

Fixes the test regression introduced with #1517.
