### PR TITLE
fix(uninstall): refresh names after language changes

### DIFF
--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -1064,7 +1064,15 @@ _scan_finalize_index() {
                 display_name = $2
                 bundle_id = $3
                 app_mtime = $4
-                if (NF >= 11) {
+                # A merged row is the 5-field scan row plus the 7 cache fields
+                # appended above, so 12 is the only width the current writers
+                # produce. The threshold has to track that sum: while the cache
+                # block was 6 fields wide, 11 named the same shape, and leaving
+                # it at 11 after the language signature landed would have let a
+                # hypothetical 11-field row take this branch and read every
+                # cached_* value shifted by one, so the signature itself would
+                # render as the display name.
+                if (NF >= 12) {
                     inline_size_kb = $5
                     cached_mtime = $6
                     cached_size_kb = $7

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -151,6 +151,10 @@ _uninstall_lproj_candidates() {
 }
 
 readonly MOLE_UNINSTALL_PREFERRED_LANGS="$(mole_uninstall_preferred_languages)"
+# Display names depend on the ordered language list. Keep the fingerprint in
+# each cache row so a language change invalidates only the derived name while
+# size and last-used metadata remain reusable.
+readonly MOLE_UNINSTALL_LANGUAGE_SIGNATURE="$(printf '%s' "$MOLE_UNINSTALL_PREFERRED_LANGS" | cksum | awk '{print $1 ":" $2}')"
 
 # The bundle's own name for a locale, read from the same InfoPlist.strings that
 # Finder consults. Prints nothing when the bundle does not localize the name,
@@ -382,7 +386,7 @@ start_uninstall_metadata_refresh() {
         local -a worker_pids=()
         local worker_idx=0
 
-        while IFS='|' read -r app_path app_mtime bundle_id display_name; do
+        while IFS='|' read -r app_path app_mtime bundle_id display_name language_signature; do
             [[ -n "$app_path" && -d "$app_path" ]] || continue
             ((worker_idx++))
             local worker_output="${updates_file}.${worker_idx}"
@@ -406,7 +410,7 @@ start_uninstall_metadata_refresh() {
                 size_kb=$(get_path_size_kb "$app_path")
                 [[ "$size_kb" =~ ^[0-9]+$ ]] || size_kb=0
 
-                printf "%s|%s|%s|%s|%s|%s|%s\n" "$app_path" "${app_mtime:-0}" "$size_kb" "${last_used_epoch:-0}" "$now_epoch" "$bundle_id" "$display_name" > "$worker_output"
+                printf "%s|%s|%s|%s|%s|%s|%s|%s\n" "$app_path" "${app_mtime:-0}" "$size_kb" "${last_used_epoch:-0}" "$now_epoch" "$bundle_id" "$display_name" "$language_signature" > "$worker_output"
             ) < /dev/null &
             worker_pids+=($!)
 
@@ -766,22 +770,24 @@ _scan_partition_cache() {
     }
 
     if [[ -s "$discovered_file" ]]; then
-        awk -F'|' -v cached_out="$cached_rows_file" -v uncached_out="$uncached_rows_file" '
+        awk -F'|' -v cached_out="$cached_rows_file" -v uncached_out="$uncached_rows_file" -v language_signature="$MOLE_UNINSTALL_LANGUAGE_SIGNATURE" '
             FILENAME == ARGV[1] {
                 cache_mtime[$1] = $2
                 cache_size[$1] = $3
                 cache_bundle[$1] = $6
                 cache_display[$1] = $7
+                cache_language[$1] = $8
                 next
             }
             {
                 path = $1
                 app_mtime = $3
-                if (cache_mtime[path] == app_mtime && cache_display[path] != "" && cache_size[path] ~ /^[0-9]+$/ && cache_size[path] > 0) {
+                if (cache_mtime[path] == app_mtime && cache_display[path] != "" && cache_language[path] == language_signature && cache_size[path] ~ /^[0-9]+$/ && cache_size[path] > 0) {
                     cached_bundle = cache_bundle[path] == "" ? "unknown" : cache_bundle[path]
                     print path "|" app_mtime "|" cached_bundle "|" cache_display[path] "|" cache_size[path] >> cached_out
                 } else {
-                    print path "|" $2 "|" app_mtime "|" cache_bundle[path] "|" cache_display[path] >> uncached_out
+                    cached_display = cache_language[path] == language_signature ? cache_display[path] : ""
+                    print path "|" $2 "|" app_mtime "|" cache_bundle[path] "|" cached_display >> uncached_out
                 }
             }
         ' "$cache_source" "$discovered_file"
@@ -978,14 +984,15 @@ _scan_finalize_index() {
             cache_updated[$1] = $5
             cache_bundle[$1] = $6
             cache_display[$1] = $7
+            cache_language[$1] = $8
             next
         }
         {
-            print $0 "|" cache_mtime[$1] "|" cache_size[$1] "|" cache_epoch[$1] "|" cache_updated[$1] "|" cache_bundle[$1] "|" cache_display[$1]
+            print $0 "|" cache_mtime[$1] "|" cache_size[$1] "|" cache_epoch[$1] "|" cache_updated[$1] "|" cache_bundle[$1] "|" cache_display[$1] "|" cache_language[$1]
         }
     ' "$cache_source" "$scan_raw_file" > "$merged_file"
     if [[ ! -s "$merged_file" && -s "$scan_raw_file" ]]; then
-        awk '{print $0 "||||||"}' "$scan_raw_file" > "$merged_file"
+        awk '{print $0 "|||||||"}' "$scan_raw_file" > "$merged_file"
     fi
 
     local current_epoch
@@ -999,6 +1006,7 @@ _scan_finalize_index() {
         -v now="$current_epoch" \
         -v floor="$MOLE_UNINSTALL_EPOCH_FLOOR" \
         -v ttl="$MOLE_UNINSTALL_META_REFRESH_TTL" \
+        -v language_signature="$MOLE_UNINSTALL_LANGUAGE_SIGNATURE" \
         -v refresh_out="$refresh_file" \
         -v snapshot_out="$cache_snapshot_file" \
         -v apps_out="$temp_file" '
@@ -1064,6 +1072,7 @@ _scan_finalize_index() {
                     cached_updated_epoch = $9
                     cached_bundle_id = $10
                     cached_display_name = $11
+                    cached_language_signature = $12
                 } else {
                     inline_size_kb = 0
                     cached_mtime = $5
@@ -1072,6 +1081,7 @@ _scan_finalize_index() {
                     cached_updated_epoch = $8
                     cached_bundle_id = $9
                     cached_display_name = $10
+                    cached_language_signature = ""
                 }
 
                 cache_match = (cached_mtime != "" && app_mtime != "" && cached_mtime == app_mtime)
@@ -1102,16 +1112,18 @@ _scan_finalize_index() {
                     needs_refresh = 1
                 } else if (cached_bundle_id == "" || cached_display_name == "") {
                     needs_refresh = 1
+                } else if (cached_language_signature != language_signature) {
+                    needs_refresh = 1
                 } else if ((now - cached_updated_epoch) > ttl) {
                     needs_refresh = 1
                 }
 
                 if (needs_refresh) {
-                    print app_path "|" app_mtime "|" bundle_id "|" display_name >> refresh_out
+                    print app_path "|" app_mtime "|" bundle_id "|" display_name "|" language_signature >> refresh_out
                 }
 
                 persist_updated_epoch = (isnum(cached_updated_epoch) && cached_updated_epoch > 0) ? cached_updated_epoch : 0
-                print app_path "|" app_mtime "|" final_size_kb "|" final_epoch "|" persist_updated_epoch "|" bundle_id "|" display_name >> snapshot_out
+                print app_path "|" app_mtime "|" final_size_kb "|" final_epoch "|" persist_updated_epoch "|" bundle_id "|" display_name "|" language_signature >> snapshot_out
                 print final_epoch "|" app_path "|" display_name "|" bundle_id "|" final_size "|" final_last_used "|" final_size_kb >> apps_out
             }
         ' "$merged_file"

--- a/tests/uninstall_scan_bash32.bats
+++ b/tests/uninstall_scan_bash32.bats
@@ -87,15 +87,10 @@ PLIST
 
 	# Seed the warm metadata cache so that the one discovered app
 	# (TestApp.app) is a cache hit: matching mtime, non-empty bundle id
-	# and display name are the conditions the awk classifier and
+	# and display name, plus a matching language signature, are the conditions
+	# the awk classifier and
 	# use_cached_scan_metadata require for the cached branch to "stick".
 	app_mtime="$(stat -f %m "$apps_root/TestApp.app")"
-	cache_dir="$HOME/.cache/mole"
-	mkdir -p "$cache_dir"
-	printf '%s|%s|4|0|0|com.test.TestApp|TestApp\n' \
-		"$apps_root/TestApp.app" "$app_mtime" \
-		> "$cache_dir/uninstall_app_metadata_v2"
-
 	done_marker="$HOME/scan.done"
 
 	# The bug not only emits "unbound variable"; the spinner subshell can
@@ -107,12 +102,19 @@ PLIST
 	(
 		env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" \
 			MOLE_TEST_NO_AUTH=1 \
-			APPS_ROOT="$apps_root" SRC_PATH="$src" \
+			APPS_ROOT="$apps_root" APP_MTIME="$app_mtime" SRC_PATH="$src" \
 			/bin/bash --noprofile --norc <<'EOF' > "$HOME/scan.out" 2> "$HOME/scan.err"
 set -euo pipefail
 
 # shellcheck source=/dev/null
 source "$SRC_PATH"
+
+# Seed the production cache schema after sourcing so the language signature
+# exactly matches the preference snapshot used by this scan.
+mkdir -p "$MOLE_UNINSTALL_META_CACHE_DIR"
+printf '%s|%s|4|0|0|com.test.TestApp|TestApp|%s\n' \
+	"$APPS_ROOT/TestApp.app" "$APP_MTIME" "$MOLE_UNINSTALL_LANGUAGE_SIGNATURE" \
+	> "$MOLE_UNINSTALL_META_CACHE_FILE"
 
 # Skip the real pkgutil receipt scan: it walks every package on the host and
 # can take longer than this test's watchdog on machines with large receipt
@@ -127,8 +129,13 @@ uninstall_print_app_search_dirs() { printf '%s\n' "$APPS_ROOT"; }
 # Bundle-id resolution would otherwise call /usr/bin/mdls and reject our
 # placeholder Info.plist. The cached branch only needs an echo-through here.
 uninstall_resolve_eligible_bundle_id() { printf '%s\n' "${2:-${1##*/}}"; }
+uninstall_resolve_display_name() {
+	: > "$HOME/name-resolved"
+	printf 'TestApp\n'
+}
 
 scan_applications > /dev/null
+[[ ! -e "$HOME/name-resolved" ]] || exit 2
 EOF
 		: > "$done_marker"
 	) &
@@ -161,6 +168,71 @@ EOF
 	# the inverted status explicitly so the assertion is portable.
 	run grep -q 'unbound variable' "$HOME/scan.err"
 	[ "$status" -ne 0 ]
+}
+
+@test "scan_applications refreshes only a cached localized name when AppleLanguages changes (#1520)" {
+	src="$HOME/uninstall_source.sh"
+	sourceable_uninstall_sh "$src"
+
+	apps_root="$HOME/Applications"
+	app_path="$apps_root/VideoFusion-macOS.app"
+	create_test_app_bundle "$app_path" "com.example.VideoFusion" "VideoFusion-macOS"
+	/usr/libexec/PlistBuddy -c "Add :CFBundleDevelopmentRegion string en" \
+		"$app_path/Contents/Info.plist"
+	mkdir -p "$app_path/Contents/Resources/en.lproj"
+	printf '"CFBundleDisplayName" = "VideoFusion";\n' \
+		> "$app_path/Contents/Resources/en.lproj/InfoPlist.strings"
+	app_mtime="$(stat -f %m "$app_path")"
+
+	bin_dir="$HOME/bin"
+	mkdir -p "$bin_dir"
+	cat > "$bin_dir/defaults" <<'EOF'
+#!/bin/sh
+printf '(\n    "en-CN",\n    "zh-Hans-CN"\n)\n'
+EOF
+	chmod +x "$bin_dir/defaults"
+
+	run env HOME="$HOME" PROJECT_ROOT="$PROJECT_ROOT" PATH="$bin_dir:$PATH" \
+		MOLE_TEST_NO_AUTH=1 APPS_ROOT="$apps_root" APP_PATH="$app_path" \
+		APP_MTIME="$app_mtime" SRC_PATH="$src" \
+		/bin/bash --noprofile --norc <<'EOF'
+set -euo pipefail
+source "$SRC_PATH"
+
+uninstall_print_app_search_dirs() { printf '%s\n' "$APPS_ROOT"; }
+pkg_receipt_nonstandard_app_paths() { return 0; }
+uninstall_quick_app_size_kb() { printf '0\n'; }
+uninstall_inline_du_size_kb() { printf '0\n'; }
+start_uninstall_metadata_refresh() { :; }
+
+mkdir -p "$MOLE_UNINSTALL_META_CACHE_DIR"
+printf '%s|%s|4096|1700000000|1700000001|com.example.VideoFusion|剪映专业版|old-language-signature\n' \
+	"$APP_PATH" "$APP_MTIME" > "$MOLE_UNINSTALL_META_CACHE_FILE"
+
+apps_file=$(scan_applications)
+result=$(cat "$apps_file")
+[[ "$result" == *"|$APP_PATH|VideoFusion|com.example.VideoFusion|4.2MB|"* ]] || {
+	printf 'unexpected scan result: %s\n' "$result" >&2
+	exit 1
+}
+[[ "$result" != *"剪映专业版"* ]] || exit 2
+
+IFS='|' read -r cached_path cached_mtime cached_size cached_epoch cached_updated \
+	cached_bundle cached_name cached_language < "$MOLE_UNINSTALL_META_CACHE_FILE"
+[[ "$cached_path" == "$APP_PATH" ]] || exit 3
+[[ "$cached_mtime" == "$APP_MTIME" ]] || exit 4
+[[ "$cached_size" == "4096" ]] || exit 5
+[[ "$cached_epoch" == "1700000000" ]] || exit 6
+[[ "$cached_updated" == "1700000001" ]] || exit 7
+[[ "$cached_bundle" == "com.example.VideoFusion" ]] || exit 8
+[[ "$cached_name" == "VideoFusion" ]] || exit 9
+[[ -n "$cached_language" && "$cached_language" != "old-language-signature" ]] || exit 10
+EOF
+
+	[ "$status" -eq 0 ] || {
+		echo "$output"
+		return 1
+	}
 }
 
 @test "app discovery treats the app suffix case-insensitively without admitting nested bundles" {


### PR DESCRIPTION
## Summary

- fingerprint the ordered `AppleLanguages` snapshot alongside each cached display name
- re-resolve only the localized name when that fingerprint changes, while retaining cached size and last-used metadata
- carry the current fingerprint through both the immediate cache snapshot and deferred metadata refresh; legacy rows without one heal on their next scan

## Why

The localized resolver added for #1520 depends on the user's language order, but the persistent v3 cache currently accepts an unchanged app as warm without checking which language produced its name. Changing macOS language preferences can therefore keep showing the old-language name indefinitely, including after the seven-day metadata refresh.

This stays outside app matching and deletion: it changes only whether a cached display name is reusable.

## Verification

- New Bash 3.2 integration regression failed on unmodified `main` by returning the cached Chinese name, then passed with the patch and retained the cached size/last-used fields.
- `MOLE_TEST_NO_AUTH=1 bats tests/uninstall.bats tests/uninstall_scan_bash32.bats` — 124/124 passed
- `./scripts/check.sh` — passed (format, `go vet`, ShellCheck, syntax, duplication and diagnostics checks)
- `go test ./...` — passed
- Full `TERM=xterm-256color MOLE_TEST_NO_AUTH=1 ./scripts/test.sh`: 1,834 passed, 6 skipped, with one unrelated pre-existing `clean_dev_caches.bats` failure reproduced unchanged on the exact base commit (`codex resolution treats a failed mdfind as unanswered`)
